### PR TITLE
Fix edit geometry

### DIFF
--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -557,7 +557,8 @@ class editionCtrl extends jController
 
         // Check the form data and redirect if needed
         $check = $form->check();
-        if ($this->geometryColumn != '' && $form->getData($this->geometryColumn) == '') {
+        $modifyGeometry = $this->layer->getEditionCapabilities()->capabilities->modifyGeometry;
+        if (strtolower($modifyGeometry) == 'true' && $this->geometryColumn != '' && $form->getData($this->geometryColumn) == '') {
             $check = false;
             $form->setErrorOn($this->geometryColumn, jLocale::get('view~edition.message.error.no.geometry'));
         }

--- a/lizmap/www/js/edition.js
+++ b/lizmap/www/js/edition.js
@@ -1310,7 +1310,7 @@ OpenLayers.Geometry.pointOnSegment = function(point, segment) {
         $('#' + submit_hidden_id).val(editionLayer['submitActor']);
 
         var msg = 'ok';
-        if( editionLayer['spatial'] ){
+        if( editionLayer['spatial'] && editionLayer['config'].capabilities.modifyGeometry == 'True'){
 
             var gColumn = form.find('input[name="liz_geometryColumn"]').val();
             var formGeom = form.find('input[name="'+gColumn+'"]').val();


### PR DESCRIPTION
We should not have an error "You cannot save this object without a geometry. Please draw the geometry on the map.", when creating a feature on a layer having the modifyGeometry capability set to false.

This is the case when the layer is based on an SQL view, so on which the geometry field is in read-only. The code that verify the value of the geometry field, should honor the modifyGeometry capability.