### PR TITLE
[Enhancement] Enable the possibility to hide the parent plot in Dataviz

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -677,6 +677,8 @@ class lizmapProject extends qgisProject {
 
             if(property_exists($lc, 'popup_display_child_plot'))
                 $plotConf['popup_display_child_plot'] = $lc->popup_display_child_plot;
+            if(property_exists($lc, 'only_show_childs'))
+                $plotConf['only_show_childs'] = $lc->only_show_childs;
             if(property_exists($lc, 'y2_field'))
                 $plotConf['plot']['y2_field'] = $lc->y2_field;
             if( !empty($lc->color) ){

--- a/lizmap/www/css/map.css
+++ b/lizmap/www/css/map.css
@@ -1190,6 +1190,7 @@ div.modal h3 .text {
 #right-dock .title .btn.btn-locate-clear,
 #right-dock .title .btn.btn-tooltip-cancel {
   background-position : -875px 0px;
+  margin-top: 3px;
 }
 #toolbar .title .btn.btn-print-clear,
 #dock .title .btn.btn-print-clear,

--- a/lizmap/www/css/media.css
+++ b/lizmap/www/css/media.css
@@ -84,6 +84,7 @@ only screen and (                   max-device-height : 640px) {
   #headermenu.mobile #locate-clear.icon {
 	background-color: transparent;
 	background-position: -850px 0px;
+	margin-top: 3px;
   }
 
   .navbar-inner {

--- a/lizmap/www/js/dataviz/dataviz.js
+++ b/lizmap/www/js/dataviz/dataviz.js
@@ -76,6 +76,13 @@ var lizDataviz = function() {
         var plot_config = dv.config.layers[plot_id];
         var html = buildPlotContainerHtml(plot_config.title, plot_config.abstract, dataviz_plot_id);
 
+        //if we chose to hide the parent plot the html variable become empty
+        if(plot_config.only_show_childs=="True")
+        {
+            html='';
+        }
+
+
         // Move plot at the end of the main container
         // to the corresponding place if id is referenced in the template
         var pgetter = '#dataviz_plot_template_' + plot_id;
@@ -89,6 +96,8 @@ var lizDataviz = function() {
     }
 
     function getPlot(plot_id, exp_filter, target_id){
+        if ( $('#'+target_id).length == 0) return;
+
         exp_filter = typeof exp_filter !== 'undefined' ?  exp_filter : null;
         target_id = typeof target_id !== 'undefined' ?  target_id : new Date().valueOf()+btoa(Math.random()).substring(0,12);
 

--- a/lizmap/www/themes/default/css/map.css
+++ b/lizmap/www/themes/default/css/map.css
@@ -12,6 +12,7 @@
 #headermenu #locate-clear.icon {
   background-color: transparent;
   background-position: -875px 0px;
+  margin-top: 5px;
 }
 #headermenu .dropdown-menu {
   background-color: #4A4A4A;


### PR DESCRIPTION
If you have checked the checkbox in the plugin for your plot you can hide the parent plot.
It's useful if you only want to see the children and hide the parent if he contain too much information without being filtered.