### PR TITLE
 attribute table - unnecessary help

### DIFF
--- a/lizmap/modules/view/locales/de_DE/map.UTF-8.properties
+++ b/lizmap/modules/view/locales/de_DE/map.UTF-8.properties
@@ -130,8 +130,6 @@ bottomdock.toolbar.btn.size.minimize.title=Minimieren
 
 attributeLayers.navbar.title=Daten
 attributeLayers.toolbar.title=Daten
-attributeLayers.toolbar.help=Hilfe
-attributeLayers.toolbar.summary=Wählen Sie zwischen den folgenden Layern und drücken Sie den Tabellenknopf, um die Daten anzuzeigen
 attributeLayers.options.title=Einstellungen
 attributeLayers.options.input.cascade.label=Filter an Unterelemente weitergeben
 

--- a/lizmap/modules/view/locales/el_GR/map.UTF-8.properties
+++ b/lizmap/modules/view/locales/el_GR/map.UTF-8.properties
@@ -111,8 +111,6 @@ bottomdock.toolbar.btn.size.minimize.title=Minimize
 
 attributeLayers.navbar.title=Δεδομένα
 attributeLayers.toolbar.title=Δεδομένα
-attributeLayers.toolbar.help=Βοήθεια
-attributeLayers.toolbar.summary=Choose among the following layers and click on the table button to display its data.
 attributeLayers.options.input.cascade.label=Cascade filter to children
 
 switcher.layer.metadata.title=Πληροφορία

--- a/lizmap/modules/view/locales/en_US/map.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/map.UTF-8.properties
@@ -138,8 +138,6 @@ bottomdock.toolbar.btn.size.minimize.title=Minimize
 
 attributeLayers.navbar.title=Data
 attributeLayers.toolbar.title=Data
-attributeLayers.toolbar.help=Help
-attributeLayers.toolbar.summary=Choose among the following layers and click on the table button to display its data.
 attributeLayers.options.title=Options
 attributeLayers.options.input.cascade.label=Cascade filter to children
 

--- a/lizmap/modules/view/locales/es_ES/map.UTF-8.properties
+++ b/lizmap/modules/view/locales/es_ES/map.UTF-8.properties
@@ -129,8 +129,6 @@ bottomdock.toolbar.btn.size.minimize.title=Minimizar
 
 attributeLayers.navbar.title=Datos
 attributeLayers.toolbar.title=Datos
-attributeLayers.toolbar.help=Ayuda
-attributeLayers.toolbar.summary=Elija de entre las siguientes capas y haga click en el botón de la tabla para mostrar sus datos
 
 attributeLayers.options.title=Opciones
 attributeLayers.options.input.cascade.label=Propagar el filtro a los hijos

--- a/lizmap/modules/view/locales/eu_ES/map.UTF-8.properties
+++ b/lizmap/modules/view/locales/eu_ES/map.UTF-8.properties
@@ -111,8 +111,6 @@ bottomdock.toolbar.btn.size.minimize.title=Minimizatu
 
 attributeLayers.navbar.title=Datuak
 attributeLayers.toolbar.title=Datuak
-attributeLayers.toolbar.help=Laguntza
-attributeLayers.toolbar.summary=Hurrengo geruzen artean aukeratu eta egin klik botoian datuak ikusteko
 attributeLayers.options.input.cascade.label=Semeentzako filtroa kaskadan
 
 switcher.layer.metadata.title=Informazioa

--- a/lizmap/modules/view/locales/fi_FI/map.UTF-8.properties
+++ b/lizmap/modules/view/locales/fi_FI/map.UTF-8.properties
@@ -111,8 +111,6 @@ bottomdock.toolbar.btn.size.minimize.title=Minimoi
 
 attributeLayers.navbar.title=Data
 attributeLayers.toolbar.title=Data
-attributeLayers.toolbar.help=Apua
-attributeLayers.toolbar.summary=Valitse seuraavista tasoista ja klikkaa taulunäppäintä näyttääksesi sen tiedot.
 attributeLayers.options.input.cascade.label=Siirrä suodatin seuraajalle
 
 switcher.layer.metadata.title=Informaatio

--- a/lizmap/modules/view/locales/fr_FR/map.UTF-8.properties
+++ b/lizmap/modules/view/locales/fr_FR/map.UTF-8.properties
@@ -138,8 +138,6 @@ bottomdock.toolbar.btn.size.minimize.title=Réduire
 
 attributeLayers.navbar.title=Données
 attributeLayers.toolbar.title=Données
-attributeLayers.toolbar.help=Aide
-attributeLayers.toolbar.summary=Choisissez une des données suivantes et cliquez sur le bouton "Données" pour afficher les données.
 attributeLayers.options.title=Options
 attributeLayers.options.input.cascade.label=Filtrer les couches filles en cascade
 

--- a/lizmap/modules/view/locales/gl_ES/map.UTF-8.properties
+++ b/lizmap/modules/view/locales/gl_ES/map.UTF-8.properties
@@ -129,8 +129,6 @@ bottomdock.toolbar.btn.size.minimize.title=Minimizar
 
 attributeLayers.navbar.title=Datos
 attributeLayers.toolbar.title=Datos
-attributeLayers.toolbar.help=Axuda
-attributeLayers.toolbar.summary=Escolla entre as seguintes capas e prema no botón da táboa para amosar os seus datos.
 attributeLayers.options.title=Opcións
 attributeLayers.options.input.cascade.label=Filtro en cadea ás (capas) fillas
 

