### PR TITLE
Qgisform hooks & template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ vagrant/vars/custom.yml
 lizmap/vendor/
 lizmap/composer.lock
 
+tests/vendor/
+tests/composer.lock

--- a/lib/jelix/events/jEvent.class.php
+++ b/lib/jelix/events/jEvent.class.php
@@ -129,6 +129,93 @@ class jEvent {
     }
 
     /**
+     * get all responses value for the given key
+     *
+     * @param string $responseKey
+     * @return array|null list of values or null if no responses for the given item
+     * @since 1.6.22
+     */
+    public function getResponseByKey($responseKey){
+        $response = array ();
+
+        foreach ($this->_responses as $key=>$listenerResponse){
+            if (is_array($listenerResponse) &&
+                isset ($listenerResponse[$responseKey])
+            ) {
+                $response[] = & $listenerResponse[$responseKey];
+            }
+        }
+        if (count($response))
+            return $response;
+        return null;
+    }
+
+    const RESPONSE_AND_OPERATOR = 0;
+
+    const RESPONSE_OR_OPERATOR = 1;
+
+    /**
+     * get a response value as boolean
+     *
+     * if there are multiple response for the same key, a OR or a AND operation
+     * is made between all of response values.
+     *
+     * @param string $responseKey
+     * @param int $operator const RESPONSE_AND_OPERATOR or RESPONSE_OR_OPERATOR
+     * @return null|boolean
+     * @since 1.6.22
+     */
+    protected function getBoolResponseByKey($responseKey, $operator = 0){
+        $response = null;
+
+        foreach ($this->_responses as $key=>$listenerResponse){
+            if (is_array($listenerResponse) &&
+                isset ($listenerResponse[$responseKey])
+            ) {
+                $value = (bool) $listenerResponse[$responseKey];
+                if ($response === null) {
+                    $response = $value;
+                }
+                else if ($operator === self::RESPONSE_AND_OPERATOR) {
+                    $response = $response && $value;
+                }
+                else if ($operator === self::RESPONSE_OR_OPERATOR) {
+                    $response = $response || $value;
+                }
+            }
+        }
+
+        return $response;
+    }
+
+    /**
+     * says if all responses items for the given key, are equals to true
+     *
+     * @param string $responseKey
+     * @return null|boolean  null if there are no responses
+     * @since 1.6.22
+     */
+    public function allResponsesByKeyAreTrue($responseKey) {
+        return $this->getBoolResponseByKey($responseKey, self::RESPONSE_AND_OPERATOR);
+    }
+
+    /**
+     * says if all responses items for the given key, are equals to false
+     *
+     * @param string $responseKey
+     * @return null|boolean  null if there are no responses
+     * @since 1.6.22
+     */
+    public function allResponsesByKeyAreFalse($responseKey) {
+        $res = $this->getBoolResponseByKey($responseKey, self::RESPONSE_OR_OPERATOR);
+        if ($res === null) {
+            return $res;
+        }
+        return !$res;
+    }
+
+
+    /**
     * gets all the responses
     * @return mixed[][]  associative array
     */
@@ -178,7 +265,7 @@ class jEvent {
     /**
     * hash table for event listened.
     * $_hash['eventName'] = array of events (by reference)
-    * @var object[] array of object
+    * @var jEventListener[]
     */
     protected static $hashListened = array ();
 

--- a/lib/jelix/plugins/tpl/common/cfunction.fetchtpl.php
+++ b/lib/jelix/plugins/tpl/common/cfunction.fetchtpl.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @package    jelix
+ * @subpackage jtpl_plugin
+ * @copyright  2019 Laurent Jouanneau
+ * @link http://jelix.org/
+ * @licence    GNU Lesser General Public Licence see LICENCE file or http://www.gnu.org/licenses/lgpl.html
+ */
+
+/**
+ * fetch the content of a template without template variables of
+ * calling template, except private variables setted by some plugins
+ *
+ * It allows to use a template as a recursive way, in a cleaner way than include,
+ * because it doesn't inherits of variables from the parent template
+ *
+ * Meta content must not use template variable given to 'fetch', as they will not
+ * be available at the time of meta processing (except if they are a copy of
+ * template variable of the parent template)
+ *
+ *
+ * <pre>{fetch 'myModule~foo', array('varname'=>'value) }</pre>
+ * @param jTplCompiler $compiler the template compiler
+ * @param array $param   0=>string the template selector (string)
+ *                       1=>array  a list of template variable to inject into the template
+ *                       2=>boolean : inherits (true) or not of private variables. default is true.
+ * @return string the php code corresponding to the function content
+ */
+function jtpl_cfunction_common_fetchtpl($compiler, $param=array()) {
+    if(!$compiler->trusted) {
+        $compiler->doError1('errors.tplplugin.untrusted.not.available','fetch');
+        return '';
+    }
+    if (count($param) < 2 || count($param) > 3) {
+      $compiler->doError2('errors.tplplugin.cfunction.bad.argument.number','fetch','2');
+      return '';
+    }
+
+    if (count($param) == 2) {
+      $param[] = 'true';
+    }
+
+    $compiler->addMetaContent('$t->meta('.$param[0].');');
+    $php = '$tplClass=get_class($t);$subTpl = new $tplClass();';
+    $php .= 'if ('.$param[2].') { $subTpl->_privateVars = $t->_privateVars;}'."\n";
+    $php .= '$subTpl->assign('.$param[1].');';
+    $php .= '$subTpl->display('.$param[0].');'."\n";
+    return $php;
+
+}

--- a/lib/jelix/plugins/tpl/html/function.ctrl_label.php
+++ b/lib/jelix/plugins/tpl/html/function.ctrl_label.php
@@ -34,11 +34,13 @@ function jtpl_function_html_ctrl_label($tpl, $ctrlname='', $format='')
         }
         $ctrl = $ctrls[$ctrlname];
     }
