### PR TITLE
[BUGFIX] disable filter on layer without geometry doesn't work

### DIFF
--- a/lizmap/www/js/attributeTable.js
+++ b/lizmap/www/js/attributeTable.js
@@ -1775,7 +1775,6 @@ var lizAttributeTable = function() {
             }
 
             function emptyLayerFilter( featureType ) {
-
                 // Empty array
                 config.layers[featureType]['filteredFeatures'] = [];
 
@@ -1785,9 +1784,9 @@ var lizAttributeTable = function() {
                 var layer = lizMap.map.getLayersByName( lizMap.cleanName(featureType) )[0];
                 if( layer ) {
                     delete layer.params['FILTER'];
-                    config.layers[featureType]['request_params']['filter'] = null;
-                    config.layers[featureType]['request_params']['exp_filter'] = null;
                 }
+                config.layers[featureType]['request_params']['filter'] = null;
+                config.layers[featureType]['request_params']['exp_filter'] = null;
 
                 lizMap.events.triggerEvent(
                     "layerFilteredFeaturesChanged",
@@ -1797,8 +1796,6 @@ var lizAttributeTable = function() {
                         'updateDrawing': true
                     }
                 );
-
-
             }
 
             function filterLayerFromSelectedFeatures( featureType ) {


### PR DESCRIPTION
A layer without geometry is not referenced in `lizMap.map` so `layer` variable is null and
 `config.layers[featureType]['request_params']['filter'] = null;`
`config.layers[featureType]['request_params']['exp_filter'] = null;`
is not executed.