### PR TITLE
[BUGFIX] Add LDAP authenticated user to default groups even if not defined in LDAP

### DIFF
--- a/lib/vendor-modules/ldapdao/plugins/auth/ldapdao/ldapdao.auth.php
+++ b/lib/vendor-modules/ldapdao/plugins/auth/ldapdao/ldapdao.auth.php
@@ -431,6 +431,15 @@ class ldapdaoAuthDriver extends jAuthDriverBase implements jIAuthDriver
                     }
                 } while ($entry = ldap_next_entry($connect, $entry));
             }
+            // Add default groups
+            $gplist = jDao::get('jacl2db~jacl2group', 'jacl2_profile')
+            ->getDefaultGroups();
+            foreach ($gplist as $group) {
+                $idx = array_search($group->name, $groups);
+                if ($idx === false) {
+                    $groups[] = $group->name;
+                }
+            }
         }
         return $groups;
     }


### PR DESCRIPTION
Fixed #926 ldapdao - add users to default "users" group, and do not remove them on group sync

Need to be backported to ldapdao jelix module.