### PR TITLE
QGIS Vector Layer - Datasource: dbname can be given when service is used

### DIFF
--- a/lib/jelix/plugins/db/pgsql/pgsql.dbconnection.php
+++ b/lib/jelix/plugins/db/pgsql/pgsql.dbconnection.php
@@ -104,6 +104,12 @@ class pgsqlDbConnection extends jDbConnection {
         // If given, no need to add host, user, database, port and password
         if(isset($this->profile['service']) && $this->profile['service'] != ''){
             $str = 'service=\''.$this->profile['service'].'\''.$str;
+
+            // Database name may be given, even if service is used
+            // dbname should not be mandatory in service file
+            if ($this->profile['database'] != '') {
+                $str .= ' dbname=\''.$this->profile['database'].'\'';
+            }
         }
         else {
             // we do a distinction because if the host is given == TCP/IP connection else unix socket

--- a/lib/jelix/plugins/db/pgsql/pgsql.dbconnection.php
+++ b/lib/jelix/plugins/db/pgsql/pgsql.dbconnection.php
@@ -107,7 +107,7 @@ class pgsqlDbConnection extends jDbConnection {
 
             // Database name may be given, even if service is used
             // dbname should not be mandatory in service file
-            if ($this->profile['database'] != '') {
+            if (isset($this->profile['database']) && $this->profile['database'] != '') {
                 $str .= ' dbname=\''.$this->profile['database'].'\'';
             }
         }

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -211,6 +211,11 @@ class qgisVectorLayer extends qgisMapLayer
                     'driver' => 'pgsql',
                     'service' => $dtParams->service,
                 );
+                // Database may be used since dbname
+                // is not mandatory in service file
+                if (!empty($dtParams->dbname)) {
+                    $jdbParams['database'] = $dtParams->dbname;
+                }
             } else {
                 $jdbParams = array(
                     'driver' => 'pgsql',


### PR DESCRIPTION
The dbname parameters is not mandatory in PostgreSQL service file.
QGIS vector datasource stores the dbname: we pass it to connection parameters
even if service is given, when dbname is not empty

Related ticket : #1722
