### PR TITLE
[BUGFIX] Install fails when the tables of Lizmap already exist

### DIFF
--- a/lizmap/modules/lizmap/install/sql/lizgeobookmark.pgsql.sql
+++ b/lizmap/modules/lizmap/install/sql/lizgeobookmark.pgsql.sql
@@ -1,16 +1,18 @@
-CREATE TABLE public.geobookmark(
-  id serial,
+CREATE TABLE IF NOT EXISTS public.geobookmark(
+  id serial PRIMARY KEY,
   usr_login text NOT NULL,
   bname text NOT NULL,
   bmap text NOT NULL,
   bparams text NOT NULL
 );
 
-ALTER TABLE public.geobookmark ADD PRIMARY KEY (id);
+DROP INDEX IF EXISTS geobookmark_usr_login_idx;
+ALTER TABLE public.geobookmark
+DROP CONSTRAINT IF EXISTS geobookmark_usr_login_fkey
 
 ALTER TABLE public.geobookmark
 ADD CONSTRAINT geobookmark_usr_login_fkey FOREIGN KEY (usr_login)
 REFERENCES jlx_user (usr_login) MATCH SIMPLE
 ON UPDATE CASCADE ON DELETE CASCADE;
 
-CREATE INDEX ON public.geobookmark( usr_login );
+CREATE INDEX geobookmark_usr_login_idx ON public.geobookmark( usr_login );

--- a/lizmap/modules/lizmap/install/sql/lizgeobookmark.sqlite.sql
+++ b/lizmap/modules/lizmap/install/sql/lizgeobookmark.sqlite.sql
@@ -1,4 +1,4 @@
-CREATE TABLE geobookmark(
+CREATE TABLE IF NOT EXISTS geobookmark(
   id integer PRIMARY KEY AUTOINCREMENT,
   usr_login text NOT NULL,
   bname text NOT NULL,
@@ -6,5 +6,7 @@ CREATE TABLE geobookmark(
   bparams text NOT NULL,
   FOREIGN KEY (usr_login) REFERENCES jlx_user (usr_login)
 );
+
+DROP INDEX IF EXISTS idx_geobookmark_usr_login;
 CREATE INDEX idx_geobookmark_usr_login ON geobookmark( usr_login );
 

--- a/lizmap/modules/lizmap/install/sql/lizlog.pgsql.sql
+++ b/lizmap/modules/lizmap/install/sql/lizlog.pgsql.sql
@@ -1,4 +1,4 @@
-CREATE TABLE log_detail (
+CREATE TABLE IF NOT EXISTS log_detail (
     id SERIAL  PRIMARY KEY,
     log_key character varying(100) NOT NULL ,
     log_timestamp timestamp DEFAULT CURRENT_TIMESTAMP,
@@ -9,7 +9,7 @@ CREATE TABLE log_detail (
     log_ip character varying(15)
 );
 
-CREATE TABLE log_counter (
+CREATE TABLE IF NOT EXISTS log_counter (
     id SERIAL  PRIMARY KEY,
     key character varying(100) NOT NULL ,
     counter INTEGER,

--- a/lizmap/modules/lizmap/install/sql/lizlog.sqlite.sql
+++ b/lizmap/modules/lizmap/install/sql/lizlog.sqlite.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "log_detail" (
+CREATE TABLE IF NOT EXISTS "log_detail" (
     "id" INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL  UNIQUE ,
     "log_key" VARCHAR NOT NULL ,
     "log_timestamp" DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -8,7 +8,7 @@ CREATE TABLE "log_detail" (
     "log_project" VARCHAR,
     "log_ip" VARCHAR);
 
-CREATE TABLE "log_counter" (
+CREATE TABLE IF NOT EXISTS "log_counter" (
     "id" INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL ,
     "key" VARCHAR NOT NULL ,
     "counter" INTEGER,


### PR DESCRIPTION
Add in SQL scripts IF EXISTS for CREATE TABLE and DROP IF EXISTS before CREATE INDEX.

Fixed #879