### PR TITLE
map.js, getLayerFeature: aCallbackNotfound and forceToLoad parameters

### DIFF
--- a/lizmap/www/js/map.js
+++ b/lizmap/www/js/map.js
@@ -6052,8 +6052,8 @@ OpenLayers.Control.HighlightFeature = OpenLayers.Class(OpenLayers.Control, {
     /**
      * Method: getLayerFeature
      */
-    getLayerFeature: function( featureType, fid, aCallback ) {
-      getLayerFeature( featureType, fid, aCallback );
+    getLayerFeature: function( featureType, fid, aCallback, aCallbackNotfound, forceToLoad ) {
+      getLayerFeature( featureType, fid, aCallback, aCallbackNotfound, forceToLoad );
     },
 
     /**

--- a/lizmap/www/js/map.js
+++ b/lizmap/www/js/map.js
@@ -5628,10 +5628,9 @@ OpenLayers.Control.HighlightFeature = OpenLayers.Class(OpenLayers.Control, {
       });
   }
 
-  function getLayerFeature( featureType, fid, aCallback ){
+  function getLayerFeature( featureType, fid, aCallback, aCallbackNotfound, forceToLoad ){
       if ( !aCallback )
           return;
-
       if ( !(featureType in config.layers) )
           return;
 
@@ -5639,19 +5638,24 @@ OpenLayers.Control.HighlightFeature = OpenLayers.Class(OpenLayers.Control, {
       var featureId = featureType + '.' + fid;
 
       // Use already retrieved feature
-      if( layerConfig['features'] && fid in layerConfig['features'] ){
+      if(!forceToLoad && layerConfig['features'] && fid in layerConfig['features'] ){
           aCallback(layerConfig['features'][fid]);
       }
       // Or get the feature via WFS in needed
       else{
           getFeatureData(featureType, null, featureId, 'extent', false, null, null,
-            function( aName, aFilter, cFeatures, cAliases ){
-              if( cFeatures.length == 1 ){
+              function( aName, aFilter, cFeatures, cAliases ){
+
+              if (cFeatures.length == 1) {
                   var feat = cFeatures[0];
-                  if( !layerConfig['features'] )
+                  if( !layerConfig['features'] ) {
                       layerConfig['features'] = {};
+                  }
                   layerConfig['features'][fid] = feat;
                   aCallback(feat);
+              }
+              else if(aCallbackNotfound) {
+                  aCallbackNotfound(featureType, fid);
               }
           });
       }
@@ -5714,7 +5718,7 @@ OpenLayers.Control.HighlightFeature = OpenLayers.Class(OpenLayers.Control, {
           crs = lizMap.config.layers[qgisName].crs;
       }
 
-      wmsOptions = {
+      var wmsOptions = {
            'LAYERS': aName
           ,'QUERY_LAYERS': aName
           ,'STYLES': ''
@@ -5726,7 +5730,7 @@ OpenLayers.Control.HighlightFeature = OpenLayers.Class(OpenLayers.Control, {
           ,'INFO_FORMAT': 'text/html'
           ,'FEATURE_COUNT': 1
           ,'FILTER': filter
-      }
+      };
 
       // Query the server
       var service = OpenLayers.Util.urlAppend(lizUrls.wms


### PR DESCRIPTION
We may need to know when the feature was not loaded, so this new
callback parameter.

Some time, a feature may appear into several layer. If it is modified
into a layer, and its WFS data already loaded for an other layer, this
data are not updated. An ugly solution is to force to load the data, by
the code which knows that the feature it processes may not be updated..