### PR TITLE
[Bugfix] Form: Use checkbox for boolean field and display labels

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisFormControl.class.php
+++ b/lizmap/modules/lizmap/classes/qgisFormControl.class.php
@@ -473,6 +473,30 @@ class qgisFormControl
                 break;
         }
 
+        // Rework for boolean
+        if ($this->fieldDataType == 'boolean' &&
+            in_array($markup, array('menulist', 'checkboxes'))) {
+            // Get data list, to use label
+            $data = $this->ctrl->datasource->data;
+            // Set control
+            $this->ctrl = new jFormsControlCheckbox($this->ref);
+            // Check data list
+            foreach ($data as $k=>$v) {
+                $strK = strtolower($k);
+                if ($strK === 'true' || $strK === 't' ||
+                    intval($k) === 1 || $strK === 'on') {
+                    // Check info
+                    $this->ctrl->valueOnCheck = $k;
+                    $this->ctrl->valueLabelOnCheck = $v;
+                } else if ($strK === 'false' || $strK === 'f' ||
+                    intval($k) === 0 || $strK === 'off') {
+                    // Uncheck info
+                    $this->ctrl->valueOnCheck = $k;
+                    $this->ctrl->valueLabelOnUncheck = $v;
+                }
+            }
+        }
+
         // Set control main properties
         $this->setControlMainProperties();
     }
@@ -520,6 +544,11 @@ class qgisFormControl
 
                 case 'time':
                     $this->ctrl->datatype = new jDatatypeTime();
+
+                    break;
+
+                case 'boolean':
+                    $this->ctrl->datatype = new jDatatypeBoolean();
 
                     break;
             }

--- a/lizmap/plugins/formbuilder/htmlbootstrap/htmlbootstrap.formbuilder.php
+++ b/lizmap/plugins/formbuilder/htmlbootstrap/htmlbootstrap.formbuilder.php
@@ -150,7 +150,12 @@ class htmlbootstrapFormBuilder extends \jelix\forms\Builder\HtmlBuilder
      */
     public function outputControlLabel($ctrl, $format = '', $editMode = true)
     {
-        if ($ctrl->type == 'hidden' || $ctrl->type == 'button' || $ctrl->type == 'checkbox') {
+        if ($ctrl->type == 'hidden' || $ctrl->type == 'button') {
+            return;
+        }
+        else if ($ctrl->type == 'checkbox' &&
+            $ctrl->valueLabelOnCheck === '' &&
+            $ctrl->valueLabelOnUncheck === '') {
             return;
         }
         $widget = $this->getWidget($ctrl, $this->rootWidget);

--- a/lizmap/plugins/formwidget/checkbox_htmlbootstrap/checkbox_htmlbootstrap.formwidget.php
+++ b/lizmap/plugins/formwidget/checkbox_htmlbootstrap/checkbox_htmlbootstrap.formwidget.php
@@ -15,26 +15,70 @@ class checkbox_htmlbootstrapFormWidget extends checkbox_htmlFormWidget
 
     public function outputControl()
     {
-        $this->labelAttributes['class'] = 'checkbox';
+
+        if($this->ctrl->valueLabelOnCheck !== '' or $this->ctrl->valueLabelOnUncheck !== '') {
+            $this->labelAttributes['class'] = 'radio jforms-radio';
+        } else {
+            $this->labelAttributes['class'] = 'checkbox';
+        }
         $attrLabel = $this->getLabelAttributes(true);
-        echo '<label class="',$attrLabel['class'],'" for="',$this->getId(),'"',$attrLabel['idLabel'],$attrLabel['hint'],'>';
 
         $attr = $this->getControlAttributes();
 
-        if ($this->ctrl->valueOnCheck == $this->getValue()) {
-            $attr['checked'] = 'checked';
+        if($this->ctrl->valueLabelOnCheck !== '' or $this->ctrl->valueLabelOnUncheck !== '') {
+
+            echo '<label class="',$attrLabel['class'],'" ',$attrLabel['idLabel'],$attrLabel['hint'],'>';
+
+            if($this->ctrl->valueOnCheck == $this->getValue()){
+                $attr['checked'] = "checked";
+            }
+            $attr['value'] = $this->ctrl->valueOnCheck;
+            $attr['type'] = 'radio';
+            // attribute readonly is not enough to make checkboxes readonly. Note that value won't be sent by submit but it is not a problem as it is readonly
+            if (array_key_exists('readonly', $attr)) {
+                $attr['disabled'] = 'disabled';
+            }
+
+            echo '<input';
+            $this->_outputAttr($attr);
+            echo '/>';
+            echo htmlspecialchars($this->ctrl->valueLabelOnCheck);
+            echo "</label>\n";
+
+
+            echo '<label class="',$attrLabel['class'],'" ',$attrLabel['idLabel'],$attrLabel['hint'],'>';
+
+            if($this->ctrl->valueOnCheck == $this->getValue()){
+                unset($attr['checked']);
+            }
+            else if($this->ctrl->valueOnUncheck == $this->getValue()){
+                $attr['checked'] = "checked";
+            }
+            $attr['value'] = $this->ctrl->valueOnUncheck;
+
+            echo '<input';
+            $this->_outputAttr($attr);
+            echo '/>';
+            echo htmlspecialchars($this->ctrl->valueLabelOnUncheck);
+            echo "</label>\n";
+        } else {
+            echo '<label class="',$attrLabel['class'],'" for="',$this->getId(),'"',$attrLabel['idLabel'],$attrLabel['hint'],'>';
+
+            if ($this->ctrl->valueOnCheck == $this->getValue()) {
+                $attr['checked'] = 'checked';
+            }
+            $attr['value'] = $this->ctrl->valueOnCheck;
+            $attr['type'] = 'checkbox';
+            // attribute readonly is not enough to make checkboxes readonly. Note that value won't be sent by submit but it is not a problem as it is readonly
+            if (array_key_exists('readonly', $attr)) {
+                $attr['disabled'] = 'disabled';
+            }
+            echo '<input';
+            $this->_outputAttr($attr);
+            echo '/>';
+            echo htmlspecialchars($this->ctrl->label), $attrLabel['reqHtml'];
+            echo "</label>\n";
         }
-        $attr['value'] = $this->ctrl->valueOnCheck;
-        $attr['type'] = 'checkbox';
-        // attribute readonly is not enough to make checkboxes readonly. Note that value won't be sent by submit but it is not a problem as it is readonly
-        if (array_key_exists('readonly', $attr)) {
-            $attr['disabled'] = 'disabled';
-        }
-        echo '<input';
-        $this->_outputAttr($attr);
-        echo '/>';
-        echo htmlspecialchars($this->ctrl->label), $attrLabel['reqHtml'];
-        echo "</label>\n";
         $this->outputJs();
     }
 }


### PR DESCRIPTION
The right form control for boolean field is checkbox.

In QGIS the editing widget can be defined to be a menulist, but the control does not correctly check boolean value.

The commit force control to be a checkbox if the field is boolean. It defined labels for check and uncheck.