### PR TITLE
[Bugfix] Support parsing GeoJSON of geometry with Z and/or M dimension

### DIFF
--- a/lizmap/www/js/atlas.js
+++ b/lizmap/www/js/atlas.js
@@ -355,7 +355,9 @@ var lizAtlas = function() {
         function runAtlasItem(feature){
 
             // Use OL tools to reproject feature geometry
-            var format = new OpenLayers.Format.GeoJSON();
+            var format = new OpenLayers.Format.GeoJSON({
+                ignoreExtraDims: true
+            });
             var feat = format.read(feature)[0];
             var f = feat.clone();
             var proj = lizMap.config.layers[lizAtlasConfig.layername]['featureCrs'];

--- a/lizmap/www/js/attributeTable.js
+++ b/lizmap/www/js/attributeTable.js
@@ -3304,6 +3304,7 @@ var lizAttributeTable = function() {
             // get features
             $.post( getFeatureUrlData['url'], getFeatureUrlData['options'], function(result) {
                     var gFormat = new OpenLayers.Format.GeoJSON({
+                        ignoreExtraDims: true,
                         externalProjection: lConfig.crs,
                         internalProjection: lizMap.map.getProjection()
                     });

--- a/lizmap/www/js/map.js
+++ b/lizmap/www/js/map.js
@@ -1546,7 +1546,9 @@ var lizMap = function() {
     } else {
       // zoom to val
       var feat = locate.features[val];
-      var format = new OpenLayers.Format.GeoJSON();
+      var format = new OpenLayers.Format.GeoJSON({
+          ignoreExtraDims: true
+      });
       feat = format.read(feat)[0];
 
       if( feat.geometry != null){
@@ -4953,6 +4955,7 @@ OpenLayers.Control.HighlightFeature = OpenLayers.Class(OpenLayers.Control, {
               var tconfig = config.tooltipLayers[fName];
 
               var gFormat = new OpenLayers.Format.GeoJSON({
+                  ignoreExtraDims: true,
                   externalProjection: lConfig['featureCrs'],
                   internalProjection: lizMap.map.getProjection()
               });
@@ -5752,7 +5755,9 @@ OpenLayers.Control.HighlightFeature = OpenLayers.Class(OpenLayers.Control, {
 
   function zoomToOlFeature( feature, proj, zoomAction ){
       zoomAction = typeof zoomAction !== 'undefined' ?  zoomAction : 'zoom';
-      var format = new OpenLayers.Format.GeoJSON();
+      var format = new OpenLayers.Format.GeoJSON({
+          ignoreExtraDims: true
+      });
       var feat = format.read(feature)[0];
       if( feat && 'geometry' in feat ){
           feat.geometry.transform( proj, lizMap.map.getProjection() );

--- a/lizmap/www/js/timemanager.js
+++ b/lizmap/www/js/timemanager.js
@@ -159,7 +159,9 @@ var lizTimemanager = function() {
                     var protocol = new OpenLayers.Protocol.HTTP({
                         url:  service,
                         params: wfsOptions,
-                        format: new OpenLayers.Format.GeoJSON()
+                        format: new OpenLayers.Format.GeoJSON({
+                            ignoreExtraDims: true
+                        })
                     });
                     tmLayerConfig['protocol'] = protocol;
 


### PR DESCRIPTION
OpenLayers GeoJSON format has an attribute to read 3-4D points : `ignoreExtraDims`

The commit adds `ignoreExtraDims: true` to all `new OpenLayers.Format.GeoJSON`