### PR TITLE
New commands to migrate lizmap data from a sqlite database to pgsql/mysql

### DIFF
--- a/lizmap/modules/lizmap/controllers/config.cmdline.php
+++ b/lizmap/modules/lizmap/controllers/config.cmdline.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @copyright 2019 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license   MPL-2.0
+ */
+
+
+class configCtrl extends jControllerCmdLine
+{
+    /**
+     * Options to the command line
+     *  'method_name' => array('-option_name' => true/false)
+     * true means that a value should be provided for the option on the command line.
+     */
+    protected $allowed_options = array(
+    );
+
+    /**
+     * Parameters for the command line
+     * 'method_name' => array('parameter_name' => true/false)
+     * false means that the parameter is optional. All parameters which follow an optional parameter
+     * is optional.
+     */
+    protected $allowed_parameters = array(
+        'migratelog' => array(
+        ),
+        'migrateusers' => array(
+        ),
+    );
+
+    /**
+     * Help.
+     */
+    public $help = array(
+
+        'migratelog' => 'Migrate log data from a sqlite database to the current database
+
+        Use :
+        php lizmap/scripts/script.php lizmap~config:migratelog
+
+        ',
+        'migrateusers' => 'Migrate users data from a sqlite database to the current database (experimental)
+
+        Use :
+        php lizmap/scripts/script.php lizmap~config:migrateusers
+
+        ',
+    );
+
+
+    /**
+     * Migrate log data from a sqlite database to the current database
+     */
+    public function migratelog()
+    {
+        /** @var jResponseCmdline $rep */
+        $rep = $this->getResponse();
+        $logMigrator = new \Lizmap\Logger\MigratorFromSqlite();
+        try {
+            $res = $logMigrator->migrateLog();
+        }
+        catch(\UnexpectedValueException $e) {
+            $rep->addContent("Error during the migration: ".$e->getMessage()."\n");
+            $rep->setExitCode(1);
+            return $rep;
+        }
+
+        switch ($res) {
+            case $logMigrator::MIGRATE_RES_ALREADY_MIGRATED:
+                $rep->addContent("It seems already migrated, there are some data into logCounter or logDetail table\n");
+                break;
+            case $logMigrator::MIGRATE_RES_OK:
+                $rep->addContent("Migration done\n");
+                break;
+            case 0:
+                $rep->addContent("Unknown error\n");
+                break;
+            default:
+                $rep->addContent("Unknown result\n");
+        }
+        return $rep;
+    }
+
+
+    /**
+     * Migrate users data from a sqlite database to the current database
+     */
+    public function migrateusers()
+    {
+        /** @var jResponseCmdline $rep */
+        $rep = $this->getResponse();
+        $logMigrator = new \Lizmap\Users\MigratorFromSqlite();
+        try {
+            $res = $logMigrator->migrateUsersAndRights();
+        }
+        catch(\UnexpectedValueException $e) {
+            $rep->addContent("Error during the migration: ".$e->getMessage()."\n");
+            $rep->setExitCode(1);
+            return $rep;
+        }
+
+        switch ($res) {
+            case $logMigrator::MIGRATE_RES_ALREADY_MIGRATED:
+                $rep->addContent("It seems already migrated, there are some data into existing users tables\n");
+                break;
+            case $logMigrator::MIGRATE_RES_OK:
+                $rep->addContent("Migration done\n");
+                break;
+            case 0:
+                $rep->addContent("Unknown error\n");
+                break;
+            default:
+                $rep->addContent("Unknown result\n");
+        }
+        return $rep;
+    }
+}

--- a/lizmap/modules/lizmap/controllers/database.cmdline.php
+++ b/lizmap/modules/lizmap/controllers/database.cmdline.php
@@ -8,7 +8,7 @@
  */
 
 
