### PR TITLE
Embed, Popup : open the complete map in the embedded maps and the map.js side of statistics in popups for layers with children

### DIFF
--- a/lizmap/modules/view/controllers/embed.classic.php
+++ b/lizmap/modules/view/controllers/embed.classic.php
@@ -34,6 +34,8 @@ class embedCtrl extends lizMapCtrl {
         // display tooltip at bottom
         $jsCode = "
         $( document ).ready( function() {
+
+
           lizMap.events.on({
             'uicreated':function(evt){
               // it's an embedded content
@@ -67,6 +69,8 @@ class embedCtrl extends lizMapCtrl {
                 $('#button-switcher').click();
               if ( $('#overview-toggle').hasClass('active') )
                 $('#overview-toggle').click();
+
+              $('#mapmenu .nav-list > li.permaLink a').attr('data-original-title', lizDict['embed.open.map']);
             },
             'dockopened': function(evt) {
                 // one tool at a time
@@ -87,6 +91,12 @@ class embedCtrl extends lizMapCtrl {
                   $('div.locate-layer select').hide();
                   $('span.custom-combobox').show();
                   $('#locate div.locate-layer input.custom-combobox-input').autocomplete('option', 'position', {my : 'left top', at: 'left bottom'});
+                }
+
+                if ( evt.id == 'permaLink' ) {
+                    window.open(window.location.href.replace('embed','map'));
+                    $('#mapmenu ul li.nav-minidock.active a').click();
+                    return false;
                 }
             }
           });
@@ -113,7 +123,7 @@ class embedCtrl extends lizMapCtrl {
 
   protected function getProjectDockables() {
     $assign = parent::getProjectDockables();
-    $available = array('switcher', 'metadata', 'locate', 'measure', 'tooltip-layer');//, 'print', 'permaLink'
+    $available = array('switcher', 'metadata', 'locate', 'measure', 'tooltip-layer', 'permaLink');//, 'print', 'permaLink'
     $dAssign = array();
     foreach ( $assign['dockable'] as $dock ) {
         if ( in_array( $dock->id, $available ) )

--- a/lizmap/modules/view/locales/en_US/dictionnary.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/dictionnary.UTF-8.properties
@@ -107,3 +107,5 @@ atlas.toolbar.stop=Stop
 atlas.toolbar.pause=Pause
 atlas.toolbar.next=Next
 atlas.toolbar.prev=Previous
+
+embed.open.map=Open the map in full screen

--- a/lizmap/modules/view/locales/fr_FR/dictionnary.UTF-8.properties
+++ b/lizmap/modules/view/locales/fr_FR/dictionnary.UTF-8.properties
@@ -97,3 +97,5 @@ geobookmark.confirm.delete=Êtes-vous sûr de vouloir supprimer ce géosignet ?
 popup.msg.no.result=Aucun objet n'a été identifié à cet endroit.
 
 generic.btn.close.title=Fermer
+
+embed.open.map=Ouvrir la carte en plein écran

--- a/lizmap/www/css/map.css
+++ b/lizmap/www/css/map.css
@@ -882,6 +882,7 @@ div.modal h3 {
 div.modal h3 span.title {
   display : block;
   padding : 0.5em 0.5em 0.5em 0.7em;
+  background-color: #4A4A4A;
 }
 #toolbar h3 span.menu-content,
 #menu h3 span.ui-icon,
@@ -980,6 +981,7 @@ div.modal h3 .icon {
   background-repeat:no-repeat;
   width:20px;
   height:20px;
+  background-position: -25px 0px;
 }
 div.modal h3 .icon {
   background-position: 0px -20px;
@@ -1353,13 +1355,13 @@ div.modal h3 .text {
 }
 
 #mini-dock div.locate div.menu-content {
-	line-height: 10px;
+  line-height: 10px;
 }
 
 #mini-dock div.locate div.menu-content hr {
-	margin: 10px 0;
-	border-top: 1px solid #eeeeee;
-	border-bottom: 2px solid #4c4c4c;
+  margin: 10px 0;
+  border-top: 1px solid #eeeeee;
+  border-bottom: 2px solid #4c4c4c;
 }
 
 #menu .ui-accordion-content {
@@ -2080,7 +2082,7 @@ a.btn.btn-opacity-layer.active {
 
 .lizmapPopup.olPopup .lizmapPopupDiv .lizmapPopupChildren h4,
 #map-content .lizmapPopupDiv .lizmapPopupChildren h4,
-#popupcontent .lizmapPopupDiv .lizmapPopupChildren h4, 
+#popupcontent .lizmapPopupDiv .lizmapPopupChildren h4,
 .lizmapPopupChildren h4{
     margin: 0 10px;
     color: black !important;

--- a/lizmap/www/js/dataviz/dataviz.js
+++ b/lizmap/www/js/dataviz/dataviz.js
@@ -120,7 +120,6 @@ var lizDataviz = function() {
     function buildPlot(id, conf){
         // Build plot with plotly
         Plotly.newPlot(id, conf.data, conf.layout, {displayModeBar: false});
-
         // Add events to resize plot when needed
         lizMap.events.on({
             dockopened: function(e) {


### PR DESCRIPTION
There is now a way to open the complete map from an embedded map, it will give the possibility to the user to get a better view of the map if the embedded map is too small. 
It will not solve #815 problem but it can be helpful.

The part about dataviz is a feature we are working on who should be completed pretty soon, it will permit users to visualize the statistics of child layer if dataviz is configured for her.
 When you click on the parent on the map, the charts who were configured will appear in the popup, but filtered for only the children of this parent. It will permit you to get statistics for each point and not only the global stats. (May not be too clear but we will explain it betters in the documentation when it's finished)