### PR TITLE
Fix gpg: cannot open '/dev/tty': No such device or address"

### DIFF
--- a/vagrant/roles/qgis/tasks/qgis_server.yml
+++ b/vagrant/roles/qgis/tasks/qgis_server.yml
@@ -28,7 +28,7 @@
 # Debian : Install QGIS from repository
 
 - name: Add QGIS repository key - 1
-  shell: wget -O - {{ qgis_repository_debian_key_url }} | gpg --import
+  shell: wget -O - {{ qgis_repository_debian_key_url }} | gpg --no-tty --import
   when: qgis_install_source == 'repository'
 
 - name: Add QGIS repository key - 2


### PR DESCRIPTION
Execution failed with message gpg: cannot open '/dev/tty': No such device or address". With --no-tty it is ok now.
Environnement : ubuntu 18.04, virtualbox 6.0, vagrant 2.2.2