### PR TITLE
compression maximum des png allant dans le cache

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapProxy.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProxy.class.php
@@ -310,7 +310,7 @@ class lizmapProxy {
             # Output the image as a string (use PHP buffering)
             ob_start();
             if(preg_match('#png#', $params['format']))
-                imagepng($image, null);
+                imagepng($image, null, 9);
             else
                 imagejpeg($image, null, 80);
             $data = ob_get_contents(); // read from buffer


### PR DESCRIPTION
Le paramètre 'quality' de la fonction imagepng ( resource $image [, mixed $to [, **int $quality** [, int $filters ]]] ) permet de plus compresser les images qu'actuellement.
La valeur par défaut est à 6, je la passe à 9 (le max).
Ceci se fait uniquement pour les images en cache pour ne pas ralentir la génération d'images non mises en cache.