### PR TITLE
Support of proxy parameters for http requests to external services

### DIFF
--- a/lib/jelix/plugins/tpl/html/block.ifctrl_value.php
+++ b/lib/jelix/plugins/tpl/html/block.ifctrl_value.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @package     jelix
+ * @subpackage  jtpl_plugin
+ * @author      Laurent Jouanneau
+ * @copyright   2018 Laurent Jouanneau
+ * @link        https://jelix.org
+ * @licence     GNU Lesser General Public Licence see LICENCE file or http://www.gnu.org/licenses/lgpl.html
+ */
+
+/**
+ * a special if block to test easily the current control value
+ * TO BE USED inside a {formcontrols} block
+ *
+ * {ifctrl_value 'name', 'expected-value'} some tpl {else} some other tpl {/ifctrl_value}
+ *
+ * @param jTplCompiler $compiler the template compiler
+ * @param boolean $begin true if it is the begin of block, else false
+ * @param array $params 0=>'name',etc. to match against current control name and expected value
+ * @return string the php code corresponding to the begin or end of the block
+ */
+function jtpl_block_html_ifctrl_value($compiler, $begin, $params=array())
+{
+    if($begin){
+        if(count($params)==0) {
+            $content='';
+            $compiler->doError1('errors.tplplugin.block.bad.argument.number','ifctrl_value', '1+');
+        }
+        else if(count($params)==1) {
+            $content = ' if(isset($t->_privateVars[\'__ctrlref\'])&&';
+            $content .= '$t->_privateVars[\'__form\']->getData($t->_privateVars[\'__ctrlref\']) == '.$params[0].'):';
+
+        } else {
+            $content = ' if(isset($t->_privateVars[\'__ctrlref\'])&&(';
+            $content .= '$t->_privateVars[\'__ctrlref\']=='.$params[0].') &&';
+            $content .= '$t->_privateVars[\'__form\']->getData('.$params[0].') == '.$params[1].'):';
+        }
+    }else{
+        $content = ' endif; ';
+    }
+    return $content;
+}
+
+

--- a/lizmap/modules/admin/forms/config_services.form.xml
+++ b/lizmap/modules/admin/forms/config_services.form.xml
@@ -92,10 +92,37 @@
 </menulist>
 
 <menulist ref="proxyMethod" required="true">
-  <label locale="admin~admin.form.admin_services.proxyMethod.label"/>
-  <item value="php" selected="true" locale="admin~admin.form.admin_services.proxyMethod.php.label"/>
-  <item value="curl" locale="admin~admin.form.admin_services.proxyMethod.curl.label"/>
+    <label locale="admin~admin.form.admin_services.proxyMethod.label"/>
+    <item value="php" selected="true" locale="admin~admin.form.admin_services.proxyMethod.php.label"/>
+    <item value="curl" locale="admin~admin.form.admin_services.proxyMethod.curl.label"/>
 </menulist>
+
+<group ref="requestProxyEnabled" withcheckbox="true">
+    <oncheckvalue locale="admin~admin.form.admin_services.requestProxy.enabled" value="1"/>
+    <onuncheckvalue locale="admin~admin.form.admin_services.requestProxy.disabled" value="0" />
+    <label locale="admin~admin.form.admin_services.requestProxy.label"/>
+    <input ref="requestProxyHost" required="true">
+        <label locale="admin~admin.form.admin_services.requestProxyHost.label"/>
+    </input>
+    <input  type="integer" ref="requestProxyPort" required="true">
+        <label locale="admin~admin.form.admin_services.requestProxyPort.label"/>
+    </input>
+    <radiobuttons ref="requestProxyType">
+        <label locale="admin~admin.form.admin_services.requestProxyType.label"/>
+        <item value="http">http</item>
+        <item value="socks5">socks5</item>
+    </radiobuttons>
+    <input ref="requestProxyUser">
+        <label locale="admin~admin.form.admin_services.requestProxyUser.label"/>
+    </input>
+    <secret ref="requestProxyPassword">
+        <label locale="admin~admin.form.admin_services.requestProxyPassword.label"/>
+    </secret>
+    <input ref="requestProxyNotForDomain">
+        <label locale="admin~admin.form.admin_services.requestProxyNotForDomain.label"/>
+    </input>
+</group>
+
 
 <menulist ref="debugMode" required="true">
   <label locale="admin~admin.form.admin_services.debugMode.label"/>

