### PR TITLE
[BUGFIX] CSS selector must only select direct children

### DIFF
--- a/lizmap/www/js/map.js
+++ b/lizmap/www/js/map.js
@@ -6452,7 +6452,7 @@ OpenLayers.Control.HighlightFeature = OpenLayers.Class(OpenLayers.Control, {
 
           // hide mini-dock if no tool is active
           if ( $('#mapmenu ul li.nav-minidock.active').length == 0 ) {
-              $('#mini-dock-content .tab-pane.active').removeClass('active');
+              $('#mini-dock-content > .tab-pane.active').removeClass('active');
               $('#mini-dock-tabs li.active').removeClass('active');
           }
 


### PR DESCRIPTION
Actually with "Montpellier - Intranet map example" if we open permalink tool, permalink in input is hidden because the CSS selector hide all children not only direct children.