### PR TITLE
Fix edition when featureId contains multiple id

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -525,7 +525,7 @@ class qgisVectorLayer extends qgisMapLayer{
           $returnKeys[] = '"' . $key . '"';
       }
       $returnKeysString = implode(', ', $returnKeys);
-      // For spatialite, we will run a complentary query to retrieve the pkeys
+      // For spatialite, we will run a complementary query to retrieve the pkeys
       if( $this->provider == 'postgres' ){
           $sql.= '  RETURNING '. $returnKeysString;
       }
@@ -547,7 +547,7 @@ class qgisVectorLayer extends qgisMapLayer{
               }
           } else {
               // Exec the request
-              $rs = $cnx->exec($sql);
+              $cnx->exec($sql);
               $sqlpk = 'SELECT ' . $returnKeysString . ' FROM '.$dtParams->table.$uwhere;
               $rspk = $cnx->query($sqlpk);
               foreach($rspk as $line){

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -23,10 +23,10 @@ class editionCtrl extends jController {
   /** @var string layer name (<layername> in QGIS project) */
   private $layerName = '';
 
-  /** @var string featureId parameter from the request */
+  /** @var string featureId parameter from the request, an integer or a string with coma separated integers */
   private $featureIdParam = Null;
 
-  /** @var integer|string  an integer or a string with coma separated integers */
+  /** @var integer|string  an integer or an array of integers */
   private $featureId = Null;
 
   /** @var object feature data as a PHP object from GeoJSON via json_decode */
@@ -87,16 +87,17 @@ class editionCtrl extends jController {
   private function getEditionParameters($save=false){
 
     // Get the project
-    $project = $this->param('project');
-    $repository = $this->param('repository');
-    $layerId = $this->param('layerId');
-    $featureIdParam = $this->param('featureId');
-
-    if($save){
+    if ($save) {
       $project = $this->param('liz_project');
       $repository = $this->param('liz_repository');
       $layerId = $this->param('liz_layerId');
       $featureIdParam = $this->param('liz_featureId');
+    }
+    else {
+        $project = $this->param('project');
+        $repository = $this->param('repository');
+        $layerId = $this->param('layerId');
+        $featureIdParam = $this->param('featureId');
     }
 
     if(!$project){
@@ -168,7 +169,7 @@ class editionCtrl extends jController {
 
 
     // feature Id (optional, only for edition and save)
-    if(preg_match('#,#', $featureIdParam))
+    if (strpos($featureIdParam, ',') !== false)
       $featureId = preg_split('#,#', $featureIdParam);
     else
       $featureId = $featureIdParam;
@@ -201,8 +202,17 @@ class editionCtrl extends jController {
     // Get features primary key field values corresponding to featureId(s)
     if( !empty($featureId) ){
         $typename = $this->layer->getShortName();
-        if ( !$typename or $typename == '' )
+        if ( !$typename or $typename == '' ) {
             $typename = str_replace(' ', '_', $this->layer->getName());
+        }
+        if (is_array($featureId)) {
+            $featureId = implode(',', array_map(function($id) use($typename) {
+                return $typename . '.' . $id;
+            }, $featureId));
+        }
+        else {
+            $featureId = $typename . '.' . $featureId;
+        }
         $wfsparams = array(
             'SERVICE' => 'WFS',
             'VERSION' => '1.0.0',
@@ -211,7 +221,7 @@ class editionCtrl extends jController {
             'OUTPUTFORMAT' => 'GeoJSON',
             'GEOMETRYNAME' => 'none',
             'PROPERTYNAME' => implode(',',$this->primaryKeys),
-            'FEATUREID' => $typename . '.' . $featureId
+            'FEATUREID' => $featureId
         );
 
         $wfsrequest = new lizmapWFSRequest( $this->project, $wfsparams );
@@ -248,7 +258,7 @@ class editionCtrl extends jController {
     // Get editLayer capabilities
     $eCapabilities = $this->layer->getEditionCapabilities();
     if ( $eCapabilities->capabilities->createFeature != 'True' ) {
-    jMessage::add(jLocale::get('view~edition.message.error.layer.editable.create'), 'LayerNotEditable');
+        jMessage::add(jLocale::get('view~edition.message.error.layer.editable.create'), 'LayerNotEditable');
         return $this->serviceAnswer();
     }
 
@@ -344,7 +354,7 @@ class editionCtrl extends jController {
     $form->setData('liz_repository', $this->repository->getKey());
     $form->setData('liz_project', $this->project->getKey());
     $form->setData('liz_layerId', $this->layerId);
-    $form->setData('liz_featureId', $this->featureId);
+    $form->setData('liz_featureId', $this->featureIdParam);
 
     // Dynamically add form controls based on QGIS layer information
     $qgisForm = null;
@@ -679,17 +689,13 @@ class editionCtrl extends jController {
       return $this->serviceAnswer();
     }
 
-    $featureId = $this->param('featureId');
-    if( !$featureId ) {
+    if( !$this->featureId ) {
       jMessage::add(jLocale::get('view~edition.message.error.parameter.featureId'), 'error');
       return $this->serviceAnswer();
     }
 
-    if(ctype_digit($this->featureId))
-      $featureId = array($this->featureId);
-
     // Create form instance to get uploads file
-    $form = jForms::create('view~edition', $featureId);
+    $form = jForms::create('view~edition', $this->featureId);
     if(!$form){
       jMessage::add('An error has been raised when creating the form', 'formNotDefined');
       return $this->serviceAnswer();

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -169,10 +169,15 @@ class editionCtrl extends jController {
 
 
     // feature Id (optional, only for edition and save)
-    if (strpos($featureIdParam, ',') !== false)
-      $featureId = preg_split('#,#', $featureIdParam);
-    else
-      $featureId = $featureIdParam;
+    if (strpos($featureIdParam, ',') !== false) {
+        $featureId = preg_split('#,#', $featureIdParam);
+    }
+    else if (strpos($featureIdParam, '@@') !== false) {
+        $featureId = preg_split('#@@#', $featureIdParam);
+    }
+    else {
+        $featureId = $featureIdParam;
+    }
 
     // Define class private properties
     $this->project = $lproj;

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -206,9 +206,9 @@ class editionCtrl extends jController {
             $typename = str_replace(' ', '_', $this->layer->getName());
         }
         if (is_array($featureId)) {
-            $featureId = implode(',', array_map(function($id) use($typename) {
-                return $typename . '.' . $id;
-            }, $featureId));
+            // QGIS3 (at least <=3.4) doesn't support pk with multiple fields
+            // but 2.18 supports it.
+            $featureId = $typename . '.'.implode('@@', $featureId);
         }
         else {
             $featureId = $typename . '.' . $featureId;


### PR DESCRIPTION
At some places, we should use the text version of featureId instead of the PHP version.
Else if featureId is an array, we have some PHP notices and bad values : "Array" instead of a string with integers separated by coma.