### PR TITLE
Force hidden legend only when active Fix #994

### DIFF
--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -435,7 +435,7 @@ class lizMapCtrl extends jController
       $( document ).ready( function() {
         lizMap.events.on({
           'uicreated':function(evt){
-            $('#button-switcher').click();
+            $('li.switcher.active #button-switcher').click();
           }
         });
       });


### PR DESCRIPTION
We should avoid javascript to hide legend but I let it like it is because there might be some side effects I'm not aware of