### PR TITLE
QGIS Vector Layer - Datasource: dbname can be given when service is used

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -284,6 +284,11 @@ class qgisVectorLayer extends qgisMapLayer
                     'driver' => 'pgsql',
                     'service' => $dtParams->service,
                 );
+                // Database may be used since dbname
+                // is not mandatory in service file
+                if (!empty($dtParams->dbname)) {
+                    $jdbParams['database'] = $dtParams->dbname;
+                }
             } else {
                 $jdbParams = array(
                     'driver' => 'pgsql',


### PR DESCRIPTION
Backport of fix applied in master, but not yet in branch `release_3_3`. 
See issue #1722 and PR #1723 

@laurentj @rldhont not sure this won't create issues when merging `release_3_3` into `master` ?