### PR TITLE
allow setting the layers opacity levels in custom JS

### DIFF
--- a/lizmap/www/js/switcher-layers-actions.js
+++ b/lizmap/www/js/switcher-layers-actions.js
@@ -149,7 +149,10 @@ var lizLayerActionButtons = function() {
                     currentOpacity = opacityLayers[aName];
                 }
                 html+= '<input type="hidden" class="opacityLayer '+isBaselayer+'" value="'+aName+'">';
-                var opacities = [0.2, 0.4, 0.6, 0.8, 1];
+                var opacities = lizMap.config.options.layersOpacities;
+                if(typeof opacities === 'undefined') {
+                    opacities = [0.2, 0.4, 0.6, 0.8, 1];
+                    }
                 for ( var i=0, len=opacities.length; i<len; i++ ) {
                     var oactive = '';
                     if(currentOpacity == opacities[i])


### PR DESCRIPTION
the default behaviour is not changed
but in a custom script, one can do
```

lizMap.events.on({
    uicreated: function(e) {
        lizMap.config.options.layerOpacities = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1];
    }
});
```
in future this could be added to the plugin config
Signed-off-by: Marco Bernasocchi <marco@opengis.ch>