### PR TITLE
Fix: lizmapProxy::constructUrl() should be static

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapProxy.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProxy.class.php
@@ -54,7 +54,7 @@ class lizmapProxy {
     }
 
 
-    public function constructUrl ( $params ) {
+    public static function constructUrl ( $params ) {
         $ser = lizmap::getServices();
         $url = $ser->wmsServerURL.'?';
 


### PR DESCRIPTION
It is called statically by qgisServer class. And all other methods
of lizmapProxy are static.