### PR TITLE
switch from datavizTheme to theme

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -1034,10 +1034,10 @@ class lizmapProject extends qgisProject
         ) {
             $config['dataviz']['location'] = $this->cfg->options->datavizLocation;
         }
-        if (property_exists($this->cfg->options, 'datavizTheme')
-            and in_array($this->cfg->options->datavizTheme, array('dark', 'light'))
+        if (property_exists($this->cfg->options, 'theme')
+            and in_array($this->cfg->options->theme, array('dark', 'light'))
         ) {
-            $config['dataviz']['theme'] = $this->cfg->options->datavizTheme;
+            $config['dataviz']['theme'] = $this->cfg->options->theme;
         }
 
         return $config;


### PR DESCRIPTION
I know, it's less readable like this for now.
But as soon as we will move to Lizmap 4, the setting will move to the dataviz section:

```
    "dataviz": {
        "layers": []
        "config": [
              "theme":"light"
         ]
    },
```

So just to be in the move to Lizmap 4 ;-)