### PR TITLE
adding JelixInfos class

### DIFF
--- a/lizmap/modules/lizmap/classes/jelixInfos.class.php
+++ b/lizmap/modules/lizmap/classes/jelixInfos.class.php
@@ -1,0 +1,210 @@
+<?php
+
+class jelixInfos implements lizmapAppContext
+{
+    /**
+     * Method permitting to call a static method from jApp.
+     *
+     * @param string $info   The name of the method you want to call
+     * @param array  $params An array containing the params you want
+     *                       to pass to $info
+     */
+    public function jAppInfos($info, $params)
+    {
+        if (!$params || !isset($params[0])) {
+            return jApp::$info();
+        }
+
+        return jApp::$info(...$params);
+    }
+
+    /**
+     * Call and return the result of jAcl2::check().
+     *
+     * @param array $params An array containing the params to be passed to jAcl2::check()
+     *
+     * @return bool The result of jAcl2::check()
+     */
+    public function jAcl2CheckResult($params)
+    {
+        return jAcl2::check(...$params);
+    }
+
+    /**
+     * Return the jAcl2DbUserGroup::getGroups/getGroupList() result.
+     *
+     * @param bool $list True if you want to get the jAcl2DbUserGroup::getGroupList() result
+     */
+    public function jAcl2DbUserGroups($list = false)
+    {
+        if ($list) {
+            return jAcl2DbUserGroup::getGroupList();
+        }
+
+        return jAcl2dbUserGroup::getGroups();
+    }
+
+    /**
+     * Return the result of jAuth::isConnected().
+     *
+     * @return bool
+     */
+    public function jAuthIsConnected()
+    {
+        return jAuth::IsConnected();
+    }
+
+    /**
+     * Return the result of jAuth::getUserSession().
+     */
+    public function jAuthGetUserSession()
+    {
+        return jAuth::getUserSession();
+    }
+
+    /**
+     * Return the result of a jCache method.
+     *
+     * @param string $method The method to call
+     * @param array  $params An array containing the parameters
+     *                       to pass to $method
+     */
+    public function jCacheHandler($method, $params)
+    {
+        if (!$params || !isset($params[0])) {
+            return jCache::$method();
+        }
+
+        return jCache::$method(...$params);
+    }
+
+    /**
+     * Return the result of jProfile::createVirtualProfile.
+     *
+     * @param string $category The profile category to create
+     * @param string $name     The profile name
+     * @param array  $params   The parameters of the profile
+     */
+    public function createVirtualProfile($category, $name, $params)
+    {
+        return jProfiles::createVirtualProfile($category, $name, $params);
+    }
+
+    /**
+     * Return the properties of a profile by calling jProfile::get().
+     *
+     * @param string The profile category
+     * @param string the profile name
+     * @param bool If true and if the profile doesn't exist, throw an error
+     * instead of getting the default profile
+     * @param mixed $category
+     * @param mixed $name
+     * @param mixed $noDefault
+     */
+    public function getProfile($category, $name = '', $noDefault = false)
+    {
+        return jProfile::get($category, $name, $noDefault);
+    }
+
+    /**
+     * Call jEvent::notify().
+     *
+     * @param string The name of the event
+     * @param array the parameters of the event
+     * @param mixed $name
+     * @param mixed $params
+     */
+    public function eventNotify($name, $params = array())
+    {
+        return jEvent::notify($name, $params);
+    }
+
+    /**
+     * Return the connection to a Db by calling jDb::getConnection().
+     *
+     * @param string $name The profile name to use, if empty, use the default one
+     */
+    public function getDbConnection($name = '')
+    {
+        return jDb::getConnection($name);
+    }
+
+    /**
+     * Return the result of a jDbConnection method.
+     *
+     * @param jDbConnection $cnx    The Db Connection on which to call the method
+     * @param string        $method The method to call
+     * @param array         $params An array containing the parameters
+     *                              to pass to $method
+     */
+    public function useDbConnection($cnx, $method, $params)
+    {
+        if (!$params || !isset($params[0])) {
+            return $cnx->{$method}();
+        }
+
+        return $cnx->{$method}(...$params);
+    }
+
+    /**
+     * Get a string in a specific language.
+     *
+     * @param string $key The Jelix selector corresponding to the string
+     *                    you want to get
+     */
+    public function getLocale($key)
+    {
+        return jLocale::get($key);
+    }
+
+    /**
+     * Call jTpl::assign on a jTpl Instance.
+     *
+     * @param jTpl         $tpl   The jTpl instance on which to call assign
+     * @param array|string $name  the name of the value to assign or
+     *                            an array ($key => $value) containing the name and the value to assign
+     * @param string       $value the value to assign if $name is not an array
+     */
+    public function tplAssign($tpl, $name, $value = null)
+    {
+        $tpl->assign($name, $value);
+    }
+
+    /**
+     * Call and return the result of jTpl::fetch.
+     *
+     * @param jTpl   $tpl        the jTpl instance on which to call fetch
+     * @param string $name       The Jelix selector to get the template
+     * @param string $outputType The type of the output
+     */
+    public function tplFetch($tpl, $name, $outputType = '')
+    {
+        return $tpl->fetch($name, $outputType);
+    }
+
+    /**
+     * Return the result of a jDao method.
+     *
+     * @param string $method The method to call
+     * @param array  $params An array containing the parameters
+     *                       to pass to $method
+     */
+    public function jDaoHandler($method, $params)
+    {
+        if (!$params || !isset($params[0])) {
+            return jDao::$method();
+        }
+
+        return jDao::$method(...$params);
+    }
+
+    /**
+     * Call and return the result of jForms::create().
+     *
+     * @param string $formSelector the Jelix Selector of the form file
+     */
+    public function createJForm($formSelector)
+    {
+        return jForms::create($formSelector);
+    }
+}

