### PR TITLE
Update attributeTable.js

### DIFF
--- a/lizmap/www/assets/js/attributeTable.js
+++ b/lizmap/www/assets/js/attributeTable.js
@@ -1333,7 +1333,34 @@ var lizAttributeTable = function() {
                             case 'long':
                             case 'unsignedLong':
                                 colConf['mRender'] = function( data, type, full, meta ){
-                                    return parseInt(data);
+                                    // Translate field ( language translation OR code->label translation )
+                                    var colMeta = meta.settings.aoColumns[meta.col];
+                                    var colName = colMeta.mData
+                                    var translation_dict = null;
+                                    var tdata = data;
+                                    if(data || data === 0)
+                                        tdata = lizMap.translateWfsFieldValues(aName, colName, data.toString(), translation_dict);
+                                    if( tdata === null )
+                                        tdata = data;
+
+                                    // Replace media and URL with links
+                                    if( !tdata || !( typeof tdata === 'string') )
+                                        return tdata;
+                                    if( tdata.substr(0,6) == 'media/' || tdata.substr(0,7) == '/media/' || tdata.substr(0,9) == '../media/'){
+                                        var rdata = tdata;
+                                        if( tdata.substr(0,7) == '/media/' )
+                                            rdata = tdata.slice(1);
+                                        return '<a href="' + mediaLinkPrefix + '&path=' + rdata + '" target="_blank">' + colMeta.title + '</a>';
+                                    }
+                                    else if( tdata.substr(0,4) == 'http' || tdata.substr(0,3) == 'www' ){
+                                        var rdata = tdata;
+                                        if(tdata.substr(0,3) == 'www')
+                                            rdata = 'http://' + tdata;
+                                        return '<a href="' + rdata + '" target="_blank">' + tdata + '</a>';
+                                    }
+                                    else
+                                        return tdata;
+                                    //return parseInt(data);
                                 }
                                 colConf['className'] = 'text-right';
                                 break;

--- a/lizmap/www/assets/js/attributeTable.js
+++ b/lizmap/www/assets/js/attributeTable.js
@@ -1280,6 +1280,20 @@ var lizAttributeTable = function() {
 
                 return false;
             }
+            
+            function valueMapInAttributeTable( aName, data, type, full, meta ){
+            // Translate field ( language translation OR code->label translation )
+                var colMeta = meta.settings.aoColumns[meta.col];
+                var colName = colMeta.mData
+                var translation_dict = null;
+                var tdata = data;
+                if(data || data === 0)
+                    tdata = lizMap.translateWfsFieldValues(aName, colName, data.toString(), translation_dict);
+                if( tdata === null )
+                    tdata = data;
+                
+                return tdata;
+            }
 
             function createDatatableColumns(aName, atFeatures, geometryType, canEdit, canDelete, isChild, isPivot, hiddenFields, cAliases, cTypes){
                 var columns = [];
@@ -1332,36 +1346,11 @@ var lizAttributeTable = function() {
                             case 'unsignedInt':
                             case 'long':
                             case 'unsignedLong':
-                                colConf['mRender'] = function( data, type, full, meta ){
+                                colConf['mRender'] = function(data, type, full, meta ){
                                     // Translate field ( language translation OR code->label translation )
-                                    var colMeta = meta.settings.aoColumns[meta.col];
-                                    var colName = colMeta.mData
-                                    var translation_dict = null;
-                                    var tdata = data;
-                                    if(data || data === 0)
-                                        tdata = lizMap.translateWfsFieldValues(aName, colName, data.toString(), translation_dict);
-                                    if( tdata === null )
-                                        tdata = data;
-
-                                    // Replace media and URL with links
-                                    if( !tdata || !( typeof tdata === 'string') )
-                                        return tdata;
-                                    if( tdata.substr(0,6) == 'media/' || tdata.substr(0,7) == '/media/' || tdata.substr(0,9) == '../media/'){
-                                        var rdata = tdata;
-                                        if( tdata.substr(0,7) == '/media/' )
-                                            rdata = tdata.slice(1);
-                                        return '<a href="' + mediaLinkPrefix + '&path=' + rdata + '" target="_blank">' + colMeta.title + '</a>';
-                                    }
-                                    else if( tdata.substr(0,4) == 'http' || tdata.substr(0,3) == 'www' ){
-                                        var rdata = tdata;
-                                        if(tdata.substr(0,3) == 'www')
-                                            rdata = 'http://' + tdata;
-                                        return '<a href="' + rdata + '" target="_blank">' + tdata + '</a>';
-                                    }
-                                    else
-                                        return tdata;
-                                    //return parseInt(data);
-                                }
+                                    return valueMapInAttributeTable( aName, data, type, full, meta );  
+                                };
+                                
                                 colConf['className'] = 'text-right';
                                 break;
                             case 'decimal':
@@ -1377,14 +1366,7 @@ var lizAttributeTable = function() {
                             default:
                                 colConf['mRender'] = function( data, type, full, meta ){
                                     // Translate field ( language translation OR code->label translation )
-                                    var colMeta = meta.settings.aoColumns[meta.col];
-                                    var colName = colMeta.mData
-                                    var translation_dict = null;
-                                    var tdata = data;
-                                    if(data)
-                                        tdata = lizMap.translateWfsFieldValues(aName, colName, data.toString(), translation_dict);
-                                    if( tdata === null )
-                                        tdata = data;
+                                    var tdata = valueMapInAttributeTable( aName, data, type, full, meta );
 
                                     // Replace media and URL with links
                                     if( !tdata || !( typeof tdata === 'string') )


### PR DESCRIPTION
<!---Thanks for your contribution and describing your PR.-->

## Description
This pull request is related to the issue #747 . As explained in the issue we have made some changes to a js file suggested by @mdouchin in order to display description labels instead of values in the attribute table for columns with ValueMap widget (see https://github.com/3liz/lizmap-javascript-scripts/pull/25). The script works perfectly with text columns but the attributeTable.js file requires some changes in order to make it work also with numeric columns.
The js script, in fact, is based on the translateWfsFieldValues() function which is triggered only for text columns in the attributeTable.js file. Hence I added the same function used for cType default to the numeric cType condition. With these changes to the attributeTable.js file, the js script seems to work perfectly both with text and numeric columns.
