### PR TITLE
Set WFS version to 1.0.0 as default

### DIFF
--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -405,9 +405,14 @@ class serviceCtrl extends jController {
                 )
             );
         } else if( $service == 'wfs' ) {
+            $version = '1.0.0';
+            if ( array_key_exists( 'version', $this->params ) ) {
+                $version = $this->params['version'];
+            }
             $request = new lizmapWFSRequest( $this->project, array(
                     'service'=>'WFS',
-                    'request'=>'GetCapabilities'
+                    'request'=>'GetCapabilities',
+                    'version'=>$version
                 )
             );
         } else if( $service == 'wmts' ) {


### PR DESCRIPTION
QGIS Server 3.4 use version 1.1.0 by default for WFS. Actually Lizmap expect 1.0.0 so we use this version as default.
Fix #1084  