### PR TITLE
Cache files should have rights defined in the configuration

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapCache.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapCache.class.php
@@ -333,8 +333,7 @@ class lizmapCache {
             $cacheDirectory = $cacheRootDirectory.'/'.$repository.'/'.$project.'/'.$layers.'/'.$crs.'/';
 
             // Create directory if needed
-            if(!file_exists($cacheDirectory))
-                mkdir($cacheDirectory, 0750, true);
+            jFile::createDir($cacheDirectory);
 
             // Virtual cache profile parameter
             $cacheParams = array(
@@ -342,9 +341,7 @@ class lizmapCache {
                 "cache_dir"=>$cacheDirectory,
                 "file_locking"=>True,
                 "directory_level"=>"5",
-                "directory_umask"=>"0750",
                 "file_name_prefix"=>"lizmap_",
-                "cache_file_umask"=>"0650",
                 "ttl"=>$cacheExpiration
             );
 
@@ -356,8 +353,7 @@ class lizmapCache {
 
             // Directory where to store the sqlite database
             $cacheDirectory = $cacheRootDirectory.'/'.$repository.'/'.$project.'/';
-            if(!file_exists($cacheDirectory))
-                mkdir($cacheDirectory, 0750, true); // Create directory if needed
+            jFile::createDir($cacheDirectory); // Create directory if needed
             $cacheDatabase = $cacheDirectory.$layers.'_'.$crs.'.db';
             $cachePdoDsn = 'sqlite:'.$cacheDatabase;
 

--- a/lizmap/modules/lizmap/classes/lizmapProxy.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProxy.class.php
@@ -342,8 +342,7 @@ class lizmapProxy {
             $cacheDirectory = $cacheRootDirectory.'/'.$repository.'/'.$project.'/'.$layers.'/'.$crs.'/';
 
             // Create directory if needed
-            if(!file_exists($cacheDirectory))
-                mkdir($cacheDirectory, 0750, true);
+            jFile::createDir($cacheDirectory);
 
             // Virtual cache profile parameter
             $cacheParams = array(
@@ -351,9 +350,7 @@ class lizmapProxy {
                 "cache_dir"=>$cacheDirectory,
                 "file_locking"=>True,
                 "directory_level"=>"5",
-                "directory_umask"=>"0750",
                 "file_name_prefix"=>"lizmap_",
-                "cache_file_umask"=>"0650",
                 "ttl"=>$cacheExpiration
             );
 
@@ -365,8 +362,7 @@ class lizmapProxy {
 
             // Directory where to store the sqlite database
             $cacheDirectory = $cacheRootDirectory.'/'.$repository.'/'.$project.'/';
-            if(!file_exists($cacheDirectory))
-                mkdir($cacheDirectory, 0750, true); // Create directory if needed
+            jFile::createDir($cacheDirectory); // Create directory if needed
             $cacheDatabase = $cacheDirectory.$layers.'_'.$crs.'.db';
             $cachePdoDsn = 'sqlite:'.$cacheDatabase;
 

--- a/lizmap/var/config/localconfig.ini.php.dist
+++ b/lizmap/var/config/localconfig.ini.php.dist
@@ -4,3 +4,6 @@
 ; put here configuration variables that are specific to this installation
 
 
+; chmod for files created by Lizmap and Jelix
+;chmodFile=0664
+;chmodDir=0775

--- a/lizmap/var/config/profiles.ini.php.dist
+++ b/lizmap/var/config/profiles.ini.php.dist
@@ -67,11 +67,11 @@ cache_dir=
 file_locking=1
 ; directory level. Set the directory structure level. 0 means "no directory structure", 1 means "one level of directory", 2 means "two levels"...
 directory_level=0
-; umask for directory structure (default '0700')
+; umask for directory structure (default jelix one : 0775)
 directory_umask=
 ; prefix for cache files (default 'jelix_cache')
 file_name_prefix=
-; umask for cache files (default '0600')
+; umask for cache files (default jelix one: 0664)
 cache_file_umask=
 
 ; Parameters for db driver :


### PR DESCRIPTION
Rights values should not be defined directly into the code
because these values may not be suitable for the server configuration
or for the needs of the user.

So let's used values defined in the Jelix configuration.