### PR TITLE
[Bugfix] Print layer opacities

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -302,6 +302,20 @@ class lizmapProject extends qgisProject
             }
         }
 
+        $layerWithOpacities = $qgs_xml->xpath('//maplayer/layerOpacity[.!=1]/parent::*');
+        if ($layerWithOpacities && count($layerWithOpacities) > 0) {
+            jLog::log('Layers with opacities', 'error');
+            foreach( $layerWithOpacities as $layerWithOpacitiy ) {
+                $name = (string) $layerWithOpacitiy->layername;
+                jLog::log('Layer with opacity: '.$name, 'error');
+                if (property_exists($this->cfg->layers, $name)) {
+                    $opacity = (float) $layerWithOpacitiy->layerOpacity;
+                    jLog::log('Layer with opacity: '.$name.' '.$opacity, 'error');
+                    $this->cfg->layers->{$name}->opacity = $opacity;
+                }
+            }
+        }
+
         $groupsWithShortName = $qgs_xml->xpath("//layer-tree-group/customproperties/property[@key='wmsShortName']/parent::*/parent::*");
         if ($groupsWithShortName && count($groupsWithShortName) > 0) {
             foreach ($groupsWithShortName as $group) {

--- a/lizmap/www/js/map.js
+++ b/lizmap/www/js/map.js
@@ -4217,7 +4217,22 @@ var lizMap = function() {
               if( 'STYLES' in l.params && l.params['STYLES'].length > 0 )
                 lst = l.params['STYLES'];
               styleLayers.push( lst );
-              opacityLayers.push(parseInt(255*l.opacity));
+
+              // Get config to get qgis layer opacity
+              var qgisName = null;
+              if ( l.name in cleanNameMap )
+                  qgisName = getLayerNameByCleanName(layer.name);
+              var configLayer = null;
+              if ( qgisName )
+                  configLayer = config.layers[qgisName];
+              if ( !configLayer )
+                  configLayer = config.layers[l.params['LAYERS']];
+              if ( !configLayer )
+                  configLayer = config.layers[l.name];
+              if ( configLayer && ('opacity' in configLayer) )
+                opacityLayers.push(parseInt(255*l.opacity*configLayer.opacity));
+              else
+                opacityLayers.push(parseInt(255*l.opacity));
             }
         }
       });


### PR DESCRIPTION
The `GetPrint` request's `OPACITIES` parameter overrides the layer opacities define in QGIS Project.

To fix it, lizmap reads the layer opacities in QGIS project, provides it in config and use it in `GetPrint` url.