### PR TITLE
fix popups that use QGIS maptip

### DIFF
--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -613,6 +613,11 @@ class serviceCtrl extends jController {
          $QGISLayersParams['info_format'] = 'text/xml';
        }
 
+       // Always request maptip to QGIS server so we can decide if to use it later
+       $QGISLayersParams['with_maptip'] = 'true';
+       // Always request geometry to QGIS server so we can decide if to use it later
+       $QGISLayersParams['with_geometry'] = 'true';
+
        $bparams = http_build_query($QGISLayersParams);
        $querystring = $url . $bparams;
 


### PR DESCRIPTION
Currently Lizmap connected to a QGIS 3.x server always show popups in auto mode. This is a **regression** in lizmap because it didn't catchup with a change in QGIS GetFeatureInfo implementation.

QGIS 3.x fetches geometry and maptip in feature info only if they are requested by the client.
See [QGIS](https://github.com/qgis/QGIS/commit/5bd63b7e1789a72c2692d8d61fab267ec2258eb5
) for the commit and [QWC2](https://github.com/qgis/qwc2-demo-app/issues/55) for a discussion.

This patch restores the functionality of using QGIS' maptip as popup content