### PR TITLE
Allow disabling project switcher completely

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -1591,7 +1591,7 @@ class lizmapProject extends qgisProject
         $services = lizmap::getServices();
 
         // only maps and show project switcher
-        if ($services->onlyMaps or $services->projectSwitcher) {
+        if ($services->projectSwitcher) {
             $dockableName = 'projects';
             if ($services->onlyMaps) {
                 $dockableName = 'home';

--- a/lizmap/modules/view/templates/map_menu.tpl
+++ b/lizmap/modules/view/templates/map_menu.tpl
@@ -1,18 +1,16 @@
 <div style="">
     <ul class="nav nav-list">
       {assign $onlyMaps=False}
-      {assign $hometitle=@view~default.repository.list.title@}
+      {assign $hometitle=@view~default.home.title@}
       {foreach $dockable as $dock}
         {if $dock->id == 'home'}
+          {assign $hometitle=@view~default.repository.list.title@}
           {assign $onlyMaps=True}
         {/if}
         {if $dock->id == 'projects'}
           {assign $hometitle=@view~default.home.title@}
         {/if}
       {/foreach}
-      {if $onlyMaps }
-        {assign $hometitle="Reload"}
-      {/if}
       {if !$onlyMaps }
       <li class="home">
         <a href="{jurl 'view~default:index'}" rel="tooltip" data-original-title="{$hometitle}" data-placement="right" data-container="#content">

--- a/lizmap/modules/view/templates/map_menu.tpl
+++ b/lizmap/modules/view/templates/map_menu.tpl
@@ -11,7 +11,7 @@
           {assign $hometitle=@view~default.home.title@}
         {/if}
       {/foreach}
-      {if !$onlyMaps }
+      {if !$onlyMaps}
       <li class="home">
         <a href="{jurl 'view~default:index'}" rel="tooltip" data-original-title="{$hometitle}" data-placement="right" data-container="#content">
           <span class="icon"></span>

--- a/lizmap/modules/view/templates/map_menu.tpl
+++ b/lizmap/modules/view/templates/map_menu.tpl
@@ -10,7 +10,10 @@
           {assign $hometitle=@view~default.home.title@}
         {/if}
       {/foreach}
-      {if !$onlyMaps}
+      {if $onlyMaps }
+        {assign $hometitle="Reload"}
+      {/if}
+      {if !$onlyMaps }
       <li class="home">
         <a href="{jurl 'view~default:index'}" rel="tooltip" data-original-title="{$hometitle}" data-placement="right" data-container="#content">
           <span class="icon"></span>


### PR DESCRIPTION
This will allow completely turning off the project switcher effectively allowing lizmap to be used in a single map mode.
The behavior is:
- Onlymaps ON, projectswitcher ON: show one house icon for the project switcher (usual LM behavior)
- Onlymaps ON, projectswitcher OFF: show one house icon to reload the current map
- Onlymaps OFF, projectswitcher ON: show two icons (house and folder) to either go to project listing or show the project switcher
- Onlymaps OFF, projectswitcher OFF: show one house icon to go to project listing 