### PR TITLE
[Bugfix] Quote schema for search_path in dbParams for GetFeature

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -295,7 +295,7 @@ class qgisVectorLayer extends qgisMapLayer
                 );
             }
             if (!empty($dtParams->schema)) {
-                $jdbParams['search_path'] = $dtParams->schema . ',public';
+                $jdbParams['search_path'] = '"'.$dtParams->schema . '",public';
             }
         } elseif ($this->provider == 'ogr'
             and preg_match('#(gpkg|sqlite)$#', $dtParams->dbname ) ) {


### PR DESCRIPTION
The Layer schema has to be quote in the search_path parameter of the db connection to avoid problem with `-`, upper character, etc