### PR TITLE
[Edition] Be more permissive for text and less for boolean

### DIFF
--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -327,7 +327,7 @@ class editionCtrl extends jController {
       $tableAlone = $exp[1];
       $schema = $exp[0];
     }
-    
+
     // Set some private properties
     $this->schema = $schema;
     $this->table = $table;
@@ -961,8 +961,16 @@ class editionCtrl extends jController {
               $value = 'NULL';
             break;
           case 'text':
+            if ( is_null($value) or strlen((string)$value) == 0)
+              $value = 'NULL';
+            else
+              $value = $cnx->quote($value);
           case 'boolean':
-            if ( !$value or empty($value))
+            $strVal = strtolower($value);
+            if($strVal != 'true' &&  $strVal !== 't' && intval($value) != 1 &&
+               $strVal !== 'on' && $value !== true &&
+               $strVal != 'false' &&  $strVal !== 'f' && intval($value) != 0 &&
+               $strVal !== 'off' && $value !== false)
               $value = 'NULL';
             else
               $value = $cnx->quote($value);


### PR DESCRIPTION
The way that lizmap was verifying the value for text and boolean was too
simple and strict. If the value is Null or empty, NULL is stored. This test
excluded to store '0' and 0.0.

The fix adds more specific tests.