### PR TITLE
Fix issue in the admin menu: impossible to back to the parent page

### DIFF
--- a/lizmap/var/themes/default/master_admin/zone_admin_menu.tpl
+++ b/lizmap/var/themes/default/master_admin/zone_admin_menu.tpl
@@ -3,10 +3,7 @@
          {if $bloc->label}<li class="nav-header">{$bloc->label|eschtml}</li>{/if}
          {foreach $bloc->childItems as $item}
                 <li {if $item->id == $selectedMenuItem} class="active"{/if}>
-                    {if $item->id == $selectedMenuItem && $item->type == 'url'}
-                        <a href="" onclick="return false;"{if $item->icon}
-                        style="background-image:url({$item->icon});"{/if}>{$item->label|eschtml}</a>
-                    {elseif $item->type == 'url'}
+                    {if $item->type == 'url'}
                         <a href="{$item->content|eschtml}"{if $item->icon}
                         style="background-image:url({$item->icon});"{/if}>{$item->label|eschtml}</a>
                     {else}


### PR DESCRIPTION
Clicking on the link corresponding to a parent page of a section is not possible.

For example, when we click on a link on "Lizmap configuration",
then we go to modify the config or a repository, the link
"Lizmap configuration" becomes inactive and has the bad URL.

We cannot back to the lizmap configuration with the menu.