### PR TITLE
Popup - Improve the display of children popup in a more compact table

### DIFF
--- a/lizmap/www/js/map.js
+++ b/lizmap/www/js/map.js
@@ -3340,7 +3340,41 @@ var lizMap = function() {
                                 //console.log(data);
                                 var popupReg = new RegExp('lizmapPopupTable', 'g');
                                 data = data.replace(popupReg, 'table table-condensed table-striped lizmapPopupTable');
-                                self.parent().append('<div class="lizmapPopupChildren">'+data+'</div>');
+				//Manage if the user choose to create a table for children 
+				var childPopup=data;
+
+				if(rConfigLayer.popupSource=='qgis')
+				{
+					childPopup=$('<div class="lizmapPopupChildren">'+data+'</div>');
+					if(childPopup.find('.lizmap_merged'))
+					{		
+						childPopup.find("h4").each(function(i,e){
+						    if(i != 0 )
+							$(e).remove();
+				       	 	});
+
+						childPopup.find(".lizmapPopupHeader").each(function(i,e){
+				       	     	   if(i != 0 )
+							$(e).remove();
+				       		 });
+
+						childPopup.find(".lizmapPopupDiv").contents().unwrap();
+						childPopup.find(".lizmap_merged").contents().unwrap();	
+						childPopup.find(".lizmapPopupDiv").remove();
+						childPopup.find(".lizmap_merged").remove();
+
+						childPopup.find(".lizmapPopupHidden").hide();
+	
+				       		var tChildPopup = $("<table class='lizmap_merged'></table>");
+						childPopup.append(tChildPopup);
+				      	 	childPopup.find('tr').appendTo(tChildPopup);
+		
+						childPopup.children('tbody').remove();
+	
+					}
+				}
+				
+                                self.parent().append(childPopup);
                                 if ( popup )
                                     popup.verifySize();
                             }


### PR DESCRIPTION
You can choose to visualize the children of a layer. You have to choose the Qgis mode et at the very least add the class `lizmap_merged` to your table. You only need to create a normal table in HTML and you can manage it better with the use of classes `lizmapPopupHeader` and `lizmapPopupHidden`