### PR TITLE
Hide the "data" button when there is no displayed attribute tables

### DIFF
--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -15,7 +15,11 @@ class lizMapCtrl extends jController
     protected $repositoryKey;
     // projectKey: Used to pass project key
     protected $projectKey;
-    // projectObj: Used to pass project Object (no need to rebuild it)
+
+    /**
+     * Used to pass project Object (no need to rebuild it)
+     * @var lizmapProject
+     */
     protected $projectObj;
 
     // forceHiddenProjectVisible: Used to override plugin configuration hideProject


### PR DESCRIPTION
The data panel and its corresponding button should not be shown when
there is no attribute table set with the "hideLayer=False" into the
map configuration.