--- a/lizmap/modules/lizmap/classes/jelixInfos.class.php
+++ b/lizmap/modules/lizmap/classes/jelixInfos.class.php
@@ -3,19 +3,11 @@
 class jelixInfos implements lizmapAppContext
 {
     /**
-     * Method permitting to call a static method from jApp.
-     *
-     * @param string $info   The name of the method you want to call
-     * @param array  $params An array containing the params you want
-     *                       to pass to $info
+     * call and return jApp::config.
      */
-    public function jAppInfos($info, $params)
+    public function appConfig()
     {
-        if (!$params || !isset($params[0])) {
-            return jApp::$info();
-        }
-
-        return jApp::$info(...$params);
+        return jApp::config();
     }
 
     /**
@@ -25,7 +17,7 @@ class jelixInfos implements lizmapAppContext
      *
      * @return bool The result of jAcl2::check()
      */
-    public function jAcl2CheckResult($params)
+    public function aclCheckResult($params)
     {
         return jAcl2::check(...$params);
     }
@@ -35,7 +27,7 @@ class jelixInfos implements lizmapAppContext
      *
      * @param bool $list True if you want to get the jAcl2DbUserGroup::getGroupList() result
      */
-    public function jAcl2DbUserGroups($list = false)
+    public function aclDbUserGroups($list = false)
     {
         if ($list) {
             return jAcl2DbUserGroup::getGroupList();
@@ -49,7 +41,7 @@ class jelixInfos implements lizmapAppContext
      *
      * @return bool
      */
-    public function jAuthIsConnected()
+    public function UserIsConnected()
     {
         return jAuth::IsConnected();
     }
@@ -57,7 +49,7 @@ class jelixInfos implements lizmapAppContext
     /**
      * Return the result of jAuth::getUserSession().
      */
-    public function jAuthGetUserSession()
+    public function getUserSession()
     {
         return jAuth::getUserSession();
     }
@@ -69,15 +61,15 @@ class jelixInfos implements lizmapAppContext
      * @param array  $params An array containing the parameters
      *                       to pass to $method
      */
-    public function jCacheHandler($method, $params)
+    public function getCache($key, $profile = '')
     {
-        if (!$params || !isset($params[0])) {
-            return jCache::$method();
-        }
-
-        return jCache::$method(...$params);
+        return jCache::get($key, $profile);
     }
 
+    public function normalizeCacheKey($key)
+    {
+        return jCache::normalizeKey($key);
+    }
     /**
      * Return the result of jProfile::createVirtualProfile.
      *
@@ -158,44 +150,13 @@ class jelixInfos implements lizmapAppContext
     }
 
     /**
-     * Call jTpl::assign on a jTpl Instance.
-     *
-     * @param jTpl         $tpl   The jTpl instance on which to call assign
-     * @param array|string $name  the name of the value to assign or
-     *                            an array ($key => $value) containing the name and the value to assign
-     * @param string       $value the value to assign if $name is not an array
-     */
-    public function tplAssign($tpl, $name, $value = null)
-    {
-        $tpl->assign($name, $value);
-    }
-
-    /**
-     * Call and return the result of jTpl::fetch.
-     *
-     * @param jTpl   $tpl        the jTpl instance on which to call fetch
-     * @param string $name       The Jelix selector to get the template
-     * @param string $outputType The type of the output
-     */
-    public function tplFetch($tpl, $name, $outputType = '')
-    {
-        return $tpl->fetch($name, $outputType);
-    }
-
-    /**
      * Return the result of a jDao method.
      *
-     * @param string $method The method to call
-     * @param array  $params An array containing the parameters
-     *                       to pass to $method
+     * @param string $jSelector
      */
-    public function jDaoHandler($method, $params)
+    public function getDao($jSelector)
     {
-        if (!$params || !isset($params[0])) {
-            return jDao::$method();
-        }
-
-        return jDao::$method(...$params);
+        return jDao::get($jSelector);
     }
 
     /**
@@ -203,7 +164,7 @@ class jelixInfos implements lizmapAppContext
      *
      * @param string $formSelector the Jelix Selector of the form file
      */
-    public function createJForm($formSelector)
+    public function createForm($formSelector)
     {
         return jForms::create($formSelector);
     }

--- a/lizmap/modules/lizmap/classes/lizmapAppContext.interface.php
+++ b/lizmap/modules/lizmap/classes/lizmapAppContext.interface.php
@@ -7,18 +7,20 @@
  */
 interface lizmapAppContext
 {
-    public function jAppInfos($info, $params);
+    public function appConfig($params);
 
-    public function jAcl2CheckResult($params);
+    public function aclCheckResult($params);
 
-    public function jAcl2DbUserGroups($list = false);
+    public function aclDbUserGroups($list = false);
 
-    public function jAuthIsConnected();
+    public function UserIsConnected();
 
-    public function jAuthGetUserSession();
+    public function getUserSession();
 
-    public function jCacheHandler($method, $params);
+    public function getCache($key, $profile = '');
 
+    public function normalizeCacheKey($key);
+    
     public function createVirtualProfile($category, $name, $params);
 
     public function getProfile($category, $name = '', $noDefault = false);
@@ -35,7 +37,7 @@ interface lizmapAppContext
 
     public function tplFetch($tpl, $name, $outputType = '');
 
-    public function jDaoHandler($method, $params);
+    public function getDao($params);
 
-    public function createJForm($formSelector);
+    public function createForm($formSelector);
 }

--- a/lizmap/modules/lizmap/classes/lizmapAppContext.interface.php
+++ b/lizmap/modules/lizmap/classes/lizmapAppContext.interface.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Interface that will be implemented to get Jelix infos so
+ * we can either send Jelix's real infos either custom infos
+ * to make our own tests.
+ */
+interface lizmapAppContext
+{
+    public function jAppInfos($info, $params);
+
+    public function jAcl2CheckResult($params);
+
+    public function jAcl2DbUserGroups($list = false);
+
+    public function jAuthIsConnected();
+
+    public function jAuthGetUserSession();
+
+    public function jCacheHandler($method, $params);
+
+    public function createVirtualProfile($category, $name, $params);
+
+    public function getProfile($category, $name = '', $noDefault = false);
+
+    public function eventNotify($eventName, $params = array());
+
+    public function getDbConnection($name = '');
+
+    public function useDbConnection($method, $params);
+
+    public function getLocale($key);
+
+    public function tplAssign($tpl, $name, $value = null);
+
+    public function tplFetch($tpl, $name, $outputType = '');
+
+    public function jDaoHandler($method, $params);
+
+    public function createJForm($formSelector);
+}

--- a/lizmap/modules/lizmap/module.xml
+++ b/lizmap/modules/lizmap/module.xml
@@ -35,6 +35,8 @@
         <class name="qgisLayerDbFieldsInfo" file="classes/qgisLayerDbFieldsInfo.class.php"/>
         <class name="qgisFormControlsInterface" file="classes/qgisFormControlsInterface.php"/>
         <class name="lizmapServices" file="classes/lizmapServices.class.php"/>
+        <class name="lizmapAppContext" file="classes/lizmapAppContext.interface.php"/>
+        <class name="jelixInfos" file="classes/jelixInfos.class.php"/>
         <namespacePathMap name="Lizmap" dir="lib"/>
     </autoload>
 </module>


### PR DESCRIPTION
Adding the JelixInfos class that allows us not to use Jelix directly in class methods.
This class will also allows us to alter the Jelix methods in the tests so we can create scenarios that can happens in some situations without having to directly touch the tested class or Jelix utilities.

This class is currently only populated with the utilities I need to test and modify the lizmapProject class but I will populate it with other utilities when I will need them.