### PR TITLE
Fix project cache with windows

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmap.class.php
+++ b/lizmap/modules/lizmap/classes/lizmap.class.php
@@ -71,8 +71,7 @@ class lizmap
         $readConfigPath = parse_ini_file(jApp::varPath().self::$lizmapConfig, true);
         $repositoryList = array();
         foreach ($readConfigPath as $section => $data) {
-            $match = preg_match('#(^repository:)#', $section, $matches);
-            if (isset($matches[0])) {
+            if (preg_match('#^(repository:)#', $section, $matches)) {
                 $repositoryList[] = str_replace($matches[0], '', $section);
             }
         }

--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -139,8 +139,15 @@ class lizmapProject extends qgisProject
         // to avoid collision in the cache engine
         $data = false;
 
+        if (jApp::config()->isWindows) {
+            // Cache backends don't support '\'
+            $fileKey = str_replace('\\', '/', $file);
+        }
+        else {
+            $fileKey = $file;
+        }
         try {
-            $data = jCache::get($file, 'qgisprojects');
+            $data = jCache::get($fileKey, 'qgisprojects');
         } catch (Exception $e) {
             // if qgisprojects profile does not exist, or if there is an
             // other error about the cache, let's log it
@@ -164,7 +171,7 @@ class lizmapProject extends qgisProject
             }
 
             try {
-                jCache::set($file, $data, null, 'qgisprojects');
+                jCache::set($fileKey, $data, null, 'qgisprojects');
             } catch (Exception $e) {
                 jLog::logEx($e, 'error');
             }
@@ -180,7 +187,10 @@ class lizmapProject extends qgisProject
     public function clearCache()
     {
         $file = $this->repository->getPath().$this->key.'.qgs';
-
+        if (jApp::config()->isWindows) {
+            // Cache backends don't support '\'
+            $file = str_replace('\\', '/', $file);
+        }
         try {
             jCache::delete($file, 'qgisprojects');
         } catch (Exception $e) {

--- a/lizmap/modules/lizmap/classes/qgisProject.class.php
+++ b/lizmap/modules/lizmap/classes/qgisProject.class.php
@@ -87,9 +87,15 @@ class qgisProject
         // For the cache key, we use the full path of the project file
         // to avoid collision in the cache engine
         $data = false;
-
+        if (jApp::config()->isWindows) {
+            // Cache backends don't support '\'
+            $fileKey = str_replace('\\', '/', $file);
+        }
+        else {
+            $fileKey = $file;
+        }
         try {
-            $data = jCache::get($file, 'qgisprojects');
+            $data = jCache::get($fileKey, 'qgisprojects');
         } catch (Exception $e) {
             // if qgisprojects profile does not exist, or if there is an
             // other error about the cache, let's log it
@@ -108,7 +114,7 @@ class qgisProject
             }
 
             try {
-                jCache::set($file, $data, null, 'qgisprojects');
+                jCache::set($fileKey, $data, null, 'qgisprojects');
             } catch (Exception $e) {
                 jLog::logEx($e, 'error');
             }
@@ -124,7 +130,10 @@ class qgisProject
     public function clearCache()
     {
         $file = $this->path;
-
+        if (jApp::config()->isWindows) {
+            // Cache backends don't support '\'
+            $file = str_replace('\\', '/', $file);
+        }
         try {
             jCache::delete($file, 'qgisprojects');
         } catch (Exception $e) {


### PR DESCRIPTION
Cache backends don't support '\' in a key. When using a file path as a key under windows, we must replace this character by '/'

Refs #1380