### PR TITLE
[Bugfix] Test QGIS Server in view/app/metatdata

### DIFF
--- a/lizmap/modules/view/controllers/app.classic.php
+++ b/lizmap/modules/view/controllers/app.classic.php
@@ -36,6 +36,27 @@ class appCtrl extends jController
         $data['dependencies']['jelix']['minversion'] = (string) $xmlLoad->dependencies->jelix->attributes()->minversion;
         $data['dependencies']['jelix']['maxversion'] = (string) $xmlLoad->dependencies->jelix->attributes()->maxversion;
 
+        // Try a request to QGIS Server
+        $data['qgis_server'] = array();
+        $params = array(
+            'service' => 'WMS',
+            'request' => 'GetCapabilities'
+        );
+        $url = lizmapProxy::constructUrl($params);
+        list($resp, $mime, $code) = lizmapProxy::getRemoteData($url);
+        if (preg_match('#ServerException#i', $resp) ||
+            preg_match('#ServiceExceptionReport#i', $resp) ||
+            preg_match('#WMS_Capabilities#i', $resp)) {
+            $data['qgis_server']['test'] = 'OK';
+        } else {
+            $data['qgis_server']['test'] = 'ERROR';
+        }
+        $data['qgis_server']['mime_type'] = $mime;
+        if ( jAcl2::check('lizmap.admin.access') ) {
+            $data['qgis_server']['http_code'] = $code;
+            $data['qgis_server']['response'] = $resp;
+        }
+
         $rep->data = $data;
 
         return $rep;


### PR DESCRIPTION
The request view/app/metadata returns a JSON with lizmap information.
The commite adds information about QGIS Server:
```
"qgis_server":{"test":"OK","mime_type":"text\/xml; charset=utf-8"}
```
Or
```
"qgis_server":{"test":"ERROR","mime_type":"text\/html; charset=iso-8859-1"}
```

If you are admin, you have extra info, like HTTP code and response.