### PR TITLE
minor fix in the default css theme

### DIFF
--- a/lizmap/www/themes/default/css/main.css
+++ b/lizmap/www/themes/default/css/main.css
@@ -16,7 +16,7 @@ a:hover {
 /* END for ie 8*/
 
 #header {
-  background : url('img/header-background-medium.png') repeat fixed #2B2B2B;
+  background : url(img/header-background-medium.png) repeat fixed #2B2B2B;
   color : #FBFBFB;
 }
 #logo {


### PR DESCRIPTION
Fix header url. The extra ' '  is broking the url header and use the default theme header instead of project theme header.

It's happening in the loading.gif i will try to see what is wrong.

Regards