### PR TITLE
Optimize db connection in layers

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -162,7 +162,8 @@ class qgisVectorLayer extends qgisMapLayer {
           if (!empty($dtParams->service)) {
               $jdbParams = array(
                   "driver" => 'pgsql',
-                  "service" => $dtParams->service
+                  "service" => $dtParams->service,
+                  "persistent" => true
               );
           } else {
               $jdbParams = array(
@@ -171,7 +172,8 @@ class qgisVectorLayer extends qgisMapLayer {
                   "port" => (integer)$dtParams->port,
                   "database" => $dtParams->dbname,
                   "user" => $dtParams->user,
-                  "password" => $dtParams->password
+                  "password" => $dtParams->password,
+                  "persistent" => true
               );
           }
       }


### PR DESCRIPTION
Layers have often the same datasource (same host/db/login/passwd). 

We could avoid to create a connection or a profile for each layer, by using the same profile/connection between layers having same datasource. 

And we could use persistent connection; so lizmap can reuse same connections between each requests.

The result may be less connections to the database, and less memory usage.