### PR TITLE
[Fix] Filter: Use AND for unique values with splitter

### DIFF
--- a/lizmap/www/js/filter.js
+++ b/lizmap/www/js/filter.js
@@ -538,7 +538,7 @@ var lizLayerFilterTool = function() {
                         var cval = clist[i];
                         filter+= sep + '"' + field + '"' + " " + lk + " '%" + cval + "%' ";
                         // if postgresql use ILIKE instead for WMS filtered requests
-                        sep = ' OR ';
+                        sep = ' AND ';
                     }
                     filter+= ' ) ';
                 } else {


### PR DESCRIPTION
In filter forms, for unique values with splitter defined, use AND for fiter to find features with all selected values.