### PR TITLE
Fix process of the alias parameter to qgisFormControl

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisFormControl.class.php
+++ b/lizmap/modules/lizmap/classes/qgisFormControl.class.php
@@ -166,7 +166,7 @@ class qgisFormControl
      *
      * @param string           $ref                name of the control
      * @param SimpleXMLElement $edittype           simplexml object corresponding to the QGIS edittype for this field
-     * @param object           $aliasXml           simplexml object corresponding to the QGIS alias for this field
+     * @param object|array|string $aliasXml        simplexml object corresponding to the QGIS alias for this field
      * @param object           $rendererCategories simplexml object corresponding to the QGIS categories of the renderer
      * @param object           $prop               Jelix object with field properties (datatype, required, etc.)
      */
@@ -202,7 +202,9 @@ class qgisFormControl
         // Set class attributes
         $this->ref = $ref;
         $this->fieldName = $ref;
-        if ($aliasXml and is_array($aliasXml) and count($aliasXml) != 0) {
+        if (is_string($aliasXml)) {
+            $this->fieldAlias = $aliasXml;
+        } elseif ($aliasXml and is_array($aliasXml) and count($aliasXml) != 0) {
             $this->fieldAlias = (string) $aliasXml[0]->attributes()->name;
         } elseif ($aliasXml and count($aliasXml) != 0) {
             $this->fieldAlias = $aliasXml;


### PR DESCRIPTION
qgisFormControl is expecting to receive a simpleXml object for the alias parameter, whereas it seems it receives a simple string.

Let's keep the process of the simpleXml object to not break custom modules, but check if it is a simple string to avoid warnings