### PR TITLE
Fix profile names cache into lizmapProxy

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapProxy.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProxy.class.php
@@ -437,7 +437,7 @@ class lizmapProxy {
             jProfiles::createVirtualProfile('jcache', $cacheName, $cacheParams);
         }
 
-        self::$_profiles[] = $cacheName;
+        self::$_profiles[$cacheName] = true;
         return $cacheName;
     }
 


### PR DESCRIPTION
Since array_key_exists is used, the profile name should be the key in the array.