### PR TITLE
[Bugfix] Read only form control cannot be required

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisForm.class.php
+++ b/lizmap/modules/lizmap/classes/qgisForm.class.php
@@ -232,6 +232,11 @@ class qgisForm implements qgisFormControlsInterface
                 $this->formPlugins[$fieldName] = 'color_html';
             }
 
+            // Force readonly to not be required
+            if ($formControl->isReadOnly && $formControl->ctrl->required) {
+                $formControl->required = false;
+                $formControl->ctrl->required = false;
+            }
             // Add the control to the form
             $form->addControl($formControl->ctrl);
             // Set readonly if needed

--- a/lizmap/modules/lizmap/classes/qgisFormControl.class.php
+++ b/lizmap/modules/lizmap/classes/qgisFormControl.class.php
@@ -552,6 +552,11 @@ class qgisFormControl
             }
         }
 
+        // Read-only can't be required
+        if ($this->isReadOnly && $this->required) {
+            $this->required = false;
+        }
+
         // Required
         if ($this->required) {
             $this->ctrl->required = true;


### PR DESCRIPTION
Some changes in QGIS 3 force required option even if the field is not editable.