### PR TITLE
Add forgot translation causing bug.

### DIFF
--- a/lizmap/modules/view/locales/fr_FR/edition.UTF-8.properties
+++ b/lizmap/modules/view/locales/fr_FR/edition.UTF-8.properties
@@ -3,6 +3,7 @@ access.denied=Vous n'avez pas le droit d'utiliser les outils d'édition.
 form.submit.label=Enregistrer
 form.data.saved=Les données ont bien été enregistrées.
 form.cancel.label=Annuler
+form.btn.clear.title=Fermer
 
 navbar.title=Édition
 


### PR DESCRIPTION
Add forgot french translation causing a bug when selecting a feature to edit. It is also missing in spanish, portugese and greek translation.
