### PR TITLE
Fix error in qgisVectorLayer when geometrytype contain parenthesis

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -450,8 +450,8 @@ class qgisVectorLayer extends qgisMapLayer
         // test type
         $rs = $cnx->query('SELECT GeometryType('.$nvalue.') as geomtype');
         $rs = $rs->fetch();
-        if (!preg_match('/'.$dbFieldsInfo->geometryType.'/', strtolower($rs->geomtype))) {
-            if (preg_match('/'.str_replace('multi', '', $dbFieldsInfo->geometryType).'/', strtolower($rs->geomtype))) {
+        if (!preg_match('/'.preg_quote($dbFieldsInfo->geometryType).'/', strtolower($rs->geomtype))) {
+            if (preg_match('/'.preg_quote(str_replace('multi', '', $dbFieldsInfo->geometryType)).'/', strtolower($rs->geomtype))) {
                 $nvalue = 'ST_Multi('.$nvalue.')';
             }
         }


### PR DESCRIPTION
I have many errors like this in some logs of a lizmap instance:

```
preg_match(): Compilation failed: unmatched parentheses at offset 5 
modules/lizmap/classes/qgisVectorLayer.class.php   453
```

It seems the geometryType may contains some parenthesis, and since these characters are reserved into a regexp, they should be quoted. 