### PR TITLE
Fixes PHP error: empty() function only supports variables

### DIFF
--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -261,8 +261,9 @@ class serviceCtrl extends jController {
           }
           $this->params['exp_filter'] = $filter;
           if( array_key_exists('propertyname', $this->params)  ){
-            if( !empty( trim($this->params["propertyname"]) ) )
-              $this->params["propertyname"].= ",$oAttribute";
+            $propertyName = trim($this->params["propertyname"]);
+            if( !empty($propertyName) )
+         	$this->params["propertyname"].= ",$oAttribute";
           }
         }
         // WMS : FILTER


### PR DESCRIPTION
This only should to happen with PHP version < 5.5
see php doc: http://php.net/manual/en/function.empty.php#refsect1-function.empty-parameters