### PR TITLE
Replace backtick with concatinated string 

### DIFF
--- a/lizmap/www/js/filter.js
+++ b/lizmap/www/js/filter.js
@@ -1249,10 +1249,7 @@ var lizLayerFilterTool = function() {
 
 }();
 
-var todo = `
-
-* Print get filtertoken if not yet set
-* Updata attribute table if displayed: display the Orange button to refresh
-* Update dataviz on filter
-
-`;
+var todo = '</br>'+
+'* Print get filtertoken if not yet set</br>'+
+'* Updata attribute table if displayed: display the Orange button to refresh</br>'+
+'* Update dataviz on filter</br>';


### PR DESCRIPTION
Since backticks leads to troubles with MS Internet Explorer, what means that the filter function cannot be used in IE.

I don't really understand how this `var todo` is used, but anyway it should not be written using backticks.