-
-    if ($ctrl->type == 'hidden')
+    if ($ctrl->type == 'hidden') {
         return;
+    }
 
-    if(!$tpl->_privateVars['__form']->isActivated($ctrl->ref)) return;
+    if (!$tpl->_privateVars['__form']->isActivated($ctrl->ref)) {
+        return;
+    };
 
     $editMode = !(isset ($tpl->_privateVars['__formViewMode']) && $tpl->_privateVars['__formViewMode']);
 

--- a/lizmap/modules/lizmap/classes/qgisAttributeEditorElement.class.php
+++ b/lizmap/modules/lizmap/classes/qgisAttributeEditorElement.class.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ *
+ * @package   lizmap
+ * @subpackage lizmap
+ * @author    3liz
+ * @copyright 2019 3liz
+ * @link      http://3liz.com
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+
+class qgisAttributeEditorElement {
+
+  protected $name;
+
+  protected $attributes = array();
+
+  protected $children = array();
+
+  function __construct(SimpleXMLElement $node) {
+    $this->name = $node->getName();
+
+    foreach($node->attributes() as $name=>$attr) {
+      $this->attributes[$name] = (string)$attr;
+    }
+
+    foreach ($node->children() as $child ) {
+      $this->children[] = new qgisAttributeEditorElement($child);
+    }
+  }
+
+  public function getName() {
+    return $this->name;
+  }
+
+  public function getAttribute($name) {
+    if (isset($this->attributes[$name])) {
+      return $this->attributes[$name];
+    }
+    return null;
+  }
+
+  /**
+   * @return qgisAttributeEditorForm[]
+   */
+  public function getChildren() {
+    return $this->children;
+  }
+
+  public function hasChildren() {
+    return count($this->children) > 0;
+  }
+
+  public function hasGroupBox() {
+    return ($this->getAttribute('groupBox') === '1');
+  }
+
+}

--- a/lizmap/modules/lizmap/classes/qgisForm.class.php
+++ b/lizmap/modules/lizmap/classes/qgisForm.class.php
@@ -489,7 +489,8 @@ class qgisForm implements qgisFormControlsInterface {
             "featureId"=>$this->featureId,
             "tablename"=>$dtParams->tablename,
             "schema"=>$dtParams->schema,
-            "loginFilteredLayers" => $loginFilteredLayers
+            "loginFilteredLayers" => $loginFilteredLayers,
+            'pkVal'=>$this->layer->getPrimaryKeyValues($feature)
         );
         $event = jEvent::notify('LizmapEditionFeaturePreDelete', $eventParams);
         if ($event->allResponsesByKeyAreTrue('deleteIsAlreadyDone')) {

--- a/lizmap/modules/lizmap/classes/qgisFormControl.class.php
+++ b/lizmap/modules/lizmap/classes/qgisFormControl.class.php
@@ -722,4 +722,32 @@ class qgisFormControl {
     $this->ctrl->datasource = $dataSource;
   }
 
+  public function isUniqueValue() {
+    return $this->fieldEditType === 2 ||
+           $this->fieldEditType === 'UniqueValues'  ||
+           $this->fieldEditType === 'UniqueValuesEditable';
+  }
+
+  public function isValueRelation() {
+    return ($this->fieldEditType === 15 ||
+            $this->fieldEditType === 'ValueRelation') &&
+            $this->valueRelationData;
+  }
+
+  public function isRelationReference() {
+    return $this->fieldEditType === 'RelationReference' &&
+           $this->relationReferenceData;
+  }
+
+  public function isUploadControl() {
+    return $this->fieldEditType === 8 ||
+        $this->fieldEditType === 'FileName' ||
+        $this->fieldEditType === 'Photo' ||
+        $this->fieldEditType === 'ExternalResource';
+  }
+
+  public function getControlName() {
+    // Change field name to choice for files upoad control
+    return ($this->isUploadControl()?$this->ref.'_choice':$this->ref);
+  }
 }

--- a/lizmap/modules/lizmap/classes/qgisFormControl.class.php
+++ b/lizmap/modules/lizmap/classes/qgisFormControl.class.php
@@ -747,7 +747,7 @@ class qgisFormControl {
   }
 
   public function getControlName() {
-    // Change field name to choice for files upoad control
+    // Change field name to choice for files upload control
     return ($this->isUploadControl()?$this->ref.'_choice':$this->ref);
   }
 }

