### PR TITLE
Fix qgisform null value

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisForm.class.php
+++ b/lizmap/modules/lizmap/classes/qgisForm.class.php
@@ -473,6 +473,13 @@ class qgisForm {
             $value = '{'.implode(',',$value).'}';
           }
 
+          if (($value === '' || $value === null) &&
+              !$this->formControls[$ref]->required
+          ) {
+              $values[ $ref ] = 'NULL';
+              continue;
+          }
+
           switch($this->formControls[$ref]->fieldDataType){
               case 'geometry':
                 try {
@@ -502,22 +509,20 @@ class qgisForm {
                   $value = 'NULL';
                 break;
               case 'text':
-                if ( is_null($value) or strlen((string)$value) == 0)
-                  $value = 'NULL';
-                else
-                  $value = $cnx->quote($value);
+                $value = $cnx->quote($value);
                 break;
               case 'boolean':
                 $strVal = strtolower($value);
-                if ( $strVal === '' )
-                  $value = 'NULL';
-                else if($strVal != 'true' &&  $strVal !== 't' && intval($value) != 1 &&
+                if($strVal != 'true' &&  $strVal !== 't' && intval($value) != 1 &&
                    $strVal !== 'on' && $value !== true &&
                    $strVal != 'false' &&  $strVal !== 'f' && intval($value) != 0 &&
-                   $strVal !== 'off' && $value !== false)
-                  $value = 'NULL';
-                else
-                  $value = $cnx->quote($value);
+                   $strVal !== 'off' && $value !== false
+                ) {
+                    $value = 'NULL';
+                }
+                else {
+                    $value = $cnx->quote($value);
+                }
                 break;
               default:
                 $value = $cnx->quote(

--- a/lizmap/modules/lizmap/classes/qgisForm.class.php
+++ b/lizmap/modules/lizmap/classes/qgisForm.class.php
@@ -461,6 +461,11 @@ class qgisForm {
         $values = array();
         // Loop though the fields and filter the form posted values
         foreach($fields as $ref){
+            if ($form->getControl($ref) instanceof jFormsControlUpload) {
+                $values[ $ref ] = $this->processUploadedFile($form, $ref, $cnx);
+                continue;
+            }
+
           // Get and filter the posted data foreach form control
           $value = $form->getData($ref);
 
@@ -520,60 +525,6 @@ class qgisForm {
                 );
                 break;
           }
-          if ( $form->hasUpload() && array_key_exists( $ref, $form->getUploads() ) ) {
-            $project = $this->layer->getProject();
-            $dtParams = $this->layer->getDatasourceParameters();
-            $value = $form->getData( $ref );
-            $choiceValue = $form->getData( $ref.'_choice' );
-            $hiddenValue = $form->getData( $ref.'_hidden' );
-            $repPath = $project->getRepository()->getPath();
-
-            $targetPath = 'media/upload/'.$project->getKey().'/'.$dtParams->tablename.'/'.$ref;
-            $targetFullPath = $repPath . $targetPath;
-            // Else use given root, but only if it is a child or brother of the repository path
-            if(!empty($this->formControls[$ref]->DefaultRoot) ){
-                jFile::createDir($repPath . $this->formControls[$ref]->DefaultRoot);// Need to create it to then make the realpath checks
-                if(
-                    (substr(realpath($repPath . $this->formControls[$ref]->DefaultRoot), 0, strlen(realpath($repPath))) === realpath($repPath))
-                    or
-                    (substr(realpath($repPath . $this->formControls[$ref]->DefaultRoot), 0, strlen(realpath($repPath.'/../'))) === realpath($repPath.'/../'))
-                ){
-                    $targetPath = $this->formControls[$ref]->DefaultRoot;
-                    $targetFullPath = realpath($repPath . $this->formControls[$ref]->DefaultRoot);
-                }
-            }
-
-            // update
-            if ( $choiceValue == 'update' && $value != '') {
-                $alreadyValueIdx = 0;
-                while ( file_exists( $targetFullPath.'/'.$value ) ) {
-                    $alreadyValueIdx += 1;
-                    $splitValue = explode('.', $value);
-                    $splitValue[0] = $splitValue[0].$alreadyValueIdx;
-                    $value = implode('.', $splitValue);
-                }
-                $form->saveFile( $ref, $targetFullPath, $value );
-                $value = $targetPath.'/'.$value;
-                if ( $hiddenValue && file_exists( realPath( $repPath .'/'.$hiddenValue ) ) )
-                    unlink( realPath( $repPath .'/'.$hiddenValue ) );
-            }
-            // delete
-            else if ( $choiceValue == 'delete' ) {
-                if ( $hiddenValue && file_exists( realPath( $repPath .'/'.$hiddenValue ) ) )
-                    unlink( realPath( $repPath .'/'.$hiddenValue ) );
-                $value = 'NULL';
-            } else {
-                $value = $hiddenValue;
-            }
-            if ( empty($value) )
-                $value = 'NULL';
-            else if ( $value != 'NULL' )
-                $value = $cnx->quote(
-                  filter_var($value, FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES)
-                );
-            $value = preg_replace('#/{2,3}#', '/', $value);
-          }
-
           $values[ $ref ] = $value;
         }
 
@@ -590,6 +541,66 @@ class qgisForm {
             return false;
         }
         return 0;
+    }
+
+    /**
+     * @param jFormsBase $form
+     * @param string $ref
+     * @param jDbConnection $cnx
+     */
+    protected function processUploadedFile($form, $ref, $cnx) {
+        $project = $this->layer->getProject();
+        $dtParams = $this->layer->getDatasourceParameters();
+        $value = $form->getData( $ref );
+        $choiceValue = $form->getData( $ref.'_choice' );
+        $hiddenValue = $form->getData( $ref.'_hidden' );
+        $repPath = $project->getRepository()->getPath();
+
+        $targetPath = 'media/upload/'.$project->getKey().'/'.$dtParams->tablename.'/'.$ref;
+        $targetFullPath = $repPath . $targetPath;
+        // Else use given root, but only if it is a child or brother of the repository path
+        if(!empty($this->formControls[$ref]->DefaultRoot) ){
+            jFile::createDir($repPath . $this->formControls[$ref]->DefaultRoot);// Need to create it to then make the realpath checks
+            if(
+                (substr(realpath($repPath . $this->formControls[$ref]->DefaultRoot), 0, strlen(realpath($repPath))) === realpath($repPath))
+                or
+                (substr(realpath($repPath . $this->formControls[$ref]->DefaultRoot), 0, strlen(realpath($repPath.'/../'))) === realpath($repPath.'/../'))
+            ){
+                $targetPath = $this->formControls[$ref]->DefaultRoot;
+                $targetFullPath = realpath($repPath . $this->formControls[$ref]->DefaultRoot);
+            }
+        }
+
+        // update
+        if ( $choiceValue == 'update' && $value != '') {
+            $alreadyValueIdx = 0;
+            while ( file_exists( $targetFullPath.'/'.$value ) ) {
+                $alreadyValueIdx += 1;
+                $splitValue = explode('.', $value);
+                $splitValue[0] = $splitValue[0].$alreadyValueIdx;
+                $value = implode('.', $splitValue);
+            }
+            $form->saveFile( $ref, $targetFullPath, $value );
+            $value = $targetPath.'/'.$value;
+            if ( $hiddenValue && file_exists( realPath( $repPath .'/'.$hiddenValue ) ) )
+                unlink( realPath( $repPath .'/'.$hiddenValue ) );
+        }
+        // delete
+        else if ( $choiceValue == 'delete' ) {
+            if ( $hiddenValue && file_exists( realPath( $repPath .'/'.$hiddenValue ) ) )
+                unlink( realPath( $repPath .'/'.$hiddenValue ) );
+            $value = 'NULL';
+        } else {
+            $value = $hiddenValue;
+        }
+        if ( empty($value) )
+            $value = 'NULL';
+        else if ( $value != 'NULL' )
+            $value = $cnx->quote(
+                filter_var($value, FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES)
+            );
+        $value = preg_replace('#/{2,3}#', '/', $value);
+        return $value;
     }
 
     /**


### PR DESCRIPTION
After the submit, qgisform convert some empty values '' to 0 instead of null. it causes issues when the value represents a foreign key. In this case, most of time 0 is not valid...