### PR TITLE
#headermenu #toggleLocate hidden

### DIFF
--- a/lizmap/www/js/map.js
+++ b/lizmap/www/js/map.js
@@ -1688,6 +1688,8 @@ var lizMap = function() {
             updateSwitcherSize();
             return false;
           });
+          if ( !('locateByLayer' in config) )
+            $('#toggleLocate').parent().hide();
 
           // Toggle Metadata
           $('#displayMetadata').click(function(){


### PR DESCRIPTION
Hide the button toggle locate in the header menu when there are no locateByLayer in the config of the map
