### PR TITLE
Fix issues with temporary files created by lizmapWFSRequests

### DIFF
--- a/lib/jelix/core/response/jResponseBinary.class.php
+++ b/lib/jelix/core/response/jResponseBinary.class.php
@@ -56,6 +56,11 @@ final class jResponseBinary  extends jResponse {
     public $mimeType = 'application/octet-stream';
 
     /**
+     * Delete file after the upload
+     */
+    public $deleteFileAfterSending = false;
+
+    /**
      * send the content or the file to the browser.
      * @return bool true it it's ok
      * @throws jException
@@ -83,9 +88,17 @@ final class jResponseBinary  extends jResponse {
             if (is_readable ($this->fileName) && is_file ($this->fileName)) {
                 $this->_httpHeaders['Content-Length']=filesize ($this->fileName);
                 $this->sendHttpHeaders();
+                if ($this->deleteFileAfterSending) {
+                    // ignore, to be able to delete file
+                    ignore_user_abort(true);
+                }
                 session_write_close();
                 readfile ($this->fileName);
                 flush();
+                if ($this->deleteFileAfterSending) {
+                    ob_clean();
+                    unlink($this->fileName);
+                }
             }
             else {
                 throw new jException('jelix~errors.repbin.unknown.file' , $this->fileName);

--- a/lizmap/modules/lizmap/classes/lizmapWFSRequest.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapWFSRequest.class.php
@@ -389,7 +389,7 @@ class lizmapWFSRequest extends lizmapOGCRequest
         // To avoid memory issues, we do not ask PostgreSQL for a unique big line containing the geojson
         // but asked for a feature in JSON per line
         // the we store the data into a file
-        $path = sys_get_temp_dir().'/'.time().session_id().'_wfs'.'.csv';
+        $path = tempnam(sys_get_temp_dir(), 'wfs_'.session_id().'_');
         $fd = fopen($path, 'w');
         fwrite($fd, '
 {

--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -1286,6 +1286,7 @@ class serviceCtrl extends jController
 
         if (property_exists($result, 'file') and $result->file and is_file($result->data)) {
             $rep->fileName = $result->data;
+            $rep->deleteFileAfterSending = true;
         } else {
             $rep->content = $result->data; // causes memory_limit for big content
         }
@@ -1298,9 +1299,7 @@ class serviceCtrl extends jController
             // force download
             $rep->doDownload = true;
 
-            if (property_exists($result, 'file') and $result->file and is_file($result->data)) {
-                $rep->fileName = $result->data;
-            } else {
+            if ($rep->fileName == '' && $rep->content != '') {
                 // debug 1st line blank from QGIS Server
                 $rep->content = preg_replace('/^[\n\r]/', '', $result->data);
             }


### PR DESCRIPTION
- fix the name of the file to have a unique name per requests
- delete files after sending them to the browser to keep a clean /tmp

Refs #1185