--- a/lizmap/modules/view/locales/it_IT/map.UTF-8.properties
+++ b/lizmap/modules/view/locales/it_IT/map.UTF-8.properties
@@ -129,8 +129,6 @@ bottomdock.toolbar.btn.size.minimize.title=Minimizza
 
 attributeLayers.navbar.title=Dati
 attributeLayers.toolbar.title=Dati
-attributeLayers.toolbar.help=Aiuto
-attributeLayers.toolbar.summary=Scegli uno dei layer qui di seguito e clicca sul pulsante tabella per mostrare i suoi dati.
 attributeLayers.options.title=Opzioni
 attributeLayers.options.input.cascade.label=Propaga il filtro alla tabella figlio
 

--- a/lizmap/modules/view/locales/nl_NL/map.UTF-8.properties
+++ b/lizmap/modules/view/locales/nl_NL/map.UTF-8.properties
@@ -129,8 +129,6 @@ bottomdock.toolbar.btn.size.minimize.title=Verkleinen
 
 attributeLayers.navbar.title=Gegevens
 attributeLayers.toolbar.title=Gegevens
-attributeLayers.toolbar.help=Hulp
-attributeLayers.toolbar.summary=Kies tussen de volgende lagen en klik op de tabelknop om de gegevens weer te geven.
 attributeLayers.options.title=Opties
 attributeLayers.options.input.cascade.label=Getrapte filter naar onderliggende gegevens
 

--- a/lizmap/modules/view/locales/pl_PL/map.UTF-8.properties
+++ b/lizmap/modules/view/locales/pl_PL/map.UTF-8.properties
@@ -129,8 +129,6 @@ bottomdock.toolbar.btn.size.minimize.title=Minimalizuj
 
 attributeLayers.navbar.title=Dane
 attributeLayers.toolbar.title=Dane
-attributeLayers.toolbar.help=Pomoc
-attributeLayers.toolbar.summary=Wybierz spomiędzy dostępnych warstw i kliknij przycisk tabeli, by wyświetlić tabelę atrybutów
 attributeLayers.options.title=Opcje
 attributeLayers.options.input.cascade.label=Filtr kaskadowy
 

--- a/lizmap/modules/view/locales/pt_BR/map.UTF-8.properties
+++ b/lizmap/modules/view/locales/pt_BR/map.UTF-8.properties
@@ -129,8 +129,6 @@ bottomdock.toolbar.btn.size.minimize.title=Minimizar
 
 attributeLayers.navbar.title=Listar registros
 attributeLayers.toolbar.title=Listar registros
-attributeLayers.toolbar.help=Ajuda
-attributeLayers.toolbar.summary=Escolha entre as seguintes Camadas e clique no botão tabela para exibir seus dados.
 attributeLayers.options.title=Opções
 attributeLayers.options.input.cascade.label=Aplicar filtro em cascata
 

--- a/lizmap/modules/view/locales/pt_PT/map.UTF-8.properties
+++ b/lizmap/modules/view/locales/pt_PT/map.UTF-8.properties
@@ -129,8 +129,6 @@ bottomdock.toolbar.btn.size.minimize.title=Minimizar
 
 attributeLayers.navbar.title=Listar registos
 attributeLayers.toolbar.title=Listar registos
-attributeLayers.toolbar.help=Ajuda
-attributeLayers.toolbar.summary=Escolher entre as camadas seguintes e clicar no botão de detalhe respetivo para visualizar os dados.
 attributeLayers.options.title=Opções
 attributeLayers.options.input.cascade.label=Filtro em cascata
 

--- a/lizmap/modules/view/locales/ru_RU/map.UTF-8.properties
+++ b/lizmap/modules/view/locales/ru_RU/map.UTF-8.properties
@@ -125,8 +125,6 @@ bottomdock.toolbar.btn.size.maximize.title=Развернуть
 bottomdock.toolbar.btn.size.minimize.title=Свернуть
 attributeLayers.navbar.title=Данные
 attributeLayers.toolbar.title=Данные
-attributeLayers.toolbar.help=Справка
-attributeLayers.toolbar.summary=Выберите слой для отображения таблицы атрибутов.
 attributeLayers.options.title=Опции
 attributeLayers.options.input.cascade.label=Применить фильтр к дочерним объектам
 

--- a/lizmap/modules/view/locales/sv_SE/map.UTF-8.properties
+++ b/lizmap/modules/view/locales/sv_SE/map.UTF-8.properties
@@ -112,8 +112,6 @@ bottomdock.toolbar.btn.size.minimize.title=Minimera
 
 attributeLayers.navbar.title=Data
 attributeLayers.toolbar.title=Data
-attributeLayers.toolbar.help=Hjälp
-attributeLayers.toolbar.summary=Välj mellan följande lager och klicka på tabellknappen för att visa lagrets data.
 attributeLayers.options.input.cascade.label=Aktiver filter i undertabell
 
 switcher.layer.metadata.title=Information

--- a/lizmap/modules/view/templates/map_attributeLayers.tpl
+++ b/lizmap/modules/view/templates/map_attributeLayers.tpl
@@ -2,8 +2,6 @@
   <div class="tab-content" id="attribute-table-container">
 
     <div class="tab-pane active attribute-content bottom-content" id="attribute-summary" >
-      <b>{@view~map.attributeLayers.toolbar.help@}</b>
-      <p>{@view~map.attributeLayers.toolbar.summary@}</p>
 
       <div id="attribute-layer-list"></div>
 


### PR DESCRIPTION
the behavior is intuitive

i propose also this change to gain some space
![imagem](https://user-images.githubusercontent.com/10053874/34070699-b2208f06-e262-11e7-873e-c1f3b57dfbab.png)

or remove `<b>{@view~map.attributeLayers.options.title@}</b>`