--- a/lizmap/modules/lizmap/classes/qgisFormControlsInterface.php
+++ b/lizmap/modules/lizmap/classes/qgisFormControlsInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @package   lizmap
+ * @subpackage lizmap
+ * @author    3liz
+ * @copyright 2019 3liz
+ * @link      http://3liz.com
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+
+interface qgisFormControlsInterface {
+
+    /**
+     * @return qgisFormControl[]
+     */
+    public function getQgisControls();
+
+    /**
+     * @param string $name
+     * @return qgisFormControl|null null if the control does not exists
+     */
+    public function getQgisControl($name);
+
+    /**
+     * Return the control name for the jForms form
+     * @param string $name the name of the qgis control
+     * @return null|string  null if the control does not exist
+     */
+    public function getFormControlName($name);
+}

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -272,6 +272,16 @@ class editionCtrl extends jController {
     $form = jForms::create('view~edition');
     $form->setData( 'liz_future_action', $this->param('liz_future_action', 'close') );
 
+    // event to add custom field in the jForms form
+    jEvent::notify('LizmapEditionCreateForm', array(
+        'form'=>$form,
+        'action'=>'create',
+        "project"=>$this->project,
+        "repository"=>$this->repository,
+        "layer"=>$this->layer,
+        "status"=>$this->param('status', 0)
+    ));
+
     // Redirect to the display action
     $rep = $this->getResponse('redirect');
     $rep->params = array(
@@ -315,6 +325,17 @@ class editionCtrl extends jController {
       return $this->serviceAnswer();
     }
     $form->setData( 'liz_future_action', $this->param('liz_future_action', 'close') );
+    // event to add custom field in the jForms form
+    jEvent::notify('LizmapEditionCreateForm', array(
+        'form'=>$form,
+        'action'=>'modify',
+        "project"=>$this->project,
+        "repository"=>$this->repository,
+        "layer"=>$this->layer,
+        "featureId"=>$this->featureId,
+        "featureData"=>$this->featureData,
+        "status"=>$this->param('status', 0)
+    ));
 
     // Redirect to the display action
     $rep = $this->getResponse('redirect');
@@ -334,7 +355,7 @@ class editionCtrl extends jController {
   /**
    * Display the edition form (output as html fragment)
    *
-   * @return jResponseHtmlFragment HTML code containing the form.
+   * @return jResponseHtmlFragment|jResponseRedirect HTML code containing the form.
    */
   public function editFeature(){
 
@@ -360,6 +381,18 @@ class editionCtrl extends jController {
     $form->setData('liz_project', $this->project->getKey());
     $form->setData('liz_layerId', $this->layerId);
     $form->setData('liz_featureId', $this->featureIdParam);
+
+    // event to add custom field into the jForms form before setting data in it
+    $eventParams = array(
+        'form'=>$form,
+        "project"=>$this->project,
+        "repository"=>$this->repository,
+        "layer"=>$this->layer,
+        "featureId"=>$this->featureId,
+        "featureData"=>$this->featureData,
+        "status"=>$this->param('status', 0)
+    );
+    jEvent::notify('LizmapEditionEditGetForm', $eventParams);
 
     // Dynamically add form controls based on QGIS layer information
     $qgisForm = null;
@@ -471,6 +504,13 @@ class editionCtrl extends jController {
     $tpl->assign('title', $title);
     $tpl->assign('form', $qgisForm->getForm());
 
+    // event to add custom fields into the jForms form, or to modify those that
+    // have been added by QgisForm, and to inject custom data into the template
+    // useful if the template has been redefined in a theme
+    $eventParams['qgisForm'] = $qgisForm;
+    $eventParams["tpl"] = $tpl;
+    jEvent::notify('LizmapEditionEditQgisForm', $eventParams);
+
     $content = $tpl->fetch('view~edition_form');
 
     // Return html fragment response
@@ -503,6 +543,20 @@ class editionCtrl extends jController {
       return $this->serviceAnswer();
     }
 
+    $this->getWfsFeature();
+
+    // event to add custom field into the jForms form before setting data in it
+    $eventParams = array(
+        'form'=>$form,
+        "project"=>$this->project,
+        "repository"=>$this->repository,
+        "layer"=>$this->layer,
+        "featureId"=>$this->featureId,
+        "featureData"=>$this->featureData,
+        "status"=>$this->param('status', 0)
+    );
+    jEvent::notify('LizmapEditionSaveGetForm', $eventParams);
+
     // Dynamically add form controls based on QGIS layer information
     // And save data into the edition table (insert or update line)
     $save =True;
@@ -515,8 +569,11 @@ class editionCtrl extends jController {
         return $this->serviceAnswer();
     }
 
+    // event to add or modify some control after QgisForm has added its own controls
+    $eventParams['qgisForm']  = $qgisForm;
+    jEvent::notify('LizmapEditionSaveGetQgisForm', $eventParams);
+
     // Get data from the request and set the form controls data accordingly
-    $this->getWfsFeature();
     $form->initFromRequest();
 
     // Check the form data and redirect if needed
@@ -524,6 +581,12 @@ class editionCtrl extends jController {
     if ( $this->geometryColumn != '' && $form->getData( $this->geometryColumn ) == '' ) {
       $check = False;
       $form->setErrorOn($this->geometryColumn, jLocale::get('view~edition.message.error.no.geometry') );
+    }
+
+    // event to add additionnal checks
+    $event = jEvent::notify('LizmapEditionSaveCheckForm', $eventParams);
+    if ($event->allResponsesByKeyAreTrue('check') === false) {
+        $check = false;
     }
 
     $rep = $this->getResponse('redirect');
@@ -726,23 +789,39 @@ class editionCtrl extends jController {
         }
     }
 
+    // event to add additionnal checks
+    $eventParams = array(
+        'form'=>$form,
+        'qgisForm' => $qgisForm,
+        "project"=>$this->project,
+        "repository"=>$this->repository,
+        "layer"=>$this->layer,
+        "featureId"=>$this->featureId,
+        "featureData"=>$this->featureData
+    );
+    jEvent::notify('LizmapEditionPreDelete', $eventParams);
+
     try {
       $rs = $qgisForm->deleteFromDb( $feature );
       if ( $rs ) {
-        jMessage::add( jLocale::get('view~edition.message.success.delete'), 'success');
-
+          jMessage::add( jLocale::get('view~edition.message.success.delete'), 'success');
+          $eventParams["deleteFiles"] = $deleteFiles;
+          $eventParams["success"] = true;
           foreach( $deleteFiles as $path ) {
               if ( file_exists( $path ) )
                 unlink( $path );
           }
       } else {
         jMessage::add( jLocale::get('view~edition.message.error.delete'), 'error');
+        $eventParams["success"] = false;
       }
 
     } catch (Exception $e) {
       jLog::log("An error has been raised when saving form data edition to db : ".$e->getMessage() ,'error');
       jMessage::add( jLocale::get('view~edition.message.error.delete'), 'error');
+      $eventParams["success"] = false;
     }
+    jEvent::notify('LizmapEditionPostDelete', $eventParams);
     return $this->serviceAnswer();
   }
 

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -403,9 +403,8 @@ class editionCtrl extends jController {
     else if ( $form->hasUpload() ) {
         $repPath = $this->repository->getPath();
         $dtParams = $this->layer->getDatasourceParameters();
-        $qgisFormControls = $qgisForm->getFormControls();
         foreach( $form->getUploads() as $upload ) {
-            $DefaultRoot = $qgisFormControls[$upload->ref]->DefaultRoot;
+            $DefaultRoot = $qgisForm->getQgisControl($upload->ref)->DefaultRoot;
             // If not default root is set, the use old method media/upload/projectname/tablename/
             $targetPath = 'media/upload/'.$this->project->getKey().'/'.$dtParams->tablename.'/'.$upload->ref .'/';
             $targetFullPath = $repPath . $targetPath;
@@ -464,25 +463,20 @@ class editionCtrl extends jController {
     if ( !$title or $title == '' )
         $title = 'No title';
 
-    // Get form layout
-    $_layerXmlZero = $this->layerXml;
-    $layerXmlZero = $_layerXmlZero[0];
-    $_editorlayout = $layerXmlZero->xpath('editorlayout');
-    $attributeEditorFormTemplate = $qgisForm->getHtmlForm();
 
     // Use template to create html form content
     $tpl = new jTpl();
-    $tpl->assign(array(
-      'title'=>$title,
-      'attributeEditorFormTemplate'=>$attributeEditorFormTemplate
-    ));
+    $tpl->assign('attributeEditorForm', $qgisForm->getAttributesEditorForm());
+    $tpl->assign('fieldNames', $qgisForm->getFieldNames());
+    $tpl->assign('title', $title);
+    $tpl->assign('form', $qgisForm->getForm());
+
     $content = $tpl->fetch('view~edition_form');
 
     // Return html fragment response
     $rep = $this->getResponse('htmlfragment');
     $rep->addContent($content);
     return $rep;
-
   }
 
   /**

--- a/lizmap/modules/lizmap/module.xml
+++ b/lizmap/modules/lizmap/module.xml
@@ -30,6 +30,7 @@
         <class name="qgisVectorLayer" file="classes/qgisVectorLayer.class.php" />
         <class name="qgisForm" file="classes/qgisForm.class.php" />
         <class name="qgisFormControl" file="classes/qgisFormControl.class.php" />
+        <class name="qgisAttributeEditorElement" file="classes/qgisAttributeEditorElement.class.php" />
         <class name="qgisLayerDbFieldsInfo" file="classes/qgisLayerDbFieldsInfo.class.php" />
         <namespacePathMap name="Lizmap" dir="lib" />
     </autoload>

--- a/lizmap/modules/lizmap/module.xml
+++ b/lizmap/modules/lizmap/module.xml
@@ -32,6 +32,7 @@
         <class name="qgisFormControl" file="classes/qgisFormControl.class.php" />
         <class name="qgisAttributeEditorElement" file="classes/qgisAttributeEditorElement.class.php" />
         <class name="qgisLayerDbFieldsInfo" file="classes/qgisLayerDbFieldsInfo.class.php" />
+        <class name="qgisFormControlsInterface" file="classes/qgisFormControlsInterface.php" />
         <namespacePathMap name="Lizmap" dir="lib" />
     </autoload>
 </module>

--- a/lizmap/modules/view/templates/edition_form.tpl
+++ b/lizmap/modules/view/templates/edition_form.tpl
@@ -8,4 +8,30 @@
 
 {jmessage_bootstrap}
 
-{$attributeEditorFormTemplate}
+{form $form, "lizmap~edition:saveFeature", array(), "htmlbootstrap", 
+        array("errorDecorator"=>"lizEditionErrorDecorator")}
+
+{if $attributeEditorForm}
+
+    {fetchtpl 'view~edition_form_container', array('container'=>$attributeEditorForm)}
+    
+{else}
+    {formcontrols $fieldNames}
+    <div class="control-group">
+        {ctrl_label}
+        <div class="controls">
+            {ctrl_control}
+        </div>
+    </div>
+    {/formcontrols}
+{/if}
+
+
+    <div class="control-group">
+        {ctrl_label "liz_future_action"}
+        <div class="controls">
+            {ctrl_control "liz_future_action"}
+        </div>
+    </div>
+    <div class="jforms-submit-buttons form-actions">{formreset}{formsubmit}</div>
+{/form}

--- a/lizmap/modules/view/templates/edition_form_container.tpl
+++ b/lizmap/modules/view/templates/edition_form_container.tpl
@@ -1,0 +1,54 @@
+
+
+{foreach $container->getChildrenBeforeTab() as $child}
+    {if $child->isGroupBox()}
+        <fieldset>
+        <legend style="font-weight:bold;">{$child->getName()}</legend>
+            <div class="jforms-table-group" id="{$child->getHtmlId()}">
+            {fetchtpl 'view~edition_form_container',array('container'=>$child)}
+            </div>
+        </fieldset>
+    {else}
+        <div class="control-group">
+            {ctrl_label $child->getCtrlRef()}
+            <div class="controls">
+                {ctrl_control $child->getCtrlRef()}
+            </div>
+        </div>
+    {/if}
+{/foreach}
+
+{if $container->hasTabChildren()}
+<ul id="{$container->getParentId()}-tabs" class="nav nav-tabs">
+    {foreach $container->getTabChildren() as $tabChild}
+    <li><a href="#{$tabChild->getHtmlId()}"
+           data-toggle="tab">{$tabChild->getName()}</a></li>
+    {/foreach}
+</ul>
+
+<div id="{$container->getParentId()}-tab-content" class="tab-content">
+    {foreach $container->getTabChildren() as $tabChild}
+        <div class="tab-pane" id="{$tabChild->getHtmlId()}">
+            {fetchtpl 'view~edition_form_container',array('container'=>$tabChild)}
+        </div>
+    {/foreach}
+</div>
+{/if}
+
+{foreach $container->getChildrenAfterTab() as $child}
+    {if $child->isGroupBox()}
+        <fieldset>
+            <legend style="font-weight:bold;">{$child->getName()}</legend>
+            <div class="jforms-table-group" id="{$child->getHtmlId()}">
+                {fetchtpl 'view~edition_form_container',array('container'=>$child)}
+            </div>
+        </fieldset>
+    {else}
+        <div class="control-group">
+            {ctrl_label $child->getCtrlRef()}
+            <div class="controls">
+                {ctrl_control $child->getCtrlRef()}
+            </div>
+        </div>
+    {/if}
+{/foreach}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,11 @@
+This directory contains some unit tests.
+
+To launch tests:
+
+- install the lizmap application
+- install [Composer](http://getcomposer.org) and launch
+  `composer install` in a shell in this directory. It will
+  install phpunit and some other libs.
+- then you can run vendor/bin/phpunit.
+
+

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+
+require_once(__DIR__.'/../lizmap/application.init.php');
+require_once(LIB_PATH.'jelix-tests/classes/junittestcase.class.php');
+require_once(LIB_PATH.'jelix-tests/classes/junittestcasedb.class.php');
+
+jApp::setEnv('lizmaptests');
+if (file_exists(jApp::tempPath())) {
+    jAppManager::clearTemp(jApp::tempPath());
+}

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "3liz/lizmap-tests",
+    "type": "application",
+    "authors": [
+        {
+            "name": "Laurent Jouanneau",
+            "email": "dev@ljouanneau.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.6.0",
+        "phpunit/phpunit": "^5.7.27"
+    },
+    "autoload": {
+        "classmap": ["../lizmap/modules/lizmap/classes/" ]
+    },
+    "minimum-stability": "stable"
+}

--- a/tests/edition/qgisAttributeFormTest.php
+++ b/tests/edition/qgisAttributeFormTest.php
@@ -1,0 +1,353 @@
+<?php
+
+
+class dummyQgisFormControls implements qgisFormControlsInterface {
+
+    /**
+     * @return qgisFormControl[]
+     */
+    public function getQgisControls() {
+        return [];
+    }
+
+    /**
+     * @param string $name
+     * @return qgisFormControl|null null if the control does not exists
+     */
+    public function getQgisControl($name) {
+        return null;
+    }
+
+    /**
+     * Return the control name for the jForms form
+     * @param string $name the name of the qgis control
+     * @return null|string  null if the control does not exist
+     */
+    public function getFormControlName($name) {
+        return $name;
+    }
+
+}
+
+class qgisAttributeFormTest extends PHPUnit_Framework_TestCase {
+
+
+    function testSimpleContainer() {
+        $xml = '<attributeEditorForm>
+            <attributeEditorField showLabel="1" index="0" name="pkuid"/>
+            <attributeEditorField showLabel="1" index="1" name="name"/>
+            <attributeEditorField showLabel="1" index="2" name="description"/>
+      </attributeEditorForm>';
+        $sXml = simplexml_load_string($xml);
+        $controls = new dummyQgisFormControls();
+        $element = new qgisAttributeEditorElement($controls, $sXml, 'foo', 0,0);
+
+        $this->assertEquals(3, count($element->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($element->getChildrenAfterTab()));
+        $this->assertEquals(0, count($element->getTabChildren()));
+        $this->assertEquals('', $element->getName());
+        $this->assertFalse($element->isGroupBox());
+        $this->assertFalse($element->isTabPanel());
+        $this->assertTrue($element->isContainer());
+        $this->assertTrue($element->hasChildren());
+        $this->assertEquals('foo', $element->getHtmlId());
+        $this->assertEquals('foo', $element->getParentId());
+
+        $cc = $element->getChildrenBeforeTab()[0];
+
+        $this->assertEquals(0, count($cc->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($cc->getChildrenAfterTab()));
+        $this->assertEquals(0, count($cc->getTabChildren()));
+        $this->assertEquals('pkuid', $cc->getName());
+        $this->assertFalse($cc->isGroupBox());
+        $this->assertFalse($cc->isTabPanel());
+        $this->assertFalse($cc->isContainer());
+        $this->assertFalse($cc->hasChildren());
+        $this->assertEquals('foo-0', $cc->getHtmlId());
+        $this->assertEquals('foo', $cc->getParentId());
+
+        $cc = $element->getChildrenBeforeTab()[1];
+
+        $this->assertEquals(0, count($cc->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($cc->getChildrenAfterTab()));
+        $this->assertEquals(0, count($cc->getTabChildren()));
+        $this->assertEquals('name', $cc->getName());
+        $this->assertFalse($cc->isGroupBox());
+        $this->assertFalse($cc->isTabPanel());
+        $this->assertFalse($cc->isContainer());
+        $this->assertFalse($cc->hasChildren());
+        $this->assertEquals('foo-1', $cc->getHtmlId());
+        $this->assertEquals('foo', $cc->getParentId());
+
+        $cc = $element->getChildrenBeforeTab()[2];
+
+        $this->assertEquals(0, count($cc->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($cc->getChildrenAfterTab()));
+        $this->assertEquals(0, count($cc->getTabChildren()));
+        $this->assertEquals('description', $cc->getName());
+        $this->assertFalse($cc->isGroupBox());
+        $this->assertFalse($cc->isTabPanel());
+        $this->assertFalse($cc->isContainer());
+        $this->assertFalse($cc->hasChildren());
+        $this->assertEquals('foo-2', $cc->getHtmlId());
+        $this->assertEquals('foo', $cc->getParentId());
+
+    }
+
+    function testSimpleGroupBox() {
+        $xml = '<attributeEditorForm>
+           <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Generic" groupBox="1" columnCount="0">
+            <attributeEditorField showLabel="1" index="0" name="pkuid"/>
+            <attributeEditorField showLabel="1" index="1" name="name"/>
+            <attributeEditorField showLabel="1" index="2" name="description"/>
+          </attributeEditorContainer>
+      </attributeEditorForm>';
+        $sXml = simplexml_load_string($xml);
+        $controls = new dummyQgisFormControls();
+        $element = new qgisAttributeEditorElement($controls, $sXml, 'foo', 0,0);
+        $this->assertEquals(1, count($element->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($element->getChildrenAfterTab()));
+        $this->assertEquals(0, count($element->getTabChildren()));
+        $this->assertEquals('', $element->getName());
+
+        $this->assertFalse($element->isGroupBox());
+        $this->assertFalse($element->isTabPanel());
+        $this->assertTrue($element->isContainer());
+        $this->assertTrue($element->hasChildren());
+        $this->assertEquals('foo', $element->getHtmlId());
+        $this->assertEquals('foo', $element->getParentId());
+
+        $c = $element->getChildrenBeforeTab()[0];
+
+        $this->assertEquals(3, count($c->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($c->getChildrenAfterTab()));
+        $this->assertEquals(0, count($c->getTabChildren()));
+        $this->assertEquals('Generic', $c->getName());
+
+        $this->assertTrue($c->isGroupBox());
+        $this->assertFalse($c->isTabPanel());
+        $this->assertTrue($c->isContainer());
+        $this->assertTrue($c->hasChildren());
+        $this->assertEquals('foo-group0', $c->getHtmlId());
+        $this->assertEquals('foo', $c->getParentId());
+
+        $cc = $c->getChildrenBeforeTab()[0];
+
+        $this->assertEquals(0, count($cc->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($cc->getChildrenAfterTab()));
+        $this->assertEquals(0, count($cc->getTabChildren()));
+        $this->assertEquals('pkuid', $cc->getName());
+        $this->assertFalse($cc->isGroupBox());
+        $this->assertFalse($cc->isTabPanel());
+        $this->assertFalse($cc->isContainer());
+        $this->assertFalse($cc->hasChildren());
+        $this->assertEquals('foo-group0-0', $cc->getHtmlId());
+        $this->assertEquals('foo-group0', $cc->getParentId());
+
+        $cc = $c->getChildrenBeforeTab()[1];
+
+        $this->assertEquals(0, count($cc->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($cc->getChildrenAfterTab()));
+        $this->assertEquals(0, count($cc->getTabChildren()));
+        $this->assertEquals('name', $cc->getName());
+        $this->assertFalse($cc->isGroupBox());
+        $this->assertFalse($cc->isTabPanel());
+        $this->assertFalse($cc->isContainer());
+        $this->assertFalse($cc->hasChildren());
+        $this->assertEquals('foo-group0-1', $cc->getHtmlId());
+        $this->assertEquals('foo-group0', $cc->getParentId());
+
+        $cc = $c->getChildrenBeforeTab()[2];
+
+        $this->assertEquals(0, count($cc->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($cc->getChildrenAfterTab()));
+        $this->assertEquals(0, count($cc->getTabChildren()));
+        $this->assertEquals('description', $cc->getName());
+        $this->assertFalse($cc->isGroupBox());
+        $this->assertFalse($cc->isTabPanel());
+        $this->assertFalse($cc->isContainer());
+        $this->assertFalse($cc->hasChildren());
+        $this->assertEquals('foo-group0-2', $cc->getHtmlId());
+        $this->assertEquals('foo-group0', $cc->getParentId());
+    }
+
+    function testTabAttributesForm() {
+        $xml = '<attributeEditorForm>
+        <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Description" groupBox="0" columnCount="0">
+          <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Generic" groupBox="1" columnCount="0">
+            <attributeEditorField showLabel="1" index="0" name="pkuid"/>
+            <attributeEditorField showLabel="1" index="1" name="name"/>
+            <attributeEditorField showLabel="1" index="2" name="description"/>
+          </attributeEditorContainer>
+          <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Other" groupBox="1" columnCount="0">
+            <attributeEditorField showLabel="1" index="4" name="date"/>
+            <attributeEditorField showLabel="1" index="5" name="type"/>
+            <attributeEditorField showLabel="1" index="3" name="user"/>
+          </attributeEditorContainer>
+        </attributeEditorContainer>
+        <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Photo" groupBox="0" columnCount="0">
+          <attributeEditorField showLabel="1" index="6" name="photo"/>
+        </attributeEditorContainer>
+      </attributeEditorForm>';
+        $sXml = simplexml_load_string($xml);
+        $controls = new dummyQgisFormControls();
+        $element = new qgisAttributeEditorElement($controls, $sXml, 'foo', 0,0);
+        $this->assertEquals(0, count($element->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($element->getChildrenAfterTab()));
+        $this->assertEquals(2, count($element->getTabChildren()));
+        $this->assertEquals('', $element->getName());
+        $this->assertFalse($element->isGroupBox());
+        $this->assertFalse($element->isTabPanel());
+        $this->assertTrue($element->isContainer());
+        $this->assertTrue($element->hasChildren());
+        $this->assertEquals('foo', $element->getHtmlId());
+        $this->assertEquals('foo', $element->getParentId());
+
+        $photogroup = $element->getTabChildren()[1];
+
+        $this->assertEquals(1, count($photogroup->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($photogroup->getChildrenAfterTab()));
+        $this->assertEquals(0, count($photogroup->getTabChildren()));
+        $this->assertEquals('Photo', $photogroup->getName());
+        $this->assertFalse($photogroup->isGroupBox());
+        $this->assertTrue($photogroup->isTabPanel());
+        $this->assertTrue($photogroup->isContainer());
+        $this->assertTrue($photogroup->hasChildren());
+        $this->assertEquals('foo-tab1', $photogroup->getHtmlId());
+        $this->assertEquals('foo', $photogroup->getParentId());
+
+        $cc = $photogroup->getChildrenBeforeTab()[0];
+
+        $this->assertEquals(0, count($cc->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($cc->getChildrenAfterTab()));
+        $this->assertEquals(0, count($cc->getTabChildren()));
+        $this->assertEquals('photo', $cc->getName());
+        $this->assertFalse($cc->isGroupBox());
+        $this->assertFalse($cc->isTabPanel());
+        $this->assertFalse($cc->isContainer());
+        $this->assertFalse($cc->hasChildren());
+        $this->assertEquals('foo-tab1-0', $cc->getHtmlId());
+        $this->assertEquals('foo-tab1', $cc->getParentId());
+
+
+        $tab = $element->getTabChildren()[0];
+
+        $this->assertEquals(2, count($tab->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($tab->getChildrenAfterTab()));
+        $this->assertEquals(0, count($tab->getTabChildren()));
+        $this->assertEquals('Description', $tab->getName());
+        $this->assertFalse($tab->isGroupBox());
+        $this->assertTrue($tab->isTabPanel());
+        $this->assertTrue($tab->isContainer());
+        $this->assertTrue($tab->hasChildren());
+        $this->assertEquals('foo-tab0', $tab->getHtmlId());
+        $this->assertEquals('foo', $tab->getParentId());
+
+        $tab1 = $tab->getChildrenBeforeTab()[0];
+
+        $this->assertEquals(3, count($tab1->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($tab1->getChildrenAfterTab()));
+        $this->assertEquals(0, count($tab1->getTabChildren()));
+        $this->assertEquals('Generic', $tab1->getName());
+        $this->assertTrue($tab1->isGroupBox());
+        $this->assertFalse($tab1->isTabPanel());
+        $this->assertTrue($tab1->isContainer());
+        $this->assertTrue($tab1->hasChildren());
+        $this->assertEquals('foo-tab0-group0', $tab1->getHtmlId());
+        $this->assertEquals('foo-tab0', $tab1->getParentId());
+
+        $tab2 = $tab->getChildrenBeforeTab()[1];
+
+        $this->assertEquals(3, count($tab2->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($tab2->getChildrenAfterTab()));
+        $this->assertEquals(0, count($tab2->getTabChildren()));
+        $this->assertEquals('Other', $tab2->getName());
+        $this->assertTrue($tab2->isGroupBox());
+        $this->assertFalse($tab2->isTabPanel());
+        $this->assertTrue($tab2->isContainer());
+        $this->assertTrue($tab2->hasChildren());
+        $this->assertEquals('foo-tab0-group1', $tab2->getHtmlId());
+        $this->assertEquals('foo-tab0', $tab2->getParentId());
+
+
+        $cc = $tab1->getChildrenBeforeTab()[0];
+
+        $this->assertEquals(0, count($cc->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($cc->getChildrenAfterTab()));
+        $this->assertEquals(0, count($cc->getTabChildren()));
+        $this->assertEquals('pkuid', $cc->getName());
+        $this->assertFalse($cc->isGroupBox());
+        $this->assertFalse($cc->isTabPanel());
+        $this->assertFalse($cc->isContainer());
+        $this->assertFalse($cc->hasChildren());
+        $this->assertEquals('foo-tab0-group0-0', $cc->getHtmlId());
+        $this->assertEquals('foo-tab0-group0', $cc->getParentId());
+
+        $cc = $tab1->getChildrenBeforeTab()[1];
+
+        $this->assertEquals(0, count($cc->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($cc->getChildrenAfterTab()));
+        $this->assertEquals(0, count($cc->getTabChildren()));
+        $this->assertEquals('name', $cc->getName());
+        $this->assertFalse($cc->isGroupBox());
+        $this->assertFalse($cc->isTabPanel());
+        $this->assertFalse($cc->isContainer());
+        $this->assertFalse($cc->hasChildren());
+        $this->assertEquals('foo-tab0-group0-1', $cc->getHtmlId());
+        $this->assertEquals('foo-tab0-group0', $cc->getParentId());
+
+        $cc = $tab1->getChildrenBeforeTab()[2];
+
+        $this->assertEquals(0, count($cc->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($cc->getChildrenAfterTab()));
+        $this->assertEquals(0, count($cc->getTabChildren()));
+        $this->assertEquals('description', $cc->getName());
+        $this->assertFalse($cc->isGroupBox());
+        $this->assertFalse($cc->isTabPanel());
+        $this->assertFalse($cc->isContainer());
+        $this->assertFalse($cc->hasChildren());
+        $this->assertEquals('foo-tab0-group0-2', $cc->getHtmlId());
+        $this->assertEquals('foo-tab0-group0', $cc->getParentId());
+
+
+        $cc = $tab2->getChildrenBeforeTab()[0];
+
+        $this->assertEquals(0, count($cc->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($cc->getChildrenAfterTab()));
+        $this->assertEquals(0, count($cc->getTabChildren()));
+        $this->assertEquals('date', $cc->getName());
+        $this->assertFalse($cc->isGroupBox());
+        $this->assertFalse($cc->isTabPanel());
+        $this->assertFalse($cc->isContainer());
+        $this->assertFalse($cc->hasChildren());
+        $this->assertEquals('foo-tab0-group1-0', $cc->getHtmlId());
+        $this->assertEquals('foo-tab0-group1', $cc->getParentId());
+
+        $cc = $tab2->getChildrenBeforeTab()[1];
+
+        $this->assertEquals(0, count($cc->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($cc->getChildrenAfterTab()));
+        $this->assertEquals(0, count($cc->getTabChildren()));
+        $this->assertEquals('type', $cc->getName());
+        $this->assertFalse($cc->isGroupBox());
+        $this->assertFalse($cc->isTabPanel());
+        $this->assertFalse($cc->isContainer());
+        $this->assertFalse($cc->hasChildren());
+        $this->assertEquals('foo-tab0-group1-1', $cc->getHtmlId());
+        $this->assertEquals('foo-tab0-group1', $cc->getParentId());
+
+        $cc = $tab2->getChildrenBeforeTab()[2];
+
+        $this->assertEquals(0, count($cc->getChildrenBeforeTab()));
+        $this->assertEquals(0, count($cc->getChildrenAfterTab()));
+        $this->assertEquals(0, count($cc->getTabChildren()));
+        $this->assertEquals('user', $cc->getName());
+        $this->assertFalse($cc->isGroupBox());
+        $this->assertFalse($cc->isTabPanel());
+        $this->assertFalse($cc->isContainer());
+        $this->assertFalse($cc->hasChildren());
+        $this->assertEquals('foo-tab0-group1-2', $cc->getHtmlId());
+        $this->assertEquals('foo-tab0-group1', $cc->getParentId());
+
+    }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="bootstrap.php">
+  <testsuites>
+    <testsuite name="lizmap">
+
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -2,7 +2,7 @@
 <phpunit bootstrap="bootstrap.php">
   <testsuites>
     <testsuite name="lizmap">
-
+      <directory>edition/</directory>
     </testsuite>
   </testsuites>
 </phpunit>


### PR DESCRIPTION
This set of patchs allows to customize forms generated by qgisForm, used to edit features.

It allows :

- to customize the html, by replacing the new template, by an other one in a theme
- to do things at different steps of the forms' life, by responding to new events, so a custom module can add data processing on edited data, or customize the final form.