--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -73,9 +73,21 @@ form.admin_services.message.cacheExpiration.wrong=Server cache expiration time m
 form.admin_services.rootRepositories.label=Root folder of repositories
 form.admin_services.rootRepositories.help=The root folder of repositories can limit the Lizmap directory to 1 folder. If a path is set here, it is no longer possible to define the path of a Lizmap directory.
 form.admin_services.relativeWMSPath.label=Does the server use relative path from root folder?
-form.admin_services.proxyMethod.label=Send request to QGIS Server with
+form.admin_services.proxyMethod.label=Send request to QGIS Server or request to external services with
 form.admin_services.proxyMethod.php.label=PHP
 form.admin_services.proxyMethod.curl.label=Curl
+
+form.admin_services.requestProxy.label=Use a proxy server to do requests to external services
+form.admin_services.requestProxy.enabled=Use a proxy server
+form.admin_services.requestProxy.disabled=No proxy
+form.admin_services.requestProxyHost.label=Host of the proxy server
+form.admin_services.requestProxyPort.label=Port of the proxy server
+form.admin_services.requestProxyType.label=Type of the proxy
+form.admin_services.requestProxyUser.label=Login to access to the proxy server
+form.admin_services.requestProxyPassword.label=Password to access to the proxy server
+form.admin_services.requestProxyNotForDomain.label=Domains for which the proxy will not be used
+
+
 form.admin_services.debugMode.label=Debug mode
 form.admin_services.debugMode.0.label=Off
 form.admin_services.debugMode.1.label=Log

--- a/lizmap/modules/admin/templates/config.tpl
+++ b/lizmap/modules/admin/templates/config.tpl
@@ -18,8 +18,19 @@
     <table class="table services-table">
       {formcontrols }
         <tr>
+        {ifctrl 'requestProxyEnabled'}
+          {ifctrl_value '0'}
+            <th>{ctrl_label}</th><td>{ctrl_value}</td>
+          {else}
+            <td colspan="2">
+              {ctrl_value}
+            </td>
+          {/ifctrl_value}
+        {else}
         <th>{ctrl_label}</th><td>{ctrl_value}</td>
+        {/ifctrl}
       </tr>
+
       {/formcontrols}
     </table>
     {/formdata}

--- a/lizmap/modules/admin/templates/config.tpl
+++ b/lizmap/modules/admin/templates/config.tpl
@@ -14,14 +14,15 @@
   <!--Services-->
   <div>
     <h2>{@admin~admin.configuration.services.label@}</h2>
-    <table class="table">
-      {formcontrols $servicesForm}
-      <tr>
+    {formdata $servicesForm ,'htmlbootstrap', array()}
+    <table class="table services-table">
+      {formcontrols }
+        <tr>
         <th>{ctrl_label}</th><td>{ctrl_value}</td>
       </tr>
       {/formcontrols}
     </table>
-
+    {/formdata}
     <!-- Modify -->
     {ifacl2 'lizmap.admin.services.update'}
     <div class="form-actions">

--- a/lizmap/modules/dynamicLayers/controllers/map.classic.php
+++ b/lizmap/modules/dynamicLayers/controllers/map.classic.php
@@ -47,14 +47,7 @@ class mapCtrl extends jController {
         $querystring = $url . $rparams;
 
         // Get remote data
-        $lizmapCache = jClasses::getService('lizmap~lizmapCache');
-        $getRemoteData = $lizmapCache->getRemoteData(
-          $querystring,
-          $this->services->proxyMethod,
-          $this->services->debugMode
-        );
-        $data = $getRemoteData[0];
-        $mime = $getRemoteData[1];
+        list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring);
 
         // Get returned response and redirect to appropriate project page
         $json = json_decode( $data );

