### PR TITLE
Put data from qgs files to a cache

### DIFF
--- a/lib/jelix-plugins/cache/file/file.cache.php
+++ b/lib/jelix-plugins/cache/file/file.cache.php
@@ -176,7 +176,6 @@ class fileCacheDriver implements jICacheDriver {
 
         $filePath = $this->_getCacheFilePath($key);
         $this->_createDir(dirname($filePath));
-
         if ($this->_setFileContent ($filePath,$var)) {
 
             switch($ttl) {
@@ -393,8 +392,11 @@ class fileCacheDriver implements jICacheDriver {
     protected function _getCacheFilePath($key){
 
         $path = $this->_getPath($key);
-        $fileName = $this->_file_name_prefix."___".$key.self::CACHEEXT;
-        return $path . $fileName;
+        if (DIRECTORY_SEPARATOR === '\\') {
+            // Windows doesn't like colon in file names
+            $key = str_replace(':', '_.._', $key);
+        }
+        return $path . $key.self::CACHEEXT;
 
     }
 
@@ -406,18 +408,17 @@ class fileCacheDriver implements jICacheDriver {
     */
     protected function _getPath($key){
 
-        $path = $this->_cache_dir;
-        $prefix = $this->_file_name_prefix;
-
+        $path = $this->_cache_dir.$this->_file_name_prefix. DIRECTORY_SEPARATOR;
         if ($this->_directory_level>0) {
             $hash = md5($key);
             for ($i=0;$i<$this->_directory_level;$i++) {
-                $path=$path.$prefix.'__'.substr($hash, 0, $i + 1). DIRECTORY_SEPARATOR;
+                $path .= substr($hash, 0, $i + 1). DIRECTORY_SEPARATOR;
             }
         }
-
+        if ($key[0] == '/' || $key[0] == DIRECTORY_SEPARATOR) {
+            $path .= $this->_file_name_prefix. DIRECTORY_SEPARATOR;
+        }
         return $path;
-
     }
 
     /**

--- a/lib/jelix/core/log/jSyslogLogger.class.php
+++ b/lib/jelix/core/log/jSyslogLogger.class.php
@@ -38,6 +38,7 @@ class jSyslogLogger implements jILogger {
      * @param jILogMessage $message the message to log
      */
     function logMessage($message) {
+        $type = $message->getCategory();
         if (isset($this->catSyslog[$type])) {
             $priority = $this->catSyslog[$type];
         }

--- a/lib/jelix/utils/jCache.class.php
+++ b/lib/jelix/utils/jCache.class.php
@@ -426,7 +426,7 @@ class jCache {
      * @return boolean
      */
     protected static function _checkKey($key){
-        if (!preg_match('/^[a-z0-9_]+$/i',$key) || strlen($key) > 255) {
+        if (!preg_match('/^[a-z0-9_\\/:\\.\\-]+$/i',$key) || strlen($key) > 255) {
             throw new jException('jelix~cache.error.invalid.key',$key);
         }
     }

--- a/lib/php5redis/README.md
+++ b/lib/php5redis/README.md
@@ -5,7 +5,7 @@ php-redis contains php5 class for connecting with redis database with methods fo
 Quick start
 -----------
 * Install Redis from [redis.io](http://redis.io/download "Redis")
-* Download latest php-redis class from [here](https://github.com/sash/php-redis/archives/master)
+* Download latest php-redis class from [here](https://github.com/jelix/php-redis/archives/master)
 * Write some code:
 
 		# Connecting
@@ -27,3 +27,4 @@ Changelog
 		- Redis implements the __call magic method. Any non-implemented redis method can be called via ->methodname(param1, ...)
 	1.2 - pipeline support. ->pipeline_begin() and then execute any number of commands - each will return null
 		Then run ->pipeline_responses() to get all of the responses as array and end the pipeline mode
+    1.2.1 - fix quit() error, undefined variable on connection errors, and add closing during destruction of the object

--- a/lib/php5redis/Redis.php
+++ b/lib/php5redis/Redis.php
@@ -5,7 +5,7 @@ class RedisException extends Exception {}
  * 
  * @author sash
  * @license LGPL
- * @version 1.2
+ * @version 1.2.1
  */
 class Redis {
 	private $port;
@@ -32,7 +32,7 @@ class Redis {
 		}
 		$msg = "Cannot open socket to {$this->host}:{$this->port}";
 		if ($errno || $errmsg)
-			$msg .= "," . ($errno ? " error $errno" : "") . ($errmsg ? " $errmsg" : "");
+			$msg .= "," . ($errno ? " error $errno" : "") . ($errstr ? " $errstr" : "");
 		throw new RedisException ( "$msg." );
 	}
 	private function debug($msg){
@@ -134,8 +134,9 @@ class Redis {
 		elseif ($readResp) {
 			return $this->cmdResponse ();
 		}
-		else
+		else {
 			return '';
+		}
 	}
 	function disconnect() {
 		if ($this->_sock)
@@ -346,7 +347,7 @@ class Redis {
 	 * @return string
 	 */
 	function type($key){
-		return $this->cms ( array("TYPE", $key) );
+		return $this->cmd ( array("TYPE", $key) );
 	}
 	
 	////////////////////////////////
@@ -785,10 +786,15 @@ class Redis {
 	////////////////////////////////
 	/**
 	 * Provide information and statistics about the server
+	 * @param $section
 	 * @return unknown_type
 	 */
-	function info(){
-		return $this->cmd ( "INFO" );
+	function info($section = false){
+		if ($section === false) {
+			return $this->cmd ( "INFO" );
+		} else {
+			return $this->cmd ( array("INFO", $section) );
+		}
 	}
 	
 	/**

--- a/lizmap/modules/admin/controllers/config.classic.php
+++ b/lizmap/modules/admin/controllers/config.classic.php
@@ -802,6 +802,9 @@ class configCtrl extends jController {
     $lproj = lizmap::getProject($repository.'~'.$project);
     $project = $lproj->getKey();
 
+    // Remove project cache
+    jCache::delete($lrep->getPath().$project.'.qgs', 'qgisprojects');
+
     // Remove the cache for the layer
     $cacheRootDirectory = $ser->cacheRootDirectory;
     $cacheProjectDir = $cacheRootDirectory.'/'.$lrep->getKey().'/'.$project.'/';

--- a/lizmap/modules/lizmap/classes/lizmap.class.php
+++ b/lizmap/modules/lizmap/classes/lizmap.class.php
@@ -139,6 +139,10 @@ class lizmap{
 
     /**
      * Get a project
+     * @return lizmapProject (null if it does not exist)
+     * @FIXME all calls to getProject construct $key. Why not to
+     * deliver directly $rep and $project? It could avoid
+     * a preg_match
      */
     public static function getProject ($key){
       $match = preg_match('/(?P<rep>\w+)~(?P<proj>\w+)/', $key, $matches);

--- a/lizmap/modules/lizmap/classes/lizmap.class.php
+++ b/lizmap/modules/lizmap/classes/lizmap.class.php
@@ -151,9 +151,12 @@ class lizmap{
         return self::$projectInstances[$key];
 
       jClasses::inc('lizmap~lizmapProject');
-      $proj = new lizmapProject($matches['proj'], $rep);
-      if ( $proj->getKey() != $matches['proj'] )
+      try {
+        $proj = new lizmapProject($matches['proj'], $rep);
+      }
+      catch(Exception $e) {
         return null;
+      }
       self::$projectInstances[$key] = $proj;
       return $proj;
     }

--- a/lizmap/modules/lizmap/classes/lizmap.class.php
+++ b/lizmap/modules/lizmap/classes/lizmap.class.php
@@ -80,11 +80,13 @@ class lizmap{
      *
      */
     public static function getRepository ($key){
-      if ( !in_array($key, self::$repositories) )
-        if ( !in_array($key, self::getRepositoryList()) )
+      if ( !in_array($key, self::$repositories) ) {
+        if ( !in_array($key, self::getRepositoryList()) ) {
           return null;
+        }
+      }
 
-      if ( in_array($key, self::$repositoryInstances) )
+      if ( array_key_exists($key, self::$repositoryInstances) )
         return self::$repositoryInstances[$key];
 
       jClasses::inc('lizmap~lizmapRepository');
@@ -128,7 +130,7 @@ class lizmap{
         $ini->removeValue(null, $section);
         $ini->save();
         self::getRepositoryList();
-        if ( in_array($key, self::$repositoryInstances) )
+        if ( array_key_exists($key, self::$repositoryInstances) )
             unset(self::$repositoryInstances[$key]);
         return true;
       }
@@ -147,7 +149,7 @@ class lizmap{
       if ( $rep == null)
         return null;
 
-      if ( in_array($key, self::$projectInstances) )
+      if ( isset(self::$projectInstances[$key]) )
         return self::$projectInstances[$key];
 
       jClasses::inc('lizmap~lizmapProject');

--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -78,6 +78,11 @@ class lizmapProject{
     protected $editionLayers = array();
 
     /**
+     * @var boolean
+     */
+    protected $useLayerIDs = false;
+
+    /**
      * constructor
      * key : the project name
      * rep : the repository has a lizmapRepository class
@@ -238,6 +243,7 @@ class lizmapProject{
         $this->printCapabilities = $this->readPrintCapabilities($this->xml, $this->cfg);
         $this->locateByLayer = $this->readLocateByLayers($this->xml, $this->cfg);
         $this->editionLayers = $this->readEditionLayers($this->xml, $this->cfg);
+        $this->useLayerIDs = $this->readUseLayerIDs($this->xml);
     }
 
     public function getQgisProjectVersion(){
@@ -745,6 +751,11 @@ class lizmapProject{
         return $editionLayers;
     }
 
+    protected function readUseLayerIDs($xml) {
+        $WMSUseLayerIDs = $xml->xpath( "//properties/WMSUseLayerIDs" );
+        return ( count($WMSUseLayerIDs) > 0 && $WMSUseLayerIDs[0] == 'true' );
+    }
+
     public function getUpdatedConfig(){
         $qgsLoad = $this->xml;
 
@@ -792,8 +803,7 @@ class lizmapProject{
         if( $relations )
             $configJson->relations = $relations;
 
-        $WMSUseLayerIDs = $this->xml->xpath( "//properties/WMSUseLayerIDs" );
-        if ( count($WMSUseLayerIDs) > 0 && $WMSUseLayerIDs[0] == 'true' ) {
+        if ( $this->useLayerIDs ) {
             $configJson->options->useLayerIDs = 'True';
         }
 

--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -1067,6 +1067,7 @@ class lizmapProject{
         // only maps
         if($services->onlyMaps) {
                 $projectsTpl = new jTpl();
+                $projectsTpl->assign('excludedProject', '');
                 $dockable[] = new lizmapMapDockItem(
                     'home',
                     jLocale::get('view~default.repository.list.title'),

--- a/lizmap/modules/lizmap/classes/lizmapRepository.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapRepository.class.php
@@ -124,7 +124,7 @@ class lizmapRepository{
             $qgsFiles[] = $file;
         }
         closedir($dh);
-        jClasses::inc('lizmap~lizmapProject');
+
         foreach ($qgsFiles as $qgsFile) {
           if (in_array($qgsFile.'.cfg',$cfgFiles))
             $projects[] = lizmap::getProject($this->key.'~'.substr($qgsFile,0,-4));

--- a/lizmap/modules/lizmap/classes/qgisMapLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisMapLayer.class.php
@@ -38,30 +38,29 @@ class qgisMapLayer{
   // xml layer element
   protected $xmlLayer = null;
 
-  // project layer
+  /**
+   * @var lizmapProject
+   */
   protected $project = null;
 
   /**
    * constructor
-   * xmlLayer : the XML map layer representation
+   * @param lizmapProject $project
+   * @param array $propLayer  list of properties values
    */
-  public function __construct ( $project, $xmlLayer ) {
-    $this->id = (string)$xmlLayer->attributes()->type;
-    $this->id = (string)$xmlLayer->id;
+  public function __construct ( $project, $propLayer ) {
+    $this->type = $propLayer['type'];
+    $this->id = $propLayer['id'];
 
-    $this->name = (string)$xmlLayer->layername;
-    $this->title = (string)$xmlLayer->title;
-    if ( $this->title == '' )
-        $this->title = $this->name;
-    $this->abstract = (string)$xmlLayer->abstract;
+    $this->name = $propLayer['layername'];
+    $this->title = $propLayer['title'];
+    $this->abstract = $propLayer['abstract'];
 
-    $this->proj4 = (string)$xmlLayer->srs->spatialrefsys->proj4;
-    $this->srid = (integer)$xmlLayer->srs->spatialrefsys->srid;
+    $this->proj4 = $propLayer['proj4'];
+    $this->srid = $propLayer['srid'];
 
-    $this->datasource = (string)$xmlLayer->datasource;
-    $this->provider = (string)$xmlLayer->provider;
-
-    $this->xmlLayer = $xmlLayer;
+    $this->datasource = $propLayer['datasource'];
+    $this->provider = $propLayer['provider'];
     $this->project = $project;
   }
 

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -14,16 +14,22 @@ class qgisVectorLayer extends qgisMapLayer{
   // layer type
   protected $type = 'vector';
 
+  protected $fields = array();
+
+  protected $aliases = array();
+
+  protected $wfsFields = array();
+
   /**
    * constructor
-   * xmlLayer : the XML map layer representation
+   * @param lizmapProject $project
+   * @param array $propLayer  list of properties values
    */
-  public function __construct ( $project, $xmlLayer ) {
-    parent::__construct( $project, $xmlLayer );
-    /*
-    if( $this->type == 'vector') {
-    }
-     */
+  public function __construct ( $project, $propLayer ) {
+    parent::__construct( $project, $propLayer );
+    $this->fields = $propLayer['fields'];
+    $this->aliases = $propLayer['aliases'];
+    $this->wfsFields = $propLayer['wfsFields'];
   }
 
   public function getDatasourceParameters() {
@@ -81,35 +87,14 @@ class qgisVectorLayer extends qgisMapLayer{
   }
 
   public function getFields() {
-      $fields = array();
-      $edittypes = $this->xmlLayer->xpath(".//edittype");
-      foreach( $edittypes as $edittype ) {
-          $fields[] = (string) $edittype->attributes()->name;
-      }
-      return $fields;
+      return $this->fields;
   }
 
   public function getAliasFields() {
-      $fields = $this->getFields();
-      $aliases = array();
-      foreach( $fields as $f ) {
-          $aliases[$f] = $f;
-          $alias = $this->xmlLayer->xpath("aliases/alias[@field='".$f."']");
-          if( count($alias) != 0 ) {
-            $alias = $alias[0];
-            $aliases[$f] = (string)$alias['name'];
-          }
-      }
-      return $aliases;
+      return $this->aliases;
   }
 
   public function getWfsFields() {
-      $fields = $this->getFields();
-      $excludeFields = $this->xmlLayer->xpath(".//excludeAttributesWFS/attribute");
-      foreach( $excludeFields as $eField ) {
-          $eField = (string) $eField;
-          array_splice( $fields, array_search( $eField, $fields ), 1 );
-      }
-      return $fields;
+      return $this->wfsFields;
   }
 }

--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -12,6 +12,9 @@
 class serviceCtrl extends jController {
 
 
+  /**
+   * @var lizmapProject
+   */
   protected $project = '';
   protected $repository = '';
   protected $services = '';
@@ -1073,5 +1076,4 @@ class serviceCtrl extends jController {
         lizmap::logMetric('LIZMAP_SERVICE_GETMAP');
         return $rep;
   }
-
 }

--- a/lizmap/modules/lizmap/install/upgrade_qgisprojectcache.php
+++ b/lizmap/modules/lizmap/install/upgrade_qgisprojectcache.php
@@ -1,0 +1,24 @@
+<?php
+class lizmapModuleUpgrader_qgisprojectcache extends jInstallerModule {
+
+    public $targetVersions = array(
+        '3.0beta4.1'
+    );
+    public $date = '2016-05-05';
+
+    function install() {
+
+        if( $this->firstExec('cacheqgis') ) {
+            $profiles = new jIniFileModifier(jApp::configPath('profiles.ini.php'));
+            if (!$profiles->isSection('jcache:qgisprojects')) {
+                $profiles->setValues(array(
+                    'enabled'=>1,
+                    'driver'=>'file',
+                    'ttl' => 0
+                    ), 'jcache:qgisprojects');
+                $profiles->save();
+            }
+        }
+    }
+
+}

--- a/lizmap/modules/lizmap/module.xml
+++ b/lizmap/modules/lizmap/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module xmlns="http://jelix.org/ns/module/1.0">
     <info id="info@3liz.com" name="lizmap" createdate="2011-06-15">
-        <version date="2016-04-04">3.0beta4</version>
+        <version date="2016-05-05">3.0beta4.1</version>
         <label lang="en_US">lizmap</label>
         <description lang="en_US" />
         <license URL="http://www.mozilla.org/MPL/">Mozilla Public License</license>

--- a/lizmap/modules/view/templates/map_projects.tpl
+++ b/lizmap/modules/view/templates/map_projects.tpl
@@ -1,5 +1,5 @@
 <div id="projects">
-  {zone 'view~main_view', array('excludedProject'=>$repository.'~'.$project)}
+  {zone 'view~main_view', array('excludedProject'=>$excludedProject)}
   <script>
   {literal}
   $(document).ready(function () {

--- a/lizmap/var/config/profiles.ini.php.dist
+++ b/lizmap/var/config/profiles.ini.php.dist
@@ -36,15 +36,8 @@ database="var:db/logs.db"
 ; name of the default profil to use for cache
 default=myapp
 
-; each section correspond to a cache profile
-; the name of the section is the name of the profile, to use as an argument
-; for jCache methods
-; Parameters in each sections depends of the driver type
 
 [jcache:myapp]
-
-; Parameters common to all drivers :
-
 ; disable or enable cache for this profile
 enabled=1
 ; driver type (file, db, memcached)
@@ -89,4 +82,7 @@ cache_file_umask=
 ;servers = memcache_host1:11211,memcache_host2:11211,memcache_host3:11211 i.e HOST_NAME:PORT
 ;servers = 
 
-
+[jcache:qgisprojects]
+enabled=1
+driver=file
+ttl=0


### PR DESCRIPTION
Reading the xml file of projects (*.qgs) takes many time (and many memory). And it is readed at each request, so for each tiles. 

Now the XML content is readed only one time, and needed data are put in a cache. Xml file is readed only if it has changed. And so, most of methods of LizmapProject don't read anymore the xml content, and just return data readed from the cache. Except some few methods that read the xml file everytime : getXmlLayers(), getXmlLayerByKeyword($key), getComposer( $title ), getXmlLayer()