### PR TITLE
[BUGFIX] Filter children even if no children found after parent filtering

### DIFF
--- a/lizmap/www/js/attributeTable.js
+++ b/lizmap/www/js/attributeTable.js
@@ -2401,6 +2401,8 @@ var lizAttributeTable = function() {
                         // only if typeName filter aFilter was originally set
                         if( aFilter && cData['parentValues'].length > 0 && cascade != 'removeChildrenFilter' )
                             cFilter = wmsCname + ':"' + cData['fieldToFilter'] + '" IN ( ' + cData['parentValues'].join() + ' )';
+                        else if( aFilter && cascade != 'removeChildrenFilter' )
+                            cFilter = wmsCname + ':"' + cData['fieldToFilter'] + '" IN ( -99999 )';
 
                         config.layers[cName]['request_params']['filter'] = cFilter;
 


### PR DESCRIPTION
If a filter is launched and if no children found, the filter was deactivated for the children layer.

The fix provided creates a filter if the parent is filtered and the children layer has to be filtered.