### PR TITLE
[BUGFIX] The bottomdock will no longer hide a zoomed point

### DIFF
--- a/lizmap/www/css/map.css
+++ b/lizmap/www/css/map.css
@@ -494,7 +494,7 @@ SubDock
 
 #bottom-dock.visible {
   opacity: 1;
-  height: 50%;
+  height: 48%;
 
 }#bottom-dock.half-transparent {
   opacity: 0.5;


### PR DESCRIPTION
Will fix #898 