### PR TITLE
Update edition.classic.php

### DIFF
--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -429,7 +429,7 @@ class editionCtrl extends jController {
           $sql.= " AND f_table_schema = " . $cnx->quote($schema);
           $sql.= " AND f_table_name = " . $cnx->quote($tableAlone);
           $res = $cnx->query($sql);
-	  $res = $res->fetch();
+          $res = $res->fetch();
           if( $res )
             $this->geometryType = strtolower($res->type);
         }

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -364,6 +364,7 @@ class editionCtrl extends jController {
     // Set some private properties
     $this->table = $table;
     $this->tableName = $tableAlone;
+    $this->schemaName = $schema;
     $this->whereClause = $sql;
     $driver = $this->providerDriverMap[$this->provider];
 
@@ -424,7 +425,7 @@ class editionCtrl extends jController {
         // If postgresql, get real geometryType from geometry_columns (jelix prop gives 'geometry')
         if( $this->provider == 'postgres' and $this->geometryType == 'geometry' ){
           $cnx = jDb::getConnection($this->layerId);
-          $res = $cnx->query('SELECT type FROM geometry_columns WHERE f_table_name = '.$cnx->quote($this->tableName));
+          $res = $cnx->query('SELECT type FROM geometry_columns WHERE f_table_schema = '.$cnx->quote($this->schemaName).' AND f_table_name = '.$cnx->quote($this->tableName));
           $res = $res->fetch();
           if( $res )
             $this->geometryType = strtolower($res->type);

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -426,7 +426,7 @@ class editionCtrl extends jController {
           $cnx = jDb::getConnection($this->layerId);
           $sql = "SELECT type FROM geometry_columns";
           $sql.= " WHERE 2>1";
-          $sql.= " AND t_table_schema = " . $cnx->quote($schema);
+          $sql.= " AND f_table_schema = " . $cnx->quote($schema);
           $sql.= " AND f_table_name = " . $cnx->quote($tableAlone);
           $res = $cnx->query($sql);
 	  $res = $res->fetch();

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -359,12 +359,11 @@ class editionCtrl extends jController {
       $tableAlone = $exp[1];
       $schema = $exp[0];
     }
-    $this->schema = $schema;
-
+    
     // Set some private properties
+    $this->schema = $schema;
     $this->table = $table;
     $this->tableName = $tableAlone;
-    $this->schemaName = $schema;
     $this->whereClause = $sql;
     $driver = $this->providerDriverMap[$this->provider];
 
@@ -425,8 +424,12 @@ class editionCtrl extends jController {
         // If postgresql, get real geometryType from geometry_columns (jelix prop gives 'geometry')
         if( $this->provider == 'postgres' and $this->geometryType == 'geometry' ){
           $cnx = jDb::getConnection($this->layerId);
-          $res = $cnx->query('SELECT type FROM geometry_columns WHERE f_table_schema = '.$cnx->quote($this->schemaName).' AND f_table_name = '.$cnx->quote($this->tableName));
-          $res = $res->fetch();
+          $sql = "SELECT type FROM geometry_columns";
+          $sql.= " WHERE 2>1";
+          $sql.= " AND t_table_schema = " . $cnx->quote($schema);
+          $sql.= " AND f_table_name = " . $cnx->quote($tableAlone);
+          $res = $cnx->query($sql);
+	  $res = $res->fetch();
           if( $res )
             $this->geometryType = strtolower($res->type);
         }


### PR DESCRIPTION
Fixes the issue https://github.com/3liz/lizmap-web-client/issues/845.
When two tables have the same name in two different schema, Lizmap ask the geometry_columns view to get the geometry type of the table... but get the first geometry type of both tables returned by the query, the the only one of the wanted table of the right schema.