### PR TITLE
[BUGFIX] Make readonly checkbox really readonly

### DIFF
--- a/lizmap/plugins/formbuilder/htmlbootstrap/htmlbootstrap.formbuilder.php
+++ b/lizmap/plugins/formbuilder/htmlbootstrap/htmlbootstrap.formbuilder.php
@@ -652,6 +652,10 @@ jFormsJQ.declareForm(jFormsJQ.tForm);
         $attr['value'] = $ctrl->valueOnCheck;
         $attr['type'] = 'checkbox';
         echo '<input';
+        // attribute readonly is not enough to make checkboxes readonly. Note that value won't be sent by submit but it is not a problem as it is readonly
+        if(array_key_exists('readonly', $attr)){
+            echo ' disabled ';
+        }
         $this->_outputAttr($attr);
         echo $this->_endt;
 


### PR DESCRIPTION
No javascript involved. Checkbox need to be disabled to be readonly, note that value won't be sent by submit but it is not a problem as it is readonly. We might also disabled other readonly input, this way we don't send a value that we know has not changed, this is the same idea that for https://github.com/3liz/lizmap-web-client/issues/954.
Fix first point in https://github.com/3liz/lizmap-web-client/issues/958.