### PR TITLE
child objets in popup with QGIS server 3. Fix #1024

### DIFF
--- a/lizmap/www/js/map.js
+++ b/lizmap/www/js/map.js
@@ -3644,6 +3644,7 @@ var lizMap = function() {
                             ,'STYLES': ''
                             ,'SERVICE': 'WMS'
                             ,'VERSION': '1.3.0'
+                            ,'CRS': 'EPSG:3857'
                             ,'REQUEST': 'GetFeatureInfo'
                             ,'EXCEPTIONS': 'application/vnd.ogc.se_inimage'
                             ,'FEATURE_COUNT': popupMaxFeatures


### PR DESCRIPTION
I am not sure if it is ok to put EPSG:3857 or we should take base layer projection in case people use other projection than this.