### PR TITLE
[Bugfix] Add local JS for date picker form widget

### DIFF
--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -145,8 +145,21 @@ class lizMapCtrl extends jController
         $www = $confUrlEngine['jelixWWWPath'];
         $rep->addJSLink($www.'jquery/include/jquery.include.js');
         $rep->addJSLink($www.'js/jforms_jquery.js');
-        $rep->addJSLink($www.'js/jforms/datepickers/default/init.js');
-        $rep->addJSLink($www.'js/jforms/datepickers/default/ui.en.js');
+
+        // Add datepickers jForms js
+        $confDate = &jApp::config()->datepickers;
+        $rep->addJSLink($confDate['default']);
+        if (isset($confDate['default.js'])) {
+            $js = $confDate['default.js'];
+            foreach($js as $file) {
+                $file = str_replace('$lang', jLocale::getCurrentLang(), $file);
+                if (strpos($file, 'jquery.ui.datepicker-en.js') !== false) {
+                    continue;
+                }
+                $rep->addJSLink($file);
+            }
+        }
+        // Add other jForms js
         $rep->addJSLink($bp.'js/fileUpload/jquery.fileupload.js');
         $rep->addJSLink($bp.'js/bootstrapErrorDecoratorHtml.js');
 


### PR DESCRIPTION
Locale files for date picker widget was not added to the html map template, so date picker in edition form was not localized.

This PR completed the commit 1784a4e52114043ec9fb27af5fb6a622ab54a0e5 and the fix of
edition form - date widget display #521