--- a/lizmap/modules/lizmap/classes/lizmapCache.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapCache.class.php
@@ -58,7 +58,7 @@ class lizmapCache {
      * @deprecated
     */
     static public function getRemoteData($url, $proxyMethod=null, $debug=null){
-        return lizmapProxy::getRemoteData($url);
+        return lizmapProxy::getRemoteData($url, $proxyMethod, $debug);
     }
 
 

--- a/lizmap/modules/lizmap/classes/lizmapOGCRequest.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapOGCRequest.class.php
@@ -108,26 +108,12 @@ class lizmapOGCRequest {
         $querystring = $this->constructUrl();
 
         // Get remote data
-        $getRemoteData = lizmapProxy::getRemoteData(
-          $querystring,
-          $this->services->proxyMethod,
-          $this->services->debugMode
-        );
-        $data = $getRemoteData[0];
-        $mime = $getRemoteData[1];
-        $code = $getRemoteData[2];
+        list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring);
 
         // Retry if 500 error ( hackish, but QGIS Server segfault sometimes with cache issue )
         if( $code == 500 ){
           // Get remote data
-          $getRemoteData = lizmapProxy::getRemoteData(
-            $querystring,
-            $this->services->proxyMethod,
-            $this->services->debugMode
-          );
-          $data = $getRemoteData[0];
-          $mime = $getRemoteData[1];
-          $code = $getRemoteData[2];
+            list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring);
         }
 
         return (object) array(

--- a/lizmap/modules/lizmap/classes/lizmapProxy.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProxy.class.php
@@ -153,7 +153,7 @@ class lizmapProxy {
             curl_setopt($ch, CURLOPT_HTTPHEADER, self::encodeHttpHeaders($options['headers']));
             curl_setopt($ch, CURLOPT_URL, $url);
 
-            if ($services->requestProxyHost != '') {
+            if ($services->requestProxyEnabled && $services->requestProxyHost != '') {
                 $proxy = $services->requestProxyHost;
                 if ($services->requestProxyPort) {
                     $proxy .= ':'.$services->requestProxyPort;
@@ -199,7 +199,7 @@ class lizmapProxy {
                 'method'=>strtoupper($options['method'])
             );
 
-            if ($services->requestProxyHost != '') {
+            if ($services->requestProxyEnabled && $services->requestProxyHost != '') {
                 $okproxy = true;
                 if ($services->requestProxyNotForDomain) {
                     $noProxy = preg_split('/\s*,\s*/', $services->requestProxyNotForDomain);

--- a/lizmap/modules/lizmap/classes/lizmapProxy.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProxy.class.php
@@ -71,13 +71,23 @@ class lizmapProxy {
 
 
     /**
-    * Get remote data from URL, with curl or internal php functions.
-    * @param string $url Url of the remote data to fetch.
-    * @param text $proxyMethod Method for the proxy : 'php' (default) or 'curl'.
-    * @param integer $debug 0 or 1 to get debug log.
-    * @return array($data, $mime, $http_code) Array containing the data and the mime type.
-    */
-    static public function getRemoteData($url, $proxyMethod='php', $debug=0, $method='get'){
+     * Get remote data from URL, with curl or internal php functions.
+     * @param string $url Url of the remote data to fetch.
+     * @param string|null $proxyMethod Method for the proxy : 'php' (default) or 'curl'.
+     *                  if null, it uses the method indicated into lizmapService
+     * @param integer|null $debug 0 or 1 to get debug log.
+     *                  if null, it uses the method indicated into lizmapService
+     * @return array($data, $mime, $http_code) Array containing the data and the mime type.
+     */
+    static public function getRemoteData($url, $proxyMethod=null, $debug=null, $method='get'){
+
+        if ($proxyMethod === null) {
+            $proxyMethod = lizmap::getServices()->proxyMethod;
+        }
+
+        if ($debug === null) {
+            $debug = lizmap::getServices()->debugMode;
+        }
 
         // Initialize responses
         $data = '';
@@ -344,14 +354,11 @@ class lizmapProxy {
         $builtParams = str_replace($a, $b, $builtParams);
 
         // Get data from the map server
-        $proxyMethod = $ser->proxyMethod;
-        $getRemoteData = lizmapProxy::getRemoteData($url . $builtParams, $proxyMethod, $debug, 'post');
-        $data = $getRemoteData[0];
-        $mime = $getRemoteData[1];
-        $code = $getRemoteData[2];
+        list($data, $mime, $code) = lizmapProxy::getRemoteData($url . $builtParams, null, null, 'post');
 
-        if($debug)
+        if ($debug) {
             lizmap::logMetric('LIZMAP_PROXY_REQUEST_QGIS_MAP');
+        }
 
         if ( $useCache && !preg_match('/^image/',$mime) )
             $useCache = False;

--- a/lizmap/modules/lizmap/classes/lizmapServices.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapServices.class.php
@@ -38,6 +38,12 @@ class lizmapServices{
       'rootRepositories',
       'relativeWMSPath',
       'proxyMethod',
+      'requestProxyHost',
+      'requestProxyPort',
+      'requestProxyUser',
+      'requestProxyPassword',
+      'requestProxyType',
+      'requestProxyNotForDomain',
       'debugMode',
       'cacheRootDirectory',
       'cacheRedisHost',
@@ -63,6 +69,12 @@ class lizmapServices{
       'rootRepositories',
       'relativeWMSPath',
       'proxyMethod',
+      'requestProxyHost',
+      'requestProxyPort',
+      'requestProxyUser',
+      'requestProxyPassword',
+      'requestProxyType',
+      'requestProxyNotForDomain',
       'debugMode',
       'cacheRootDirectory',
       'cacheRedisHost',
@@ -114,8 +126,18 @@ class lizmapServices{
     public $rootRepositories = '';
     // Does the server use relative Path from root folder?
     public $relativeWMSPath = '0';
-    // proxy method : use curl or file_get_contents
+    // proxy method : use curl ('curl') or file_get_contents ('php')
     public $proxyMethod = '';
+
+    public $requestProxyHost = '';
+    public $requestProxyPort = '';
+    public $requestProxyUser = '';
+    public $requestProxyPassword = '';
+    // proxy type: 'http' or 'socks5'. Only used with the curl proxyMethod
+    public $requestProxyType = 'http';
+    // list of domains separated by a comma, to which the proxy is not used
+    public $requestProxyNotForDomain = 'localhost';
+
     // debug mode : none or log
     public $debugMode = '';
     // Cache root directory

--- a/lizmap/modules/lizmap/classes/lizmapServices.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapServices.class.php
@@ -38,6 +38,7 @@ class lizmapServices{
       'rootRepositories',
       'relativeWMSPath',
       'proxyMethod',
+      'requestProxyEnabled',
       'requestProxyHost',
       'requestProxyPort',
       'requestProxyUser',
@@ -69,6 +70,7 @@ class lizmapServices{
       'rootRepositories',
       'relativeWMSPath',
       'proxyMethod',
+      'requestProxyEnabled',
       'requestProxyHost',
       'requestProxyPort',
       'requestProxyUser',
@@ -129,6 +131,7 @@ class lizmapServices{
     // proxy method : use curl ('curl') or file_get_contents ('php')
     public $proxyMethod = '';
 
+    public $requestProxyEnabled = false;
     public $requestProxyHost = '';
     public $requestProxyPort = '';
     public $requestProxyUser = '';
@@ -228,8 +231,12 @@ class lizmapServices{
     }
 
     public function hideSensitiveProperties(){
-      if ( isset($this->data['hideSensitiveServicesProperties']) && $this->data['hideSensitiveServicesProperties'] != '0')
-        return true;
+      if ( isset($this->data['hideSensitiveServicesProperties'])
+          && $this->data['hideSensitiveServicesProperties'] != '0'
+      ) {
+          return true;
+      }
+
       return false;
     }
 

--- a/lizmap/modules/lizmap/classes/lizmapWFSRequest.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapWFSRequest.class.php
@@ -72,14 +72,7 @@ class lizmapWFSRequest extends lizmapOGCRequest {
         $querystring = $this->constructUrl();
 
         // Get remote data
-        $getRemoteData = lizmapProxy::getRemoteData(
-          $querystring,
-          $this->services->proxyMethod,
-          $this->services->debugMode
-        );
-        $data = $getRemoteData[0];
-        $mime = $getRemoteData[1];
-        $code = $getRemoteData[2];
+        list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring);
 
         return (object) array(
             'code' => $code,
@@ -131,14 +124,7 @@ class lizmapWFSRequest extends lizmapOGCRequest {
         $querystring = $this->constructUrl();
 
         // Get remote data
-        $getRemoteData = lizmapProxy::getRemoteData(
-            $querystring,
-            $this->services->proxyMethod,
-            $this->services->debugMode
-        );
-        $data = $getRemoteData[0];
-        $mime = $getRemoteData[1];
-        $code = $getRemoteData[2];
+        list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring);
 
         if ( $mime == 'text/plain' && strtolower( $this->param('outputformat') ) == 'geojson' ) {
             $mime = 'text/json';

--- a/lizmap/modules/lizmap/classes/lizmapWMSRequest.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapWMSRequest.class.php
@@ -153,14 +153,7 @@ class lizmapWMSRequest extends lizmapOGCRequest {
         $querystring = $this->constructUrl();
 
         // Get remote data
-        $getRemoteData = lizmapProxy::getRemoteData(
-          $querystring,
-          $this->services->proxyMethod,
-          $this->services->debugMode
-        );
-        $data = $getRemoteData[0];
-        $mime = $getRemoteData[1];
-        $code = $getRemoteData[2];
+        list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring);
 
         return (object) array(
             'code' => $code,

--- a/lizmap/modules/lizmap/classes/qgisServer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisServer.class.php
@@ -40,10 +40,8 @@ class qgisServer {
             'request'=>'GetCapabilitiesAtlas'
         );
         $url = lizmapProxy::constructUrl($params);
-        $getRemoteData = lizmapProxy::getRemoteData($url);
-        $data = $getRemoteData[0];
-        $mime = $getRemoteData[1];
-        if($mime=='text/json'){
+        list($data, $mime, $code) = lizmapProxy::getRemoteData($url);
+        if ($mime=='text/json') {
             $json = json_decode($data);
             $metadata = $json->metadata;
             $plugins[$metadata->name] = array('version' => $metadata->version);

--- a/lizmap/modules/lizmap/controllers/ign.classic.php
+++ b/lizmap/modules/lizmap/controllers/ign.classic.php
@@ -63,13 +63,11 @@ class ignCtrl extends jController {
     );
 
     $url .= http_build_query($params);
-    $curl_handle = curl_init();
-    curl_setopt($curl_handle, CURLOPT_URL, $url);
-    curl_setopt($curl_handle, CURLOPT_RETURNTRANSFER, TRUE);
-    curl_setopt($curl_handle, CURLOPT_HTTPHEADER, array('Expect:'));
-    curl_setopt($curl_handle, CURLOPT_REFERER, jUrl::getFull('lizmap~ign:address'));
-    $content = curl_exec($curl_handle);
-    curl_close($curl_handle);
+    list($content, $mime, $code) = lizmapProxy::getRemoteData($url, array(
+        "method" => 'get',
+        "referer" => jUrl::getFull('lizmap~ign:address'),
+        "headers" => array('Expect'=>'')
+    ));
 
     $rep->content = $content;
 

--- a/lizmap/modules/lizmap/controllers/osm.classic.php
+++ b/lizmap/modules/lizmap/controllers/osm.classic.php
@@ -38,13 +38,12 @@ class osmCtrl extends jController {
       $params['viewbox'] = $bbox;
 
     $url .= http_build_query($params);
-    $curl_handle = curl_init();
-    curl_setopt($curl_handle, CURLOPT_URL, $url);
-    curl_setopt($curl_handle, CURLOPT_RETURNTRANSFER, TRUE);
-    curl_setopt($curl_handle, CURLOPT_HTTPHEADER, array('Expect:'));
-    curl_setopt($curl_handle, CURLOPT_REFERER, jUrl::getFull("view~default:index"));
-    $content = curl_exec($curl_handle);
-    curl_close($curl_handle);
+
+    list($content, $mime, $code) = lizmapProxy::getRemoteData($url, array(
+        "method" => 'get',
+        "referer" => jUrl::getFull("view~default:index"),
+        "headers" => array('Expect'=>'')
+    ));
 
     $rep->content = $content;
 

--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -596,14 +596,7 @@ class serviceCtrl extends jController {
       $querystring = $url . implode('&', $keyValueParameters);
 
       // Query external WMS layers
-      $ch = curl_init();
-      curl_setopt($ch, CURLOPT_HEADER, 0);
-      curl_setopt($ch, CURLOPT_URL, $querystring);
-      curl_setopt( $ch, CURLOPT_SSL_VERIFYPEER, false );
-      curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-      curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-      $data = curl_exec($ch);
-      curl_close($ch);
+      list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring);
 
       $xml = simplexml_load_string($data);
 
@@ -963,7 +956,7 @@ class serviceCtrl extends jController {
     $querystring = $url . implode('&', $data);
 
     // Get remote data
-    list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring, null, null, 'post');
+    list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring, array('method'=>'post'));
 
     $rep = $this->getResponse('binary');
     $rep->mimeType = $mime;
@@ -1015,7 +1008,7 @@ class serviceCtrl extends jController {
     $querystring = $url . implode('&', $data);
 
     // Get remote data
-    list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring, null, null, 'post');
+    list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring, array('method'=>'post'));
 
     $rep = $this->getResponse('binary');
     $rep->mimeType = $mime;
@@ -1110,19 +1103,11 @@ class serviceCtrl extends jController {
     $querystring = $url . implode('&', $data);
 
     // Get data form server
-    $ch = curl_init();
-    curl_setopt($ch, CURLOPT_HEADER, 0);
-    curl_setopt($ch, CURLOPT_URL, $querystring);
-    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false );
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: text/xml'));
-    curl_setopt($ch, CURLOPT_POST, 1);
-    curl_setopt($ch, CURLOPT_POSTFIELDS, $xml_post);
-    $data = curl_exec($ch);
-    $info = curl_getinfo($ch);
-    $mime = $info['content_type'];
-    curl_close($ch);
+    list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring , array(
+        "method" => "post",
+        "headers" => array('Content-Type' => 'text/xml'),
+        "body" => $xml_post
+    ));
 
     $rep = $this->getResponse('binary');
     $rep->mimeType = $mime;

--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -121,14 +121,14 @@ class serviceCtrl extends jController {
 
   /**
   * Send an OGC service Exception
-  * @param $SERVICE the OGC service
-  * @return XML OGC Service Exception.
+  * @return jResponseXml XML OGC Service Exception.
   */
   protected function serviceException(){
     $messages = jMessage::getAll();
     if (!$messages) {
         $messages = array();
     }
+    /** @var jResponseXml $rep */
     $rep = $this->getResponse('xml');
     $rep->contentTpl = 'lizmap~wms_exception';
     $rep->content->assign('messages', $messages);
@@ -405,7 +405,7 @@ class serviceCtrl extends jController {
   * GetContext
   * @param string $repository Lizmap Repository
   * @param string $project Name of the project : mandatory.
-  * @return text/xml Web Map Context.
+  * @return jResponse text/xml Web Map Context.
   */
   function GetContext(){
 
@@ -419,18 +419,15 @@ class serviceCtrl extends jController {
     $querystring = $url . $bparams;
 
     // Get remote data
-    $getRemoteData = lizmapProxy::getRemoteData(
-      $querystring,
-      $this->services->proxyMethod,
-      $this->services->debugMode
-    );
-    $data = $getRemoteData[0];
-    $mime = $getRemoteData[1];
+    list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring);
 
     // Replace qgis server url in the XML (hide real location)
     $sUrl = jUrl::getFull(
       "lizmap~service:index",
-      array("repository"=>$this->repository->getKey(), "project"=>$this->project->getKey()),
+      array(
+          "repository"=>$this->repository->getKey(),
+          "project"=>$this->project->getKey()
+      ),
       0,
       $_SERVER['SERVER_NAME']
     );
@@ -648,13 +645,7 @@ class serviceCtrl extends jController {
        $querystring = $url . $bparams;
 
        // Get remote data
-       $getRemoteData = lizmapProxy::getRemoteData(
-         $querystring,
-         $this->services->proxyMethod,
-         $this->services->debugMode
-       );
-       $data = $getRemoteData[0];
-       $mime = $getRemoteData[1];
+       list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring);
 
        // Get HTML content if needed
        if($toHtml and preg_match('#/xml#', $mime)){
@@ -972,15 +963,7 @@ class serviceCtrl extends jController {
     $querystring = $url . implode('&', $data);
 
     // Get remote data
-    $getRemoteData = lizmapProxy::getRemoteData(
-      $querystring,
-      $this->services->proxyMethod,
-      $this->services->debugMode,
-      'post'
-    );
-    $data = $getRemoteData[0];
-    $mime = $getRemoteData[1];
-    $code = $getRemoteData[2];
+    list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring, null, null, 'post');
 
     $rep = $this->getResponse('binary');
     $rep->mimeType = $mime;
@@ -1032,15 +1015,7 @@ class serviceCtrl extends jController {
     $querystring = $url . implode('&', $data);
 
     // Get remote data
-    $getRemoteData = lizmapProxy::getRemoteData(
-      $querystring,
-      $this->services->proxyMethod,
-      $this->services->debugMode,
-      'post'
-    );
-    $data = $getRemoteData[0];
-    $mime = $getRemoteData[1];
-    $code = $getRemoteData[2];
+    list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring, null, null, 'post');
 
     $rep = $this->getResponse('binary');
     $rep->mimeType = $mime;
@@ -1081,13 +1056,7 @@ class serviceCtrl extends jController {
     $querystring = $url . $bparams;
 
     // Get remote data
-    $getRemoteData = lizmapProxy::getRemoteData(
-      $querystring,
-      $this->services->proxyMethod,
-      $this->services->debugMode
-    );
-    $data = $getRemoteData[0];
-    $mime = $getRemoteData[1];
+    list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring);
 
     // Return response
     $rep = $this->getResponse('binary');
@@ -1233,13 +1202,7 @@ class serviceCtrl extends jController {
     $querystring = $url . $bparams;
 
     // Get remote data
-    $getRemoteData = lizmapProxy::getRemoteData(
-      $querystring,
-      $this->services->proxyMethod,
-      $this->services->debugMode
-    );
-    $data = $getRemoteData[0];
-    $mime = $getRemoteData[1];
+    list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring);
 
     if( $returnJson ) {
         $jsonData = array();

--- a/lizmap/plugins/formbuilder/htmlbootstrap/htmlbootstrap.formbuilder.php
+++ b/lizmap/plugins/formbuilder/htmlbootstrap/htmlbootstrap.formbuilder.php
@@ -24,6 +24,31 @@ class htmlbootstrapFormBuilder extends \jelix\forms\Builder\HtmlBuilder {
         'choice' => array( 'class' => 'form-inline', 'itemLabelClass'=>'radio')
     );
 
+    public function outputMetaContent($t) {
+        $resp= jApp::coord()->response;
+        if($resp === null || $resp->getType() !='html'){
+            return;
+        }
+
+        $confUrlEngine = &jApp::config()->urlengine;
+        $www = $confUrlEngine['jelixWWWPath'];
+        $jq = $confUrlEngine['jqueryPath'];
+        $resp->addJSLink($jq.'jquery.js');
+        $resp->addJSLink($jq.'include/jquery.include.js');
+        $resp->addJSLink($www.'js/jforms_jquery.js');
+        $resp->addCSSLink($www.'design/jform.css');
+
+        //we loop on root control has they fill call the outputMetaContent recursively
+        foreach( $this->_form->getRootControls() as $ctrlref=>$ctrl) {
+            if($ctrl->type == 'hidden') continue;
+            if(!$this->_form->isActivated($ctrlref)) continue;
+
+            $widget = $this->getWidget($ctrl, $this->rootWidget);
+            $widget->outputMetaContent($resp);
+        }
+    }
+
+
     public function outputAllControls() {
         $modal = $this->getOption('local');
 

--- a/lizmap/plugins/formbuilder/htmlbootstrap/htmlbootstrap.formbuilder.php
+++ b/lizmap/plugins/formbuilder/htmlbootstrap/htmlbootstrap.formbuilder.php
@@ -51,22 +51,22 @@ class htmlbootstrapFormBuilder extends \jelix\forms\Builder\HtmlBuilder {
 
     public function outputAllControls() {
         $modal = $this->getOption('local');
-
         echo '<div class="jforms-table">';
         foreach( $this->_form->getRootControls() as $ctrlref=>$ctrl){
             if($ctrl->type == 'submit' || $ctrl->type == 'reset' || $ctrl->type == 'hidden') continue;
             if(!$this->_form->isActivated($ctrlref)) continue;
+            echo '<div class="control-group">';
             if($ctrl->type == 'group') {
                 $this->outputControl($ctrl);
             }
             else {
-                echo '<div class="control-group">';
+
                 $this->outputControlLabel($ctrl);
                 echo '<div class="controls">';
                 $this->outputControl($ctrl);
                 echo "</div>\n";
-                echo "</div>\n";
             }
+            echo "</div>\n";
         }
         echo "</div>\n";
 

--- a/lizmap/www/css/admin.css
+++ b/lizmap/www/css/admin.css
@@ -28,3 +28,39 @@
     list-style: none;
     color: #FFF;
 }
+
+
+fieldset legend {
+    width:auto;
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+    border-bottom: 0px;
+    font-size:14px;
+}
+
+fieldset legend label {
+    display:inline-block;
+}
+
+fieldset {
+    border: 1px solid #c5c5c5;
+    padding: 1em;
+    margin-bottom: 1em;
+}
+
+.services-table th {
+    width: 30%;
+    min-width: 10em;
+}
+
+.form-horizontal .control-label {
+    width: 240px;
+}
+
+.form-horizontal .controls {
+    margin-left: 250px;
+}
+
+.table .table {
+    background-color:transparent;
+}


### PR DESCRIPTION
There are new possible parameters into lizmapConfig.ini.php, allowing to configure a proxy for requests  to external services. These parameters can be changed in the configuration form of Lizmap.

Some refactorizations have been made in order to call external services only from a single method, `lizmapProxy::getRemoteData()`, instead of having curl calls in many places in the code.

Fixes #932 