### PR TITLE
lizmapeditionformclosed event not editionformclosed

### DIFF
--- a/lizmap/www/js/edition.js
+++ b/lizmap/www/js/edition.js
@@ -737,7 +737,7 @@ OpenLayers.Geometry.pointOnSegment = function(point, segment) {
         } else {
             // trigger edition form closed
             lizMap.events.triggerEvent(
-                'editionformclosed'
+                'lizmapeditionformclosed'
             );
         }
     }
@@ -1149,7 +1149,7 @@ OpenLayers.Geometry.pointOnSegment = function(point, segment) {
         } else if ( form.length == 0 ) {
             // trigger edition form closed
             lizMap.events.triggerEvent(
-                'editionformclosed'
+                'lizmapeditionformclosed'
             );
         }
 


### PR DESCRIPTION
To be homogeneous with naming events we should call this event lizmapeditionformclosed unless we want to remove all 'lizmap' string at the begin of events.