### PR TITLE
Fix the type of the features property into layer objects of lizmap

### DIFF
--- a/lizmap/www/js/atlas.js
+++ b/lizmap/www/js/atlas.js
@@ -95,11 +95,8 @@ var lizAtlas = function() {
             var s_field = lizAtlasConfig['sortField'];
             if ( !s_field )
                 s_field = pkey_field;
-            for(var i in lizAtlasConfig.features){
-
+            lizAtlasConfig.features.forEach(function(feat){
                 // Get feature
-                var feat = lizAtlasConfig.features[i];
-                var fid = feat.id.split('.').pop();
                 var pk_val = feat.properties[pkey_field];
 
                 // Add feature in dictionary for further ref
@@ -107,7 +104,7 @@ var lizAtlas = function() {
 
                 // Add feature to sorted oject
                 items.push(feat.properties);
-            }
+            });
 
             items.sort(function(a, b) {
                 var nameA = a[s_field];


### PR DESCRIPTION
It supposed to be an object, as the code in maps.js suggests, but some code in attributeTables.js create this property as an Array instead of an Object.

We fix the type as Object, as it is more efficient than an array, since feature id could be large numbers. 

We don't use a Map because of the support of IE10.