### PR TITLE
Use Qgis default value to set default value on form controls

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisFormControl.class.php
+++ b/lizmap/modules/lizmap/classes/qgisFormControl.class.php
@@ -28,6 +28,9 @@ class qgisFormControl
     // Qgis field name
     public $fieldName = '';
 
+    // QGIS default value
+    public $defaultValue = null;
+
     // Qgis field type
     public $fieldEditType = '';
 
@@ -171,11 +174,12 @@ class qgisFormControl
      *
      * @param string           $ref                name of the control
      * @param SimpleXMLElement $edittype           simplexml object corresponding to the QGIS edittype for this field
-     * @param object|array|string $aliasXml        simplexml object corresponding to the QGIS alias for this field
-     * @param object           $rendererCategories simplexml object corresponding to the QGIS categories of the renderer
      * @param object           $prop               Jelix object with field properties (datatype, required, etc.)
+     * @param object|array|string $aliasXml        simplexml object corresponding to the QGIS alias for this field
+     * @param string           $defaultValue       the QGIS expression of the default value
+     * @param object           $rendererCategories simplexml object corresponding to the QGIS categories of the renderer
      */
-    public function __construct($ref, $edittype, $aliasXml = null, $rendererCategories = null, $prop)
+    public function __construct($ref, $edittype, $prop, $aliasXml = null, $defaultValue=null, $rendererCategories = null)
     {
 
     // Add new editTypes naming convention since QGIS 2.4
@@ -215,6 +219,8 @@ class qgisFormControl
             $this->fieldAlias = $aliasXml;
         }
         $this->fieldDataType = $this->castDataType[strtolower($prop->type)];
+
+        $this->defaultValue = $defaultValue;
 
         if ($prop->notNull && !$prop->autoIncrement) {
             $this->required = true;
@@ -526,6 +532,10 @@ class qgisFormControl
         // Required
         if ($this->required) {
             $this->ctrl->required = true;
+        }
+
+        if ($this->defaultValue !== null) {
+            $this->ctrl->defaultValue = $this->defaultValue;
         }
     }
 

--- a/lizmap/modules/lizmap/classes/qgisProject.class.php
+++ b/lizmap/modules/lizmap/classes/qgisProject.class.php
@@ -574,7 +574,7 @@ class qgisProject
     {
         $WMSUseLayerIDs = $xml->xpath('//properties/WMSUseLayerIDs');
 
-        return  $WMSUseLayerIDs && count($WMSUseLayerIDs) > 0 && $WMSUseLayerIDs[0] == 'true';
+        return $WMSUseLayerIDs && count($WMSUseLayerIDs) > 0 && $WMSUseLayerIDs[0] == 'true';
     }
 
     /**
@@ -624,7 +624,6 @@ class qgisProject
                     }
                 }
 
-                $items = $xmlLayer->xpath('//item');
                 if ($layer['title'] == '') {
                     $layer['title'] = $layer['name'];
                 }
@@ -632,6 +631,7 @@ class qgisProject
                     $fields = array();
                     $wfsFields = array();
                     $aliases = array();
+                    $defaults = array();
                     $edittypes = $xmlLayer->xpath('.//edittype');
                     if ($edittypes) {
                         foreach ($edittypes as $edittype) {
@@ -641,6 +641,8 @@ class qgisProject
                             }
                             $fields[] = $field;
                             $wfsFields[] = $field;
+                            $aliases[$field] = $field;
+                            $defaults[$field] = null;
                         }
                     } else {
                         $fieldconfigurations = $xmlLayer->xpath('.//fieldConfiguration/field');
@@ -652,19 +654,27 @@ class qgisProject
                                 }
                                 $fields[] = $field;
                                 $wfsFields[] = $field;
+                                $aliases[$field] = $field;
+                                $defaults[$field] = null;
                             }
                         }
                     }
-                    foreach ($fields as $field) {
-                        $aliases[$field] = $field;
-                        $alias = $xmlLayer->xpath("aliases/alias[@field='".$field."']");
-                        if ($alias && count($alias) != 0) {
-                            $alias = $alias[0];
-                            $aliases[$field] = (string) $alias['name'];
+
+                    if (isset($xmlLayer->aliases->alias)) {
+                        foreach($xmlLayer->aliases->alias as $alias) {
+                            $aliases[(string) $alias['field']] = (string) $alias['name'];
                         }
                     }
+
+                    if (isset($xmlLayer->defaults->default)) {
+                        foreach($xmlLayer->defaults->default as $default) {
+                            $defaults[(string) $default['field']] = (string) $default['expression'];
+                        }
+                    }
+
                     $layer['fields'] = $fields;
                     $layer['aliases'] = $aliases;
+                    $layer['defaults'] = $defaults;
                     $layer['wfsFields'] = $wfsFields;
 
                     $excludeFields = $xmlLayer->xpath('.//excludeAttributesWFS/attribute');

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -16,7 +16,15 @@ class qgisVectorLayer extends qgisMapLayer
 
     protected $fields = array();
 
+    /**
+     * @var string[]  list of aliases name for each fields
+     */
     protected $aliases = array();
+
+    /**
+     * @var string[]  list of default value (as QGIS expressions) for each fields
+     */
+    protected $defaultValues = array();
 
     protected $wfsFields = array();
 
@@ -57,6 +65,7 @@ class qgisVectorLayer extends qgisMapLayer
         parent::__construct($project, $propLayer);
         $this->fields = $propLayer['fields'];
         $this->aliases = $propLayer['aliases'];
+        $this->defaultValues = $propLayer['defaults'];
         $this->wfsFields = $propLayer['wfsFields'];
     }
 
@@ -65,9 +74,39 @@ class qgisVectorLayer extends qgisMapLayer
         return $this->fields;
     }
 
+    /**
+     * list of aliases
+     * @return string[]
+     */
     public function getAliasFields()
     {
         return $this->aliases;
+    }
+
+    /**
+     * List of default values for each fields
+     *
+     * Values are QGIS expressions or may be null when no default value is given
+     *
+     * @return string[]
+     */
+    public function getDefaultValues()
+    {
+        return $this->defaultValues;
+    }
+
+    /**
+     * Get the QGIS expression of the default value of the given field
+     *
+     * @param string $fieldName
+     * @return string|null null if there is no default value
+     */
+    public function getDefaultValue($fieldName)
+    {
+        if (isset($this->defaultValues[$fieldName])) {
+            return $this->defaultValues[$fieldName];
+        }
+        return null;
     }
 
     public function getWfsFields()

--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -1381,6 +1381,7 @@ class serviceCtrl extends jController
                 $layer = $this->project->getLayer($layer->id);
                 $aliases = $layer->getAliasFields();
                 $jsonData['aliases'] = (object) $aliases;
+                $jsonData['defaults'] = (object) $layer->getDefaultValues();
             }
             $jsonData = json_encode((object) $jsonData);
 


### PR DESCRIPTION
Default values other than raw strings or number, are ignored.

Parameters of qgisFormControl constructor are changed:
- new parameter $defaultValue
- $prop parameter is put before parameters that have a default value,
  else it is not a correct php syntax.