### PR TITLE
Remove annoying logs about libspatialite.so

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -1014,27 +1014,11 @@ class lizmapProject extends qgisProject {
 
             // Check ability to load spatialite extension
             // And remove ONLY spatialite layers if no extension found
-            $spatial = false;
+            $spatialiteExt = '';
             if ( class_exists('SQLite3') ) {
-                // Try with mod_spatialite
-                try{
-                    $db = new SQLite3(':memory:');
-                    $spatial = @$db->loadExtension('mod_spatialite.so'); # loading SpatiaLite as an extension
-                }catch(Exception $e){
-                    //jLog::logEx($e);
-                    $spatial = False;
-                }
-                // Try with libspatialite
-                if( !$spatial )
-                    try{
-                        $db = new SQLite3(':memory:');
-                        $spatial = @$db->loadExtension('libspatialite.so'); # loading SpatiaLite as an extension
-                    }catch(Exception $e){
-                        //jLog::logEx($e);
-                        $spatial = False;
-                    }
+                $spatialiteExt = $this->getSpatialiteExtension();
             }
-            if(!$spatial){
+            if (!$spatialiteExt) {
                 jLog::log('Spatialite is not available', 'error');
                 foreach( $editionLayers as $key=>$obj ){
                     $layerXml = $this->getXmlLayer2($xml, $obj->layerId );
@@ -1592,4 +1576,39 @@ class lizmapProject extends qgisProject {
         return False;
     }
 
+    private $spatialiteExt = null;
+
+    public function getSpatialiteExtension() {
+        if ($this->spatialiteExt !== null) {
+            return $this->spatialiteExt;
+        }
+
+        // Try with mod_spatialite
+        try{
+            $db = new SQLite3(':memory:');
+            $this->spatialiteExt = 'mod_spatialite.so';
+            $spatial = @$db->loadExtension($this->spatialiteExt); # loading SpatiaLite as an extension
+            if ($spatial) {
+                return $this->spatialiteExt;
+            }
+        }catch(Exception $e){
+            //jLog::logEx($e);
+            $spatial = False;
+        }
+        // Try with libspatialite
+        if( !$spatial ) {
+            try{
+                $db = new SQLite3(':memory:');
+                $this->spatialiteExt = 'libspatialite.so';
+                $spatial = @$db->loadExtension($this->spatialiteExt); # loading SpatiaLite as an extension
+                if ($spatial) {
+                    return $this->spatialiteExt;
+                }
+            }catch(Exception $e){
+                //jLog::logEx($e);
+            }
+        }
+        $this->spatialiteExt = '';
+        return '';
+    }
 }

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -115,7 +115,7 @@ class qgisVectorLayer extends qgisMapLayer{
         return $this->connection;
 
     if( $this->provider != 'spatialite' && $this->provider != 'postgres') {
-        jLog::log('Unkown provider "'.$this->provider.'" to get connection!','error');
+        jLog::log('Unknown provider "'.$this->provider.'" to get connection!','error');
         return null;
     }
 
@@ -129,11 +129,12 @@ class qgisVectorLayer extends qgisMapLayer{
         $dtParams = $this->getDatasourceParameters();
         $jdbParams = array();
         if( $this->provider == 'spatialite' ){
+          $spatialiteExt = $this->project->getSpatialiteExtension();
           $repository = $this->project->getRepository();
           $jdbParams = array(
             "driver" => 'sqlite3',
             "database" => realpath($repository->getPath().$dtParams->dbname),
-            "extensions"=>"mod_spatialite.so,libspatialite.so"
+            "extensions"=>$spatialiteExt
           );
         } else if( $this->provider == 'postgres' ){
           if(!empty($dtParams->service)){


### PR DESCRIPTION
qgisVectorLayer open a sqlite connection by indicating both mod_spatialite.so
and lib_spatialite.so, although only one is available obviously. And so it causes some
notices that pollute logs files. The connection should be open with the right
extension.