### PR TITLE
Fix bug WFS layers not in attribute table

### DIFF
--- a/lizmap/www/js/attributeTable.js
+++ b/lizmap/www/js/attributeTable.js
@@ -3139,6 +3139,7 @@ var lizAttributeTable = function() {
 
     var options = '';
     var selectionLayersSorted = [];
+    var selectionLayersNotSorted = [];
     featureTypes.each( function(){
         var self = $(this);
         var lname = lizMap.getNameByTypeName( self.find('Name').text() );
@@ -3147,11 +3148,22 @@ var lizAttributeTable = function() {
             && config.layers[lname]['geometryType'] != 'none'
             && config.layers[lname]['geometryType'] != 'unknown') {
             var lConfig = config.layers[lname];
-            selectionLayersSorted[config.attributeLayers[lname].order] = '<option value="'+lname+'">'+lConfig.title+'</option>';        }
+            var selectionOption = '<option value="'+lname+'">'+lConfig.title+'</option>';
+
+            if(lname in config.attributeLayers){
+                selectionLayersSorted[config.attributeLayers[lname].order] = selectionOption;
+            }else{
+                selectionLayersNotSorted.push(selectionOption);
+            }
+        }
     });
 
+    // We put selection layers which are also set in attribute table tool first then others
     for (var i = 0; i < selectionLayersSorted.length; i++) {
         options += selectionLayersSorted[i];
+    }
+    for (var i = 0; i < selectionLayersNotSorted.length; i++) {
+        options += selectionLayersNotSorted[i];
     }
 
     if ( options == '' ) {


### PR DESCRIPTION
Fix #1125 and probably a bug when users activate WFS for a layer and don't use it in attribute table.