-class configCtrl extends jControllerCmdLine
+class databaseCtrl extends jControllerCmdLine
 {
     /**
      * Options to the command line
@@ -39,13 +39,13 @@ class configCtrl extends jControllerCmdLine
         'migratelog' => 'Migrate log data from a sqlite database to the current database
 
         Use :
-        php lizmap/scripts/script.php lizmap~config:migratelog
+        php lizmap/scripts/script.php lizmap~database:migratelog
 
         ',
         'migrateusers' => 'Migrate users data from a sqlite database to the current database (experimental)
 
         Use :
-        php lizmap/scripts/script.php lizmap~config:migrateusers
+        php lizmap/scripts/script.php lizmap~database:migrateusers
 
         ',
     );
@@ -83,7 +83,6 @@ class configCtrl extends jControllerCmdLine
         }
         return $rep;
     }
-
 
     /**
      * Migrate users data from a sqlite database to the current database

--- a/lizmap/modules/lizmap/install/sql/lizlog.mysql.sql
+++ b/lizmap/modules/lizmap/install/sql/lizlog.mysql.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `log_detail` (
+CREATE TABLE IF NOT EXISTS `log_detail` (
     `id` INTEGER  AUTO_INCREMENT NOT NULL,
     `log_key` VARCHAR(100) NOT NULL ,
     `log_timestamp` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -10,7 +10,7 @@ CREATE TABLE `log_detail` (
     PRIMARY KEY (`id`)
 );
 
-CREATE TABLE `log_counter` (
+CREATE TABLE IF NOT EXISTS `log_counter` (
     `id` INTEGER AUTO_INCREMENT  NOT NULL ,
     `key` VARCHAR(100) NOT NULL ,
     `counter` INTEGER,

--- a/lizmap/modules/lizmap/lib/Logger/MigratorFromSqlite.php
+++ b/lizmap/modules/lizmap/lib/Logger/MigratorFromSqlite.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * @author    3liz
+ * @copyright 2019 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+namespace Lizmap\Logger;
+
+
+class MigratorFromSqlite {
+
+    function __construct()
+    {
+
+    }
+
+    const MIGRATE_RES_OK = 1;
+    const MIGRATE_RES_ALREADY_MIGRATED = 2;
+
+    protected function copyTable($daoSelector, $oldProfile, $newProfile)
+    {
+        $daoNew = \jDao::get($daoSelector, $newProfile);
+        $daoSqlite = \jDao::create($daoSelector, $oldProfile);
+        $properties = array_keys($daoSqlite->getProperties());
+        foreach($daoSqlite->findAll() as $rec) {
+            $daoRec = \jDao::createRecord($daoSelector, $newProfile);
+            foreach($properties as $prop) {
+                $daoRec->$prop = $rec->$prop;
+            }
+            $daoNew->insert($daoRec);
+        }
+    }
+
+    function migrateLog($profileName = 'lizlog') {
+
+        $profile = \jProfiles::get('jdb', $profileName);
+        if (!$profile) {
+            throw new \UnexpectedValueException('No lizlog profile defined into profiles.ini.php', 1);
+        }
+
+        if ($profile['driver'] == 'sqlite3') {
+            throw new \UnexpectedValueException('Database for lizlog is still sqlite3. Configure the lizlog profile onto an other database type into profiles.ini.php', 2);
+        }
+
+        $sqliteFile = \jApp::varPath('db/logs.db');
+        if (!file_exists($sqliteFile)) {
+            throw new \UnexpectedValueException('No logs.db file containing logs to migrate', 3);
+        }
+
+        $jdbParams = array(
+            'driver' => 'sqlite3',
+            'database' => 'var:db/logs.db',
+        );
+
+        // Create the virtual jdb profile
+        \jProfiles::createVirtualProfile('jdb', 'oldlizlog', $jdbParams);
+        $this->createLogTables($profileName);
+
+        $daoCounterNew = \jDao::create('lizmap~logCounter', $profileName);
+        $daoDetailsNew = \jDao::get('lizmap~logDetail', $profileName);
+
+        if ($daoCounterNew->countAll() > 0 || $daoDetailsNew->countAll() > 0) {
+            return self::MIGRATE_RES_ALREADY_MIGRATED;
+        }
+
+        $this->copyTable('lizmap~logCounter', 'oldlizlog', $profileName);
+        $this->copyTable('lizmap~logDetail', 'oldlizlog', $profileName);
+
+        return self::MIGRATE_RES_OK;
+    }
+
+
+    protected function createLogTables($profile) {
+
+        $db = \jDb::getConnection($profile);
+        $tools = $db->tools();
+        $file = \jApp::getModulePath('lizmap').'/install/sql/lizlog.'.$db->dbms.'.sql';
+        $db->beginTransaction();
+        try {
+            $tools->execSQLScript($file);
+            $db->commit();
+        }
+        catch(\Exception $e) {
+            $db->rollback();
+            throw $e;
+        }
+    }
+}

--- a/lizmap/modules/lizmap/lib/Users/MigratorFromSqlite.php
+++ b/lizmap/modules/lizmap/lib/Users/MigratorFromSqlite.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * @author    3liz
+ * @copyright 2019 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+namespace Lizmap\Users;
+
+
+class MigratorFromSqlite {
+
+    function __construct()
+    {
+
+    }
+
+    const MIGRATE_RES_OK = 1;
+    const MIGRATE_RES_ALREADY_MIGRATED = 2;
+
+    function migrateUsersAndRights() {
+
+        $sqliteFile = \jApp::varPath('db/jauth.db');
+        if (!file_exists($sqliteFile)) {
+            throw new \UnexpectedValueException('No jauth.db file containing users to migrate', 3);
+        }
+
+        list($daoUserSelector, $profile) = $this->createUsersTables();
+        $this->createAclTables($profile);
+
+        $jdbParams = array(
+            'driver' => 'sqlite3',
+            'database' => 'var:db/jauth.db',
+        );
+
+        // Create the virtual jdb profile
+        \jProfiles::createVirtualProfile('jdb', 'oldjauth', $jdbParams);
+
+        $daoUsersNew = \jDao::create($daoUserSelector, $profile);
+        $daoGeoBkmNew = \jDao::get('lizmap~geobookmark', $profile);
+
+        if ($daoUsersNew->countAll() > 0 || $daoGeoBkmNew->countAll() > 0) {
+            return self::MIGRATE_RES_ALREADY_MIGRATED;
+        }
+
+        $this->copyTable($daoUserSelector, 'oldjauth', $profile);
+        $this->copyTable('lizmap~geobookmark', 'oldjauth', $profile);
+        $this->copyTable('jacl2db~jacl2subjectgroup', 'oldjauth', $profile);
+        $this->copyTable('jacl2db~jacl2subject', 'oldjauth', $profile);
+        $this->copyTable('jacl2db~jacl2group', 'oldjauth', $profile);
+        $this->copyTable('jacl2db~jacl2usergroup', 'oldjauth', $profile);
+        $this->copyTable('jacl2db~jacl2rights', 'oldjauth', $profile);
+
+        return self::MIGRATE_RES_OK;
+    }
+
+    protected function copyTable($daoSelector, $oldProfile, $newProfile)
+    {
+        $daoNew = \jDao::get($daoSelector, $newProfile);
+        $daoSqlite = \jDao::create($daoSelector, $oldProfile);
+        $properties = array_keys($daoSqlite->getProperties());
+        foreach($daoSqlite->findAll() as $rec) {
+            $daoRec = \jDao::createRecord($daoSelector, $newProfile);
+            foreach($properties as $prop) {
+                $daoRec->$prop = $rec->$prop;
+            }
+            $daoNew->insert($daoRec);
+        }
+    }
+
+
+    protected function createUsersTables()
+    {
+        // retrieve the configuration of jauth
+        $config = \jIniFile::read(\jApp::configPath('admin/auth.coord.ini.php'));
+
+        // retrieve the driver used from the global configuration if exists
+        if (isset(\jApp::config()->coordplugin_auth) && isset(\jApp::config()->coordplugin_auth['driver'])) {
+            $config['driver'] = trim(\jApp::config()->coordplugin_auth['driver']);
+        }
+
+        // retrieve the dao selector from the driver configuration
+        $daoSelector = $config[$config['driver']]['dao'];
+        $profile = $config[$config['driver']]['profile'];
+
+        $profile = \jProfiles::get('jdb', $profile);
+        if (!$profile) {
+            throw new \UnexpectedValueException("No $profile profile defined into profiles.ini.php", 1);
+        }
+
+        if ($profile['driver'] == 'sqlite3') {
+            throw new \UnexpectedValueException('Database for jAuth is still sqlite3. Configure the jauth profile ontop an other database type into profiles.ini.php', 2);
+        }
+
+        // verify that the table already exists or not
+        $db = \jDb::getConnection($profile);
+        $schema = $db->schema();
+        $table = $schema->getTable('jlx_users');
+        if ($table) {
+            return array($daoSelector, $profile);
+        }
+
+        // the table does not exists, let's create it
+        $mapper = new \jDaoDbMapper($profile);
+        $mapper->createTableFromDao($daoSelector);
+
+        $tools = $db->tools();
+        $file = \jApp::getModulePath('lizmap').'/install/sql/lizgeobookmark.'.$db->dbms.'.sql';
+        $db->beginTransaction();
+        try {
+            $tools->execSQLScript($file);
+            $db->commit();
+        }
+        catch(\Exception $e) {
+            $db->rollback();
+            throw $e;
+        }
+        return array($daoSelector, $profile);
+    }
+
+    protected function createAclTables($profile) {
+
+        $db = \jDb::getConnection($profile);
+        $tools = $db->tools();
+        $file = \jApp::getModulePath('jacl2db').'/install/sql/install_jacl2.schema.'.$db->dbms.'.sql';
+        $db->beginTransaction();
+        try {
+            $tools->execSQLScript($file);
+            $db->commit();
+        }
+        catch(\Exception $e) {
+            $db->rollback();
+            throw $e;
+        }
+    }
+}
+
+


### PR DESCRIPTION
New commands allow to migrate all users/acl tables from sqlite to pgsql, as well as to migrate log table.

```
php lizmap/scripts/script.php lizmap~database:migratelog
php lizmap/scripts/script.php lizmap~database:migrateusers
```

`migrateusers` is experimental. 
`migratelog` has been well tested, and will be needed on our infrastructure.