### PR TITLE
fixing syntax error

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -966,7 +966,7 @@ class lizmapProject extends qgisProject
                 $user = jAuth::getUserSession();
                 $login = $user->login;
                 if (property_exists($loginFilteredConfig, 'filterPrivate') &&
-                    $this>optionToBoolean($loginFilteredConfig->filterPrivate)
+                    $this->optionToBoolean($loginFilteredConfig->filterPrivate)
                 ) {
                     $filter = "\"${attribute}\" IN ( '".$login."' , 'all' )";
                 } else {


### PR DESCRIPTION
There was a '-' missing in lizmapProject and the getLoginFilter method can crash.
