### PR TITLE
Lizmap\Project\Repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
 branches:
   only:
     - master
+    - refactor
 
 jobs:
   include:

--- a/lizmap/modules/admin/classes/listProjectDatasource.class.php
+++ b/lizmap/modules/admin/classes/listProjectDatasource.class.php
@@ -22,7 +22,7 @@ class listProjectDatasource extends jFormsDynamicDatasource
         $criteria = $form->getData($this->criteriaFrom[0]);
         if ($criteria && array_key_exists($criteria, $this->data)) {
             $rep = lizmap::getRepository($criteria);
-            $projects = $rep->getProjects();
+            $projects = $rep->getProjects(lizmap::getAppContext(), lizmap::getServices());
             foreach ($projects as $p) {
                 $pOptions = $p->getOptions();
                 if (property_exists($pOptions, 'hideProject') && $pOptions->hideProject == 'True') {

--- a/lizmap/modules/lizmap/classes/lizmap.class.php
+++ b/lizmap/modules/lizmap/classes/lizmap.class.php
@@ -67,7 +67,7 @@ class lizmap
         return self::$lizmapServicesInstance;
     }
 
-    public function getAppContext()
+    public static function getAppContext()
     {
         if (!self::$appContext) {
             self::$appContext = new \Lizmap\App\JelixContext();
@@ -363,7 +363,7 @@ class lizmap
             return null;
         }
 
-        return $rep->getProject($matches['proj']);
+        return $rep->getProject($matches['proj'], self::getAppContext(), self::getServices());
     }
 
     /**

--- a/lizmap/modules/lizmap/classes/lizmap.class.php
+++ b/lizmap/modules/lizmap/classes/lizmap.class.php
@@ -29,11 +29,20 @@ class lizmap
      */
     protected static $repositoryInstances = array();
 
-    // lizmapServices instance
+    /**
+     * @var lizmapServices The lizmapServices instance for the singleton
+     */
     protected static $lizmapServicesInstance = null;
 
-    // lizmapLogConfigInstance
+    /**
+     * @var lizmapLogConfig The lizmapLogConfig instance for the singleton
+     */
     protected static $lizmapLogConfigInstance = null;
+
+    /**
+     * @var lizmapJelixContext The jelixContext instance for the singleton
+     */
+    protected static $appContext = null;
 
     /**
      * this is a static class, so private constructor.
@@ -56,6 +65,15 @@ class lizmap
         }
 
         return self::$lizmapServicesInstance;
+    }
+
+    public function getAppContext()
+    {
+        if (!self::$appContext) {
+            self::$appContext = new \Lizmap\App\JelixContext();
+        }
+
+        return self::$appContext;
     }
 
     public static function saveServices()

--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -18,7 +18,7 @@ use Lizmap\Project;
   * Verify this methods are not used in external modules so we can delete them without risk, otherwise, we have to implement them
   * in Project and call it here
   */
-class lizmapProject extends qgisProject
+class lizmapProject
 {
     /**
      * @var project
@@ -30,9 +30,9 @@ class lizmapProject extends qgisProject
      * @param string           $key : the project name
      * @param lizmapRepository $rep : the repository
      */
-    public function __construct($key, $rep)
+    public function __construct($key, $rep, $context, $services)
     {
-        $this->proj = new \Lizmap\Project\project($key, $rep, lizmap::getAppContext(), lizmap::getServices());
+        $this->proj = new \Lizmap\Project\project($key, $rep, $context, $services);
     }
 
     public function clearCache()

--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -9,146 +9,21 @@
  *
  * @license Mozilla Public License : http://www.mozilla.org/MPL/
  */
+
+use Lizmap\Project;
+
+ /**
+  * @deprecated 
+  * @FIXME getXml, getComposer
+  * Verify this methods are not used in external modules so we can delete them without risk, otherwise, we have to implement them
+  * in Project and call it here
+  */
 class lizmapProject extends qgisProject
 {
     /**
-     * @var lizmapRepository
+     * @var project
      */
-    protected $repository;
-    /**
-     * @var SimpleXMLElement QGIS project XML
-     */
-    protected $xml;
-    /**
-     * @var object CFG project JSON
-     */
-    protected $cfg;
-
-    /**
-     * @var array services properties
-     */
-    protected $properties = array(
-        'repository',
-        'id',
-        'title',
-        'abstract',
-        'proj',
-        'bbox',
-    );
-
-    /**
-     * Lizmap project key.
-     *
-     * @var string
-     */
-    protected $key = '';
-
-    /**
-     * QGIS project filemtime.
-     *
-     * @var string
-     */
-    protected $qgsmtime = '';
-
-    /**
-     * Lizmap config filemtime.
-     *
-     * @var string
-     */
-    protected $qgscfgmtime = '';
-
-    /**
-     * @var array Lizmap repository configuration data
-     */
-    protected $data = array();
-
-    /**
-     * Version of QGIS which wrote the project.
-     *
-     * @var null|int
-     */
-    protected $qgisProjectVersion;
-
-    /**
-     * @var array contains WMS info
-     */
-    protected $WMSInformation;
-
-    /**
-     * @var string
-     */
-    protected $canvasColor = '';
-
-    /**
-     * @var array authid => proj4
-     */
-    protected $allProj4 = array();
-
-    /**
-     * @var array for each referenced layer, there is an item
-     *            with referencingLayer, referencedField, referencingField keys.
-     *            There is also a 'pivot' key
-     */
-    protected $relations = array();
-
-    /**
-     * @var array list of themes
-     */
-    protected $themes = array();
-
-    /**
-     * @var array list of layer orders: layer name => order
-     */
-    protected $layersOrder = array();
-
-    /**
-     * @var array
-     */
-    protected $printCapabilities = array();
-
-    /**
-     * @var array
-     */
-    protected $locateByLayer = array();
-
-    /**
-     * @var array
-     */
-    protected $formFilterLayers = array();
-
-    /**
-     * @var array
-     */
-    protected $editionLayers = array();
-
-    /**
-     * @var array
-     */
-    protected $attributeLayers = array();
-
-    /**
-     * @var bool
-     */
-    protected $useLayerIDs = false;
-
-    /**
-     * @var array List of cached properties
-     */
-    protected $cachedProperties = array('WMSInformation', 'canvasColor', 'allProj4',
-        'relations', 'themes', 'layersOrder', 'printCapabilities', 'locateByLayer', 'formFilterLayers',
-        'editionLayers', 'attributeLayers', 'useLayerIDs', 'layers', 'data', 'cfg', 'qgisProjectVersion', );
-
-
-    /**
-     * version of the format of data stored in the cache.
-     *
-     * This number should be increased each time you change the structure of the
-     * properties of qgisProject (ex: adding some new data properties into the $layers).
-     * So you'll be sure that the cache will be updated when Lizmap code source
-     * is updated on a server
-     */
-    const CACHE_FORMAT_VERSION = 1;
-
+    protected $proj;
     /**
      * constructor.
      *
@@ -157,105 +32,12 @@ class lizmapProject extends qgisProject
      */
     public function __construct($key, $rep)
     {
-        $this->key = $key;
-        $this->repository = $rep;
-
-        $file = $rep->getPath().$key.'.qgs';
-
-        // Verifying if the files exist
-        if (!file_exists($file)) {
-            throw new UnknownLizmapProjectException('The QGIS project '.$file.' does not exist!');
-        }
-        if (!file_exists($file.'.cfg')) {
-            throw new UnknownLizmapProjectException('The lizmap config '.$file.'.cfg does not exist!');
-        }
-
-        // For the cache key, we use the full path of the project file
-        // to avoid collision in the cache engine
-        $data = false;
-
-        $fileKey = jCache::normalizeKey($file);
-        try {
-            $data = jCache::get($fileKey, 'qgisprojects');
-        } catch (Exception $e) {
-            // if qgisprojects profile does not exist, or if there is an
-            // other error about the cache, let's log it
-            jLog::logEx($e, 'error');
-        }
-
-        if ($data === false ||
-            $data['qgsmtime'] < filemtime($file) ||
-            $data['qgscfgmtime'] < filemtime($file.'.cfg') ||
-            !isset($data['format_version']) ||
-            $data['format_version'] != self::CACHE_FORMAT_VERSION
-        ) {
-            // FIXME reading XML could take time, so many process could
-            // read it and construct the cache at the same time. We should
-            // have a kind of lock to avoid this issue.
-            $this->readProject($key, $rep);
-            $data['qgsmtime'] = filemtime($file);
-            $data['qgscfgmtime'] = filemtime($file.'.cfg');
-            $data['format_version'] = self::CACHE_FORMAT_VERSION;
-            foreach ($this->cachedProperties as $prop) {
-                $data[$prop] = $this->{$prop};
-            }
-
-            try {
-                jCache::set($fileKey, $data, null, 'qgisprojects');
-            } catch (Exception $e) {
-                jLog::logEx($e, 'error');
-            }
-        } else {
-            foreach ($this->cachedProperties as $prop) {
-                if(array_key_exists($prop, $data)){
-                    $this->{$prop} = $data[$prop];
-                }
-            }
-        }
-        $this->qgsmtime = $data['qgsmtime'];
-        $this->qgscfgmtime = $data['qgscfgmtime'];
-
-        $this->path = $file;
+        $this->proj = new \Lizmap\Project\project($key, $rep, lizmap::getJelixInfos(), lizmap::getServices());
     }
 
     public function clearCache()
     {
-        $file = $this->repository->getPath().$this->key.'.qgs';
-        $fileKey = jCache::normalizeKey($file);
-        try {
-            jCache::delete($fileKey, 'qgisprojects');
-        } catch (Exception $e) {
-            // if qgisprojects profile does not exist, or if there is an
-            // other error about the cache, let's log it
-            jLog::logEx($e, 'error');
-        }
-    }
-
-    /**
-     * temporary function to read xml for some methods that relies on
-     * xml data that are not yet stored in the cache.
-     *
-     * @return SimpleXMLElement
-     *
-     * @deprecated
-     */
-    protected function getXml()
-    {
-        if ($this->xml) {
-            return $this->xml;
-        }
-        $qgs_path = $this->repository->getPath().$this->key.'.qgs';
-        if (!file_exists($qgs_path) ||
-            !file_exists($qgs_path.'.cfg')) {
-            throw new Error('Files of project '.$this->key.' does not exists');
-        }
-        $xml = simplexml_load_file($qgs_path);
-        if ($xml === false) {
-            throw new Exception('Qgs File of project '.$this->key.' has invalid content');
-        }
-        $this->xml = $xml;
-
-        return $xml;
+        $this->proj->clearCache();
     }
 
     /**
@@ -266,439 +48,107 @@ class lizmapProject extends qgisProject
      */
     protected function readProject($key, $rep)
     {
-        $qgs_path = $rep->getPath().$key.'.qgs';
-
-        if (!file_exists($qgs_path) ||
-            !file_exists($qgs_path.'.cfg')) {
-            throw new UnknownLizmapProjectException("Files of project ${key} does not exists");
-        }
-
-        $config = jFile::read($qgs_path.'.cfg');
-        $this->cfg = json_decode($config);
-        if ($this->cfg === null) {
-            throw new UnknownLizmapProjectException(".qgs.cfg File of project ${key} has invalid content");
-        }
-
-        $configOptions = $this->cfg->options;
-
-        try {
-            parent::readXmlProject($qgs_path);
-        } catch (Exception $e) {
-            throw $e;
-        }
-        $qgs_xml = $this->xml;
-
-        // Complete data
-        $this->data['repository'] = $rep->getKey();
-        $this->data['id'] = $key;
-        if (!array_key_exists('title', $this->data)) {
-            $this->data['title'] = ucfirst($key);
-        }
-        if (!array_key_exists('abstract', $this->data)) {
-            $this->data['abstract'] = '';
-        }
-        $this->data['proj'] = $configOptions->projection->ref;
-        $this->data['bbox'] = implode(', ', $configOptions->bbox);
-
-        // Update WMSInformation
-        $this->WMSInformation['ProjectCrs'] = $this->data['proj'];
-
-        // get WMS getCapabilities full URL
-        $this->data['wmsGetCapabilitiesUrl'] = jUrl::getFull(
-            'lizmap~service:index',
-            array(
-                'repository' => $rep->getKey(),
-                'project' => $key,
-                'SERVICE' => 'WMS',
-                'VERSION' => '1.3.0',
-                'REQUEST' => 'GetCapabilities',
-            )
-        );
-
-        // get WMTS getCapabilities full URL
-        $this->data['wmtsGetCapabilitiesUrl'] = jUrl::getFull(
-            'lizmap~service:index',
-            array(
-                'repository' => $rep->getKey(),
-                'project' => $key,
-                'SERVICE' => 'WMTS',
-                'VERSION' => '1.0.0',
-                'REQUEST' => 'GetCapabilities',
-            )
-        );
-
-        $shortNames = $qgs_xml->xpath('//maplayer/shortname');
-        if ($shortNames && count($shortNames) > 0) {
-            foreach ($shortNames as $sname) {
-                $sname = (string) $sname;
-                $xmlLayer = $qgs_xml->xpath("//maplayer[shortname='${sname}']");
-                if (count($xmlLayer) == 0) {
-                    continue;
-                }
-                $xmlLayer = $xmlLayer[0];
-                $name = (string) $xmlLayer->layername;
-                if (property_exists($this->cfg->layers, $name)) {
-                    $this->cfg->layers->{$name}->shortname = $sname;
-                }
-            }
-        }
-
-        $layerWithOpacities = $qgs_xml->xpath('//maplayer/layerOpacity[.!=1]/parent::*');
-        if ($layerWithOpacities && count($layerWithOpacities) > 0) {
-            foreach( $layerWithOpacities as $layerWithOpacitiy ) {
-                $name = (string) $layerWithOpacitiy->layername;
-                if (property_exists($this->cfg->layers, $name)) {
-                    $opacity = (float) $layerWithOpacitiy->layerOpacity;
-                    $this->cfg->layers->{$name}->opacity = $opacity;
-                }
-            }
-        }
-
-        $groupsWithShortName = $qgs_xml->xpath("//layer-tree-group/customproperties/property[@key='wmsShortName']/parent::*/parent::*");
-        if ($groupsWithShortName && count($groupsWithShortName) > 0) {
-            foreach ($groupsWithShortName as $group) {
-                $name = (string) $group['name'];
-                $shortNameProperty = $group->xpath("customproperties/property[@key='wmsShortName']");
-                if ($shortNameProperty && count($shortNameProperty) > 0) {
-                    $shortNameProperty = $shortNameProperty[0];
-                    $sname = (string) $shortNameProperty['value'];
-                    if (property_exists($this->cfg->layers, $name)) {
-                        $this->cfg->layers->{$name}->shortname = $sname;
-                    }
-                }
-            }
-        }
-        $groupsMutuallyExclusive = $qgs_xml->xpath("//layer-tree-group[@mutually-exclusive='1']");
-        if ($groupsMutuallyExclusive && count($groupsMutuallyExclusive) > 0) {
-            foreach ($groupsMutuallyExclusive as $group) {
-                $name = (string) $group['name'];
-                if (property_exists($this->cfg->layers, $name)) {
-                    $this->cfg->layers->{$name}->mutuallyExclusive = 'True';
-                }
-            }
-        }
-
-        $layersWithShowFeatureCount = $qgs_xml->xpath("//layer-tree-layer/customproperties/property[@key='showFeatureCount']/parent::*/parent::*");
-        if ($layersWithShowFeatureCount && count($layersWithShowFeatureCount) > 0) {
-            foreach ($layersWithShowFeatureCount as $layer) {
-                $name = (string) $layer['name'];
-                if (property_exists($this->cfg->layers, $name)) {
-                    $this->cfg->layers->{$name}->showFeatureCount = 'True';
-                }
-            }
-        }
-        //remove plugin layer
-        $pluginLayers = $qgs_xml->xpath('//maplayer[type="plugin"]');
-        if ($pluginLayers && count($pluginLayers) > 0) {
-            foreach ($pluginLayers as $layer) {
-                $name = (string) $layer->layername;
-                if (property_exists($this->cfg->layers, $name)) {
-                    unset($this->cfg->layers->{$name});
-                }
-            }
-        }
-        //unset cache for editionLayers
-        if (property_exists($this->cfg, 'editionLayers')) {
-            foreach ($this->cfg->editionLayers as $key => $obj) {
-                if (property_exists($this->cfg->layers, $key)) {
-                    $this->cfg->layers->{$key}->cached = 'False';
-                    $this->cfg->layers->{$key}->clientCacheExpiration = 0;
-                    if (property_exists($this->cfg->layers->{$key}, 'cacheExpiration')) {
-                        unset($this->cfg->layers->{$key}->cacheExpiration);
-                    }
-                }
-            }
-        }
-        //unset cache for loginFilteredLayers
-        if (property_exists($this->cfg, 'loginFilteredLayers')) {
-            foreach ($this->cfg->loginFilteredLayers as $key => $obj) {
-                if (property_exists($this->cfg->layers, $key)) {
-                    $this->cfg->layers->{$key}->cached = 'False';
-                    $this->cfg->layers->{$key}->clientCacheExpiration = 0;
-                    if (property_exists($this->cfg->layers->{$key}, 'cacheExpiration')) {
-                        unset($this->cfg->layers->{$key}->cacheExpiration);
-                    }
-                }
-            }
-        }
-        //unset displayInLegend for geometryType none or unknown
-        foreach ($this->cfg->layers as $key => $obj) {
-            if (property_exists($this->cfg->layers->{$key}, 'geometryType') &&
-                 ($this->cfg->layers->{$key}->geometryType == 'none' ||
-                     $this->cfg->layers->{$key}->geometryType == 'unknown')
-            ) {
-                $this->cfg->layers->{$key}->displayInLegend = 'False';
-            }
-        }
-
-        $this->printCapabilities = $this->readPrintCapabilities($qgs_xml, $this->cfg);
-        $this->locateByLayer = $this->readLocateByLayers($qgs_xml, $this->cfg);
-        $this->formFilterLayers = $this->readFormFilterLayers($qgs_xml, $this->cfg);
-        $this->editionLayers = $this->readEditionLayers($qgs_xml, $this->cfg);
-        $this->attributeLayers = $this->readAttributeLayers($qgs_xml, $this->cfg);
-        $this->layersOrder = $this->readLayersOrder($qgs_xml, $this->cfg);
+        $this->proj->readProject($key, $rep);
     }
 
     public function getQgisPath()
     {
-        return realpath($this->repository->getPath()).'/'.$this->key.'.qgs';
+        return $this->proj->getQgisPath();
     }
 
     public function getRelativeQgisPath()
     {
-        $services = lizmap::getServices();
-
-        $mapParam = $this->getQgisPath();
-        if (!$services->isRelativeWMSPath()) {
-            return $mapParam;
-        }
-
-        $rootRepositories = $services->getRootRepositories();
-        if ($rootRepositories != '' && strpos($mapParam, $rootRepositories) === 0) {
-            $mapParam = str_replace($rootRepositories, '', $mapParam);
-            $mapParam = ltrim($mapParam, '/');
-        }
-
-        return $mapParam;
+       return $this->proj->getRelativeQgisPath();
     }
 
     public function getKey()
     {
-        return $this->key;
+        return $this->proj->getKey();
     }
 
     public function getRepository()
     {
-        return $this->repository;
+        return $this->proj->getRepository();
     }
 
     public function getFileTime()
     {
-        return $this->qgsmtime;
+        return $this->proj->getFileTime();
     }
 
     public function getCfgFileTime()
     {
-        return $this->qgscfgmtime;
+        return $this->proj->getCfgFileTime();
     }
 
     public function getProperties()
     {
-        return $this->properties;
+        return $this->proj->getProperties();
     }
 
     public function getOptions()
     {
-        return $this->cfg->options;
+        return $this->proj->getOptions();
     }
 
     public function getLayers()
     {
-        return $this->cfg->layers;
+        return $this->proj->getLayers();
     }
 
     public function findLayerByAnyName($name)
     {
-        // name null or empty string
-        if ($name == null || empty($name)) {
-            return null;
-        }
-
-        // Get by name ie as written in QGIS Desktop legend
-        $layer = $this->findLayerByName($name);
-        if ($layer) {
-            return $layer;
-        }
-
-        // since 2.14 layer's name can be layer's shortName
-        $layer = $this->findLayerByShortName($name);
-        if ($layer) {
-            return $layer;
-        }
-
-        // Get layer by typename : qgis server replaces ' ' by '_' for layer names
-        $layer = $this->findLayerByTypeName($name);
-        if ($layer) {
-            return $layer;
-        }
-
-        // Get by id
-        $layer = $this->findLayerByLayerId($name);
-        if ($layer) {
-            return $layer;
-        }
-
-        // since 2.6 layer's name can be layer's title
-        return $this->findLayerByTitle($name);
+        return $this->proj->findLayerByAnyName($name);
     }
 
     public function findLayerByName($name)
     {
-        // name null or empty string
-        if ($name == null || empty($name)) {
-            return null;
-        }
-
-        if (property_exists($this->cfg->layers, $name)) {
-            return $this->cfg->layers->{$name};
-        }
-
-        return null;
+        return $this->proj->findLayerByName($name);
     }
 
     public function findLayerByShortName($shortName)
     {
-        // short name null or empty string
-        if ($shortName == null || empty($shortName)) {
-            return null;
-        }
-
-        foreach ($this->cfg->layers as $layer) {
-            if (!property_exists($layer, 'shortname')) {
-                continue;
-            }
-            if ($layer->shortname == $shortName) {
-                return $layer;
-            }
-        }
-
-        return null;
+        return $this->proj->findLayerByShortName($shortName);
     }
 
     public function findLayerByTitle($title)
     {
-        // title null or empty string
-        if ($title == null || empty($title)) {
-            return null;
-        }
-
-        foreach ($this->cfg->layers as $layer) {
-            if (!property_exists($layer, 'title')) {
-                continue;
-            }
-            if ($layer->title == $title) {
-                return $layer;
-            }
-        }
-
-        return null;
+        return $this->proj->findLayerByTitle($title);
     }
 
     public function findLayerByLayerId($layerId)
     {
-        // layer id null or empty string
-        if ($layerId == null || empty($layerId)) {
-            return null;
-        }
-
-        foreach ($this->cfg->layers as $layer) {
-            if (!property_exists($layer, 'id')) {
-                continue;
-            }
-            if ($layer->id == $layerId) {
-                return $layer;
-            }
-        }
-
-        return null;
+        return $this->proj->findLayerByLayerId($layerId);
     }
 
     public function findLayerByTypeName($typeName)
     {
-        // type name null or empty string
-        if ($typeName == null || empty($typeName)) {
-            return null;
-        }
-
-        // typeName is layerName
-        if (property_exists($this->cfg->layers, $typeName)) {
-            return $this->cfg->layers->{$typeName};
-        }
-        // typeName is cleanName or shortName
-        foreach ($this->cfg->layers as $layer) {
-            if (str_replace(' ', '_', $layer->name) == $typeName) {
-                return $layer;
-            }
-            if (!property_exists($layer, 'shortname')) {
-                continue;
-            }
-            if ($layer->shortname == $typeName) {
-                return $layer;
-            }
-        }
-
-        return null;
+        return $this->proj->findLayerByTypeName($typeName);
     }
 
     public function hasLocateByLayer()
     {
-        if (property_exists($this->cfg, 'locateByLayer')) {
-            $count = 0;
-            foreach ($this->cfg->locateByLayer as $key => $obj) {
-                ++$count;
-            }
-            if ($count != 0) {
-                return true;
-            }
-
-            return false;
-        }
-
-        return false;
+        return $this->proj->hasLocateByLayer();
     }
 
     public function hasFormFilterLayers()
     {
-        if (property_exists($this->cfg, 'formFilterLayers')) {
-            $count = 0;
-            foreach ($this->cfg->formFilterLayers as $key => $obj) {
-                ++$count;
-            }
-            if ($count != 0) {
-                return true;
-            }
-
-            return false;
-        }
-
-        return false;
+        return $this->proj->hasFormFilterLayers();
     }
 
     public function getFormFilterLayersConfig()
     {
-        $config = Null;
-        if (property_exists($this->cfg, 'formFilterLayers')) {
-            $config = $this->cfg->formFilterLayers;
-        }
-        return $config;
+        return $this->proj->getFormFilterLayersConfig();
     }
 
     public function hasTimemanagerLayers()
     {
-        if (property_exists($this->cfg, 'timemanagerLayers')) {
-            $count = 0;
-            foreach ($this->cfg->timemanagerLayers as $key => $obj) {
-                ++$count;
-            }
-            if ($count != 0) {
-                return true;
-            }
-
-            return false;
-        }
-
-        return false;
+        return $this->proj->hasTimemanagerLayers();
     }
 
     public function hasAtlasEnabled()
     {
-        if ((property_exists($this->cfg->options, 'atlasEnabled') and $this->cfg->options->atlasEnabled == 'True') // Legacy LWC < 3.4 (only one layer)
-            or
-            (property_exists($this->cfg, 'atlas') and property_exists($this->cfg->atlas, 'layers') and is_array($this->cfg->atlas->layers) and count($this->cfg->atlas->layers) > 0)) { // Multiple atlas
-            return true;
-        }
-
-        return false;
+        return $this->proj->hasAtlasEnabled();
     }
 
     /**
@@ -706,167 +156,37 @@ class lizmapProject extends qgisProject
      */
     public function getQgisServerPlugins()
     {
-        $qgisServer = jClasses::getService('lizmap~qgisServer');
-
-        return $qgisServer->getPlugins($this);
+        return $this->proj->getQgisServerPlugins();
     }
 
     public function hasTooltipLayers()
     {
-        if (property_exists($this->cfg, 'tooltipLayers')) {
-            $count = 0;
-            foreach ($this->cfg->tooltipLayers as $key => $obj) {
-                ++$count;
-            }
-            if ($count != 0) {
-                return true;
-            }
-
-            return false;
-        }
-
-        return false;
+        return $this->proj->hasTooltipLayers();
     }
 
     public function hasAttributeLayers($onlyDisplayedLayers = false)
     {
-        if (property_exists($this->cfg, 'attributeLayers')) {
-            $count = 0;
-            $hasDisplayedLayer = !$onlyDisplayedLayers;
-            foreach ($this->cfg->attributeLayers as $key => $obj) {
-                ++$count;
-                if ($onlyDisplayedLayers && !property_exists($obj, 'hideLayer') ||
-                    strtolower($obj->hideLayer) != 'true') {
-                    $hasDisplayedLayer = true;
-                }
-            }
-            if ($count != 0 && $hasDisplayedLayer) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->proj->hasAttributeLayers($onlyDisplayedLayers);
     }
 
     public function hasFtsSearches()
     {
-        // Virtual jdb profile corresponding to the layer database
-        $project = $this->key;
-        $repository = $this->repository->getKey();
-
-        $repositoryPath = realpath($this->repository->getPath());
-        $repositoryPath = str_replace('\\', '/', $repositoryPath);
-        $searchDatabase = $repositoryPath.'/default.qfts';
-
-        if (!file_exists($searchDatabase)) {
-            // Search for project database
-            $searchDatabase = $repositoryPath.'/'.$project.'.qfts';
-        }
-        if (!file_exists($searchDatabase)) {
-            return false;
-        }
-
-        $jdbParams = array(
-            'driver' => 'pdo',
-            'dsn' => 'sqlite:'.$searchDatabase,
-        );
-
-        // Create the virtual jdb profile
-        $searchJdbName = 'jdb_'.$repository.'_'.$project;
-        jProfiles::createVirtualProfile('jdb', $searchJdbName, $jdbParams);
-
-        // Check FTS db ( tables and geometry storage
-        try {
-            $cnx = jDb::getConnection($searchJdbName);
-
-            // Get metadata
-            $sql = "
-            SELECT search_id, search_name, layer_name, geometry_storage, srid
-            FROM quickfinder_toc
-            WHERE geometry_storage != 'wkb'
-            ORDER BY priority
-            ";
-            $res = $cnx->query($sql);
-            $searches = array();
-            foreach ($res as $item) {
-                $searches[$item->search_id] = array(
-                    'search_name' => $item->search_name,
-                    'layer_name' => $item->layer_name,
-                    'srid' => $item->srid,
-                );
-            }
-            if (count($searches) == 0) {
-                return false;
-            }
-
-            return array(
-                'jdb_profile' => $searchJdbName,
-                'searches' => $searches,
-            );
-        } catch (Exception $e) {
-            return false;
-        }
-
-        return false;
+        return $this->proj->hasFtsSearches();
     }
 
     public function hasEditionLayers()
     {
-        if (property_exists($this->cfg, 'editionLayers')) {
-            if (!jAcl2::check('lizmap.tools.edition.use', $this->repository->getKey())) {
-                return false;
-            }
-
-            $count = 0;
-            foreach ($this->cfg->editionLayers as $key => $eLayer) {
-                // Check if user groups intersects groups allowed by project editor
-                // If user is admin, no need to check for given groups
-                if (property_exists($eLayer, 'acl') and $eLayer->acl) {
-                    // Check if configured groups white list and authenticated user groups list intersects
-                    $editionGroups = $eLayer->acl;
-                    $editionGroups = array_map('trim', explode(',', $editionGroups));
-                    if (is_array($editionGroups) and count($editionGroups) > 0) {
-                        $userGroups = jAcl2DbUserGroup::getGroups();
-                        if (array_intersect($editionGroups, $userGroups) or jAcl2::check('lizmap.admin.repositories.delete')) {
-                            // User group(s) correspond to the groups given for this edition layer
-                            // or user is admin
-                            ++$count;
-                            unset($this->cfg->editionLayers->{$key}->acl);
-                        } else {
-                            // No match found, we deactivate the edition layer
-                            unset($this->cfg->editionLayers->{$key});
-                        }
-                    }
-                } else {
-                    ++$count;
-                }
-            }
-            if ($count != 0) {
-                return true;
-            }
-
-            return false;
-        }
-
-        return false;
+        return $this->proj->hasEditionLayers();
     }
 
     public function getEditionLayers()
     {
-        return $this->cfg->editionLayers;
+        return $this->proj->getEditionLayers();
     }
 
     public function findEditionLayerByName($name)
     {
-        if (!$this->hasEditionLayers()) {
-            return null;
-        }
-
-        if (property_exists($this->cfg->editionLayers, $name)) {
-            return $this->cfg->editionLayers->{$name};
-        }
-
-        return null;
+        return $this->proj->findEditionLayerByName($name);
     }
 
     /**
@@ -876,20 +196,7 @@ class lizmapProject extends qgisProject
      */
     public function findEditionLayerByLayerId($layerId)
     {
-        if (!$this->hasEditionLayers()) {
-            return null;
-        }
-
-        foreach ($this->cfg->editionLayers as $layer) {
-            if (!property_exists($layer, 'layerId')) {
-                continue;
-            }
-            if ($layer->layerId == $layerId) {
-                return $layer;
-            }
-        }
-
-        return null;
+        return $this->proj->findEditionLayerByLayerId($layerId);
     }
 
     /**
@@ -897,100 +204,22 @@ class lizmapProject extends qgisProject
      */
     public function hasLoginFilteredLayers()
     {
-        if (property_exists($this->cfg, 'loginFilteredLayers')) {
-            $count = 0;
-            foreach ($this->cfg->loginFilteredLayers as $key => $obj) {
-                ++$count;
-            }
-            if ($count != 0) {
-                return true;
-            }
-
-            return false;
-        }
-
-        return false;
+        return $this->proj->hasLoginFilteredLayers();
     }
 
     public function getLoginFilteredConfig($layername)
     {
-        if (!$this->hasLoginFilteredLayers()) {
-            return Null;
-        }
-
-        $ln = $layername;
-        // In case $layername is a WFS TypeName
-        $layerByTypeName = $this->findLayerByTypeName($layername);
-        if($layerByTypeName){
-            $ln = $layerByTypeName->name;
-        }
-
-        if (!property_exists($this->cfg->loginFilteredLayers, $ln)) {
-            return null;
-        }
-
-        return $this->cfg->loginFilteredLayers->{$ln};
+        return $this->proj->getLoginFilteredConfig($layername);
     }
 
     public function getLoginFilters($layers)
     {
-        $filters = array();
-
-        if (!$this->hasLoginFilteredLayers()) {
-            return $filters;
-        }
-
-        foreach ($layers as $layername) {
-            $lname = $layername;
-
-            // In case $layername is a WFS TypeName
-            $layerByTypeName = $this->findLayerByTypeName($layername);
-            if($layerByTypeName){
-                $lname = $layerByTypeName->name;
-            }
-
-            // Get config
-            $loginFilteredConfig = $this->getLoginFilteredConfig($lname);
-            if ($loginFilteredConfig == Null) {
-                continue;
-            }
-
-            // attribute to filter
-            $attribute = strtolower($loginFilteredConfig->filterAttribute);
-
-            // default no user connected
-            $filter = "\"${attribute}\" = 'all'";
-
-            // A user is connected
-            if (jAuth::isConnected()) {
-                $user = jAuth::getUserSession();
-                $login = $user->login;
-                if (property_exists($loginFilteredConfig, 'filterPrivate') &&
-                    $this->optionToBoolean($loginFilteredConfig->filterPrivate)
-                ) {
-                    $filter = "\"${attribute}\" IN ( '".$login."' , 'all' )";
-                } else {
-                    $userGroups = jAcl2DbUserGroup::getGroups();
-                    $flatGroups = implode("' , '", $userGroups);
-                    $filter = "\"${attribute}\" IN ( '".$flatGroups."' , 'all' )";
-                }
-            }
-
-            $filters[$layername] = array_merge(
-                $loginFilteredConfig,
-                array('filter' => $filter, 'layername' => $lname)
-            );
-        }
-
-        return $filters;
+        return $this->proj->getLoginFilters($layers);
     }
 
-    private function optionToBoolean($config_string) {
-        $ret = false;
-        if (strtolower((string)$config_string) == 'true') {
-            $ret = true;
-        }
-        return $ret;
+    private function optionToBoolean($config_string)
+    {
+        return $this->proj->optionToBoolean($config_string);
     }
 
     /**
@@ -998,159 +227,7 @@ class lizmapProject extends qgisProject
      */
     public function getDatavizLayersConfig()
     {
-        if (!property_exists($this->cfg, 'datavizLayers')) {
-            return false;
-        }
-        $config = array(
-            'layers' => array(),
-            'dataviz' => array(),
-            'locale' => jApp::config()->locale
-        );
-        foreach ($this->cfg->datavizLayers as $order => $lc) {
-            if (!property_exists($lc, 'layerId')) {
-                continue;
-            }
-            $layer = $this->findLayerByAnyName($lc->layerId);
-            if (!$layer) {
-                continue;
-            }
-            $title = $layer->title;
-            if (!empty($lc->title)) {
-                $title = $lc->title;
-            }
-            $plotConf = array(
-                'plot_id' => $lc->order,
-                'layer_id' => $layer->id,
-                'title' => $title,
-                'plot' => array(
-                    'type' => $lc->type,
-                    'x_field' => $lc->x_field,
-                ),
-            );
-            if (property_exists($lc, 'y_field')) {
-                $plotConf['plot']['y_field'] = $lc->y_field;
-            }
-            if (property_exists($lc, 'z_field')) {
-                $plotConf['plot']['z_field'] = $lc->z_field;
-            }
-
-            $abstract = $layer->abstract;
-            if (property_exists($lc, 'description')) {
-                $abstract = $lc->description;
-            }
-            $plotConf['abstract'] = $abstract;
-
-            if (property_exists($lc, 'x_field')) {
-                $plotConf['plot']['x_field'] = $lc->x_field;
-            }
-            if (property_exists($lc, 'y_field')) {
-                $plotConf['plot']['y_field'] = $lc->y_field;
-            }
-            if (property_exists($lc, 'popup_display_child_plot')) {
-                $plotConf['popup_display_child_plot'] = $lc->popup_display_child_plot;
-            }
-            if (property_exists($lc, 'only_show_child')) {
-                $plotConf['only_show_child'] = $lc->only_show_child;
-            }
-            if (property_exists($lc, 'y2_field')) {
-                $plotConf['plot']['y2_field'] = $lc->y2_field;
-            }
-            if (!empty($lc->color)) {
-                $plotConf['plot']['color'] = $lc->color;
-            }
-            if (property_exists($lc, 'color2') and !empty($lc->color2) ) {
-                $plotConf['plot']['color2'] = $lc->color2;
-            }
-            if (property_exists($lc, 'aggregation')) {
-                $plotConf['plot']['aggregation'] = $lc->aggregation;
-            }
-            if (property_exists($lc, 'colorfield')) {
-                $plotConf['plot']['colorfield'] = $lc->colorfield;
-            }
-            if (property_exists($lc, 'colorfield2')) {
-                $plotConf['plot']['colorfield2'] = $lc->colorfield2;
-            }
-
-            $display_legend = True;
-            if (property_exists($lc, 'display_legend')) {
-                $display_legend = $this->optionToBoolean($lc->display_legend);
-            }
-            $plotConf['plot']['display_legend'] = $display_legend;
-
-            $stacked = False;
-            if (property_exists($lc, 'stacked')) {
-                $stacked = $this->optionToBoolean($lc->stacked);
-            }
-            $plotConf['plot']['stacked'] = $stacked;
-
-            $horizontal = False;
-            if (property_exists($lc, 'horizontal')) {
-                $horizontal = $this->optionToBoolean($lc->horizontal);
-            }
-            $plotConf['plot']['horizontal'] = $horizontal;
-
-            if (property_exists($lc, 'html_template') and !empty($lc->html_template) ) {
-                $plotConf['plot']['html_template'] = $lc->html_template;
-            }
-
-            if (property_exists($lc, 'display_when_layer_visible') and !empty($lc->display_when_layer_visible) ) {
-                $plotConf['plot']['display_when_layer_visible'] = $lc->display_when_layer_visible;
-            }
-
-            if (property_exists($lc, 'traces')) {
-                $plotConf['plot']['traces'] = $lc->traces;
-            }
-
-            // Add more layout config, written like:
-            // layout_config=barmode:stack,bargap:0.5
-            if (!empty($lc->layout_config)) {
-                $layout_config = array();
-                $a = array_map('trim', explode(',', $lc->layout_config));
-                foreach ($a as $i) {
-                    $b = array_map('trim', explode(':', $i));
-                    if (is_array($b) and count($b) == 2) {
-                        $c = $b[1];
-                        if ($c == 'false') {
-                            $c = (bool) false;
-                        }
-                        if ($c == 'true') {
-                            $c = (bool) true;
-                        }
-                        $layout_config[$b[0]] = $c;
-                    }
-                }
-                if (count($layout_config) > 0) {
-                    $plotConf['plot']['layout_config'] = $layout_config;
-                }
-            }
-
-            if (property_exists($lc, 'layout')) {
-                $plotConf['plot']['layout'] = $lc->layout;
-            }
-
-            $config['layers'][$order] = $plotConf;
-
-        }
-        if (empty($config['layers'])) {
-            return false;
-        }
-
-        $config['dataviz'] = array(
-            'location' => 'dock',
-            'theme' => 'dark'
-        );
-        if (property_exists($this->cfg->options, 'datavizLocation')
-            and in_array($this->cfg->options->datavizLocation, array('dock', 'bottomdock', 'right-dock'))
-        ) {
-            $config['dataviz']['location'] = $this->cfg->options->datavizLocation;
-        }
-        if (property_exists($this->cfg->options, 'theme')
-            and in_array($this->cfg->options->theme, array('dark', 'light'))
-        ) {
-            $config['dataviz']['theme'] = $this->cfg->options->theme;
-        }
-
-        return $config;
+        return $this->proj->getDatavizLayersConfig();
     }
 
     /**
@@ -1158,30 +235,7 @@ class lizmapProject extends qgisProject
      */
     public function needsGoogle()
     {
-        $configOptions = $this->cfg->options;
-
-        return
-            (
-                property_exists($configOptions, 'googleStreets')
-                && $configOptions->googleStreets == 'True'
-            ) ||
-            (
-                property_exists($configOptions, 'googleSatellite')
-                && $configOptions->googleSatellite == 'True'
-            ) ||
-            (
-                property_exists($configOptions, 'googleHybrid')
-                && $configOptions->googleHybrid == 'True'
-            ) ||
-            (
-                property_exists($configOptions, 'googleTerrain')
-                && $configOptions->googleTerrain == 'True'
-            ) ||
-            (
-                property_exists($configOptions, 'externalSearch')
-                && $configOptions->externalSearch == 'google'
-            )
-        ;
+        return $this->proj->needsGoogle();
     }
 
     /**
@@ -1189,14 +243,7 @@ class lizmapProject extends qgisProject
      */
     public function getGoogleKey()
     {
-        $configOptions = $this->cfg->options;
-        $gkey = '';
-        if (property_exists($configOptions, 'googleKey')
-            && $configOptions->googleKey != '') {
-            $gkey = $configOptions->googleKey;
-        }
-
-        return $gkey;
+        return $this->proj->getGoogleKey();
     }
 
     /**
@@ -1206,268 +253,12 @@ class lizmapProject extends qgisProject
      */
     public function getLayerNameByIdFromConfig($layerId)
     {
-        $layers = $this->getLayers();
-        $name = null;
-        foreach ($layers as $name => $props) {
-            if ($props->id == $layerId) {
-                return $name;
-            }
-        }
-
-        return $name;
+        return $this->proj->getLayerNameByIdFromConfig($layerId);
     }
 
     protected function readPrintCapabilities($qgsLoad, $cfg)
     {
-        $printTemplates = array();
-
-        if (property_exists($cfg->options, 'print') &&
-            $cfg->options->print == 'True'
-        ) {
-            // get restricted composers
-            $rComposers = array();
-            $restrictedComposers = $qgsLoad->xpath('//properties/WMSRestrictedComposers/value');
-            if ($restrictedComposers && count($restrictedComposers) > 0) {
-                foreach ($restrictedComposers as $restrictedComposer) {
-                    $rComposers[] = (string) $restrictedComposer;
-                }
-            }
-
-            $services = lizmap::getServices();
-            // get composer qg project version < 3
-            $composers = $qgsLoad->xpath('//Composer');
-            if ($composers && count($composers) > 0) {
-                foreach ($composers as $composer) {
-                    // test restriction
-                    if (in_array((string) $composer['title'], $rComposers)) {
-                        continue;
-                    }
-                    // get composition element
-                    $composition = $composer->xpath('Composition');
-                    if (!$composition || count($composition) == 0) {
-                        continue;
-                    }
-                    $composition = $composition[0];
-
-                    // init print template element
-                    $printTemplate = array(
-                        'title' => (string) $composer['title'],
-                        'width' => (int) $composition['paperWidth'],
-                        'height' => (int) $composition['paperHeight'],
-                        'maps' => array(),
-                        'labels' => array(),
-                    );
-
-                    // get composer maps
-                    $cMaps = $composer->xpath('.//ComposerMap');
-                    if ($cMaps && count($cMaps) > 0) {
-                        foreach ($cMaps as $cMap) {
-                            $cMapItem = $cMap->xpath('ComposerItem');
-                            if (count($cMapItem) == 0) {
-                                continue;
-                            }
-                            $cMapItem = $cMapItem[0];
-                            $ptMap = array(
-                                'id' => 'map'.(string) $cMap['id'],
-                                'width' => (int) $cMapItem['width'],
-                                'height' => (int) $cMapItem['height'],
-                            );
-
-                            // Before 2.6
-                            if (property_exists($cMap->attributes(), 'overviewFrameMap') and (string) $cMap['overviewFrameMap'] != '-1') {
-                                $ptMap['overviewMap'] = 'map'.(string) $cMap['overviewFrameMap'];
-                            }
-                            // >= 2.6
-                            $cMapOverviews = $cMap->xpath('ComposerMapOverview');
-                            foreach ($cMapOverviews as $cMapOverview) {
-                                if ($cMapOverview and (string) $cMapOverview->attributes()->frameMap != '-1') {
-                                    $ptMap['overviewMap'] = 'map'.(string) $cMapOverview->attributes()->frameMap;
-                                }
-                            }
-                            // Grid
-                            $cMapGrids = $cMap->xpath('ComposerMapGrid');
-                            foreach ($cMapGrids as $cMapGrid) {
-                                if ($cMapGrid and (string) $cMapGrid->attributes()->show != '0') {
-                                    $ptMap['grid'] = 'True';
-                                }
-                            }
-                            // In QGIS 3.*
-                            // Layout maps now use a string UUID as "id", let's assume that the first map
-                            // has id 0 and so on ...
-                            if (version_compare($services->qgisServerVersion, '3.0', '>=')) {
-                                $ptMap['id'] = 'map'.(string) count($printTemplate['maps']);
-                            }
-                            $printTemplate['maps'][] = $ptMap;
-                        }
-                    }
-
-                    // get composer labels
-                    $cLabels = $composer->xpath('.//ComposerLabel');
-                    if ($cLabels && count($cLabels) > 0) {
-                        foreach ($cLabels as $cLabel) {
-                            $cLabelItem = $cLabel->xpath('ComposerItem');
-                            if (!$cLabelItem || count($cLabelItem) == 0) {
-                                continue;
-                            }
-                            $cLabelItem = $cLabelItem[0];
-                            if ((string) $cLabelItem['id'] == '') {
-                                continue;
-                            }
-                            $printTemplate['labels'][] = array(
-                                'id' => (string) $cLabelItem['id'],
-                                'htmlState' => (int) $cLabel['htmlState'],
-                                'text' => (string) $cLabel['labelText'],
-                            );
-                        }
-                    }
-
-                    // get composer attribute tables
-                    $cTables = $composer->xpath('.//ComposerAttributeTableV2');
-                    if ($cTables && count($cTables) > 0) {
-                        foreach ($cTables as $cTable) {
-                            $printTemplate['tables'][] = array(
-                                'composerMap' => (int) $cTable['composerMap'],
-                                'vectorLayer' => (string) $cTable['vectorLayer'],
-                            );
-                        }
-                    }
-
-                    // Atlas
-                    $Atlas = $composer->xpath('Atlas');
-                    if (count($Atlas) == 1) {
-                        $Atlas = $Atlas[0];
-                        $printTemplate['atlas'] = array(
-                            'enabled' => (string) $Atlas['enabled'],
-                            'coverageLayer' => (string) $Atlas['coverageLayer'],
-                        );
-                    }
-                    $printTemplates[] = $printTemplate;
-                }
-            }
-            // get layout qgs project version >= 3
-            $layouts = $qgsLoad->xpath('//Layout');
-            if ($layouts && count($layouts) > 0 &&
-                version_compare($services->qgisServerVersion, '3.0', '>=')) {
-                foreach ($layouts as $layout) {
-                    // test restriction
-                    if (in_array((string) $layout['name'], $rComposers)) {
-                        continue;
-                    }
-                    // get page element
-                    $page = $layout->xpath('PageCollection/LayoutItem[@type="65638"]');
-                    if (!$page || count($page) == 0) {
-                        continue;
-                    }
-                    $page = $page[0];
-
-                    $pageSize = explode(',', $page['size']);
-                    // init print template element
-                    $printTemplate = array(
-                        'title' => (string) $layout['name'],
-                        'width' => (int) $pageSize[0],
-                        'height' => (int) $pageSize[1],
-                        'maps' => array(),
-                        'labels' => array(),
-                    );
-
-                    // store mapping between uuid and id
-                    $mapUuidId = [];
-                    // get layout maps
-                    $lMaps = $layout->xpath('LayoutItem[@type="65639"]');
-                    if ($lMaps && count($lMaps) > 0) {
-                        // Convert xml to json config
-                        foreach ($lMaps as $lMap) {
-                            $lMapSize = explode(',', $lMap['size']);
-                            $ptMap = array(
-                                'id' => 'map'.(string) count($printTemplate['maps']),
-                                'uuid' => (string)$lMap['uuid'],
-                                'width' => (int) $lMapSize[0],
-                                'height' => (int) $lMapSize[1],
-                            );
-                            // store mapping between uuid and id
-                            $mapUuidId[(string) $lMap['uuid']] = 'map'.(string) count($printTemplate['maps']);
-
-                            // Overview
-                            $cMapOverviews = $lMap->xpath('ComposerMapOverview');
-                            foreach ($cMapOverviews as $cMapOverview) {
-                                if ($cMapOverview and (string) $cMapOverview->attributes()->show !== '0' and (string) $cMapOverview->attributes()->frameMap != '-1') {
-                                    // frameMap is an uuid
-                                    $ptMap['overviewMap'] = (string) $cMapOverview->attributes()->frameMap;
-                                }
-                            }
-                            // Grid
-                            $cMapGrids = $lMap->xpath('ComposerMapGrid');
-                            foreach ($cMapGrids as $cMapGrid) {
-                                if ($cMapGrid and (string) $cMapGrid->attributes()->show !== '0') {
-                                    $ptMap['grid'] = 'True';
-                                }
-                            }
-
-                            $printTemplate['maps'][] = $ptMap;
-                        }
-                        // Modifying overviewMap to id instead of uuid
-                        foreach ($printTemplate['maps'] as $ptMap) {
-                            if (!array_key_exists('overviewMap', $ptMap))
-                                continue;
-                            if (!array_key_exists($ptMap['overviewMap'], $mapUuidId)) {
-                                unset($ptMap['overviewMap']);
-                                continue;
-                            }
-                            $ptMap['overviewMap'] = $mapUuidId[$ptMap['overviewMap']];
-                        }
-                    }
-
-                    // get layout labels
-                    $lLabels = $layout->xpath('LayoutItem[@type="65641"]');
-                    if ($lLabels && count($lLabels) > 0) {
-                        foreach ($lLabels as $lLabel) {
-                            if ((string) $lLabel['id'] == '') {
-                                continue;
-                            }
-                            $printTemplate['labels'][] = array(
-                                'id' => (string) $lLabel['id'],
-                                'htmlState' => (int) $lLabel['htmlState'],
-                                'text' => (string) $lLabel['labelText'],
-                            );
-                        }
-                    }
-
-                    // get layout attribute tables
-                    $lTables = $layout->xpath('LayoutMultiFrame[@type="65649"]');
-                    if ($lTables && count($lTables) > 0) {
-                        foreach ($lTables as $lTable) {
-                            $composerMap = -1;
-                            if (isset($lTable['mapUuid'])) {
-                                $mapUuid = (string) $lTable['mapUuid'];
-                                if (!array_key_exists($mapUuid, $mapUuidId)) {
-                                    $mapId = $mapUuidId[$mapUuid];
-                                    $composerMap = (string) str_replace('map', '', $mapId);
-                                }
-                            }
-
-                            $printTemplate['tables'][] = array(
-                                'composerMap' => $composerMap,
-                                'vectorLayer' => (string) $lTable['vectorLayer'],
-                                'vectorLayerName' => (string) $lTable['vectorLayerName'],
-                            );
-                        }
-                    }
-
-                    // Atlas
-                    $Atlas = $layout->xpath('Atlas');
-                    if (count($Atlas) == 1) {
-                        $Atlas = $Atlas[0];
-                        $printTemplate['atlas'] = array(
-                            'enabled' => (string) $Atlas['enabled'],
-                            'coverageLayer' => (string) $Atlas['coverageLayer'],
-                        );
-                    }
-                    $printTemplates[] = $printTemplate;
-                }
-            }
-        }
-
-        return $printTemplates;
+        return $this->proj->readPrintCapabilities($qgsLoad, $cfg);
     }
 
     /**
@@ -1478,145 +269,27 @@ class lizmapProject extends qgisProject
      */
     protected function getXmlLayer2($xml, $layerId)
     {
-        return $xml->xpath("//maplayer[id='${layerId}']");
+        return $this->proj->getXmlLayer2($xml, $layerId);
     }
 
     protected function readLocateByLayers($xml, $cfg)
     {
-        $locateByLayer = array();
-        if (property_exists($cfg, 'locateByLayer')) {
-            $locateByLayer = $cfg->locateByLayer;
-            // collect layerIds
-            $locateLayerIds = array();
-            foreach ($locateByLayer as $k => $v) {
-                $locateLayerIds[] = $v->layerId;
-            }
-            // update locateByLayer with alias and filter information
-            foreach ($locateByLayer as $k => $v) {
-                $xmlLayer = $this->getXmlLayer2($xml, $v->layerId);
-                if (count($xmlLayer) == 0) {
-                    continue;
-                }
-                $xmlLayerZero = $xmlLayer[0];
-                // aliases
-                $alias = $xmlLayerZero->xpath("aliases/alias[@field='".$v->fieldName."']");
-                if ($alias && count($alias) != 0) {
-                    $alias = $alias[0];
-                    $v->fieldAlias = (string) $alias['name'];
-                    $locateByLayer->{$k} = $v;
-                }
-                if (property_exists($v, 'filterFieldName')) {
-                    $alias = $xmlLayerZero->xpath("aliases/alias[@field='".$v->filterFieldName."']");
-                    if ($alias && count($alias) != 0) {
-                        $alias = $alias[0];
-                        $v->filterFieldAlias = (string) $alias['name'];
-                        $locateByLayer->{$k} = $v;
-                    }
-                }
-                // vectorjoins
-                $vectorjoins = $xmlLayerZero->xpath('vectorjoins/join');
-                if ($vectorjoins && count($vectorjoins) != 0) {
-                    if (!property_exists($v, 'vectorjoins')) {
-                        $v->vectorjoins = array();
-                    }
-                    foreach ($vectorjoins as $vectorjoin) {
-                        $joinLayerId = (string) $vectorjoin['joinLayerId'];
-                        if (in_array($joinLayerId, $locateLayerIds)) {
-                            $v->vectorjoins[] = (object) array(
-                                'joinFieldName' => (string) $vectorjoin['joinFieldName'],
-                                'targetFieldName' => (string) $vectorjoin['targetFieldName'],
-                                'joinLayerId' => (string) $vectorjoin['joinLayerId'],
-                            );
-                        }
-                    }
-                    $locateByLayer->{$k} = $v;
-                }
-            }
-        }
-
-        return $locateByLayer;
+        return $this->proj->readLocateByLayers($xml, $cfg);
     }
 
     protected function readFormFilterLayers($xml, $cfg)
     {
-        $formFilterLayers = array();
-
-        if (property_exists($cfg, 'formFilterLayers')) {
-
-            // Add data into formFilterLayers from configuration
-            $formFilterLayers = $cfg->formFilterLayers;
-
-        }
-
-        return $formFilterLayers;
+        return $this->proj->readFormFilterLayers($xml, $cfg);
     }
 
     protected function readEditionLayers($xml, $cfg)
     {
-        $editionLayers = array();
-
-        if (property_exists($cfg, 'editionLayers')) {
-
-            // Add data into editionLayers from configuration
-            $editionLayers = $cfg->editionLayers;
-
-            // Check ability to load spatialite extension
-            // And remove ONLY spatialite layers if no extension found
-            $spatialiteExt = '';
-            if (class_exists('SQLite3')) {
-                $spatialiteExt = $this->getSpatialiteExtension();
-            }
-            if (!$spatialiteExt) {
-                jLog::log('Spatialite is not available', 'error');
-                foreach ($editionLayers as $key => $obj) {
-                    $layerXml = $this->getXmlLayer2($xml, $obj->layerId);
-                    if (count($layerXml) == 0) {
-                        continue;
-                    }
-                    $layerXmlZero = $layerXml[0];
-                    $provider = $layerXmlZero->xpath('provider');
-                    $provider = (string) $provider[0];
-                    if ($provider == 'spatialite') {
-                        unset($editionLayers->{$key});
-                    }
-                }
-            }
-        }
-
-        return $editionLayers;
+        return $this->proj->readEditionLayers($xml, $cfg);
     }
 
     protected function readAttributeLayers($xml, $cfg)
     {
-        $attributeLayers = array();
-
-        if (property_exists($cfg, 'attributeLayers')) {
-
-            // Add data into attributeLayers from configuration
-            $attributeLayers = $cfg->attributeLayers;
-
-            // Get field order & visibility
-            foreach ($attributeLayers as $key => $obj) {
-                $layerXml = $this->getXmlLayer2($xml, $obj->layerId);
-                if (count($layerXml) == 0) {
-                    continue;
-                }
-                $layerXmlZero = $layerXml[0];
-                $attributetableconfigXml = $layerXmlZero->xpath('attributetableconfig');
-                if (count($attributetableconfigXml) == 0) {
-                    continue;
-                }
-                $attributetableconfig = str_replace(
-                    '@',
-                    '',
-                    json_encode($attributetableconfigXml[0])
-                );
-                $obj->attributetableconfig = json_decode($attributetableconfig);
-                $attributeLayers->{$key} = $obj;
-            }
-        }
-
-        return $attributeLayers;
+        return $this->proj->readAttributeLayers($xml, $cfg);
     }
 
     /**
@@ -1627,74 +300,7 @@ class lizmapProject extends qgisProject
      */
     protected function readLayersOrder($xml, $cfg)
     {
-        $layersOrder = array();
-        if ($this->qgisProjectVersion >= 30000) { // For QGIS >=3.0, custom-order is in layer-tree-group
-            $customOrder = $xml->xpath('layer-tree-group/custom-order');
-            if (count($customOrder) == 0) {
-                return $layersOrder;
-            }
-            $customOrderZero = $customOrder[0];
-            if ($customOrderZero->attributes()->enabled == 1) {
-                $items = $customOrderZero->xpath('//item');
-                $lo = 0;
-                foreach  ($items as $layerI) {
-                    // Get layer name from config instead of XML for possible embedded layers
-                    $name = $this->getLayerNameByIdFromConfig($layerI);
-                    if ($name) {
-                        $layersOrder[$name] = $lo;
-                    }
-                    ++$lo;
-                }
-            } else {
-                return $layersOrder;
-            }
-        } else if ($this->qgisProjectVersion >= 20400) { // For QGIS >=2.4, new item layer-tree-canvas
-            $customOrder = $xml->xpath('//layer-tree-canvas/custom-order');
-            if (count($customOrder) == 0) {
-                return $layersOrder;
-            }
-            $customOrderZero = $customOrder[0];
-            if ($customOrderZero->attributes()->enabled == 1) {
-                $items = $customOrderZero->xpath('//item');
-                $lo = 0;
-                foreach ($items as $layerI) {
-                    // Get layer name from config instead of XML for possible embedded layers
-                    $name = $this->getLayerNameByIdFromConfig($layerI);
-                    if ($name) {
-                        $layersOrder[$name] = $lo;
-                    }
-                    ++$lo;
-                }
-            } else {
-                $items = $xml->xpath('layer-tree-group//layer-tree-layer');
-                $lo = 0;
-                foreach ($items as $layerTree) {
-                    // Get layer name from config instead of XML for possible embedded layers
-                    $name = $this->getLayerNameByIdFromConfig($layerTree->attributes()->id);
-                    if ($name) {
-                        $layersOrder[$name] = $lo;
-                    }
-                    ++$lo;
-                }
-            }
-        } else {
-            $legend = $xml->xpath('//legend');
-            if (count($legend) == 0) {
-                return $layersOrder;
-            }
-            $legendZero = $legend[0];
-            $updateDrawingOrder = (string) $legendZero->attributes()->updateDrawingOrder;
-            if ($updateDrawingOrder == 'false') {
-                $layers = $xml->xpath('//legendlayer');
-                foreach ($layers as $layer) {
-                    if ($layer->attributes()->drawingOrder and $layer->attributes()->drawingOrder >= 0) {
-                        $layersOrder[(string) $layer->attributes()->name] = (int) $layer->attributes()->drawingOrder;
-                    }
-                }
-            }
-        }
-
-        return $layersOrder;
+        return $this->proj->readLayersOrder($xml, $cfg);
     }
 
     /**
@@ -1702,284 +308,7 @@ class lizmapProject extends qgisProject
      */
     public function getUpdatedConfig()
     {
-
-        //FIXME: it's better to use clone keyword, isn't it?
-        $configRead = json_encode($this->cfg);
-        $configJson = json_decode($configRead);
-
-        // Add an option to display buttons to remove the cache for cached layer
-        // Only if appropriate right is found
-        if (jAcl2::check('lizmap.admin.repositories.delete')) {
-            $configJson->options->removeCache = 'True';
-        }
-
-        // Remove layerOrder option from config if not required
-        if (!empty($this->layersOrder)) {
-            $configJson->layersOrder = $this->layersOrder;
-        }
-
-        // set printTemplates in config
-        $configJson->printTemplates = $this->printCapabilities;
-
-        // Update locate by layer with vecctorjoins
-        $configJson->locateByLayer = $this->locateByLayer;
-
-        // Update filter form layers with vecctorjoins
-        $configJson->formFilterLayers = $this->formFilterLayers;
-
-        // Update attributeLayers with attributetableconfig
-        $configJson->attributeLayers = $this->attributeLayers;
-
-        // Remove FTP remote directory
-        if (property_exists($configJson->options, 'remoteDir')) {
-            unset($configJson->options->remoteDir);
-        }
-
-        // Remove editionLayers from config if no right to access this tool
-        if (property_exists($configJson, 'editionLayers')) {
-            if (jAcl2::check('lizmap.tools.edition.use', $this->repository->getKey())) {
-                $configJson->editionLayers = clone $this->editionLayers;
-                // Check right to edit this layer (if property "acl" is in config)
-                foreach ($configJson->editionLayers as $key => $eLayer) {
-                    // Check if user groups intersects groups allowed by project editor
-                    // If user is admin, no need to check for given groups
-                    if (property_exists($eLayer, 'acl') and $eLayer->acl) {
-                        // Check if configured groups white list and authenticated user groups list intersects
-                        $editionGroups = $eLayer->acl;
-                        $editionGroups = array_map('trim', explode(',', $editionGroups));
-                        if (is_array($editionGroups) and count($editionGroups) > 0) {
-                            $userGroups = jAcl2DbUserGroup::getGroups();
-                            if (array_intersect($editionGroups, $userGroups) or jAcl2::check('lizmap.admin.repositories.delete')) {
-                                // User group(s) correspond to the groups given for this edition layer
-                                // or the user is admin
-                                unset($configJson->editionLayers->{$key}->acl);
-                            } else {
-                                // No match found, we deactivate the edition layer
-                                unset($configJson->editionLayers->{$key});
-                            }
-                        }
-                    }
-                }
-            } else {
-                unset($configJson->editionLayers);
-            }
-        }
-
-        // Add export layer right
-        if (jAcl2::check('lizmap.tools.layer.export', $this->repository->getKey())) {
-            $configJson->options->exportLayers = 'True';
-        }
-
-        // Add WMS max width ad height
-        $services = lizmap::getServices();
-        if (array_key_exists('wmsMaxWidth', $this->data)) {
-            $configJson->options->wmsMaxWidth = $this->data['wmsMaxWidth'];
-        } else {
-            $configJson->options->wmsMaxWidth = $services->wmsMaxWidth;
-        }
-        if (array_key_exists('wmsMaxHeight', $this->data)) {
-            $configJson->options->wmsMaxHeight = $this->data['wmsMaxHeight'];
-        } else {
-            $configJson->options->wmsMaxHeight = $services->wmsMaxHeight;
-        }
-
-        // Add QGS Server version
-        $configJson->options->qgisServerVersion = $services->qgisServerVersion;
-
-        // Update config with layer relations
-        $relations = $this->getRelations();
-        if ($relations) {
-            $configJson->relations = $relations;
-        }
-
-        // Update config with project themes
-        $themes = $this->getThemes();
-        if ($themes) {
-            $configJson->themes = $themes;
-        }
-        if ($this->useLayerIDs) {
-            $configJson->options->useLayerIDs = 'True';
-        }
-
-        // Update searches informations.
-        if (!property_exists($configJson->options, 'searches')) {
-            $configJson->options->searches = array();
-        }
-        if (property_exists($configJson->options, 'externalSearch')) {
-            $externalSearch = array(
-                'type' => 'externalSearch',
-                'service' => $configJson->options->externalSearch,
-            );
-            if ($configJson->options->externalSearch == 'nominatim') {
-                $externalSearch['url'] = jUrl::get('lizmap~osm:nominatim');
-            } elseif ($configJson->options->externalSearch == 'ban') {
-                $externalSearch = array(
-                    'type' => 'BAN',
-                    'service' => 'lizmapBan',
-                    'url' => jUrl::get('lizmap~ban:search')
-                );
-            }
-            $configJson->options->searches[] = (object) $externalSearch;
-            unset($configJson->options->externalSearch);
-        }
-        // Add FTS sqlite searches (db created with from quickfinder)
-        $ftsSearches = $this->hasFtsSearches();
-        if ($ftsSearches) {
-            $configJson->options->searches[] = (object) array(
-                'type' => 'QuickFinder',
-                'service' => 'lizmapQuickFinder',
-                'url' => jUrl::get('lizmap~search:get'),
-            );
-        }
-        // Events to get additional searches
-        $searchServices = jEvent::notify('searchServiceItem', array('repository' => $this->repository->getKey(), 'project' => $this->getKey()))->getResponse();
-        foreach ($searchServices as $searchService) {
-            if (is_array($searchService)) {
-                if (array_key_exists('type', $searchService) && array_key_exists('url', $searchService)) {
-                    $configJson->options->searches[] = (object) $searchService;
-                }
-            } elseif (is_object($searchService)) {
-                if (property_exists($searchService, 'type') && property_exists($searchService, 'url')) {
-                    $configJson->options->searches[] = $searchService;
-                }
-            }
-        }
-
-        // Update dataviz config
-        if (property_exists($configJson, 'datavizLayers')) {
-            $datavizLayers = $this->getDatavizLayersConfig();
-            if ($datavizLayers) {
-                $configJson->datavizLayers = $datavizLayers;
-            } else {
-                unset($configJson->datavizLayers);
-            }
-        }
-
-        // Get server plugins
-        $qplugins = $this->getQgisServerPlugins();
-        $configJson->qgisServerPlugins = $qplugins;
-
-        // Check layers group visibility
-        $userGroups = Array('');
-        if (jAuth::isConnected()) {
-            $userGroups = jAcl2DbUserGroup::getGroups();
-        }
-        $layersToRemove = array();
-        foreach ($configJson->layers as $obj) {
-            // no group_visibility config, nothing to do
-            if (!property_exists($obj, 'group_visibility')) {
-                continue;
-            }
-            if ($obj->group_visibility === '') {
-                unset($obj->group_visibility);
-                continue;
-            }
-            // get group visibility as trimed array
-            $group_visibility = array_map('trim', explode(',', $obj->group_visibility));
-            $layerToKeep = False;
-            foreach ($userGroups as $group) {
-                if (in_array($group, $group_visibility)){
-                    $layerToKeep = True;
-                    break;
-                }
-            }
-            if (!$layerToKeep) {
-                $layersToRemove[$obj->name] = $obj;
-            }
-            unset($obj->group_visibility);
-        }
-        foreach($layersToRemove as $key => $obj) {
-            // locateByLayer
-            if (property_exists($configJson->locateByLayer, $key)) {
-                unset($configJson->locateByLayer->{$key});
-            }
-            // locateByLayer vectorjoins
-            foreach($configJson->locateByLayer as $o) {
-                if (!property_exists($o, 'vectorjoins')) {
-                    continue;
-                }
-                $vectorjoinsToKeep = array();
-                foreach($o->vectorjoins as $i=>$v) {
-                    if($v->joinLayerId != $obj->id) {
-                        $vectorjoinsToKeep[] = $o;
-                    }
-                }
-                $o->vectorjoins = $vectorjoinsToKeep;
-            }
-            // attributeLayers
-            if (property_exists($configJson->attributeLayers, $key)) {
-                unset($configJson->attributeLayers->{$key});
-            }
-            // tooltipLayers
-            if (property_exists($configJson->tooltipLayers, $key)) {
-                unset($configJson->tooltipLayers->{$key});
-            }
-            // editionLayers
-            if (property_exists($configJson->editionLayers, $key)) {
-                unset($configJson->editionLayers->{$key});
-            }
-            // datavizLayers
-            if (property_exists($configJson, 'datavizLayers')) {
-                $dvlLayers = $configJson->datavizLayers['layers'];
-                foreach($dvlLayers as $o=>$c) {
-                    if ($c['layer_id'] == $obj->id) {
-                        unset($configJson->datavizLayers['layers'][$o]);
-                    }
-                }
-            }
-            // atlas
-            if (property_exists($configJson->options, 'atlasEnabled') &&
-                $this->optionToBoolean($configJson->options->atlasEnabled) &&
-                $configJson->options->atlasLayer == $obj->id) {
-                $configJson->options->atlasLayer = '';
-                $configJson->options->atlasPrimaryKey = '';
-                $configJson->options->atlasFeatureLabel = '';
-                $configJson->options->atlasSortField = '';
-                $configJson->options->atlasEnabled = 'False';
-            }
-            // multi-atlas
-            // formFilterLayers
-            foreach($configJson->formFilterLayers as $o=>$c) {
-                if ($c['layerId'] = $obj->id) {
-                    unset($configJson->formFilterLayers[$o]);
-                }
-            }
-            // relations
-            if (array_key_exists($key, $configJson->relations)) {
-                unset($configJson->relations->{$key});
-            }
-            foreach($configJson->relations as $k => $layerRelations) {
-                if ($k == 'pivot') {
-                    continue;
-                }
-                $relationsToKeep = array();
-                foreach($layerRelations as $r) {
-                    if($r['referencingLayer'] != $obj->id) {
-                        $relationsToKeep[] = $r;
-                    }
-                }
-                if (count($relationsToKeep) > 0) {
-                    $configJson->relations[$k] = $relationsToKeep;
-                } else {
-                    unset($configJson->relations[$k]);
-                }
-            }
-            // printTemplates
-            $printTemplatesToKeep = array();
-            foreach($configJson->printTemplates as $printTemplate) {
-                if (array_key_exists('atlas', $printTemplate) &&
-                    array_key_exists('coverageLayer', $printTemplate['atlas']) &&
-                    $printTemplate['atlas']['coverageLayer'] != $obj->id) {
-                    $printTemplatesToKeep[] = $printTemplate;
-                }
-            }
-            $configJson->printTemplates = $printTemplatesToKeep;
-
-            // remove layer
-            unset($configJson->layers->{$key});
-        }
-
-        return json_encode($configJson);
+        return $this->proj->getUpdatedConfig();
     }
 
     /**
@@ -1987,28 +316,7 @@ class lizmapProject extends qgisProject
      */
     public function getFullCfg()
     {
-        return $this->cfg;
-    }
-
-    /**
-     * @FIXME: remove this method. Be sure it is not used in other projects
-     * Data provided by the returned xml element should be extracted and encapsulated
-     * into an object. Xml should not be used by callers
-     *
-     * @deprecated
-     *
-     * @param mixed $title
-     *
-     * @return null|SimpleXMLElement
-     */
-    public function getComposer($title)
-    {
-        $xmlComposer = $this->getXml()->xpath("//Composer[@title='${title}']");
-        if ($xmlComposer) {
-            return $xmlComposer[0];
-        }
-
-        return null;
+        return $this->proj->getFullCfg();
     }
 
     /**
@@ -2018,78 +326,7 @@ class lizmapProject extends qgisProject
      */
     public function getDefaultDockable()
     {
-        $dockable = array();
-        $confUrlEngine = &jApp::config()->urlengine;
-        $bp = $confUrlEngine['basePath'];
-        $jwp = $confUrlEngine['jelixWWWPath'];
-
-        // Get lizmap services
-        $services = lizmap::getServices();
-
-        if ($services->projectSwitcher) {
-            $projectsTpl = new jTpl();
-            $projectsTpl->assign('excludedProject', $this->repository->getKey().'~'.$this->getKey());
-            $dockable[] = new lizmapMapDockItem(
-                'projects',
-                jLocale::get('view~default.repository.list.title'),
-                $projectsTpl->fetch('view~map_projects'),
-                0
-            );
-        }
-
-        $switcherTpl = new jTpl();
-        $switcherTpl->assign(array(
-            'layerExport' => jAcl2::check('lizmap.tools.layer.export', $this->repository->getKey()),
-        ));
-        $dockable[] = new lizmapMapDockItem(
-            'switcher',
-            jLocale::get('view~map.switchermenu.title'),
-            $switcherTpl->fetch('view~map_switcher'),
-            1
-        );
-        //$legendTpl = new jTpl();
-        //$dockable[] = new lizmapMapDockItem('legend', 'Légende', $switcherTpl->fetch('map_legend'), 2);
-
-        $metadataTpl = new jTpl();
-        // Get the WMS information
-        $wmsInfo = $this->getWMSInformation();
-        // WMS GetCapabilities Url
-        $wmsGetCapabilitiesUrl = jAcl2::check(
-            'lizmap.tools.displayGetCapabilitiesLinks',
-            $this->repository->getKey()
-        );
-        $wmtsGetCapabilitiesUrl = $wmsGetCapabilitiesUrl;
-        if ($wmsGetCapabilitiesUrl) {
-            $wmsGetCapabilitiesUrl = $this->getData('wmsGetCapabilitiesUrl');
-            $wmtsGetCapabilitiesUrl = $this->getData('wmtsGetCapabilitiesUrl');
-        }
-        $metadataTpl->assign(array_merge(array(
-            'repositoryLabel' => $this->getData('label'),
-            'repository' => $this->repository->getKey(),
-            'project' => $this->getKey(),
-            'wmsGetCapabilitiesUrl' => $wmsGetCapabilitiesUrl,
-            'wmtsGetCapabilitiesUrl' => $wmtsGetCapabilitiesUrl,
-        ), $wmsInfo));
-        $dockable[] = new lizmapMapDockItem(
-            'metadata',
-            jLocale::get('view~map.metadata.link.label'),
-            $metadataTpl->fetch('view~map_metadata'),
-            2
-        );
-
-        if ($this->hasEditionLayers()) {
-            $tpl = new jTpl();
-            $dockable[] = new lizmapMapDockItem(
-                'edition',
-                jLocale::get('view~edition.navbar.title'),
-                $tpl->fetch('view~map_edition'),
-                3,
-                $jwp.'design/jform.css',
-                $bp.'assets/js/edition.js'
-            );
-        }
-
-        return $dockable;
+        return $this->proj->getDefaultDockable();
     }
 
     /**
@@ -2100,146 +337,7 @@ class lizmapProject extends qgisProject
      */
     public function getDefaultMiniDockable()
     {
-        $dockable = array();
-        $configOptions = $this->getOptions();
-        $bp = jApp::config()->urlengine['basePath'];
-
-        if ($this->hasAttributeLayers()) {
-            $tpl = new jTpl();
-            // Add layer-export attribute to lizmap-selection-tool component if allowed
-            $layerExport = jAcl2::check('lizmap.tools.layer.export', $this->repository->getKey()) ? "layer-export" : "";
-            $dock = new lizmapMapDockItem(
-                'selectiontool',
-                jLocale::get('view~map.selectiontool.navbar.title'),
-                '<lizmap-selection-tool '.$layerExport.'></lizmap-selection-tool>',
-                1,
-                '',
-                $bp.'assets/js/attributeTable.js'
-            );
-            $dock->icon = '<span class="icon-white icon-star" style="margin-left:2px; margin-top:2px;"></span>';
-            $dockable[] = $dock;
-        }
-
-        if ($this->hasLocateByLayer()) {
-            $tpl = new jTpl();
-            $dockable[] = new lizmapMapDockItem(
-                'locate',
-                jLocale::get('view~map.locatemenu.title'),
-                $tpl->fetch('view~map_locate'),
-                2
-            );
-        }
-
-        if (property_exists($configOptions, 'geolocation')
-            && $configOptions->geolocation == 'True') {
-            $tpl = new jTpl();
-            $tpl->assign('hasEditionLayers', $this->hasEditionLayers());
-            $dockable[] = new lizmapMapDockItem(
-                'geolocation',
-                jLocale::get('view~map.geolocate.navbar.title'),
-                $tpl->fetch('view~map_geolocation'),
-                3
-            );
-        }
-
-        if (property_exists($configOptions, 'print')
-            && $configOptions->print == 'True') {
-            $tpl = new jTpl();
-            $dockable[] = new lizmapMapDockItem(
-                'print',
-                jLocale::get('view~map.print.navbar.title'),
-                $tpl->fetch('view~map_print'),
-                4
-            );
-        }
-
-        if (property_exists($configOptions, 'measure')
-            && $configOptions->measure == 'True') {
-            $tpl = new jTpl();
-            $dockable[] = new lizmapMapDockItem(
-                'measure',
-                jLocale::get('view~map.measure.navbar.title'),
-                $tpl->fetch('view~map_measure'),
-                5
-            );
-        }
-
-        if ($this->hasTooltipLayers()) {
-            $tpl = new jTpl();
-            $dockable[] = new lizmapMapDockItem(
-                'tooltip-layer',
-                jLocale::get('view~map.tooltip.navbar.title'),
-                $tpl->fetch('view~map_tooltip'),
-                6,
-                '',
-                ''
-            );
-        }
-
-        if ($this->hasTimemanagerLayers()) {
-            $tpl = new jTpl();
-            $dockable[] = new lizmapMapDockItem(
-                'timemanager',
-                jLocale::get('view~map.timemanager.navbar.title'),
-                $tpl->fetch('view~map_timemanager'),
-                7,
-                '',
-                $bp.'assets/js/timemanager.js'
-            );
-        }
-
-        // Permalink
-        if (true) {
-            // Get geobookmark if user is connected
-            $gbCount = false;
-            $gbList = null;
-            if (jAuth::isConnected()) {
-                $juser = jAuth::getUserSession();
-                $usr_login = $juser->login;
-                $daogb = jDao::get('lizmap~geobookmark');
-                $conditions = jDao::createConditions();
-                $conditions->addCondition('login', '=', $usr_login);
-                $conditions->addCondition(
-                    'map',
-                    '=',
-                    $this->repository->getKey().':'.$this->getKey()
-                );
-                $gbList = $daogb->findBy($conditions);
-                $gbCount = $daogb->countBy($conditions);
-            }
-            $tpl = new jTpl();
-            $tpl->assign('gbCount', $gbCount);
-            $tpl->assign('gbList', $gbList);
-            $gbContent = null;
-            if ($gbList) {
-                $gbContent = $tpl->fetch('view~map_geobookmark');
-            }
-            $tpl = new jTpl();
-            $tpl->assign(array(
-                'repository' => $this->repository->getKey(),
-                'project' => $this->getKey(),
-                'gbContent' => $gbContent,
-            ));
-            $dockable[] = new lizmapMapDockItem(
-                'permaLink',
-                jLocale::get('view~map.permalink.navbar.title'),
-                $tpl->fetch('view~map_permalink'),
-                8
-            );
-        }
-
-        if (property_exists($configOptions, 'draw')
-            && $configOptions->draw == 'True') {
-            $tpl = new jTpl();
-            $dockable[] = new lizmapMapDockItem(
-                'draw',
-                jLocale::get('view~map.draw.navbar.title'),
-                $tpl->fetch('view~map_draw'),
-                9
-            );
-        }
-
-        return $dockable;
+        return $this->proj->getDefaultMiniDockable();
     }
 
     /**
@@ -2249,23 +347,7 @@ class lizmapProject extends qgisProject
      */
     public function getDefaultBottomDockable()
     {
-        $dockable = array();
-        $bp = jApp::config()->urlengine['basePath'];
-
-        if ($this->hasAttributeLayers(true)) {
-            $form = jForms::create('view~attribute_layers_option');
-            $assign = array('form' => $form);
-            $dockable[] = new lizmapMapDockItem(
-                'attributeLayers',
-                jLocale::get('view~map.attributeLayers.navbar.title'),
-                array('view~map_attributeLayers', $assign),
-                1,
-                '',
-                $bp.'assets/js/attributeTable.js'
-            );
-        }
-
-        return $dockable;
+        return $this->proj->getDefaultBottomDockable();
     }
 
     /**
@@ -2275,70 +357,11 @@ class lizmapProject extends qgisProject
      */
     public function checkAcl()
     {
-
-        // Check right on repository
-        if (!jAcl2::check('lizmap.repositories.view', $this->repository->getKey())) {
-            return false;
-        }
-
-        // Check acl option is configured in project config
-        if (!property_exists($this->cfg->options, 'acl') || !is_array($this->cfg->options->acl) || empty($this->cfg->options->acl)) {
-            return true;
-        }
-
-        // Check user is authenticated
-        if (!jAuth::isConnected()) {
-            return false;
-        }
-
-        // Check user is admin -> ok, give permission
-        if (jAcl2::check('lizmap.admin.repositories.delete')) {
-            return true;
-        }
-
-        // Check if configured groups white list and authenticated user groups list intersects
-        $aclGroups = $this->cfg->options->acl;
-        $userGroups = jAcl2DbUserGroup::getGroups();
-        if (array_intersect($aclGroups, $userGroups)) {
-            return true;
-        }
-
-        return false;
+        return $this->proj->checkAcl();
     }
-
-    private $spatialiteExt;
 
     public function getSpatialiteExtension()
     {
-        if ($this->spatialiteExt !== null) {
-            return $this->spatialiteExt;
-        }
-
-        // Try with mod_spatialite
-        try {
-            $db = new SQLite3(':memory:');
-            $this->spatialiteExt = 'mod_spatialite.so';
-            $spatial = @$db->loadExtension($this->spatialiteExt); // loading SpatiaLite as an extension
-            if ($spatial) {
-                return $this->spatialiteExt;
-            }
-        } catch (Exception $e) {
-            $spatial = false;
-        }
-        // Try with libspatialite
-        if (!$spatial) {
-            try {
-                $db = new SQLite3(':memory:');
-                $this->spatialiteExt = 'libspatialite.so';
-                $spatial = @$db->loadExtension($this->spatialiteExt); // loading SpatiaLite as an extension
-                if ($spatial) {
-                    return $this->spatialiteExt;
-                }
-            } catch (Exception $e) {
-            }
-        }
-        $this->spatialiteExt = '';
-
-        return '';
+        return $this->proj->getSpatialiteExtension();
     }
 }

--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -12,23 +12,26 @@
 
 use Lizmap\Project;
 
- /**
-  * @deprecated 
-  * @FIXME getXml, getComposer
-  * Verify this methods are not used in external modules so we can delete them without risk, otherwise, we have to implement them
-  * in Project and call it here
-  */
+/**
+ * @deprecated
+ * @FIXME getXml, getComposer
+ * Verify this methods are not used in external modules so we can delete them without risk, otherwise, we have to implement them
+ * in Project and call it here
+ */
 class lizmapProject
 {
     /**
      * @var project
      */
     protected $proj;
+
     /**
      * constructor.
      *
-     * @param string           $key : the project name
-     * @param lizmapRepository $rep : the repository
+     * @param string           $key      : the project name
+     * @param lizmapRepository $rep      : the repository
+     * @param mixed            $context
+     * @param mixed            $services
      */
     public function __construct($key, $rep, $context, $services)
     {
@@ -58,7 +61,7 @@ class lizmapProject
 
     public function getRelativeQgisPath()
     {
-       return $this->proj->getRelativeQgisPath();
+        return $this->proj->getRelativeQgisPath();
     }
 
     public function getKey()
@@ -217,17 +220,37 @@ class lizmapProject
         return $this->proj->getLoginFilters($layers);
     }
 
-    private function optionToBoolean($config_string)
-    {
-        return $this->proj->optionToBoolean($config_string);
-    }
-
     /**
      * @return array|bool
      */
     public function getDatavizLayersConfig()
     {
         return $this->proj->getDatavizLayersConfig();
+    }
+
+    public function getData($key)
+    {
+        return $this->proj->getData($key);
+    }
+
+    public function getProj4($authId)
+    {
+        return $this->proj->getProj4($authId);
+    }
+
+    public function getAllProj4()
+    {
+        return $this->proj->getAllProj4();
+    }
+
+    public function getCanvasColor()
+    {
+        return $this->proj->getCanvasColor();
+    }
+
+    public function getWMSInformation()
+    {
+        return $this->proj->getWMSInformation();
     }
 
     /**

--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -32,7 +32,7 @@ class lizmapProject extends qgisProject
      */
     public function __construct($key, $rep)
     {
-        $this->proj = new \Lizmap\Project\project($key, $rep, lizmap::getJelixInfos(), lizmap::getServices());
+        $this->proj = new \Lizmap\Project\project($key, $rep, lizmap::getAppContext(), lizmap::getServices());
     }
 
     public function clearCache()

--- a/lizmap/modules/lizmap/classes/lizmapRepository.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapRepository.class.php
@@ -152,7 +152,7 @@ class lizmapRepository
         $modified = false;
         // Modify the ini data for the repository
         foreach ($data as $k => $v) {
-            if (in_array($k, self::$properties)) {
+            if (in_array($k, self::getProperties())) {
                 // Set values in ini file
                 $ini->setValue($k, $v, $section);
                 // Modify lizmapConfigData
@@ -169,14 +169,14 @@ class lizmapRepository
         return $modified;
     }
 
-    public function getProject($key)
+    public function getProject($key, $context, $services)
     {
         if (isset($this->projectInstances[$key])) {
             return $this->projectInstances[$key];
         }
 
         try {
-            $proj = new lizmapProject($key, $this);
+            $proj = new lizmapProject($key, $this, $context, $services);
         } catch (UnknownLizmapProjectException $e) {
             throw $e;
         } catch (Exception $e) {
@@ -189,7 +189,7 @@ class lizmapRepository
         return $proj;
     }
 
-    public function getProjects()
+    public function getProjects($context, $services)
     {
         $projects = array();
         $dir = $this->getPath();
@@ -212,7 +212,7 @@ class lizmapRepository
                     $proj = null;
                     if (in_array($qgsFile.'.cfg', $cfgFiles)) {
                         try {
-                            $proj = $this->getProject(substr($qgsFile, 0, -4));
+                            $proj = $this->getProject(substr($qgsFile, 0, -4), $context, $services);
                             if ($proj != null) {
                                 $projects[] = $proj;
                             }

--- a/lizmap/modules/lizmap/lib/Project/configFile.php
+++ b/lizmap/modules/lizmap/lib/Project/configFile.php
@@ -10,7 +10,7 @@ class configFile
     {
         $this->data = json_decode($cfgFile);
         if (!$this->data) {
-            return null;
+            throw new \Exception('The file '.$cfgFile.' can not be read.');
         }
     }
 
@@ -55,15 +55,15 @@ class configFile
     /**
      * Set layers' shortname with XML data.
      *
-     * @param qgisProject $qgs_xml
+     * @param qgisProject $qgsXml
      */
-    public function setShortNames($qgs_xml)
+    public function setShortNames($qgsXml)
     {
-        $shortNames = $qgs_xml->xpathQuery('//maplayer/shortname');
+        $shortNames = $qgsXml->xpathQuery('//maplayer/shortname');
         if ($shortNames) {
             foreach ($shortNames as $sname) {
                 $sname = (string) $sname;
-                $xmlLayer = $qgs_xml->xpathQuery("//maplayer[shortname='{$sname}']");
+                $xmlLayer = $qgsXml->xpathQuery("//maplayer[shortname='{$sname}']");
                 if (!$xmlLayer) {
                     continue;
                 }
@@ -79,11 +79,11 @@ class configFile
     /**
      * Set layers' opacity with XML data.
      *
-     * @param qgisProject $qgs_xml
+     * @param qgisProject $qgsXml
      */
-    public function setLayerOpacity($qgs_xml)
+    public function setLayerOpacity($qgsXml)
     {
-        $layerWithOpacities = $qgs_xml->xpathQuery('//maplayer/layerOpacity[.!=1]/parent::*');
+        $layerWithOpacities = $qgsXml->xpathQuery('//maplayer/layerOpacity[.!=1]/parent::*');
         if ($layerWithOpacities) {
             foreach ($layerWithOpacities as $layerWithOpacitiy) {
                 $name = (string) $layerWithOpacitiy->layername;
@@ -98,11 +98,11 @@ class configFile
     /**
      * Set layers' group infos.
      *
-     * @param qgisProject $qgs_xml
+     * @param qgisProject $qgsXml
      */
-    public function setLayerGroupData()
+    public function setLayerGroupData($qgsXml)
     {
-        $groupsWithShortName = $qgs_xml->xpathQuery("//layer-tree-group/customproperties/property[@key='wmsShortName']/parent::*/parent::*");
+        $groupsWithShortName = $qgsXml->xpathQuery("//layer-tree-group/customproperties/property[@key='wmsShortName']/parent::*/parent::*");
         if ($groupsWithShortName) {
             foreach ($groupsWithShortName as $group) {
                 $name = (string) $group['name'];
@@ -116,7 +116,7 @@ class configFile
                 }
             }
         }
-        $groupsMutuallyExclusive = $qgs_xml->xpathQuery("//layer-tree-group[@mutually-exclusive='1']");
+        $groupsMutuallyExclusive = $qgsXml->xpathQuery("//layer-tree-group[@mutually-exclusive='1']");
         if ($groupsMutuallyExclusive) {
             foreach ($groupsMutuallyExclusive as $group) {
                 $name = (string) $group['name'];
@@ -130,11 +130,11 @@ class configFile
     /**
      * Set layers' last infos.
      *
-     * @param qgisProject $qgs_xml
+     * @param qgisProject $qgsXml
      */
-    public function setLayerShowFeatureCount($qgs_xml)
+    public function setLayerShowFeatureCount($qgsXml)
     {
-        $layersWithShowFeatureCount = $qgs_xml->xpathQuery("//layer-tree-layer/customproperties/property[@key='showFeatureCount']/parent::*/parent::*");
+        $layersWithShowFeatureCount = $qgsXml->xpathQuery("//layer-tree-layer/customproperties/property[@key='showFeatureCount']/parent::*/parent::*");
         if ($layersWithShowFeatureCount) {
             foreach ($layersWithShowFeatureCount as $layer) {
                 $name = (string) $layer['name'];
@@ -148,12 +148,12 @@ class configFile
     /**
      * Set/Unset some properties after reading the config file.
      *
-     * @param mixed $qgs_xml
+     * @param mixed $qgsXml
      */
-    public function unsetPropAfterRead($qgs_xml)
+    public function unsetPropAfterRead($qgsXml)
     {
         //remove plugin layer
-        $pluginLayers = $qgs_xml->xpathQuery('//maplayer[type="plugin"]');
+        $pluginLayers = $qgsXml->xpathQuery('//maplayer[type="plugin"]');
         if ($pluginLayers) {
             foreach ($pluginLayers as $layer) {
                 $name = (string) $layer->layername;

--- a/lizmap/modules/lizmap/lib/Project/configFile.php
+++ b/lizmap/modules/lizmap/lib/Project/configFile.php
@@ -8,9 +8,10 @@ class configFile
 
     public function __construct($cfgFile)
     {
-        $this->data = json_decode($cfgFile);
+        $fileContent = file_get_contents($cfgFile);
+        $this->data = json_decode($fileContent);
         if (!$this->data) {
-            throw new \Exception('The file '.$cfgFile.' can not be read.');
+            throw new \Exception('The file '.$cfgFile.' cannot be read.');
         }
     }
 

--- a/lizmap/modules/lizmap/lib/Project/configFile.php
+++ b/lizmap/modules/lizmap/lib/Project/configFile.php
@@ -14,6 +14,11 @@ class configFile
         }
     }
 
+    public function getData()
+    {
+        return $this->data;
+    }
+
     public function getProperty($propName)
     {
         if (isset($this->data->{$propName})) {

--- a/lizmap/modules/lizmap/lib/Project/configFile.php
+++ b/lizmap/modules/lizmap/lib/Project/configFile.php
@@ -251,4 +251,34 @@ class configFile
 
         return null;
     }
+
+    public function getEditionLayerByName($name)
+    {
+        $editionLayers = $this->data->editionLayers;
+        if ($editionLayers && property_exists($editionLayers, $name)) {
+            return $editionLayers->{$name};
+        }
+
+        return null;
+    }
+
+    /**
+     * @param $layerId
+     *
+     * @return null|array
+     */
+    public function getEditionLayerByLayerId($layerId)
+    {
+        $editionLayers = $this->data->editionLayers;
+        foreach ($editionLayers as $layer) {
+            if (!property_exists($layer, 'layerId')) {
+                continue;
+            }
+            if ($layer->layerId == $layerId) {
+                return $layer;
+            }
+        }
+
+        return null;
+    }
 }

--- a/lizmap/modules/lizmap/lib/Project/configFile.php
+++ b/lizmap/modules/lizmap/lib/Project/configFile.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Lizmap\Project;
+
+class configFile
+{
+    protected $data;
+
+    public function __construct($cfgFile)
+    {
+        $this->data = json_decode($cfgFile);
+        if (!$this->data) {
+            return null;
+        }
+    }
+
+    public function getProperty($propName)
+    {
+        if (isset($this->data->$propName)) {
+            return $this->data->propName;
+        } else {
+            return null;
+        }
+    }
+
+    public function &getEditableProperty($propName)
+    {
+        if (property_exists($this->data, $propName)) {
+            return $this->data->$propName;
+        } else {
+            return null;
+        }
+    }
+
+    public function unsetPropAfterRead();
+    {
+         //unset cache for editionLayers
+         if (property_exists($this->data, 'editionLayers')) {
+            foreach ($this->data->editionLayers as $key => $obj) {
+                if (property_exists($this->data->layers, $key)) {
+                    $this->data->layers->{$key}->cached = 'False';
+                    $this->data->layers->{$key}->clientCacheExpiration = 0;
+                    if (property_exists($this->data->layers->{$key}, 'cacheExpiration')) {
+                        unset($this->data->layers->{$key}->cacheExpiration);
+                    }
+                }
+            }
+        }
+        //unset cache for loginFilteredLayers
+        if (property_exists($this->data, 'loginFilteredLayers')) {
+            foreach ($this->data->loginFilteredLayers as $key => $obj) {
+                if (property_exists($this->data->layers, $key)) {
+                    $this->data->layers->{$key}->cached = 'False';
+                    $this->data->layers->{$key}->clientCacheExpiration = 0;
+                    if (property_exists($this->data->layers->{$key}, 'cacheExpiration')) {
+                        unset($this->data->layers->{$key}->cacheExpiration);
+                    }
+                }
+            }
+        }
+        //unset displayInLegend for geometryType none or unknown
+        foreach ($this->data->layers as $key => $obj) {
+            if (property_exists($this->data->layers->{$key}, 'geometryType') &&
+                 ($this->data->layers->{$key}->geometryType == 'none' ||
+                     $this->data->layers->{$key}->geometryType == 'unknown')
+            ) {
+                $this->data->layers->{$key}->displayInLegend = 'False';
+            }
+        }
+    }
+}

--- a/lizmap/modules/lizmap/lib/Project/configFile.php
+++ b/lizmap/modules/lizmap/lib/Project/configFile.php
@@ -16,26 +16,26 @@ class configFile
 
     public function getProperty($propName)
     {
-        if (isset($this->data->$propName)) {
+        if (isset($this->data->{$propName})) {
             return $this->data->propName;
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     public function &getEditableProperty($propName)
     {
         if (property_exists($this->data, $propName)) {
-            return $this->data->$propName;
-        } else {
-            return null;
+            return $this->data->{$propName};
         }
+
+        return null;
     }
 
-    public function unsetPropAfterRead();
+    public function unsetPropAfterRead()
     {
-         //unset cache for editionLayers
-         if (property_exists($this->data, 'editionLayers')) {
+        //unset cache for editionLayers
+        if (property_exists($this->data, 'editionLayers')) {
             foreach ($this->data->editionLayers as $key => $obj) {
                 if (property_exists($this->data->layers, $key)) {
                     $this->data->layers->{$key}->cached = 'False';
@@ -67,5 +67,135 @@ class configFile
                 $this->data->layers->{$key}->displayInLegend = 'False';
             }
         }
+    }
+
+    public function findLayerByAnyName($name)
+    {
+        // name null or empty string
+        if ($name == null || empty($name)) {
+            return null;
+        }
+
+        $layer = null;
+        $methods = array(
+            // Get by name ie as written in QGIS Desktop legend
+            'Name',
+            // since 2.14 layer's name can be layer's shortName
+            'ShortName',
+            // Get layer by typename : qgis server replaces ' ' by '_' for layer names
+            'TypeName',
+            // Get by id
+            'LayerId',
+            // since 2.6 layer's name can be layer's title
+            'Title',
+        );
+
+        foreach ($methods as $key) {
+            $method = 'findLayerBy'.$key;
+            $layer = $this->{$method}($name);
+            if ($layer) {
+                return $layer;
+            }
+        }
+
+        return $layer;
+    }
+
+    public function findLayerByName($name)
+    {
+        // name null or empty string
+        if ($name == null || empty($name)) {
+            return null;
+        }
+
+        if (property_exists($this->data->layers, $name)) {
+            return $this->data->layers->{$name};
+        }
+
+        return null;
+    }
+
+    public function findLayerByShortName($shortName)
+    {
+        // short name null or empty string
+        if ($shortName == null || empty($shortName)) {
+            return null;
+        }
+
+        foreach ($this->data->layers as $layer) {
+            if (!property_exists($layer, 'shortname')) {
+                continue;
+            }
+            if ($layer->shortname == $shortName) {
+                return $layer;
+            }
+        }
+
+        return null;
+    }
+
+    public function findLayerByTitle($title)
+    {
+        // title null or empty string
+        if ($title == null || empty($title)) {
+            return null;
+        }
+
+        foreach ($this->data->layers as $layer) {
+            if (!property_exists($layer, 'title')) {
+                continue;
+            }
+            if ($layer->title == $title) {
+                return $layer;
+            }
+        }
+
+        return null;
+    }
+
+    public function findLayerByLayerId($layerId)
+    {
+        // layer id null or empty string
+        if ($layerId == null || empty($layerId)) {
+            return null;
+        }
+
+        foreach ($this->data->layers as $layer) {
+            if (!property_exists($layer, 'id')) {
+                continue;
+            }
+            if ($layer->id == $layerId) {
+                return $layer;
+            }
+        }
+
+        return null;
+    }
+
+    public function findLayerByTypeName($typeName)
+    {
+        // type name null or empty string
+        if ($typeName == null || empty($typeName)) {
+            return null;
+        }
+
+        // typeName is layerName
+        if (property_exists($this->data->layers, $typeName)) {
+            return $this->data->layers->{$typeName};
+        }
+        // typeName is cleanName or shortName
+        foreach ($this->data->layers as $layer) {
+            if (str_replace(' ', '_', $layer->name) == $typeName) {
+                return $layer;
+            }
+            if (!property_exists($layer, 'shortname')) {
+                continue;
+            }
+            if ($layer->shortname == $typeName) {
+                return $layer;
+            }
+        }
+
+        return null;
     }
 }

--- a/lizmap/modules/lizmap/lib/Project/configFile.php
+++ b/lizmap/modules/lizmap/lib/Project/configFile.php
@@ -33,7 +33,7 @@ class configFile
     public function getProperty($propName)
     {
         if (isset($this->data->{$propName})) {
-            return $this->data->propName;
+            return $this->data->{$propName};
         }
 
         return null;

--- a/lizmap/modules/lizmap/lib/Project/configFile.php
+++ b/lizmap/modules/lizmap/lib/Project/configFile.php
@@ -39,18 +39,18 @@ class configFile
         return null;
     }
 
-    /**
-     * Return a reference to a property that can be edited.
-     *
-     * @param string $propName The property to get
-     */
-    public function &getEditableProperty($propName)
+    public function setProperty($prop, $value)
     {
-        if (property_exists($this->data, $propName)) {
-            return $this->data->{$propName};
+        if (property_exists($this->data, $prop)) {
+            $this->data->$prop = $value;
         }
+    }
 
-        return null;
+    public function unsetProperty($prop)
+    {
+        if (property_exists($this->data, $prop)) {
+            unset($this->data->prop);
+        }
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/Project/configFile.php
+++ b/lizmap/modules/lizmap/lib/Project/configFile.php
@@ -11,7 +11,7 @@ class configFile
         $fileContent = file_get_contents($cfgFile);
         $this->data = json_decode($fileContent);
         if (!$this->data) {
-            throw new \Exception('The file '.$cfgFile.' cannot be read.');
+            throw new \UnknownLizmapProjectException('The file '.$cfgFile.' cannot be read.');
         }
     }
 

--- a/lizmap/modules/lizmap/lib/Project/configFile.php
+++ b/lizmap/modules/lizmap/lib/Project/configFile.php
@@ -14,11 +14,21 @@ class configFile
         }
     }
 
+    /**
+     * Return the config file as an array
+     * 
+     * @return array
+     */
     public function getData()
     {
         return $this->data;
     }
 
+    /**
+     * Return the value of a given property
+     * 
+     * @param string $propName The property to get
+     */
     public function getProperty($propName)
     {
         if (isset($this->data->{$propName})) {
@@ -28,6 +38,11 @@ class configFile
         return null;
     }
 
+    /**
+     * Return a reference to a property that can be edited
+     * 
+     * @param string $propName The property to get
+     */
     public function &getEditableProperty($propName)
     {
         if (property_exists($this->data, $propName)) {
@@ -37,6 +52,9 @@ class configFile
         return null;
     }
 
+    /**
+     * Set/Unset some properties after reading the config file
+     */
     public function unsetPropAfterRead()
     {
         //unset cache for editionLayers
@@ -74,6 +92,11 @@ class configFile
         }
     }
 
+    /**
+     * Call every findLayerBy function to get a layer
+     * 
+     * @param string $name The name, shortname, typename, id or title of the layer to get
+     */
     public function findLayerByAnyName($name)
     {
         // name null or empty string
@@ -106,6 +129,11 @@ class configFile
         return $layer;
     }
 
+    /**
+     * Return the layer corresponding to name
+     * 
+     * @param string $name The name of the layer
+     */
     public function findLayerByName($name)
     {
         // name null or empty string
@@ -120,6 +148,11 @@ class configFile
         return null;
     }
 
+    /**
+     * Return the layer corresponding to shortname
+     * 
+     * @param string $shortName The shortname of the layer
+     */
     public function findLayerByShortName($shortName)
     {
         // short name null or empty string
@@ -139,6 +172,11 @@ class configFile
         return null;
     }
 
+    /**
+     * Return the layer corresponding to title
+     * 
+     * @param string $title The title of the layer
+     */
     public function findLayerByTitle($title)
     {
         // title null or empty string
@@ -158,6 +196,11 @@ class configFile
         return null;
     }
 
+    /**
+     * Return the layer corresponding to layerId
+     * 
+     * @param string $layerId The id of the layer
+     */
     public function findLayerByLayerId($layerId)
     {
         // layer id null or empty string
@@ -177,6 +220,11 @@ class configFile
         return null;
     }
 
+    /**
+     * Return the layer corresponding to typeName
+     * 
+     * @param string $typeName The type name of the layer
+     */
     public function findLayerByTypeName($typeName)
     {
         // type name null or empty string

--- a/lizmap/modules/lizmap/lib/Project/project.php
+++ b/lizmap/modules/lizmap/lib/Project/project.php
@@ -942,6 +942,54 @@ class Project
         return $this->xml->readLayersOrder($xml, $this->getLayers());
     }
 
+     /**
+     * @deprecated
+     */
+    public function findLayerByAnyName($name)
+    {
+        return $this->cfg->findLayerByAnyName($name);
+    }
+
+     /**
+     * @deprecated
+     */
+    public function findLayerByName($name)
+    {
+        return $this->cfg->findLayerByName($name);
+    }
+
+     /**
+     * @deprecated
+     */
+    public function findLayerByShortName($shortName)
+    {
+        return $this->cfg->findLayerByShortName($shortName);
+    }
+
+     /**
+     * @deprecated
+     */
+    public function findLayerByTitle($title)
+    {
+        return $this->cfg->findLayerByTitle($title);
+    }
+
+     /**
+     * @deprecated
+     */
+    public function findLayerByLayerId($layerId)
+    {
+        return $this->cfg->findLayerByLayerId($layerId);
+    }
+
+    /**
+     * @deprecated
+     */
+    public function findLayerByTypeName($typeName)
+    {
+        return $this->cfg->findLayerByTypeName($typeName);
+    }
+
     /**
      * @return false|string the JSON object corresponding to the configuration
      */

--- a/lizmap/modules/lizmap/lib/Project/project.php
+++ b/lizmap/modules/lizmap/lib/Project/project.php
@@ -267,7 +267,7 @@ class Project
         } catch (\Exception $e) {
             throw $e;
         }
-        $qgs_xml = $this->xml;
+        $qgsXml = $this->xml;
 
         // Complete data
         $this->data['repository'] = $rep->getKey();
@@ -308,18 +308,18 @@ class Project
             )
         );
 
-        $this->cfg->setShortNames($qgs_xml);
-        $this->cfg->setLayerOpacity($qgs_xml);
-        $this->cfg->setLayerGroupData($qgs_xml);
-        $this->cfg->setLayerShowFeatureCount($qgs_xml);
-        $this->cfg->unsetPropAfterRead($qgs_xml);
+        $this->cfg->setShortNames($qgsXml);
+        $this->cfg->setLayerOpacity($qgsXml);
+        $this->cfg->setLayerGroupData($qgsXml);
+        $this->cfg->setLayerShowFeatureCount($qgsXml);
+        $this->cfg->unsetPropAfterRead($qgsXml);
 
-        $this->printCapabilities = $this->readPrintCapabilities($qgs_xml, $this->cfg);
-        $this->locateByLayer = $this->readLocateByLayers($qgs_xml, $this->cfg);
-        $this->formFilterLayers = $this->readFormFilterLayers($qgs_xml, $this->cfg);
-        $this->editionLayers = $this->readEditionLayers($qgs_xml, $this->cfg);
-        $this->attributeLayers = $this->readAttributeLayers($qgs_xml, $this->cfg);
-        $this->layersOrder = $this->readLayersOrder($qgs_xml, $this->cfg);
+        $this->printCapabilities = $this->readPrintCapabilities($qgsXml, $this->cfg);
+        $this->locateByLayer = $this->readLocateByLayers($qgsXml, $this->cfg);
+        $this->formFilterLayers = $this->readFormFilterLayers($qgsXml, $this->cfg);
+        $this->editionLayers = $this->readEditionLayers($qgsXml, $this->cfg);
+        $this->attributeLayers = $this->readAttributeLayers($qgsXml, $this->cfg);
+        $this->layersOrder = $this->readLayersOrder($qgsXml, $this->cfg);
     }
 
     public function getQgisPath()

--- a/lizmap/modules/lizmap/lib/Project/project.php
+++ b/lizmap/modules/lizmap/lib/Project/project.php
@@ -1,0 +1,2251 @@
+<?php
+/**
+ * Manage and give access to lizmap configuration.
+ *
+ * @author    3liz
+ * @copyright 2012 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+namespace Lizmap\Project;
+
+class Project
+{
+    /**
+     * @var lizmapRepository
+     */
+    protected $repository;
+    /**
+     * @var projectXML QGIS project XML
+     */
+    protected $xml = null;
+    /**
+     * @var object CFG project JSON
+     */
+    protected $cfg;
+
+    /**
+     * @var array services properties
+     */
+    protected $properties = array(
+        'repository',
+        'id',
+        'title',
+        'abstract',
+        'proj',
+        'bbox',
+    );
+
+    /**
+     * @var JelixInfos The jelixInfos instance
+     */
+    protected $jelix;
+
+    /**
+     * @var lizmapServices The lizmapServices instance
+     */
+    protected $services;
+
+    /**
+     * @var string .qgs file path
+     */
+    protected $file = null;
+    /**
+     * Lizmap project key.
+     *
+     * @var string
+     */
+    protected $key = '';
+
+    /**
+     * QGIS project filemtime.
+     *
+     * @var string
+     */
+    protected $qgsmtime = '';
+
+    /**
+     * Lizmap config filemtime.
+     *
+     * @var string
+     */
+    protected $qgscfgmtime = '';
+
+    /**
+     * @var array Lizmap repository configuration data
+     */
+    protected $data = array();
+
+    /**
+     * Version of QGIS which wrote the project.
+     *
+     * @var null|int
+     */
+    protected $qgisProjectVersion;
+
+    /**
+     * @var array contains WMS info
+     */
+    protected $WMSInformation;
+
+    /**
+     * @var string
+     */
+    protected $canvasColor = '';
+
+    /**
+     * @var array authid => proj4
+     */
+    protected $allProj4 = array();
+
+    /**
+     * @var array for each referenced layer, there is an item
+     *            with referencingLayer, referencedField, referencingField keys.
+     *            There is also a 'pivot' key
+     */
+    protected $relations = array();
+
+    /**
+     * @var array list of themes
+     */
+    protected $themes = array();
+
+    /**
+     * @var array list of layer orders: layer name => order
+     */
+    protected $layersOrder = array();
+
+    /**
+     * @var array
+     */
+    protected $printCapabilities = array();
+
+    /**
+     * @var array
+     */
+    protected $locateByLayer = array();
+
+    /**
+     * @var array
+     */
+    protected $formFilterLayers = array();
+
+    /**
+     * @var array
+     */
+    protected $editionLayers = array();
+
+    /**
+     * @var array
+     */
+    protected $attributeLayers = array();
+
+    /**
+     * @var bool
+     */
+    protected $useLayerIDs = false;
+
+    /**
+     * @var array List of cached properties
+     */
+    protected $cachedProperties = array('WMSInformation', 'canvasColor', 'allProj4',
+        'relations', 'themes', 'layersOrder', 'printCapabilities', 'locateByLayer', 'formFilterLayers',
+        'editionLayers', 'attributeLayers', 'useLayerIDs', 'layers', 'data', 'cfg', 'qgisProjectVersion', );
+
+
+    /**
+     * @var string
+     */
+    private $spatialiteExt;
+
+    /**
+     * version of the format of data stored in the cache.
+     *
+     * This number should be increased each time you change the structure of the
+     * properties of qgisProject (ex: adding some new data properties into the $layers).
+     * So you'll be sure that the cache will be updated when Lizmap code source
+     * is updated on a server
+     */
+    const CACHE_FORMAT_VERSION = 1;
+
+    /**
+     * @var projectCache
+     */
+    protected $cacheHandler = null;
+
+    /**
+     * constructor.
+     *
+     * @param string           $key : the project name
+     * @param lizmapRepository $rep : the repository
+     * @param jelixInfo $jelix the instance of jelixInfos
+     */
+    public function __construct($key, $rep, $jelix, $services)
+    {
+        $this->key = $key;
+        $this->repository = $rep;
+        $this->jelix = $jelix;
+        $this->services = $services;
+
+        $file = $this->getQgisPath();
+
+        // Verifying if the files exist
+        if (!file_exists($file)) {
+            throw new UnknownLizmapProjectException('The QGIS project '.$file.' does not exist!');
+        }
+        if (!file_exists($file.'.cfg')) {
+            throw new UnknownLizmapProjectException('The lizmap config '.$file.'.cfg does not exist!');
+        }
+
+        $this->cacheHandler = new projectCache($file, $this->jelix);
+
+        $data = $this->cacheHandler->retrieveProjectData();
+
+        if ($data === false ||
+            $data['qgsmtime'] < filemtime($file) ||
+            $data['qgscfgmtime'] < filemtime($file.'.cfg') ||
+            !isset($data['format_version']) ||
+            $data['format_version'] != self::CACHE_FORMAT_VERSION
+        ) {
+            // FIXME reading XML could take time, so many process could
+            // read it and construct the cache at the same time. We should
+            // have a kind of lock to avoid this issue.
+            $this->readProject($key, $rep);
+            $data['qgsmtime'] = filemtime($file);
+            $data['qgscfgmtime'] = filemtime($file.'.cfg');
+            $data['format_version'] = self::CACHE_FORMAT_VERSION;
+            foreach ($this->cachedProperties as $prop) {
+                $data[$prop] = $this->{$prop};
+            }
+            $this->cacheHandler->storeProjectData($data);
+        } else {
+            foreach ($this->cachedProperties as $prop) {
+                if (array_key_exists($prop, $data)) {
+                    $this->{$prop} = $data[$prop];
+                }
+            }
+        }
+        $this->qgsmtime = $data['qgsmtime'];
+        $this->qgscfgmtime = $data['qgscfgmtime'];
+
+        $this->path = $file;
+    }
+
+    public function clearCache()
+    {
+        $this->cacheHandler->clearCache();
+    }
+    /**
+     * temporary function to read xml for some methods that relies on  // Replace
+     * xml data that are not yet stored in the cache.
+     *
+     * @return SimpleXMLElement
+     *
+     * @deprecated
+     */
+    protected function getXml()
+    {
+        if ($this->xml) {
+            return $this->xml;
+        }
+        $qgs_path = $this->getQgisPath();
+        if (!file_exists($qgs_path) ||
+            !file_exists($qgs_path.'.cfg')) {
+            throw new Error('Files of project '.$this->key.' does not exists');
+        }
+        $xml = simplexml_load_file($qgs_path);
+        if ($xml === false) {
+            throw new Exception('Qgs File of project '.$this->key.' has invalid content');
+        }
+        $this->xml = $xml;
+
+        return $xml;
+    }
+
+    /**
+     * Read the qgis files.
+     *
+     * @param mixed $key
+     * @param mixed $rep
+     */
+    protected function readProject($key, $rep)
+    {
+        $qgs_path = $this->getQgisPath();
+
+        if (!file_exists($qgs_path) ||
+            !file_exists($qgs_path.'.cfg')) {
+            throw new UnknownLizmapProjectException("Files of project ${key} does not exists");
+        }
+
+        $this->cfg = new configFile($qgs_path.'.cfg');
+        if ($this->cfg === null) {
+            throw new UnknownLizmapProjectException(".qgs.cfg File of project ${key} has invalid content");
+        }
+
+        $configOptions = $this->cfg->getProperty('options');
+
+        try {
+            $this->xml = new qgisProject($qgs_path);
+        } catch (Exception $e) {
+            throw $e;
+        }
+        $qgs_xml = $this->xml;
+
+        // Complete data
+        $this->data['repository'] = $rep->getKey();
+        $this->data['id'] = $key;
+        if (!array_key_exists('title', $this->data)) {
+            $this->data['title'] = ucfirst($key);
+        }
+        if (!array_key_exists('abstract', $this->data)) {
+            $this->data['abstract'] = '';
+        }
+        $this->data['proj'] = $configOptions->projection->ref;
+        $this->data['bbox'] = implode(', ', $configOptions->bbox);
+
+        // Update WMSInformation
+        $this->WMSInformation['ProjectCrs'] = $this->data['proj'];
+
+        // get WMS getCapabilities full URL
+        $this->data['wmsGetCapabilitiesUrl'] = jUrl::getFull(
+            'lizmap~service:index',
+            array(
+                'repository' => $rep->getKey(),
+                'project' => $key,
+                'SERVICE' => 'WMS',
+                'VERSION' => '1.3.0',
+                'REQUEST' => 'GetCapabilities',
+            )
+        );
+
+        // get WMTS getCapabilities full URL
+        $this->data['wmtsGetCapabilitiesUrl'] = jUrl::getFull(
+            'lizmap~service:index',
+            array(
+                'repository' => $rep->getKey(),
+                'project' => $key,
+                'SERVICE' => 'WMTS',
+                'VERSION' => '1.0.0',
+                'REQUEST' => 'GetCapabilities',
+            )
+        );
+
+        $shortNames = $qgs_xml->xpathQuery('//maplayer/shortname');
+        if ($shortNames) {
+            foreach ($shortNames as $sname) {
+                $sname = (string) $sname;
+                $xmlLayer = $qgs_xml->xpathQuery("//maplayer[shortname='${sname}']");
+                if (!$xmlLayer) {
+                    continue;
+                }
+                $xmlLayer = $xmlLayer[0];
+                $name = (string) $xmlLayer->layername;
+                $layer = $this->cfg->getEditableProp('layers');
+                if ($layer !== null && property_exists($layer, $name)) {
+                   $layer->{$name}->shortname = $sname;
+                }
+            }
+        }
+
+        $layerWithOpacities = $qgs_xml->xpathQuery('//maplayer/layerOpacity[.!=1]/parent::*');
+        if ($layerWithOpacities) {
+            foreach ($layerWithOpacities as $layerWithOpacitiy) {
+                $name = (string) $layerWithOpacitiy->layername;
+                $prop = $this->cfg->getEditableProp('layers');
+                if ($prop && property_exists($prop, $name)) {
+                    $opacity = (float) $layerWithOpacitiy->layerOpacity;
+                    $prop->{$name}->opacity = $opacity;
+                }
+            }
+        }
+
+        $groupsWithShortName = $qgs_xml->xpathQuery("//layer-tree-group/customproperties/property[@key='wmsShortName']/parent::*/parent::*");
+        if ($groupsWithShortName) {
+            foreach ($groupsWithShortName as $group) {
+                $name = (string) $group['name'];
+                $shortNameProperty = $group->xpath("customproperties/property[@key='wmsShortName']");
+                if ($shortNameProperty && count($shortNameProperty) > 0) {
+                    $shortNameProperty = $shortNameProperty[0];
+                    $sname = (string) $shortNameProperty['value'];
+                    $prop = $this->cfg->getEditableProp('layers');
+                    if ($prop && property_exists($prop, $name)) {
+                        $prop->{$name}->shortname = $sname;
+                    }
+                }
+            }
+        }
+        $groupsMutuallyExclusive = $qgs_xml->xpathQuery("//layer-tree-group[@mutually-exclusive='1']");
+        if ($groupsMutuallyExclusive) {
+            foreach ($groupsMutuallyExclusive as $group) {
+                $name = (string) $group['name'];
+                $prop = $this->cfg->getEditableProp('layers');
+                if ($prop && property_exists($prop, $name)) {
+                    $prop->{$name}->smutuallyExclusive = 'True';
+                }
+            }
+        }
+
+        $layersWithShowFeatureCount = $qgs_xml->xpathQuery("//layer-tree-layer/customproperties/property[@key='showFeatureCount']/parent::*/parent::*");
+        if ($layersWithShowFeatureCount) {
+            foreach ($layersWithShowFeatureCount as $layer) {
+                $name = (string) $layer['name'];
+                $prop = $this->cfg->getEditableProp('layers');
+                if ($prop && property_exists($prop, $name)) {
+                    $prop->{$name}->showFeatureCont = 'True';
+                }
+            }
+        }
+        //remove plugin layer
+        $pluginLayers = $qgs_xml->xpathQuery('//maplayer[type="plugin"]');
+        if ($pluginLayers) {
+            foreach ($pluginLayers as $layer) {
+                $name = (string) $layer->layername;
+                $prop = $this->cfg->getEditableProp('layers');
+                if ($prop && property_exists($prop, $name)) {
+                    unset($prop->{$name});
+                }
+            }
+        }
+
+        $this->cfg->unsetPropAfterRead();
+
+        $this->printCapabilities = $this->readPrintCapabilities($qgs_xml, $this->cfg);
+        $this->locateByLayer = $this->readLocateByLayers($qgs_xml, $this->cfg);
+        $this->formFilterLayers = $this->readFormFilterLayers($qgs_xml, $this->cfg);
+        $this->editionLayers = $this->readEditionLayers($qgs_xml, $this->cfg);
+        $this->attributeLayers = $this->readAttributeLayers($qgs_xml, $this->cfg);
+        $this->layersOrder = $this->readLayersOrder($qgs_xml, $this->cfg);
+    }
+
+    public function getQgisPath()
+    {
+        if (!$this->file) {
+            $this->file = realpath($this->repository->getPath()).'/'.$this->key.'.qgs';
+        }
+        return $this->file;
+    }
+
+    public function getRelativeQgisPath()
+    {
+        $services = $this->services; // A changer
+
+        $mapParam = $this->getQgisPath();
+        if (!$services->isRelativeWMSPath()) {
+            return $mapParam;
+        }
+
+        $rootRepositories = $services->getRootRepositories();
+        if ($rootRepositories != '' && strpos($mapParam, $rootRepositories) === 0) {
+            $mapParam = str_replace($rootRepositories, '', $mapParam);
+            $mapParam = ltrim($mapParam, '/');
+        }
+
+        return $mapParam;
+    }
+
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    public function getRepository()
+    {
+        return $this->repository;
+    }
+
+    public function getFileTime()
+    {
+        return $this->qgsmtime;
+    }
+
+    public function getCfgFileTime()
+    {
+        return $this->qgscfgmtime;
+    }
+
+    public function getProperties()
+    {
+        return $this->properties;
+    }
+
+    public function getOptions()
+    {
+        return $this->cfg->options;
+    }
+
+    public function getLayers()
+    {
+        return $this->cfg->layers;
+    }
+
+    public function findLayerByAnyName($name)
+    {
+        // name null or empty string
+        if ($name == null || empty($name)) {
+            return null;
+        }
+
+        $layer = null;
+        $methods = array(
+            // Get by name ie as written in QGIS Desktop legend
+            'Name',
+            // since 2.14 layer's name can be layer's shortName
+            'ShortName',
+            // Get layer by typename : qgis server replaces ' ' by '_' for layer names
+            'TypeName',
+            // Get by id
+            'LayerId',
+            // since 2.6 layer's name can be layer's title
+            'Title'
+        );
+        
+        foreach ($methods as $key) {
+            $method = 'findLayerBy'.$key;
+            $layer = $this->$method($name);
+            if ($layer) {
+                return $layer;
+            }
+        }
+        return $layer;
+    }
+
+    public function findLayerByName($name)
+    {
+        // name null or empty string
+        if ($name == null || empty($name)) {
+            return null;
+        }
+
+        if (property_exists($this->cfg->layers, $name)) {
+            return $this->cfg->layers->{$name};
+        }
+
+        return null;
+    }
+
+    public function findLayerByShortName($shortName)
+    {
+        // short name null or empty string
+        if ($shortName == null || empty($shortName)) {
+            return null;
+        }
+
+        foreach ($this->cfg->layers as $layer) {
+            if (!property_exists($layer, 'shortname')) {
+                continue;
+            }
+            if ($layer->shortname == $shortName) {
+                return $layer;
+            }
+        }
+
+        return null;
+    }
+
+    public function findLayerByTitle($title)
+    {
+        // title null or empty string
+        if ($title == null || empty($title)) {
+            return null;
+        }
+
+        foreach ($this->cfg->layers as $layer) {
+            if (!property_exists($layer, 'title')) {
+                continue;
+            }
+            if ($layer->title == $title) {
+                return $layer;
+            }
+        }
+
+        return null;
+    }
+
+    public function findLayerByLayerId($layerId)
+    {
+        // layer id null or empty string
+        if ($layerId == null || empty($layerId)) {
+            return null;
+        }
+
+        foreach ($this->cfg->layers as $layer) {
+            if (!property_exists($layer, 'id')) {
+                continue;
+            }
+            if ($layer->id == $layerId) {
+                return $layer;
+            }
+        }
+
+        return null;
+    }
+
+    public function findLayerByTypeName($typeName)
+    {
+        // type name null or empty string
+        if ($typeName == null || empty($typeName)) {
+            return null;
+        }
+
+        // typeName is layerName
+        if (property_exists($this->cfg->layers, $typeName)) {
+            return $this->cfg->layers->{$typeName};
+        }
+        // typeName is cleanName or shortName
+        foreach ($this->cfg->layers as $layer) {
+            if (str_replace(' ', '_', $layer->name) == $typeName) {
+                return $layer;
+            }
+            if (!property_exists($layer, 'shortname')) {
+                continue;
+            }
+            if ($layer->shortname == $typeName) {
+                return $layer;
+            }
+        }
+
+        return null;
+    }
+
+    public function hasLocateByLayer()
+    {
+        if (property_exists($this->cfg, 'locateByLayer') && is_array($this->cfg->locateByLayer) && count($this->cfg->locateByLayer)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function hasFormFilterLayers()
+    {
+        if (property_exists($this->cfg, 'formFilterLayers') && is_array($this->cfg->formFilterLayers) && count($this->cfg->formFilterLayers)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function getFormFilterLayersConfig()
+    {
+        $config = null;
+        if (property_exists($this->cfg, 'formFilterLayers')) {
+            $config = $this->cfg->formFilterLayers;
+        }
+        return $config;
+    }
+
+    public function hasTimemanagerLayers()
+    {
+        if (property_exists($this->cfg, 'timemanagerLayers') && is_array($this->cfg->timemanagerLayers) && count($this->cfg->timemanagerLayers)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function hasAtlasEnabled()
+    {
+        if ((property_exists($this->cfg->options, 'atlasEnabled') and $this->cfg->options->atlasEnabled == 'True') // Legacy LWC < 3.4 (only one layer)
+            or
+            (property_exists($this->cfg, 'atlas') and property_exists($this->cfg->atlas, 'layers') and is_array($this->cfg->atlas->layers) and count($this->cfg->atlas->layers) > 0)) { // Multiple atlas
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getQgisServerPlugins()
+    {
+        $qgisServer = jClasses::getService('lizmap~qgisServer');
+
+        return $qgisServer->getPlugins($this);
+    }
+
+    public function hasTooltipLayers()
+    {
+        if (property_exists($this->cfg, 'tooltipLayers') && count($this->cfg->tooltipLayers)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function hasAttributeLayers($onlyDisplayedLayers = false)
+    {
+        if (property_exists($this->cfg, 'attributeLayers')) {
+            $count = 0;
+            $hasDisplayedLayer = !$onlyDisplayedLayers;
+            foreach ($this->cfg->attributeLayers as $key => $obj) {
+                ++$count;
+                if ($onlyDisplayedLayers && !property_exists($obj, 'hideLayer') ||
+                    strtolower($obj->hideLayer) != 'true') {
+                    $hasDisplayedLayer = true;
+                }
+            }
+            if ($count != 0 && $hasDisplayedLayer) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function hasFtsSearches()
+    {
+        // Virtual jdb profile corresponding to the layer database
+        $project = $this->key;
+        $repository = $this->repository->getKey();
+
+        $repositoryPath = realpath($this->repository->getPath());
+        $repositoryPath = str_replace('\\', '/', $repositoryPath);
+        $searchDatabase = $repositoryPath.'/default.qfts';
+
+        if (!file_exists($searchDatabase)) {
+            // Search for project database
+            $searchDatabase = $repositoryPath.'/'.$project.'.qfts';
+        }
+        if (!file_exists($searchDatabase)) {
+            return false;
+        }
+
+        $jdbParams = array(
+            'driver' => 'pdo',
+            'dsn' => 'sqlite:'.$searchDatabase,
+        );
+
+        // Create the virtual jdb profile
+        $searchJdbName = 'jdb_'.$repository.'_'.$project;
+        $this->jelix->createVirtualProfile('jdb', $searchJdbName, $jdbParams);
+
+        // Check FTS db ( tables and geometry storage
+        try {
+            $cnx = $this->jelix->getConnection($searchJdbName);
+
+            // Get metadata
+            $sql = "
+            SELECT search_id, search_name, layer_name, geometry_storage, srid
+            FROM quickfinder_toc
+            WHERE geometry_storage != 'wkb'
+            ORDER BY priority
+            ";
+            $res = $this->jelix->useDbConnection($cnx, 'query', array($sql));
+            $searches = array();
+            foreach ($res as $item) {
+                $searches[$item->search_id] = array(
+                    'search_name' => $item->search_name,
+                    'layer_name' => $item->layer_name,
+                    'srid' => $item->srid,
+                );
+            }
+            if (count($searches) == 0) {
+                return false;
+            }
+
+            return array(
+                'jdb_profile' => $searchJdbName,
+                'searches' => $searches,
+            );
+        } catch (Exception $e) {
+            return false;
+        }
+
+        return false;
+    }
+
+    public function hasEditionLayers()
+    {
+        if (property_exists($this->cfg, 'editionLayers')) {
+            if (!$this->jelix->aclCheckResult(array('lizmap.tools.edition.use', $this->repository->getKey()))) {
+                return false;
+            }
+
+            $count = 0;
+            foreach ($this->cfg->editionLayers as $key => $eLayer) {
+                // Check if user groups intersects groups allowed by project editor
+                // If user is admin, no need to check for given groups
+                if (property_exists($eLayer, 'acl') and $eLayer->acl) {
+                    // Check if configured groups white list and authenticated user groups list intersects
+                    $editionGroups = $eLayer->acl;
+                    $editionGroups = array_map('trim', explode(',', $editionGroups));
+                    if (is_array($editionGroups) and count($editionGroups) > 0) {
+                        $userGroups = $this->jelix->aclDbUserGroups();
+                        if (array_intersect($editionGroups, $userGroups) or $this->jelix->aclCheckResult(array('lizmap.admin.repositories.delete'))) {
+                            // User group(s) correspond to the groups given for this edition layer
+                            // or user is admin
+                            ++$count;
+                            unset($this->cfg->editionLayers->{$key}->acl);
+                        } else {
+                            // No match found, we deactivate the edition layer
+                            unset($this->cfg->editionLayers->{$key});
+                        }
+                    }
+                } else {
+                    ++$count;
+                }
+            }
+            if ($count != 0) {
+                return true;
+            }
+
+            return false;
+        }
+
+        return false;
+    }
+
+    public function getEditionLayers()
+    {
+        return $this->cfg->editionLayers;
+    }
+
+    public function findEditionLayerByName($name)
+    {
+        if (!$this->hasEditionLayers()) {
+            return null;
+        }
+
+        if (property_exists($this->cfg->editionLayers, $name)) {
+            return $this->cfg->editionLayers->{$name};
+        }
+
+        return null;
+    }
+
+    /**
+     * @param $layerId
+     *
+     * @return null|array
+     */
+    public function findEditionLayerByLayerId($layerId)
+    {
+        if (!$this->hasEditionLayers()) {
+            return null;
+        }
+
+        foreach ($this->cfg->editionLayers as $layer) {
+            if (!property_exists($layer, 'layerId')) {
+                continue;
+            }
+            if ($layer->layerId == $layerId) {
+                return $layer;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasLoginFilteredLayers()
+    {
+        if (property_exists($this->cfg, 'loginFilteredLayers') && is_array($this->cfg->hasLoginFilteredLayers) && count($this->cfg->loginFilteredLayers)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function getLoginFilteredConfig($layername)
+    {
+        if (!$this->hasLoginFilteredLayers()) {
+            return null;
+        }
+
+        $ln = $layername;
+        // In case $layername is a WFS TypeName
+        $layerByTypeName = $this->findLayerByTypeName($layername);
+        if ($layerByTypeName) {
+            $ln = $layerByTypeName->name;
+        }
+
+        if (!property_exists($this->cfg->loginFilteredLayers, $ln)) {
+            return null;
+        }
+
+        return $pConfig->loginFilteredLayers->{$n};
+    }
+
+    public function getLoginFilters($layers)
+    {
+        $filters = array();
+
+        if (!$this->hasLoginFilteredLayers()) {
+            return $filters;
+        }
+
+        foreach ($layers as $layername) {
+            $lname = $layername;
+
+            // In case $layername is a WFS TypeName
+            $layerByTypeName = $this->findLayerByTypeName($layername);
+            if ($layerByTypeName) {
+                $lname = $layerByTypeName->name;
+            }
+
+            // Get config
+            $loginFilteredConfig = $this->getLoginFilteredConfig($lname);
+            if ($loginFilteredConfig == null) {
+                continue;
+            }
+
+            // attribute to filter
+            $attribute = strtolower($loginFilteredConfig->filterAttribute);
+
+            // default no user connected
+            $filter = "\"${attribute}\" = 'all'";
+
+            // A user is connected
+            if ($this->jelix->userIsConnected()) {
+                $user = $this->jelix->getUserSession();
+                $login = $user->login;
+                if (property_exists($loginFilteredConfig, 'filterPrivate') &&
+                    $this>optionToBoolean($loginFilteredConfig->filterPrivate)
+                ) {
+                    $filter = "\"${attribute}\" IN ( '".$login."' , 'all' )";
+                } else {
+                    $userGroups = $this->jelix->aclDbUserGroups();
+                    $flatGroups = implode("' , '", $userGroups);
+                    $filter = "\"${attribute}\" IN ( '".$flatGroups."' , 'all' )";
+                }
+            }
+
+            $filters[$layername] = array_merge(
+                $loginFilteredConfig,
+                array('filter' => $filter, 'layername' => $lname)
+            );
+        }
+
+        return $filters;
+    }
+
+    private function optionToBoolean($config_string)
+    {
+        $ret = false;
+        if (strtolower((string)$config_string) == 'true') {
+            $ret = true;
+        }
+        return $ret;
+    }
+
+    /**
+     * @return array|bool
+     */
+    public function getDatavizLayersConfig()
+    {
+        if (!property_exists($this->cfg, 'datavizLayers')) {
+            return false;
+        }
+        $config = array(
+            'layers' => array(),
+            'dataviz' => array(),
+            'locale' => $this->jelix->appConfig()->locale
+        );
+        foreach ($this->cfg->datavizLayers as $order => $lc) {
+            if (!property_exists($lc, 'layerId')) {
+                continue;
+            }
+            $layer = $this->findLayerByAnyName($lc->layerId);
+            if (!$layer) {
+                continue;
+            }
+            $title = $layer->title;
+            if (!empty($lc->title)) {
+                $title = $lc->title;
+            }
+            $plotConf = array(
+                'plot_id' => $lc->order,
+                'layer_id' => $layer->id,
+                'title' => $title,
+                'plot' => array(
+                    'type' => $lc->type,
+                    'x_field' => $lc->x_field,
+                ),
+            );
+
+            $properties = array(
+                'y_field',
+                'z_field',
+                'x_field',
+                'y2_field',
+                'color',
+                'color2',
+                'colorfield',
+                'colorfield2',
+                'aggregation',
+                'html_template',
+                'display_when_layer_visible',
+                'traces'
+            );
+            foreach ($properties as $prop) {
+                if (property_exists($lc, $prop)) {
+                    $plot_conf['plot'][$prop] = $lc->$prop;
+                }
+            }
+
+            if (property_exists($lc, 'popup_display_child_plot')) {
+                $plotConf['popup_display_child_plot'] = $lc->popup_display_child_plot;
+            }
+            if (property_exists($lc, 'only_show_child')) {
+                $plotConf['only_show_child'] = $lc->only_show_child;
+            }
+
+            $abstract = $layer->abstract;
+            if (property_exists($lc, 'description')) {
+                $abstract = $lc->description;
+            }
+            $plotConf['abstract'] = $abstract;
+
+            $display_legend = true;
+            if (property_exists($lc, 'display_legend')) {
+                $display_legend = $this->optionToBoolean($lc->display_legend);
+            }
+            $plotConf['plot']['display_legend'] = $display_legend;
+
+            $stacked = false;
+            if (property_exists($lc, 'stacked')) {
+                $stacked = $this->optionToBoolean($lc->stacked);
+            }
+            $plotConf['plot']['stacked'] = $stacked;
+
+            $horizontal = false;
+            if (property_exists($lc, 'horizontal')) {
+                $horizontal = $this->optionToBoolean($lc->horizontal);
+            }
+            $plotConf['plot']['horizontal'] = $horizontal;
+
+            // Add more layout config, written like:
+            // layout_config=barmode:stack,bargap:0.5
+            if (!empty($lc->layout_config)) {
+                $layout_config = array();
+                $a = array_map('trim', explode(',', $lc->layout_config));
+                foreach ($a as $i) {
+                    $b = array_map('trim', explode(':', $i));
+                    if (is_array($b) and count($b) == 2) {
+                        $c = $b[1];
+                        if ($c == 'false') {
+                            $c = (bool) false;
+                        }
+                        if ($c == 'true') {
+                            $c = (bool) true;
+                        }
+                        $layout_config[$b[0]] = $c;
+                    }
+                }
+                if (count($layout_config) > 0) {
+                    $plotConf['plot']['layout_config'] = $layout_config;
+                }
+            }
+
+            if (property_exists($lc, 'layout')) {
+                $plotConf['plot']['layout'] = $lc->layout;
+            }
+
+            $config['layers'][$order] = $plotConf;
+        }
+        if (empty($config['layers'])) {
+            return false;
+        }
+
+        $config['dataviz'] = array(
+            'location' => 'dock',
+            'theme' => 'dark'
+        );
+        if (property_exists($this->cfg->options, 'datavizLocation')
+            and in_array($this->cfg->options->datavizLocation, array('dock', 'bottomdock', 'right-dock'))
+        ) {
+            $config['dataviz']['location'] = $this->cfg->options->datavizLocation;
+        }
+        if (property_exists($this->cfg->options, 'theme')
+            and in_array($this->cfg->options->theme, array('dark', 'light'))
+        ) {
+            $config['dataviz']['theme'] = $this->cfg->options->theme;
+        }
+
+        return $config;
+    }
+
+    /**
+     * @return bool
+     */
+    public function needsGoogle()
+    {
+        $configOptions = $this->cfg->options;
+        $googleProps = array(
+            'googleStreets',
+            'googleSatellite',
+            'googleHybrid',
+            'googleTerrain'
+        );
+
+        foreach ($googleProps as $google) {
+            if (property_exists($configOptions, $google) && $configOptions->$google) {
+                return true;
+            }
+        }
+
+        return (property_exists($configOptions, 'externalSearch') && $configOptions->externalSearch == 'google');
+    }
+
+    /**
+     * @return string
+     */
+    public function getGoogleKey()
+    {
+        $configOptions = $this->cfg->options;
+        $gkey = '';
+        if (property_exists($configOptions, 'googleKey')
+            && $configOptions->googleKey != '') {
+            $gkey = $configOptions->googleKey;
+        }
+
+        return $gkey;
+    }
+
+    /**
+     * @param string $layerId
+     *
+     * @return null|string
+     */
+    public function getLayerNameByIdFromConfig($layerId)
+    {
+        $layers = $this->getLayers();
+        $name = null;
+        foreach ($layers as $name => $props) {
+            if ($props->id == $layerId) {
+                return $name;
+            }
+        }
+
+        return $name;
+    }
+
+    protected function readPrintCapabilities($qgsLoad, $cfg)
+    {
+        $printTemplates = array();
+
+        if (property_exists($cfg->options, 'print') &&
+            $cfg->options->print == 'True'
+        ) {
+            // get restricted composers
+            $rComposers = array();
+            $restrictedComposers = $qgsLoad->xpath('//properties/WMSRestrictedComposers/value');
+            if ($restrictedComposers && count($restrictedComposers) > 0) {
+                foreach ($restrictedComposers as $restrictedComposer) {
+                    $rComposers[] = (string) $restrictedComposer;
+                }
+            }
+
+            $services = $this->services;
+            // get composer qg project version < 3
+            $composers = $qgsLoad->xpath('//Composer');
+            if ($composers && count($composers) > 0) {
+                foreach ($composers as $composer) {
+                    // test restriction
+                    if (in_array((string) $composer['title'], $rComposers)) {
+                        continue;
+                    }
+                    // get composition element
+                    $composition = $composer->xpath('Composition');
+                    if (!$composition || count($composition) == 0) {
+                        continue;
+                    }
+                    $composition = $composition[0];
+
+                    // init print template element
+                    $printTemplate = array(
+                        'title' => (string) $composer['title'],
+                        'width' => (int) $composition['paperWidth'],
+                        'height' => (int) $composition['paperHeight'],
+                        'maps' => array(),
+                        'labels' => array(),
+                    );
+
+                    // get composer maps
+                    $cMaps = $composer->xpath('.//ComposerMap');
+                    if ($cMaps && count($cMaps) > 0) {
+                        foreach ($cMaps as $cMap) {
+                            $cMapItem = $cMap->xpath('ComposerItem');
+                            if (count($cMapItem) == 0) {
+                                continue;
+                            }
+                            $cMapItem = $cMapItem[0];
+                            $ptMap = array(
+                                'id' => 'map'.(string) $cMap['id'],
+                                'width' => (int) $cMapItem['width'],
+                                'height' => (int) $cMapItem['height'],
+                            );
+
+                            // Before 2.6
+                            if (property_exists($cMap->attributes(), 'overviewFrameMap') and (string) $cMap['overviewFrameMap'] != '-1') {
+                                $ptMap['overviewMap'] = 'map'.(string) $cMap['overviewFrameMap'];
+                            }
+                            // >= 2.6
+                            $cMapOverviews = $cMap->xpath('ComposerMapOverview');
+                            foreach ($cMapOverviews as $cMapOverview) {
+                                if ($cMapOverview and (string) $cMapOverview->attributes()->frameMap != '-1') {
+                                    $ptMap['overviewMap'] = 'map'.(string) $cMapOverview->attributes()->frameMap;
+                                }
+                            }
+                            // Grid
+                            $cMapGrids = $cMap->xpath('ComposerMapGrid');
+                            foreach ($cMapGrids as $cMapGrid) {
+                                if ($cMapGrid and (string) $cMapGrid->attributes()->show != '0') {
+                                    $ptMap['grid'] = 'True';
+                                }
+                            }
+                            // In QGIS 3.*
+                            // Layout maps now use a string UUID as "id", let's assume that the first map
+                            // has id 0 and so on ...
+                            if (version_compare($services->qgisServerVersion, '3.0', '>=')) {
+                                $ptMap['id'] = 'map'.(string) count($printTemplate['maps']);
+                            }
+                            $printTemplate['maps'][] = $ptMap;
+                        }
+                    }
+
+                    // get composer labels
+                    $cLabels = $composer->xpath('.//ComposerLabel');
+                    if ($cLabels && count($cLabels) > 0) {
+                        foreach ($cLabels as $cLabel) {
+                            $cLabelItem = $cLabel->xpath('ComposerItem');
+                            if (!$cLabelItem || count($cLabelItem) == 0) {
+                                continue;
+                            }
+                            $cLabelItem = $cLabelItem[0];
+                            if ((string) $cLabelItem['id'] == '') {
+                                continue;
+                            }
+                            $printTemplate['labels'][] = array(
+                                'id' => (string) $cLabelItem['id'],
+                                'htmlState' => (int) $cLabel['htmlState'],
+                                'text' => (string) $cLabel['labelText'],
+                            );
+                        }
+                    }
+
+                    // get composer attribute tables
+                    $cTables = $composer->xpath('.//ComposerAttributeTableV2');
+                    if ($cTables && count($cTables) > 0) {
+                        foreach ($cTables as $cTable) {
+                            $printTemplate['tables'][] = array(
+                                'composerMap' => (int) $cTable['composerMap'],
+                                'vectorLayer' => (string) $cTable['vectorLayer'],
+                            );
+                        }
+                    }
+
+                    // Atlas
+                    $Atlas = $composer->xpath('Atlas');
+                    if (count($Atlas) == 1) {
+                        $Atlas = $Atlas[0];
+                        $printTemplate['atlas'] = array(
+                            'enabled' => (string) $Atlas['enabled'],
+                            'coverageLayer' => (string) $Atlas['coverageLayer'],
+                        );
+                    }
+                    $printTemplates[] = $printTemplate;
+                }
+            }
+            // get layout qgs project version >= 3
+            $layouts = $qgsLoad->xpath('//Layout');
+            if ($layouts && count($layouts) > 0 &&
+                version_compare($services->qgisServerVersion, '3.0', '>=')) {
+                foreach ($layouts as $layout) {
+                    // test restriction
+                    if (in_array((string) $layout['name'], $rComposers)) {
+                        continue;
+                    }
+                    // get page element
+                    $page = $layout->xpath('PageCollection/LayoutItem[@type="65638"]');
+                    if (!$page || count($page) == 0) {
+                        continue;
+                    }
+                    $page = $page[0];
+
+                    $pageSize = explode(',', $page['size']);
+                    // init print template element
+                    $printTemplate = array(
+                        'title' => (string) $layout['name'],
+                        'width' => (int) $pageSize[0],
+                        'height' => (int) $pageSize[1],
+                        'maps' => array(),
+                        'labels' => array(),
+                    );
+
+                    // store mapping between uuid and id
+                    $mapUuidId = [];
+                    // get layout maps
+                    $lMaps = $layout->xpath('LayoutItem[@type="65639"]');
+                    if ($lMaps && count($lMaps) > 0) {
+                        // Convert xml to json config
+                        foreach ($lMaps as $lMap) {
+                            $lMapSize = explode(',', $lMap['size']);
+                            $ptMap = array(
+                                'id' => 'map'.(string) count($printTemplate['maps']),
+                                'uuid' => (string)$lMap['uuid'],
+                                'width' => (int) $lMapSize[0],
+                                'height' => (int) $lMapSize[1],
+                            );
+                            // store mapping between uuid and id
+                            $mapUuidId[(string) $lMap['uuid']] = 'map'.(string) count($printTemplate['maps']);
+
+                            // Overview
+                            $cMapOverviews = $lMap->xpath('ComposerMapOverview');
+                            foreach ($cMapOverviews as $cMapOverview) {
+                                if ($cMapOverview and (string) $cMapOverview->attributes()->show !== '0' and (string) $cMapOverview->attributes()->frameMap != '-1') {
+                                    // frameMap is an uuid
+                                    $ptMap['overviewMap'] = (string) $cMapOverview->attributes()->frameMap;
+                                }
+                            }
+                            // Grid
+                            $cMapGrids = $lMap->xpath('ComposerMapGrid');
+                            foreach ($cMapGrids as $cMapGrid) {
+                                if ($cMapGrid and (string) $cMapGrid->attributes()->show !== '0') {
+                                    $ptMap['grid'] = 'True';
+                                }
+                            }
+
+                            $printTemplate['maps'][] = $ptMap;
+                        }
+                        // Modifying overviewMap to id instead of uuid
+                        foreach ($printTemplate['maps'] as $ptMap) {
+                            if (!array_key_exists('overviewMap', $ptMap)) {
+                                continue;
+                            }
+                            if (!array_key_exists($ptMap['overviewMap'], $mapUuidId)) {
+                                unset($ptMap['overviewMap']);
+                                continue;
+                            }
+                            $ptMap['overviewMap'] = $mapUuidId[$ptMap['overviewMap']];
+                        }
+                    }
+
+                    // get layout labels
+                    $lLabels = $layout->xpath('LayoutItem[@type="65641"]');
+                    if ($lLabels && count($lLabels) > 0) {
+                        foreach ($lLabels as $lLabel) {
+                            if ((string) $lLabel['id'] == '') {
+                                continue;
+                            }
+                            $printTemplate['labels'][] = array(
+                                'id' => (string) $lLabel['id'],
+                                'htmlState' => (int) $lLabel['htmlState'],
+                                'text' => (string) $lLabel['labelText'],
+                            );
+                        }
+                    }
+
+                    // get layout attribute tables
+                    $lTables = $layout->xpath('LayoutMultiFrame[@type="65649"]');
+                    if ($lTables && count($lTables) > 0) {
+                        foreach ($lTables as $lTable) {
+                            $composerMap = -1;
+                            if (isset($lTable['mapUuid'])) {
+                                $mapUuid = (string) $lTable['mapUuid'];
+                                if (!array_key_exists($mapUuid, $mapUuidId)) {
+                                    $mapId = $mapUuidId[$mapUuid];
+                                    $composerMap = (string) str_replace('map', '', $mapId);
+                                }
+                            }
+
+                            $printTemplate['tables'][] = array(
+                                'composerMap' => $composerMap,
+                                'vectorLayer' => (string) $lTable['vectorLayer'],
+                                'vectorLayerName' => (string) $lTable['vectorLayerName'],
+                            );
+                        }
+                    }
+
+                    // Atlas
+                    $Atlas = $layout->xpath('Atlas');
+                    if (count($Atlas) == 1) {
+                        $Atlas = $Atlas[0];
+                        $printTemplate['atlas'] = array(
+                            'enabled' => (string) $Atlas['enabled'],
+                            'coverageLayer' => (string) $Atlas['coverageLayer'],
+                        );
+                    }
+                    $printTemplates[] = $printTemplate;
+                }
+            }
+        }
+
+        return $printTemplates;
+    }
+
+    /**
+     * @param SimpleXMLElement $xml
+     * @param string           $layerId
+     *
+     * @return SimpleXMLElement[]
+     */
+    protected function getXmlLayer2($xml, $layerId)
+    {
+        return $xml->xpath("//maplayer[id='${layerId}']");
+    }
+
+    protected function readLocateByLayers($xml, $cfg)
+    {
+        $locateByLayer = array();
+        if (property_exists($cfg, 'locateByLayer')) {
+            $locateByLayer = $cfg->locateByLayer;
+            // collect layerIds
+            $locateLayerIds = array();
+            foreach ($locateByLayer as $k => $v) {
+                $locateLayerIds[] = $v->layerId;
+            }
+            // update locateByLayer with alias and filter information
+            foreach ($locateByLayer as $k => $v) {
+                $xmlLayer = $this->getXmlLayer2($xml, $v->layerId);
+                if (count($xmlLayer) == 0) {
+                    continue;
+                }
+                $xmlLayerZero = $xmlLayer[0];
+                // aliases
+                $alias = $xmlLayerZero->xpath("aliases/alias[@field='".$v->fieldName."']");
+                if ($alias && count($alias) != 0) {
+                    $alias = $alias[0];
+                    $v->fieldAlias = (string) $alias['name'];
+                    $locateByLayer->{$k} = $v;
+                }
+                if (property_exists($v, 'filterFieldName')) {
+                    $alias = $xmlLayerZero->xpath("aliases/alias[@field='".$v->filterFieldName."']");
+                    if ($alias && count($alias) != 0) {
+                        $alias = $alias[0];
+                        $v->filterFieldAlias = (string) $alias['name'];
+                        $locateByLayer->{$k} = $v;
+                    }
+                }
+                // vectorjoins
+                $vectorjoins = $xmlLayerZero->xpath('vectorjoins/join');
+                if ($vectorjoins && count($vectorjoins) != 0) {
+                    if (!property_exists($v, 'vectorjoins')) {
+                        $v->vectorjoins = array();
+                    }
+                    foreach ($vectorjoins as $vectorjoin) {
+                        $joinLayerId = (string) $vectorjoin['joinLayerId'];
+                        if (in_array($joinLayerId, $locateLayerIds)) {
+                            $v->vectorjoins[] = (object) array(
+                                'joinFieldName' => (string) $vectorjoin['joinFieldName'],
+                                'targetFieldName' => (string) $vectorjoin['targetFieldName'],
+                                'joinLayerId' => (string) $vectorjoin['joinLayerId'],
+                            );
+                        }
+                    }
+                    $locateByLayer->{$k} = $v;
+                }
+            }
+        }
+
+        return $locateByLayer;
+    }
+
+    protected function readFormFilterLayers($xml, $cfg)
+    {
+        $formFilterLayers = array();
+
+        if (property_exists($cfg, 'formFilterLayers')) {
+
+            // Add data into formFilterLayers from configuration
+            $formFilterLayers = $cfg->formFilterLayers;
+        }
+
+        return $formFilterLayers;
+    }
+
+    protected function readEditionLayers($xml, $cfg)
+    {
+        $editionLayers = array();
+
+        if (property_exists($cfg, 'editionLayers')) {
+
+            // Add data into editionLayers from configuration
+            $editionLayers = $cfg->editionLayers;
+
+            // Check ability to load spatialite extension
+            // And remove ONLY spatialite layers if no extension found
+            $spatialiteExt = '';
+            if (class_exists('SQLite3')) {
+                $spatialiteExt = $this->getSpatialiteExtension();
+            }
+            if (!$spatialiteExt) {
+                jLog::log('Spatialite is not available', 'error');
+                foreach ($editionLayers as $key => $obj) {
+                    $layerXml = $this->getXmlLayer2($xml, $obj->layerId);
+                    if (count($layerXml) == 0) {
+                        continue;
+                    }
+                    $layerXmlZero = $layerXml[0];
+                    $provider = $layerXmlZero->xpath('provider');
+                    $provider = (string) $provider[0];
+                    if ($provider == 'spatialite') {
+                        unset($editionLayers->{$key});
+                    }
+                }
+            }
+        }
+
+        return $editionLayers;
+    }
+
+    protected function readAttributeLayers($xml, $cfg)
+    {
+        $attributeLayers = array();
+
+        if (property_exists($cfg, 'attributeLayers')) {
+
+            // Add data into attributeLayers from configuration
+            $attributeLayers = $cfg->attributeLayers;
+
+            // Get field order & visibility
+            foreach ($attributeLayers as $key => $obj) {
+                $layerXml = $this->getXmlLayer2($xml, $obj->layerId);
+                if (count($layerXml) == 0) {
+                    continue;
+                }
+                $layerXmlZero = $layerXml[0];
+                $attributetableconfigXml = $layerXmlZero->xpath('attributetableconfig');
+                if (count($attributetableconfigXml) == 0) {
+                    continue;
+                }
+                $attributetableconfig = str_replace(
+                    '@',
+                    '',
+                    json_encode($attributetableconfigXml[0])
+                );
+                $obj->attributetableconfig = json_decode($attributetableconfig);
+                $attributeLayers->{$key} = $obj;
+            }
+        }
+
+        return $attributeLayers;
+    }
+
+    /**
+     * @param SimpleXMLElement $xml
+     * @param $cfg
+     *
+     * @return int[]
+     */
+    protected function readLayersOrder($xml, $cfg)
+    {
+        $layersOrder = array();
+        if ($this->qgisProjectVersion >= 30000) { // For QGIS >=3.0, custom-order is in layer-tree-group
+            $customOrder = $xml->xpath('layer-tree-group/custom-order');
+            if (count($customOrder) == 0) {
+                return $layersOrder;
+            }
+            $customOrderZero = $customOrder[0];
+            if ($customOrderZero->attributes()->enabled == 1) {
+                $items = $customOrderZero->xpath('//item');
+                $lo = 0;
+                foreach ($items as $layerI) {
+                    // Get layer name from config instead of XML for possible embedded layers
+                    $name = $this->getLayerNameByIdFromConfig($layerI);
+                    if ($name) {
+                        $layersOrder[$name] = $lo;
+                    }
+                    ++$lo;
+                }
+            } else {
+                return $layersOrder;
+            }
+        } elseif ($this->qgisProjectVersion >= 20400) { // For QGIS >=2.4, new item layer-tree-canvas
+            $customOrder = $xml->xpath('//layer-tree-canvas/custom-order');
+            if (count($customOrder) == 0) {
+                return $layersOrder;
+            }
+            $customOrderZero = $customOrder[0];
+            if ($customOrderZero->attributes()->enabled == 1) {
+                $items = $customOrderZero->xpath('//item');
+                $lo = 0;
+                foreach ($items as $layerI) {
+                    // Get layer name from config instead of XML for possible embedded layers
+                    $name = $this->getLayerNameByIdFromConfig($layerI);
+                    if ($name) {
+                        $layersOrder[$name] = $lo;
+                    }
+                    ++$lo;
+                }
+            } else {
+                $items = $xml->xpath('layer-tree-group//layer-tree-layer');
+                $lo = 0;
+                foreach ($items as $layerTree) {
+                    // Get layer name from config instead of XML for possible embedded layers
+                    $name = $this->getLayerNameByIdFromConfig($layerTree->attributes()->id);
+                    if ($name) {
+                        $layersOrder[$name] = $lo;
+                    }
+                    ++$lo;
+                }
+            }
+        } else {
+            $legend = $xml->xpath('//legend');
+            if (count($legend) == 0) {
+                return $layersOrder;
+            }
+            $legendZero = $legend[0];
+            $updateDrawingOrder = (string) $legendZero->attributes()->updateDrawingOrder;
+            if ($updateDrawingOrder == 'false') {
+                $layers = $xml->xpath('//legendlayer');
+                foreach ($layers as $layer) {
+                    if ($layer->attributes()->drawingOrder and $layer->attributes()->drawingOrder >= 0) {
+                        $layersOrder[(string) $layer->attributes()->name] = (int) $layer->attributes()->drawingOrder;
+                    }
+                }
+            }
+        }
+
+        return $layersOrder;
+    }
+
+    /**
+     * @return false|string the JSON object corresponding to the configuration
+     */
+    public function getUpdatedConfig()
+    {
+
+        //FIXME: it's better to use clone keyword, isn't it?
+        $configJson = clone $this->cfg;
+
+        // Add an option to display buttons to remove the cache for cached layer
+        // Only if appropriate right is found
+        if ($this->jelix->aclCheckResult(array('lizmap.admin.repositories.delete'))) {
+            $configJson->options->removeCache = 'True';
+        }
+
+        // Remove layerOrder option from config if not required
+        if (!empty($this->layersOrder)) {
+            $configJson->layersOrder = $this->layersOrder;
+        }
+
+        // set printTemplates in config
+        $configJson->printTemplates = $this->printCapabilities;
+
+        // Update locate by layer with vecctorjoins
+        $configJson->locateByLayer = $this->locateByLayer;
+
+        // Update filter form layers with vecctorjoins
+        $configJson->formFilterLayers = $this->formFilterLayers;
+
+        // Update attributeLayers with attributetableconfig
+        $configJson->attributeLayers = $this->attributeLayers;
+
+        // Remove FTP remote directory
+        if (property_exists($configJson->options, 'remoteDir')) {
+            unset($configJson->options->remoteDir);
+        }
+
+        // Remove editionLayers from config if no right to access this tool
+        if (property_exists($configJson, 'editionLayers')) {
+            if ($this->jelix->aclCheckResult(array('lizmap.tools.edition.use', $this->repository->getKey()))) {
+                $configJson->editionLayers = clone $this->editionLayers;
+                // Check right to edit this layer (if property "acl" is in config)
+                foreach ($configJson->editionLayers as $key => $eLayer) {
+                    // Check if user groups intersects groups allowed by project editor
+                    // If user is admin, no need to check for given groups
+                    if (property_exists($eLayer, 'acl') and $eLayer->acl) {
+                        // Check if configured groups white list and authenticated user groups list intersects
+                        $editionGroups = $eLayer->acl;
+                        $editionGroups = array_map('trim', explode(',', $editionGroups));
+                        if (is_array($editionGroups) and count($editionGroups) > 0) {
+                            $userGroups = $this->jelix->aclDbUserGroups();
+                            if (array_intersect($editionGroups, $userGroups) or $this->jelix->aclCheckResult(array('lizmap.admin.repositories.delete'))) {
+                                // User group(s) correspond to the groups given for this edition layer
+                                // or the user is admin
+                                unset($configJson->editionLayers->{$key}->acl);
+                            } else {
+                                // No match found, we deactivate the edition layer
+                                unset($configJson->editionLayers->{$key});
+                            }
+                        }
+                    }
+                }
+            } else {
+                unset($configJson->editionLayers);
+            }
+        }
+
+        // Add export layer right
+        if ($this->jelix->aclCheckResult(array('lizmap.tools.layer.export', $this->repository->getKey()))) {
+            $configJson->options->exportLayers = 'True';
+        }
+
+        // Add WMS max width ad height
+        $services = $this->services;
+        if (array_key_exists('wmsMaxWidth', $this->data)) {
+            $configJson->options->wmsMaxWidth = $this->data['wmsMaxWidth'];
+        } else {
+            $configJson->options->wmsMaxWidth = $services->wmsMaxWidth;
+        }
+        if (array_key_exists('wmsMaxHeight', $this->data)) {
+            $configJson->options->wmsMaxHeight = $this->data['wmsMaxHeight'];
+        } else {
+            $configJson->options->wmsMaxHeight = $services->wmsMaxHeight;
+        }
+
+        // Add QGS Server version
+        $configJson->options->qgisServerVersion = $services->qgisServerVersion;
+
+        // Update config with layer relations
+        $relations = $this->getRelations();
+        if ($relations) {
+            $configJson->relations = $relations;
+        }
+
+        // Update config with project themes
+        $themes = $this->getThemes();
+        if ($themes) {
+            $configJson->themes = $themes;
+        }
+        if ($this->useLayerIDs) {
+            $configJson->options->useLayerIDs = 'True';
+        }
+
+        // Update searches informations.
+        if (!property_exists($configJson->options, 'searches')) {
+            $configJson->options->searches = array();
+        }
+        if (property_exists($configJson->options, 'externalSearch')) {
+            $externalSearch = array(
+                'type' => 'externalSearch',
+                'service' => $configJson->options->externalSearch,
+            );
+            if ($configJson->options->externalSearch == 'nominatim') {
+                $externalSearch['url'] = jUrl::get('lizmap~osm:nominatim');
+            } elseif ($configJson->options->externalSearch == 'ban') {
+                $externalSearch = array(
+                    'type' => 'BAN',
+                    'service' => 'lizmapBan',
+                    'url' => jUrl::get('lizmap~ban:search')
+                );
+            }
+            $configJson->options->searches[] = (object) $externalSearch;
+            unset($configJson->options->externalSearch);
+        }
+        // Add FTS sqlite searches (db created with from quickfinder)
+        $ftsSearches = $this->hasFtsSearches();
+        if ($ftsSearches) {
+            $configJson->options->searches[] = (object) array(
+                'type' => 'QuickFinder',
+                'service' => 'lizmapQuickFinder',
+                'url' => jUrl::get('lizmap~search:get'),
+            );
+        }
+        // Events to get additional searches
+        $searchServices = $this->jelix->eventNotify('searchServiceItem', array('repository' => $this->repository->getKey(), 'project' => $this->getKey()))->getResponse();
+        foreach ($searchServices as $searchService) {
+            if (is_array($searchService)) {
+                if (array_key_exists('type', $searchService) && array_key_exists('url', $searchService)) {
+                    $configJson->options->searches[] = (object) $searchService;
+                }
+            } elseif (is_object($searchService)) {
+                if (property_exists($searchService, 'type') && property_exists($searchService, 'url')) {
+                    $configJson->options->searches[] = $searchService;
+                }
+            }
+        }
+
+        // Update dataviz config
+        if (property_exists($configJson, 'datavizLayers')) {
+            $datavizLayers = $this->getDatavizLayersConfig();
+            if ($datavizLayers) {
+                $configJson->datavizLayers = $datavizLayers;
+            } else {
+                unset($configJson->datavizLayers);
+            }
+        }
+
+        // Get server plugins
+        $qplugins = $this->getQgisServerPlugins();
+        $configJson->qgisServerPlugins = $qplugins;
+
+        // Check layers group visibility
+        $userGroups = array('');
+        if ($this->jelix->userIsConnected()) {
+            $userGroups = $this->jelix->aclDbUserGroups();
+        }
+        $layersToRemove = array();
+        foreach ($configJson->layers as $obj) {
+            // no group_visibility config, nothing to do
+            if (!property_exists($obj, 'group_visibility')) {
+                continue;
+            }
+            if ($obj->group_visibility === '') {
+                unset($obj->group_visibility);
+                continue;
+            }
+            // get group visibility as trimed array
+            $group_visibility = array_map('trim', explode(',', $obj->group_visibility));
+            $layerToKeep = false;
+            foreach ($userGroups as $group) {
+                if (in_array($group, $group_visibility)) {
+                    $layerToKeep = true;
+                    break;
+                }
+            }
+            if (!$layerToKeep) {
+                $layersToRemove[$obj->name] = $obj;
+            }
+            unset($obj->group_visibility);
+        }
+        foreach ($layersToRemove as $key => $obj) {
+            // locateByLayer
+            if (property_exists($configJson->locateByLayer, $key)) {
+                unset($configJson->locateByLayer->{$key});
+            }
+            // locateByLayer vectorjoins
+            foreach ($configJson->locateByLayer as $o) {
+                if (!property_exists($o, 'vectorjoins')) {
+                    continue;
+                }
+                $vectorjoinsToKeep = array();
+                foreach ($o->vectorjoins as $i=>$v) {
+                    if ($v->joinLayerId != $obj->id) {
+                        $vectorjoinsToKeep[] = $o;
+                    }
+                }
+                $o->vectorjoins = $vectorjoinsToKeep;
+            }
+            // attributeLayers
+            if (property_exists($configJson->attributeLayers, $key)) {
+                unset($configJson->attributeLayers->{$key});
+            }
+            // tooltipLayers
+            if (property_exists($configJson->tooltipLayers, $key)) {
+                unset($configJson->tooltipLayers->{$key});
+            }
+            // editionLayers
+            if (property_exists($configJson->editionLayers, $key)) {
+                unset($configJson->editionLayers->{$key});
+            }
+            // datavizLayers
+            if (property_exists($configJson, 'datavizLayers')) {
+                $dvlLayers = $configJson->datavizLayers['layers'];
+                foreach ($dvlLayers as $o=>$c) {
+                    if ($c['layer_id'] == $obj->id) {
+                        unset($configJson->datavizLayers['layers'][$o]);
+                    }
+                }
+            }
+            // atlas
+            if (property_exists($configJson->options, 'atlasEnabled') &&
+                $this->optionToBoolean($configJson->options->atlasEnabled) &&
+                $configJson->options->atlasLayer == $obj->id) {
+                $configJson->options->atlasLayer = '';
+                $configJson->options->atlasPrimaryKey = '';
+                $configJson->options->atlasFeatureLabel = '';
+                $configJson->options->atlasSortField = '';
+                $configJson->options->atlasEnabled = 'False';
+            }
+            // multi-atlas
+            // formFilterLayers
+            foreach ($configJson->formFilterLayers as $o=>$c) {
+                if ($c['layerId'] = $obj->id) {
+                    unset($configJson->formFilterLayers[$o]);
+                }
+            }
+            // relations
+            if (array_key_exists($key, $configJson->relations)) {
+                unset($configJson->relations->{$key});
+            }
+            foreach ($configJson->relations as $k => $layerRelations) {
+                if ($k == 'pivot') {
+                    continue;
+                }
+                $relationsToKeep = array();
+                foreach ($layerRelations as $r) {
+                    if ($r['referencingLayer'] != $obj->id) {
+                        $relationsToKeep[] = $r;
+                    }
+                }
+                if (count($relationsToKeep) > 0) {
+                    $configJson->relations[$k] = $relationsToKeep;
+                } else {
+                    unset($configJson->relations[$k]);
+                }
+            }
+            // printTemplates
+            $printTemplatesToKeep = array();
+            foreach ($configJson->printTemplates as $printTemplate) {
+                if (array_key_exists('atlas', $printTemplate) &&
+                    array_key_exists('coverageLayer', $printTemplate['atlas']) &&
+                    $printTemplate['atlas']['coverageLayer'] != $obj->id) {
+                    $printTemplatesToKeep[] = $printTemplate;
+                }
+            }
+            $configJson->printTemplates = $printTemplatesToKeep;
+
+            // remove layer
+            unset($configJson->layers->{$key});
+        }
+
+        return json_encode($configJson);
+    }
+
+    /**
+     * @return object
+     */
+    public function getFullCfg()
+    {
+        return $this->cfg;
+    }
+
+    /**
+     * @FIXME: remove this method. Be sure it is not used in other projects
+     * Data provided by the returned xml element should be extracted and encapsulated
+     * into an object. Xml should not be used by callers
+     *
+     * @deprecated
+     *
+     * @param mixed $title
+     *
+     * @return null|SimpleXMLElement
+     */
+    public function getComposer($title)
+    {
+        $xmlComposer = $this->getXml()->xpath("//Composer[@title='${title}']");
+        if ($xmlComposer) {
+            return $xmlComposer[0];
+        }
+
+        return null;
+    }
+
+    /**
+     * @throws jExceptionSelector
+     *
+     * @return lizmapMapDockItem[]
+     */
+    public function getDefaultDockable()
+    {
+        $dockable = array();
+        $confUrlEngine = &$this->jelix->appConfig()->urlengine;
+        $bp = $confUrlEngine['basePath'];
+        $jwp = $confUrlEngine['jelixWWWPath'];
+
+        // Get lizmap services
+        $services = $this->services; // A changer
+
+        if ($services->projectSwitcher) {
+            $projectsTpl = new jTpl();
+            $ProjectsTpl->assign('excludedProject', $this->repository->getKey().'~'.$this->getKey());
+            $dockable[] = new lizmapMapDockItem(
+                'projects',
+                $this->jelix->getLocale('view~default.repository.list.title'),
+                $projectsTpl->fetch('view~map_projects'),
+                0
+            );
+        }
+
+        $switcherTpl = new jTpl();
+        $switcherTpl->assign(array(
+            'layerExport' => $this->jelix->aclCheckResult(array('lizmap.tools.layer.export', $this->repository->getKey())),
+        ));
+        $dockable[] = new lizmapMapDockItem(
+            'switcher',
+            $this->jelix->getLocale('view~map.switchermenu.title'),
+            $switcherTpl->fetch('view~map_switcher'),
+            1
+        );
+        //$legendTpl = new jTpl();
+        //$dockable[] = new lizmapMapDockItem('legend', 'Légende', $switcherTpl->fetch('map_legend'), 2);
+
+        $metadataTpl = new jTpl();
+        // Get the WMS information
+        $wmsInfo = $this->getWMSInformation();
+        // WMS GetCapabilities Url
+        $wmsGetCapabilitiesUrl = $this->jelix->aclCheckResult(
+            array(
+            'lizmap.tools.displayGetCapabilitiesLinks',
+            $this->repository->getKey())
+        );
+        $wmtsGetCapabilitiesUrl = $wmsGetCapabilitiesUrl;
+        if ($wmsGetCapabilitiesUrl) {
+            $wmsGetCapabilitiesUrl = $this->getData('wmsGetCapabilitiesUrl');
+            $wmtsGetCapabilitiesUrl = $this->getData('wmtsGetCapabilitiesUrl');
+        }
+        $metadataTpl->assign(array_merge(array(
+            'repositoryLabel' => $this->getData('label'),
+            'repository' => $this->repository->getKey(),
+            'project' => $this->getKey(),
+            'wmsGetCapabilitiesUrl' => $wmsGetCapabilitiesUrl,
+            'wmtsGetCapabilitiesUrl' => $wmtsGetCapabilitiesUrl,
+        ), $wmsInfo));
+        $dockable[] = new lizmapMapDockItem(
+            'metadata',
+            $this->jelix->getLocale('view~map.metadata.link.label'),
+            $metadataTpl->fetch('view~map_metadata'),
+            2
+        );
+
+        if ($this->hasEditionLayers()) {
+            $tpl = new jTpl();
+            $dockable[] = new lizmapMapDockItem(
+                'edition',
+                $this->jelix->getLocale('view~edition.navbar.title'),
+                $tpl->fetch('view~map_edition'),
+                3,
+                $jwp.'design/jform.css',
+                $bp.'assets/js/edition.js'
+            );
+        }
+
+        return $dockable;
+    }
+
+    /**
+     * @throws jException
+     * @throws jExceptionSelector
+     *
+     * @return lizmapMapDockItem[]
+     */
+    public function getDefaultMiniDockable()
+    {
+        $dockable = array();
+        $configOptions = $this->getOptions();
+        $bp = $this->jelix->appConfig()->urlengine['basePath'];
+
+        if ($this->hasAttributeLayers()) {
+            $tpl = new jTpl();
+            // Add layer-export attribute to lizmap-selection-tool component if allowed
+            $layerExport = $this->jelix->aclCheckResult(array('lizmap.tools.layer.export', $this->repository->getKey())) ? "layer-export" : "";
+            $dock = new lizmapMapDockItem(
+                'selectiontool',
+                $this->jelix->getLocale('view~map.selectiontool.navbar.title'),
+                '<lizmap-selection-tool '.$layerExport.'></lizmap-selection-tool>',
+                1,
+                '',
+                $bp.'assets/js/attributeTable.js'
+            );
+            $dock->icon = '<span class="icon-white icon-star" style="margin-left:2px; margin-top:2px;"></span>';
+            $dockable[] = $dock;
+        }
+
+        if ($this->hasLocateByLayer()) {
+            $tpl = new jTpl();
+            $dockable[] = new lizmapMapDockItem(
+                'locate',
+                $this->jelix->getLocale('view~map.locatemenu.title'),
+                $tpl->fetch('view~map_locate'),
+                2
+            );
+        }
+
+        if (property_exists($configOptions, 'geolocation')
+            && $configOptions->geolocation == 'True') {
+            $tpl = new jTpl();
+            $tpl->assign('hasEditionLayers', $this->hasEditionLayers());
+            $dockable[] = new lizmapMapDockItem(
+                'geolocation',
+                $this->jelix->getLocale('view~map.geolocate.navbar.title'),
+                $tpl->fetch('view~map_geolocation'),
+                3
+            );
+        }
+
+        if (property_exists($configOptions, 'print')
+            && $configOptions->print == 'True') {
+            $tpl = new jTpl();
+            $dockable[] = new lizmapMapDockItem(
+                'print',
+                $this->jelix->getLocale('view~map.print.navbar.title'),
+                $tpl->fetch('view~map_print'),
+                4
+            );
+        }
+
+        if (property_exists($configOptions, 'measure')
+            && $configOptions->measure == 'True') {
+            $tpl = new jTpl();
+            $dockable[] = new lizmapMapDockItem(
+                'measure',
+                $this->jelix->getLocale('view~map.measure.navbar.title'),
+                $tpl->fetch('view~map_measure'),
+                5
+            );
+        }
+
+        if ($this->hasTooltipLayers()) {
+            $tpl = new jTpl();
+            $dockable[] = new lizmapMapDockItem(
+                'tooltip-layer',
+                $this->jelix->getLocale('view~map.tooltip.navbar.title'),
+                $tpl->fetch('view~map_tooltip'),
+                6,
+                '',
+                ''
+            );
+        }
+
+        if ($this->hasTimemanagerLayers()) {
+            $tpl = new jTpl();
+            $dockable[] = new lizmapMapDockItem(
+                'timemanager',
+                $this->jelix->getLocale('view~map.timemanager.navbar.title'),
+                $tpl->fetch('view~map_timemanager'),
+                7,
+                '',
+                $bp.'assets/js/timemanager.js'
+            );
+        }
+
+        // Permalink
+        if (true) {
+            // Get geobookmark if user is connected
+            $gbCount = false;
+            $gbList = null;
+            if ($this->jelix->userIsConnected()) {
+                $juser = $this->jelix->getUserSession();
+                $usr_login = $juser->login;
+                $daogb = getDao('lizmap~geobookmark');
+                $conditions = jDao::createConditions();
+                $conditions->addCondition('login', '=', $usr_login);
+                $conditions->addCondition(
+                    'map',
+                    '=',
+                    $this->repository->getKey().':'.$this->getKey()
+                );
+                $gbList = $daogb->findBy($conditions);
+                $gbCount = $daogb->countBy($conditions);
+            }
+            $tpl = new jTpl();
+            $tpl->assign('gbCount', $gbCount);
+            $tpl->assign('gbList', $gbList);
+            $gbContent = null;
+            if ($gbList) {
+                $gbContent = $tpl->fetch('view~map_geobookmark');
+            }
+            $tpl = new jTpl();
+            $tpl->assign(array(
+                'repository' => $this->repository->getKey(),
+                'project' => $this->getKey(),
+                'gbContent' => $gbContent,
+            ));
+            $dockable[] = new lizmapMapDockItem(
+                'permaLink',
+                $this->jelix->getLocale('view~map.permalink.navbar.title'),
+                $tpl->fetch('view~map_permalink'),
+                8
+            );
+        }
+
+        if (property_exists($configOptions, 'draw')
+            && $configOptions->draw == 'True') {
+            $tpl = new jTpl();
+            $dockable[] = new lizmapMapDockItem(
+                'draw',
+                $this->jelix->getLocale('view~map.draw.navbar.title'),
+                $tpl->fetch('view~map_draw'),
+                9
+            );
+        }
+
+        return $dockable;
+    }
+
+    /**
+     * @throws jExceptionSelector
+     *
+     * @return lizmapMapDockItem[]
+     */
+    public function getDefaultBottomDockable()
+    {
+        $dockable = array();
+        $bp = $this->jelix->appConfig()->urlengine['basePath'];
+
+        if ($this->hasAttributeLayers(true)) {
+            $form = $this->jelix->createForm('view~attribute_layers_option');
+            $assign = array('form' => $form);
+            $dockable[] = new lizmapMapDockItem(
+                'attributeLayers',
+                $this->jelix->getLocale('view~map.attributeLayers.navbar.title'),
+                array('view~map_attributeLayers', $assign),
+                1,
+                '',
+                $bp.'assets/js/attributeTable.js'
+            );
+        }
+
+        return $dockable;
+    }
+
+    /**
+     * Check acl rights on the project.
+     *
+     * @return bool true if the current user as rights on the project
+     */
+    public function checkAcl()
+    {
+
+        // Check right on repository
+        if (!$this->jelix->aclCheckResult(array('lizmap.repositories.view', $this->repository->getKey()))) {
+            return false;
+        }
+
+        // Check acl option is configured in project config
+        if (!property_exists($this->cfg->options, 'acl') || !is_array($this->cfg->options->acl) || empty($this->cfg->options->acl)) {
+            return true;
+        }
+
+        // Check user is authenticated
+        if (!$this->jelix->userIsConnected()) {
+            return false;
+        }
+
+        // Check user is admin -> ok, give permission
+        if ($this->jelix->aclCheckResult(array('lizmap.admin.repositories.delete'))) {
+            return true;
+        }
+
+        // Check if configured groups white list and authenticated user groups list intersects
+        $aclGroups = $this->cfg->options->acl;
+        $userGroups = $this->jelix->aclDbUserGroups();
+        if (array_intersect($aclGroups, $userGroups)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function getSpatialiteExtension()
+    {
+        if ($this->spatialiteExt !== null) {
+            return $this->spatialiteExt;
+        }
+
+        // Try with mod_spatialite
+        try {
+            $db = new SQLite3(':memory:');
+            $this->spatialiteExt = 'mod_spatialite.so';
+            $spatial = @$db->loadExtension($this->spatialiteExt); // loading SpatiaLite as an extension
+            if ($spatial) {
+                return $this->spatialiteExt;
+            }
+        } catch (Exception $e) {
+            $spatial = false;
+        }
+        // Try with libspatialite
+        if (!$spatial) {
+            try {
+                $db = new SQLite3(':memory:');
+                $this->spatialiteExt = 'libspatialite.so';
+                $spatial = @$db->loadExtension($this->spatialiteExt); // loading SpatiaLite as an extension
+                if ($spatial) {
+                    return $this->spatialiteExt;
+                }
+            } catch (Exception $e) {
+            }
+        }
+        $this->spatialiteExt = '';
+
+        return '';
+    }
+}

--- a/lizmap/modules/lizmap/lib/Project/project.php
+++ b/lizmap/modules/lizmap/lib/Project/project.php
@@ -385,6 +385,35 @@ class Project
         return $this->cfg->getProperty('layers');
     }
 
+    public function getData($key)
+    {
+        if (array_key_exists($key, $this->data)) {
+            return $this->data[$key];
+        }
+
+        return $this->xml->getData($key);
+    }
+
+    public function getProj4($authId)
+    {
+        return $this->xml->getProj4($authId);
+    }
+
+    public function getAllProj4()
+    {
+        return $this->xml->getAllProj4();
+    }
+
+    public function getCanvasColor()
+    {
+        return $this->xml->getCanvasColor();
+    }
+
+    public function getWMSInformation()
+    {
+        return $this->xml->getWMSInformation();
+    }
+
     public function hasLocateByLayer()
     {
         $locate = $this->cfg->getProperty('locateByLayer');
@@ -446,7 +475,7 @@ class Project
     public function hasTooltipLayers()
     {
         $tooltip = $this->cfg->getProperty('tooltipLayers');
-        if ($tooltip && count($tooltip)) {
+        if ($tooltip && count((array) $tooltip)) {
             return true;
         }
 
@@ -464,7 +493,7 @@ class Project
                     $hasDisplayedLayer = true;
                 }
             }
-            if (count($attributeLayers) && $hasDisplayedLayer) {
+            if (count((array) $attributeLayers) && $hasDisplayedLayer) {
                 return true;
             }
         }
@@ -865,7 +894,7 @@ class Project
     protected function readPrintCapabilities($qgsLoad, $cfg)
     {
         $printTemplates = array();
-        $options = $cfg->getProp('options');
+        $options = $this->getOptions();
         if ($options && $options->print == 'True') {
             $printTemplates = $qgsLoad->getPrintTemplates();
         }
@@ -920,7 +949,7 @@ class Project
 
     protected function readAttributeLayers($xml, $cfg)
     {
-        $attributeLayers = $cfg->getEditableProp('attributeLayers');
+        $attributeLayers = $cfg->getEditableProperty('attributeLayers');
 
         if ($attributeLayers) {
             $xml->readAttributeLayers($attributeLayers);
@@ -939,43 +968,53 @@ class Project
      */
     protected function readLayersOrder($xml, $cfg)
     {
-        return $this->xml->readLayersOrder($xml, $this->getLayers());
+        return $xml->readLayersOrder($xml, $this->getLayers());
     }
 
-     /**
+    /**
      * @deprecated
+     *
+     * @param mixed $name
      */
     public function findLayerByAnyName($name)
     {
         return $this->cfg->findLayerByAnyName($name);
     }
 
-     /**
+    /**
      * @deprecated
+     *
+     * @param mixed $name
      */
     public function findLayerByName($name)
     {
         return $this->cfg->findLayerByName($name);
     }
 
-     /**
+    /**
      * @deprecated
+     *
+     * @param mixed $shortName
      */
     public function findLayerByShortName($shortName)
     {
         return $this->cfg->findLayerByShortName($shortName);
     }
 
-     /**
+    /**
      * @deprecated
+     *
+     * @param mixed $title
      */
     public function findLayerByTitle($title)
     {
         return $this->cfg->findLayerByTitle($title);
     }
 
-     /**
+    /**
      * @deprecated
+     *
+     * @param mixed $layerId
      */
     public function findLayerByLayerId($layerId)
     {
@@ -984,6 +1023,8 @@ class Project
 
     /**
      * @deprecated
+     *
+     * @param mixed $typeName
      */
     public function findLayerByTypeName($typeName)
     {

--- a/lizmap/modules/lizmap/lib/Project/project.php
+++ b/lizmap/modules/lizmap/lib/Project/project.php
@@ -659,13 +659,7 @@ class Project
         if (!$this->hasEditionLayers()) {
             return null;
         }
-
-        $editionLayers = $this->cfg->getProperty('editionLayers');
-        if ($editionLayers && property_exists($editionLayers, $name)) {
-            return $editionLayers->{$name};
-        }
-
-        return null;
+        return $this->cfg->getEditionLayerByName($name);
     }
 
     /**
@@ -678,18 +672,7 @@ class Project
         if (!$this->hasEditionLayers()) {
             return null;
         }
-
-        $editionLayers = $this->cfg->getProperty('editionLayers');
-        foreach ($editionLayers as $layer) {
-            if (!property_exists($layer, 'layerId')) {
-                continue;
-            }
-            if ($layer->layerId == $layerId) {
-                return $layer;
-            }
-        }
-
-        return null;
+        return $this->cfg->getEditionLayerByLayerId($layerId);
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/Project/projectCache.php
+++ b/lizmap/modules/lizmap/lib/Project/projectCache.php
@@ -1,41 +1,52 @@
 <?php
 
 namespace Lizmap\Project;
+use Lizmap\App;
 
 class projectCache
 {
     /**
-     * The Cache profile
+     * The Cache profile.
+     *
      * @var string
      */
     protected $profile = 'qgisprojects';
 
     /**
-     * The path of the project file
+     * The path of the project file.
+     *
      * @var string
      */
     protected $file;
 
     /**
-     * The key to access data in the cache
+     * The key to access data in the cache.
+     *
      * @var string
      */
     protected $fileKey;
 
     /**
-     * @var jelixInfos
+     * @var App\AppContextInterface
      */
-    protected $jelix;
+    protected $appContext;
 
-    public function __construct($file, $jelix)
+    /**
+     * Construct the object.
+     *
+     * @param string              $file       The full path of the project
+     * @param App\appContextInterface $appContext The interface to call Jalix
+     */
+    public function __construct($file, App\appContextInterface $appContext)
     {
         $this->file = $file;
-        $this->fileKey = $this->jelix->normalizeCacheKey($file);
-        $this->jelix = $jelix;
+        $this->fileKey = $this->appContext->normalizeCacheKey($file);
+        $this->appContext = $appContext;
     }
 
     /**
-     * Returns the Project data stored in Cache
+     * Returns the Project data stored in Cache.
+     *
      * @return array|bool
      */
     public function retrieveProjectData()
@@ -45,39 +56,41 @@ class projectCache
         $data = false;
 
         try {
-            $data = $this->jelix->getCache($this->$fileKey, $this->profile);
-        } catch (Exception $e) {
+            $data = $this->appContext->getCache($this->fileKey, $this->profile);
+        } catch (\Exception $e) {
             // if qgisprojects profile does not exist, or if there is an
             // other error about the cache, let's log it
-            jLog::logEx($e, 'error');
+            \jLog::logEx($e, 'error');
         }
+
         return $data;
     }
 
     /**
      * Store project Data in Cache.
+     *
      * @param array $data The datas to store
      */
     public function storeProjectData($data)
     {
         try {
-            jCache::set($this->$fileKey, $data, null, $this->profile);
-        } catch (Exception $e) {
-            jLog::logEx($e, 'error');
+            \jCache::set($this->fileKey, $data, null, $this->profile);
+        } catch (\Exception $e) {
+            \jLog::logEx($e, 'error');
         }
     }
 
     /**
-     * Erase the project data from the cache
+     * Erase the project data from the cache.
      */
     public function clearCache()
     {
         try {
-            jCache::delete($fileKey, $this->profile);
-        } catch (Exception $e) {
+            \jCache::delete($this->fileKey, $this->profile);
+        } catch (\Exception $e) {
             // if qgisprojects profile does not exist, or if there is an
             // other error about the cache, let's log it
-            jLog::logEx($e, 'error');
+            \jLog::logEx($e, 'error');
         }
     }
 }

--- a/lizmap/modules/lizmap/lib/Project/projectCache.php
+++ b/lizmap/modules/lizmap/lib/Project/projectCache.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Lizmap\Project;
+
 use Lizmap\App;
 
 class projectCache
@@ -34,14 +35,14 @@ class projectCache
     /**
      * Construct the object.
      *
-     * @param string              $file       The full path of the project
+     * @param string                  $file       The full path of the project
      * @param App\appContextInterface $appContext The interface to call Jalix
      */
     public function __construct($file, App\appContextInterface $appContext)
     {
         $this->file = $file;
-        $this->fileKey = $this->appContext->normalizeCacheKey($file);
         $this->appContext = $appContext;
+        $this->fileKey = $this->appContext->normalizeCacheKey($file);
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/Project/projectCache.php
+++ b/lizmap/modules/lizmap/lib/Project/projectCache.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Lizmap\Project;
+
+class projectCache
+{
+    /**
+     * The Cache profile
+     * @var string
+     */
+    protected $profile = 'qgisprojects';
+
+    /**
+     * The path of the project file
+     * @var string
+     */
+    protected $file;
+
+    /**
+     * The key to access data in the cache
+     * @var string
+     */
+    protected $fileKey;
+
+    /**
+     * @var jelixInfos
+     */
+    protected $jelix;
+
+    public function __construct($file, $jelix)
+    {
+        $this->file = $file;
+        $this->fileKey = $this->jelix->normalizeCacheKey($file);
+        $this->jelix = $jelix;
+    }
+
+    /**
+     * Returns the Project data stored in Cache
+     * @return array|bool
+     */
+    public function retrieveProjectData()
+    {
+        // For the cache key, we use the full path of the project file
+        // to avoid collision in the cache engine
+        $data = false;
+
+        try {
+            $data = $this->jelix->getCache($this->$fileKey, $this->profile);
+        } catch (Exception $e) {
+            // if qgisprojects profile does not exist, or if there is an
+            // other error about the cache, let's log it
+            jLog::logEx($e, 'error');
+        }
+        return $data;
+    }
+
+    /**
+     * Store project Data in Cache.
+     * @param array $data The datas to store
+     */
+    public function storeProjectData($data)
+    {
+        try {
+            jCache::set($this->$fileKey, $data, null, $this->profile);
+        } catch (Exception $e) {
+            jLog::logEx($e, 'error');
+        }
+    }
+
+    /**
+     * Erase the project data from the cache
+     */
+    public function clearCache()
+    {
+        try {
+            jCache::delete($fileKey, $this->profile);
+        } catch (Exception $e) {
+            // if qgisprojects profile does not exist, or if there is an
+            // other error about the cache, let's log it
+            jLog::logEx($e, 'error');
+        }
+    }
+}

--- a/lizmap/modules/lizmap/lib/Project/qgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/qgisProject.php
@@ -303,43 +303,6 @@ class qgisProject
     }
 
     /**
-     * @FIXME: remove this method. Be sure it is not used in other projects.
-     * Data provided by the returned xml element should be extracted and encapsulated
-     * into an object. Xml should not be used by callers
-     *
-     * @return SimpleXMLElement[]
-     *
-     * @deprecated
-     */
-    public function getXmlLayers()
-    {
-        return $this->getXml()->xpath('//maplayer');
-    }
-
-    /**
-     * @FIXME: remove this method. Be sure it is not used in other projects.
-     * Data provided by the returned xml element should be extracted and encapsulated
-     * into an object. Xml should not be used by callers
-     *
-     * @deprecated
-     *
-     * @param mixed $layerId
-     *
-     * @return SimpleXMLElement[]
-     */
-    public function getXmlLayer($layerId)
-    {
-        $layer = $this->getLayerDefinition($layerId);
-        if ($layer && array_key_exists('embedded', $layer) && $layer['embedded'] == 1) {
-            $qgsProj = new qgisProject(realpath(dirname($this->path).DIRECTORY_SEPARATOR.$layer['projectPath']));
-
-            return $qgsProj->getXml()->xpath("//maplayer[id='{$layerId}']");
-        }
-
-        return $this->getXml()->xpath("//maplayer[id='{$layerId}']");
-    }
-
-    /**
      * @param SimpleXMLElement $xml
      * @param string           $layerId
      *
@@ -348,38 +311,6 @@ class qgisProject
     protected function getXmlLayer2($xml, $layerId)
     {
         return $xml->xpath("//maplayer[id='{$layerId}']");
-    }
-
-    /**
-     * @FIXME: remove this method. Be sure it is not used in other projects
-     * Data provided by the returned xml element should be extracted and encapsulated
-     * into an object. Xml should not be used by callers
-     *
-     * @deprecated
-     *
-     * @param mixed $key
-     *
-     * @return SimpleXMLElement[]
-     */
-    public function getXmlLayerByKeyword($key)
-    {
-        return $this->getXml()->xpath("//maplayer/keywordList[value='{$key}']/parent::*");
-    }
-
-    /**
-     * @FIXME: remove this method. Be sure it is not used in other projects.
-     * Data provided by the returned xml element should be extracted and encapsulated
-     * into an object. Xml should not be used by callers
-     *
-     * @deprecated
-     *
-     * @param mixed $relationId
-     *
-     * @return SimpleXMLElement[]
-     */
-    public function getXmlRelation($relationId)
-    {
-        return $this->getXml()->xpath("//relation[@id='{$relationId}']");
     }
 
     /**
@@ -815,32 +746,6 @@ class qgisProject
         }
 
         return $layersOrder;
-    }
-
-    /**
-     * temporary function to read xml for some methods that relies on
-     * xml data that are not yet stored in the cache.
-     *
-     * @return SimpleXMLElement
-     *
-     * @deprecated
-     */
-    protected function getXml()
-    {
-        if ($this->xml) {
-            return $this->xml;
-        }
-        $qgs_path = $this->path;
-        if (!file_exists($qgs_path)) {
-            throw new Exception('The QGIS project '.$qgs_path.' does not exist!');
-        }
-        $xml = simplexml_load_file($qgs_path);
-        if ($xml === false) {
-            throw new Exception('The QGIS project '.$qgs_path.' has invalid content!');
-        }
-        $this->xml = $xml;
-
-        return $xml;
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/Project/qgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/qgisProject.php
@@ -1,0 +1,804 @@
+<?php
+/**
+ * Manage and give access to qgis project.
+ *
+ * @author    3liz
+ * @copyright 2017 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+namespace Lizmap\Project;
+
+class qgisProject
+{
+    /**
+     * @var string QGIS project path
+     */
+    protected $path;
+
+    /**
+     * @var SimpleXMLElement QGIS project XML
+     */
+    protected $xml;
+
+    /**
+     * @var array QGIS project data
+     */
+    protected $data = array();
+
+    /**
+     * Version of QGIS which wrote the project.
+     *
+     * @var int
+     */
+    protected $qgisProjectVersion;
+
+    /**
+     * @var array contains WMS info
+     */
+    protected $WMSInformation;
+
+    /**
+     * @var string
+     */
+    protected $canvasColor = '';
+
+    /**
+     * @var array authid => proj4
+     */
+    protected $allProj4 = array();
+
+    /**
+     * @var array for each referenced layer, there is an item
+     *            with referencingLayer, referencedField, referencingField keys.
+     *            There is also a 'pivot' key
+     */
+    protected $relations = array();
+
+    /**
+     * @var array list of themes
+     */
+    protected $themes = array();
+
+    /**
+     * @var bool
+     */
+    protected $useLayerIDs = false;
+
+    /**
+     * @var array[] list of layers. Each item is a list of layer properties
+     */
+    protected $layers = array();
+
+    /**
+     * @var array List of cached properties
+     */
+    protected $cachedProperties = array('WMSInformation', 'canvasColor', 'allProj4',
+        'relations', 'themes', 'useLayerIDs', 'layers', 'data', 'qgisProjectVersion', );
+
+    protected $jelix = null;
+
+    /**
+     * constructor.
+     *
+     * @param string $file : the QGIS project path
+     */
+    public function __construct($file, $jelix)
+    {
+        if (!$this->jelix) {
+            $this->jelix = $jelix;
+        }
+        // Verifying if the files exist
+        if (!file_exists($file)) {
+            throw new Exception('The QGIS project '.$file.' does not exist!');
+        }
+
+        // For the cache key, we use the full path of the project file
+        // to avoid collision in the cache engine
+        $data = false;
+        $cache = new projectCache($file, $this->jelix);
+        try {
+            $data = $cache->getProjectData();
+        } catch (Exception $e) {
+            // if qgisprojects profile does not exist, or if there is an
+            // other error about the cache, let's log it
+            jLog::logEx($e, 'error');
+        }
+
+        if ($data === false ||
+            $data['qgsmtime'] < filemtime($file)) {
+            // FIXME reading XML could take time, so many process could
+            // read it and construct the cache at the same time. We should
+            // have a kind of lock to avoid this issue.
+            $this->readXmlProject($file);
+            $data['qgsmtime'] = filemtime($file);
+            foreach ($this->cachedProperties as $prop) {
+                $data[$prop] = $this->{$prop};
+            }
+
+            try {
+                $cache->storeProjectData($data);
+            } catch (Exception $e) {
+                jLog::logEx($e, 'error');
+            }
+        } else {
+            foreach ($this->cachedProperties as $prop) {
+                $this->{$prop} = $data[$prop];
+            }
+        }
+
+        $this->path = $file;
+    }
+
+    public function clearCache()
+    {
+        $cache = new projectCache($file, $this->jelix);
+        $cache->clearCache();
+    }
+
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    public function getData($key)
+    {
+        if (!array_key_exists($key, $this->data)) {
+            return null;
+        }
+
+        return $this->data[$key];
+    }
+
+    public function getQgisProjectVersion()
+    {
+        return $this->qgisProjectVersion;
+    }
+
+    public function getWMSInformation()
+    {
+        return $this->WMSInformation;
+    }
+
+    public function getCanvasColor()
+    {
+        return $this->canvasColor;
+    }
+
+    public function getProj4($authId)
+    {
+        if (!array_key_exists($authId, $this->data)) {
+            return null;
+        }
+
+        return $this->allProj4[$authId];
+    }
+
+    public function getAllProj4()
+    {
+        return $this->allProj4;
+    }
+
+    public function getRelations()
+    {
+        return $this->relations;
+    }
+
+    public function getThemes()
+    {
+        return $this->themes;
+    }
+
+    /**
+     * @param $layerId
+     *
+     * @return null|int|string
+     */
+    public function getLayerDefinition($layerId)
+    {
+        $layers = array_filter($this->layers, function ($layer) use ($layerId) {
+            return $layer['id'] == $layerId;
+        });
+        if (count($layers)) {
+            // get first key found in the filtered layers
+            $k = key($layers);
+
+            return $layers[$k];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param $layerId
+     *
+     * @return null|qgisMapLayer|qgisVectorLayer
+     */
+    public function getLayer($layerId)
+    {
+        /** @var array[] $layers */
+        $layers = array_filter($this->layers, function ($layer) use ($layerId) {
+            return $layer['id'] == $layerId;
+        });
+        if (count($layers)) {
+            // get first key found in the filtered layers
+            $k = key($layers);
+            if ($layers[$k]['type'] == 'vector') {
+                return new qgisVectorLayer($this, $layers[$k]);
+            }
+
+            return new qgisMapLayer($this, $layers[$k]);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return null|qgisMapLayer|qgisVectorLayer
+     */
+    public function getLayerByKeyword($key)
+    {
+        /** @var array[] $layers */
+        $layers = array_filter($this->layers, function ($layer) use ($key) {
+            return in_array($key, $layer['keywords']);
+        });
+        if (count($layers)) {
+            // get first key found in the filtered layers
+            $k = key($layers);
+            if ($layers[$k]['type'] == 'vector') {
+                return new qgisVectorLayer($this, $layers[$k]);
+            }
+
+            return new qgisMapLayer($this, $layers[$k]);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return qgisMapLayer[]|qgisVectorLayer[]
+     */
+    public function findLayersByKeyword($key)
+    {
+        /** @var array[] $foundLayers */
+        $foundLayers = array_filter($this->layers, function ($layer) use ($key) {
+            return in_array($key, $layer['keywords']);
+        });
+        $layers = array();
+        if ($foundLayers) {
+            foreach ($foundLayers as $layer) {
+                if ($layer['type'] == 'vector') {
+                    $layers[] = new qgisVectorLayer($this, $layer);
+                } else {
+                    $layers[] = new qgisMapLayer($this, $layer);
+                }
+            }
+        }
+
+        return $layers;
+    }
+
+    /**
+     * Execute an xpath Query on the XML content and return the result.
+     * @param string $query The query to execute
+     */
+    public function xpathQuery($query)
+    {
+        $ret = $this->xml->xpath($query);
+        if (!$ret || empty($ret)) {
+            $ret = null;
+        }
+        return $ret;
+    }
+
+    /**
+     * @FIXME: remove this method. Be sure it is not used in other projects.
+     * Data provided by the returned xml element should be extracted and encapsulated
+     * into an object. Xml should not be used by callers
+     *
+     * @return SimpleXMLElement[]
+     *
+     * @deprecated
+     */
+    public function getXmlLayers()
+    {
+        return $this->getXml()->xpath('//maplayer');
+    }
+
+    /**
+     * @FIXME: remove this method. Be sure it is not used in other projects.
+     * Data provided by the returned xml element should be extracted and encapsulated
+     * into an object. Xml should not be used by callers
+     *
+     * @deprecated
+     *
+     * @param mixed $layerId
+     *
+     * @return SimpleXMLElement[]
+     */
+    public function getXmlLayer($layerId)
+    {
+        $layer = $this->getLayerDefinition($layerId);
+        if ($layer && array_key_exists('embedded', $layer) && $layer['embedded'] == 1) {
+            $qgsProj = new qgisProject(realpath(dirname($this->path).DIRECTORY_SEPARATOR.$layer['projectPath']));
+
+            return $qgsProj->getXml()->xpath("//maplayer[id='${layerId}']");
+        }
+
+        return $this->getXml()->xpath("//maplayer[id='${layerId}']");
+    }
+
+    /**
+     * @FIXME: remove this method. Be sure it is not used in other projects
+     * Data provided by the returned xml element should be extracted and encapsulated
+     * into an object. Xml should not be used by callers
+     *
+     * @deprecated
+     *
+     * @param mixed $key
+     *
+     * @return SimpleXMLElement[]
+     */
+    public function getXmlLayerByKeyword($key)
+    {
+        return $this->getXml()->xpath("//maplayer/keywordList[value='${key}']/parent::*");
+    }
+
+    /**
+     * @FIXME: remove this method. Be sure it is not used in other projects.
+     * Data provided by the returned xml element should be extracted and encapsulated
+     * into an object. Xml should not be used by callers
+     *
+     * @deprecated
+     *
+     * @param mixed $relationId
+     *
+     * @return SimpleXMLElement[]
+     */
+    public function getXmlRelation($relationId)
+    {
+        return $this->getXml()->xpath("//relation[@id='${relationId}']");
+    }
+
+    /**
+     * temporary function to read xml for some methods that relies on
+     * xml data that are not yet stored in the cache.
+     *
+     * @return SimpleXMLElement
+     *
+     * @deprecated
+     */
+    protected function getXml()
+    {
+        if ($this->xml) {
+            return $this->xml;
+        }
+        $qgs_path = $this->path;
+        if (!file_exists($qgs_path)) {
+            throw new Exception('The QGIS project '.$qgs_path.' does not exist!');
+        }
+        $xml = simplexml_load_file($qgs_path);
+        if ($xml === false) {
+            throw new Exception('The QGIS project '.$qgs_path.' has invalid content!');
+        }
+        $this->xml = $xml;
+
+        return $xml;
+    }
+
+    /**
+     * Read the qgis files.
+     *
+     * @param mixed $qgs_path
+     */
+    protected function readXmlProject($qgs_path)
+    {
+        if (!file_exists($qgs_path)) {
+            throw new Exception('The QGIS project '.basename($qgs_path).' does not exist!');
+        }
+
+        $qgs_xml = simplexml_load_file($qgs_path);
+        if ($qgs_xml === false) {
+            throw new Exception('The QGIS project '.basename($qgs_path).' has invalid content!');
+        }
+        $this->path = $qgs_path;
+        $this->xml = $qgs_xml;
+
+        // Build data
+        $this->data = array(
+        );
+
+        // get title from WMS properties
+        if (property_exists($qgs_xml->properties, 'WMSServiceTitle')) {
+            if (!empty($qgs_xml->properties->WMSServiceTitle)) {
+                $this->data['title'] = (string) $qgs_xml->properties->WMSServiceTitle;
+            }
+        }
+
+        // get abstract from WMS properties
+        if (property_exists($qgs_xml->properties, 'WMSServiceAbstract')) {
+            $this->data['abstract'] = (string) $qgs_xml->properties->WMSServiceAbstract;
+        }
+
+        // get keyword list from WMS properties
+        if (property_exists($qgs_xml->properties, 'WMSKeywordList')) {
+            $values = array();
+            foreach ($qgs_xml->properties->WMSKeywordList->value as $value) {
+                if ((string) $value !== '') {
+                    $values[] = (string) $value;
+                }
+            }
+            $this->data['keywordList'] = implode(', ', $values);
+        }
+
+        // get WMS max width
+        if (property_exists($qgs_xml->properties, 'WMSMaxWidth')) {
+            $this->data['wmsMaxWidth'] = (int) $qgs_xml->properties->WMSMaxWidth;
+        }
+        if (!array_key_exists('WMSMaxWidth', $this->data) or !$this->data['wmsMaxWidth']) {
+            unset($this->data['wmsMaxWidth']);
+        }
+
+        // get WMS max height
+        if (property_exists($qgs_xml->properties, 'WMSMaxHeight')) {
+            $this->data['wmsMaxHeight'] = (int) $qgs_xml->properties->WMSMaxHeight;
+        }
+        if (!array_key_exists('WMSMaxHeight', $this->data) or !$this->data['wmsMaxHeight']) {
+            unset($this->data['wmsMaxHeight']);
+        }
+
+        // get QGIS project version
+        $qgisRoot = $qgs_xml->xpath('//qgis');
+        $qgisRootZero = $qgisRoot[0];
+        $qgisProjectVersion = (string) $qgisRootZero->attributes()->version;
+        $qgisProjectVersion = explode('-', $qgisProjectVersion);
+        $qgisProjectVersion = $qgisProjectVersion[0];
+        $qgisProjectVersion = explode('.', $qgisProjectVersion);
+        $a = '';
+        foreach ($qgisProjectVersion as $k) {
+            if (strlen($k) == 1) {
+                $a .= '0'.$k;
+            } else {
+                $a .= $k;
+            }
+        }
+        $qgisProjectVersion = (int) $a;
+        $this->qgisProjectVersion = $qgisProjectVersion;
+
+        $this->WMSInformation = $this->readWMSInformation($qgs_xml);
+        $this->canvasColor = $this->readCanvasColor($qgs_xml);
+        $this->allProj4 = $this->readAllProj4($qgs_xml);
+        $this->relations = $this->readRelations($qgs_xml);
+        $this->themes = $this->readThemes($qgs_xml);
+        $this->useLayerIDs = $this->readUseLayerIDs($qgs_xml);
+        $this->layers = $this->readLayers($qgs_xml);
+    }
+
+    protected function readWMSInformation($qgsLoad)
+    {
+
+        // Default metadata
+        $WMSServiceTitle = '';
+        $WMSServiceAbstract = '';
+        $WMSKeywordList = '';
+        $WMSExtent = '';
+        $ProjectCrs = '';
+        $WMSOnlineResource = '';
+        $WMSContactMail = '';
+        $WMSContactOrganization = '';
+        $WMSContactPerson = '';
+        $WMSContactPhone = '';
+        if ($qgsLoad) {
+            $WMSServiceTitle = (string) $qgsLoad->properties->WMSServiceTitle;
+            $WMSServiceAbstract = (string) $qgsLoad->properties->WMSServiceAbstract;
+
+            $values = array();
+            foreach ($qgsLoad->properties->WMSKeywordList->value as $value) {
+                if ((string) $value !== '') {
+                    $values[] = (string) $value;
+                }
+            }
+            $WMSKeywordList = implode(', ', $values);
+
+            $WMSExtent = $qgsLoad->properties->WMSExtent->value[0];
+            $WMSExtent .= ', '.$qgsLoad->properties->WMSExtent->value[1];
+            $WMSExtent .= ', '.$qgsLoad->properties->WMSExtent->value[2];
+            $WMSExtent .= ', '.$qgsLoad->properties->WMSExtent->value[3];
+            $WMSOnlineResource = (string) $qgsLoad->properties->WMSOnlineResource;
+            $WMSContactMail = (string) $qgsLoad->properties->WMSContactMail;
+            $WMSContactOrganization = (string) $qgsLoad->properties->WMSContactOrganization;
+            $WMSContactPerson = (string) $qgsLoad->properties->WMSContactPerson;
+            $WMSContactPhone = (string) $qgsLoad->properties->WMSContactPhone;
+        }
+        if (isset($qgsLoad->mapcanvas)) {
+            $ProjectCrs = (string) $qgsLoad->mapcanvas->destinationsrs->spatialrefsys->authid;
+        }
+
+        return array(
+            'WMSServiceTitle' => $WMSServiceTitle,
+            'WMSServiceAbstract' => $WMSServiceAbstract,
+            'WMSKeywordList' => $WMSKeywordList,
+            'WMSExtent' => $WMSExtent,
+            'ProjectCrs' => $ProjectCrs,
+            'WMSOnlineResource' => $WMSOnlineResource,
+            'WMSContactMail' => $WMSContactMail,
+            'WMSContactOrganization' => $WMSContactOrganization,
+            'WMSContactPerson' => $WMSContactPerson,
+            'WMSContactPhone' => $WMSContactPhone,
+        );
+    }
+
+    /**
+     * @param SimpleXMLElement $xml
+     *
+     * @return string
+     */
+    protected function readCanvasColor($xml)
+    {
+        $red = $xml->xpath('//properties/Gui/CanvasColorRedPart');
+        $green = $xml->xpath('//properties/Gui/CanvasColorGreenPart');
+        $blue = $xml->xpath('//properties/Gui/CanvasColorBluePart');
+
+        return 'rgb('.$red[0].','.$green[0].','.$blue[0].')';
+    }
+
+    /**
+     * @param SimpleXMLElement $xml
+     *
+     * @return array
+     */
+    protected function readAllProj4($xml)
+    {
+        $srsList = array();
+        $spatialrefsys = $xml->xpath('//spatialrefsys');
+        foreach ($spatialrefsys as $srs) {
+            $srsList[(string) $srs->authid] = (string) $srs->proj4;
+        }
+
+        return $srsList;
+    }
+
+    /**
+     * @param SimpleXMLElement $xml
+     *
+     * @return null|array[]
+     */
+    protected function readThemes($xml)
+    {
+        $xmlThemes = $xml->xpath('//visibility-presets');
+        $themes = array();
+
+        if($xmlThemes){
+            foreach ($xmlThemes[0] as $theme) {
+                $themeObj = $theme->attributes();
+                if (!array_key_exists((string) $themeObj->name, $themes)) {
+                    $themes[(string) $themeObj->name] = array();
+                }
+
+                // Copy layers and their attributes
+                foreach ($theme->layer as $layer) {
+                    $layerObj = $layer->attributes();
+                    $themes[(string) $themeObj->name]['layers'][(string) $layerObj->id] = array(
+                        'style' => (string) $layerObj->style,
+                        'expanded' => (string) $layerObj->expanded
+                    );
+                }
+
+                // Copy expanded group nodes
+                foreach ($theme->{'expanded-group-nodes'}->{'expanded-group-node'} as $expandedGroupNode) {
+                    $expandedGroupNodeObj = $expandedGroupNode->attributes();
+                    $themes[(string) $themeObj->name]['expandedGroupNode'][] = (string) $expandedGroupNodeObj->id;
+                }
+            }
+            return $themes;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param SimpleXMLElement $xml
+     *
+     * @return null|array[]
+     */
+    protected function readRelations($xml)
+    {
+        $xmlRelations = $xml->xpath('//relations');
+        $relations = array();
+        $pivotGather = array();
+        $pivot = array();
+        if ($xmlRelations) {
+            foreach ($xmlRelations[0] as $relation) {
+                $relationObj = $relation->attributes();
+                $fieldRefObj = $relation->fieldRef->attributes();
+                if (!array_key_exists((string) $relationObj->referencedLayer, $relations)) {
+                    $relations[(string) $relationObj->referencedLayer] = array();
+                }
+
+                $relations[(string) $relationObj->referencedLayer][] = array(
+                    'referencingLayer' => (string) $relationObj->referencingLayer,
+                    'referencedField' => (string) $fieldRefObj->referencedField,
+                    'referencingField' => (string) $fieldRefObj->referencingField,
+                );
+
+                if (!array_key_exists((string) $relationObj->referencingLayer, $pivotGather)) {
+                    $pivotGather[(string) $relationObj->referencingLayer] = array();
+                }
+
+                $pivotGather[(string) $relationObj->referencingLayer][(string) $relationObj->referencedLayer] = (string) $fieldRefObj->referencingField;
+            }
+
+            // Keep only child with at least to parents
+            foreach ($pivotGather as $pi => $vo) {
+                if (count($vo) > 1) {
+                    $pivot[$pi] = $vo;
+                }
+            }
+            $relations['pivot'] = $pivot;
+
+            return $relations;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param SimpleXMLElement $xml
+     *
+     * @return bool
+     */
+    protected function readUseLayerIDs($xml)
+    {
+        $WMSUseLayerIDs = $xml->xpath('//properties/WMSUseLayerIDs');
+
+        return $WMSUseLayerIDs && count($WMSUseLayerIDs) > 0 && $WMSUseLayerIDs[0] == 'true';
+    }
+
+    /**
+     * @param SimpleXMLElement $xml
+     *
+     * @throws Exception
+     *
+     * @return array[] list of layers. Each item is a list of layer properties
+     */
+    protected function readLayers($xml)
+    {
+        $xmlLayers = $xml->xpath('//maplayer');
+        $layers = array();
+        if (!$xmlLayers) {
+            return $layers;
+        }
+
+        foreach ($xmlLayers as $xmlLayer) {
+            $attributes = $xmlLayer->attributes();
+            if (isset($attributes['embedded']) && (string) $attributes->embedded == '1') {
+                $qgsProj = new qgisProject(realpath(dirname($this->path).DIRECTORY_SEPARATOR.(string) $attributes->project));
+                $layer = $qgsProj->getLayerDefinition((string) $attributes->id);
+                $layer['embedded'] = 1;
+                $layer['projectPath'] = (string) $attributes->project;
+                $layers[] = $layer;
+            } else {
+                $layer = array(
+                    'type' => (string) $attributes->type,
+                    'id' => (string) $xmlLayer->id,
+                    'name' => (string) $xmlLayer->layername,
+                    'shortname' => (string) $xmlLayer->shortname,
+                    'title' => (string) $xmlLayer->title,
+                    'abstract' => (string) $xmlLayer->abstract,
+                    'proj4' => (string) $xmlLayer->srs->spatialrefsys->proj4,
+                    'srid' => (int) $xmlLayer->srs->spatialrefsys->srid,
+                    'authid' => (int) $xmlLayer->srs->spatialrefsys->authid,
+                    'datasource' => (string) $xmlLayer->datasource,
+                    'provider' => (string) $xmlLayer->provider,
+                    'keywords' => array(),
+                );
+                $keywords = $xmlLayer->xpath('./keywordList/value');
+                if ($keywords) {
+                    foreach ($keywords as $keyword) {
+                        if ((string) $keyword != '') {
+                            $layer['keywords'][] = (string) $keyword;
+                        }
+                    }
+                }
+
+                if ($layer['title'] == '') {
+                    $layer['title'] = $layer['name'];
+                }
+                if ($layer['type'] == 'vector') {
+                    $fields = array();
+                    $wfsFields = array();
+                    $aliases = array();
+                    $defaults = array();
+                    $constraints = array();
+                    $edittypes = $xmlLayer->xpath('.//edittype');
+                    if ($edittypes) {
+                        foreach ($edittypes as $edittype) {
+                            $field = (string) $edittype->attributes()->name;
+                            if (in_array($field, $fields)) {
+                                continue; // QGIS sometimes stores them twice
+                            }
+                            $fields[] = $field;
+                            $wfsFields[] = $field;
+                            $aliases[$field] = $field;
+                            $defaults[$field] = null;
+                            $constraints[$field] = null;
+                        }
+                    } else {
+                        $fieldconfigurations = $xmlLayer->xpath('.//fieldConfiguration/field');
+                        if ($fieldconfigurations) {
+                            foreach ($fieldconfigurations as $fieldconfiguration) {
+                                $field = (string) $fieldconfiguration->attributes()->name;
+                                if (in_array($field, $fields)) {
+                                    continue; // QGIS sometimes stores them twice
+                                }
+                                $fields[] = $field;
+                                $wfsFields[] = $field;
+                                $aliases[$field] = $field;
+                                $defaults[$field] = null;
+                                $constraints[$field] = null;
+                            }
+                        }
+                    }
+
+                    if (isset($xmlLayer->aliases->alias)) {
+                        foreach($xmlLayer->aliases->alias as $alias) {
+                            $aliases[(string) $alias['field']] = (string) $alias['name'];
+                        }
+                    }
+
+                    if (isset($xmlLayer->defaults->default)) {
+                        foreach($xmlLayer->defaults->default as $default) {
+                            $defaults[(string) $default['field']] = (string) $default['expression'];
+                        }
+                    }
+
+                    if (isset($xmlLayer->constraints->constraint)) {
+                        foreach($xmlLayer->constraints->constraint as $constraint) {
+                            $c = array(
+                                'constraints' => 0,
+                                'notNull' => false,
+                                'unique' => false,
+                                'exp' => false
+                            );
+                            $c['constraints'] = (int) $constraint['constraints'];
+                            if ( $c['constraints'] > 0 ) {
+                                $c['notNull'] = ((int) $constraint['notnull_strength'] > 0);
+                                $c['unique'] = ((int) $constraint['unique_strength'] > 0);
+                                $c['exp'] = ((int) $constraint['exp_strength'] > 0);
+                            }
+                            $constraints[(string) $constraint['field']] = $c;
+                        }
+                    }
+
+                    $layer['fields'] = $fields;
+                    $layer['aliases'] = $aliases;
+                    $layer['defaults'] = $defaults;
+                    $layer['constraints'] = $constraints;
+                    $layer['wfsFields'] = $wfsFields;
+
+                    $excludeFields = $xmlLayer->xpath('.//excludeAttributesWFS/attribute');
+                    if ($excludeFields && count($excludeFields) > 0) {
+                        foreach ($excludeFields as $eField) {
+                            $eField = (string) $eField;
+                            if (!in_array($eField, $wfsFields)) {
+                                continue; // QGIS sometimes stores them twice
+                            }
+                            array_splice($wfsFields, array_search($eField, $wfsFields), 1);
+                        }
+                        $layer['wfsFields'] = $wfsFields;
+                    }
+                }
+                $layers[] = $layer;
+            }
+        }
+
+        return $layers;
+    }
+}

--- a/lizmap/modules/lizmap/lib/Project/qgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/qgisProject.php
@@ -85,12 +85,17 @@ class qgisProject
     protected $appContext;
 
     /**
+     * @var lizmapServices
+     */
+    protected $services;
+
+    /**
      * constructor.
      *
      * @param string $file  : the QGIS project path
      * @param mixed  $jelix
      */
-    public function __construct($file, $jelix)
+    public function __construct($file, $jelix, $services)
     {
         if (!$this->appContext) {
             $this->appContext = $jelix;
@@ -106,6 +111,7 @@ class qgisProject
         $cache = new projectCache($file, $this->appContext);
         $this->xml = simplexml_load_file($file);
         $this->path = $file;
+        $this->services = $services;
 
         try {
             $data = $cache->retrieveProjectData();
@@ -125,14 +131,12 @@ class qgisProject
             foreach ($this->cachedProperties as $prop) {
                 $data[$prop] = $this->{$prop};
             }
-
             try {
                 $cache->storeProjectData($data);
             } catch (\Exception $e) {
                 \jLog::logEx($e, 'error');
             }
         } else {
-            \jLog::log('je passe: construct else', 'error');
             foreach ($this->cachedProperties as $prop) {
                 $this->{$prop} = $data[$prop];
             }
@@ -1015,7 +1019,7 @@ class qgisProject
         foreach ($xmlLayers as $xmlLayer) {
             $attributes = $xmlLayer->attributes();
             if (isset($attributes['embedded']) && (string) $attributes->embedded == '1') {
-                $qgsProj = new qgisProject(realpath(dirname($this->path).DIRECTORY_SEPARATOR.(string) $attributes->project), $this->appContext);
+                $qgsProj = new qgisProject(realpath(dirname($this->path).DIRECTORY_SEPARATOR.(string) $attributes->project), $this->appContext, $this->services);
                 $layer = $qgsProj->getLayerDefinition((string) $attributes->id);
                 $layer['embedded'] = 1;
                 $layer['projectPath'] = (string) $attributes->project;

--- a/lizmap/modules/lizmap/lib/Project/qgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/qgisProject.php
@@ -135,17 +135,6 @@ class qgisProject
         $this->path = $file;
     }
 
-    public function clearCache()
-    {
-        $cache = new projectCache($file, $this->jelix);
-        $cache->clearCache();
-    }
-
-    public function getPath()
-    {
-        return $this->path;
-    }
-
     public function getData($key)
     {
         if (!array_key_exists($key, $this->data)) {

--- a/lizmap/modules/lizmap/lib/Project/repository.php
+++ b/lizmap/modules/lizmap/lib/Project/repository.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Manage and give access to lizmap configuration.
+ *
+ * @author    3liz
+ * @copyright 2012 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+ namespace Lizmap\Project;
+
+class repository
+{
+    // Lizmap configuration file path (relative to the path folder)
+    private $config = 'config/lizmapConfig.ini.php';
+
+    /**
+     * services properties.
+     *
+     * @deprecated
+     */
+    public static $properties = array(
+        'label',
+        'path',
+        'allowUserDefinedThemes',
+    );
+
+    /**
+     * services properties options.
+     *
+     * @deprecated
+     */
+    public static $propertiesOptions = array(
+        'label' => array(
+            'fieldType' => 'text',
+            'required' => true,
+        ),
+        'path' => array(
+            'fieldType' => 'text',
+            'required' => true,
+        ),
+        'allowUserDefinedThemes' => array(
+            'fieldType' => 'checkbox',
+            'required' => false,
+        ),
+    );
+
+    // Lizmap repository key
+    private $key = '';
+    // Lizmap repository configuration data
+    private $data = array();
+    /**
+     * @var lizmapProject[] list of projects. keys are projects names
+     */
+    protected $projectInstances = array();
+    // The configuration files folder path
+    private $varPath = '';
+
+    /**
+     * lizmapRepository Constructor
+     * Do not call it, if you want to instanciate a lizmapRepository, you should
+     * do it with the lizmapServices::getLizmapRepository method
+     *
+     * @param string $key the name of the repository
+     * @param array $data the repository data
+     * @param string $varPath the configuration files folder path
+     */
+
+    public function __construct($key, $data, $varPath)
+    {
+        $properties = self::getProperties();
+        $this->varPath = $varPath;
+
+        // Set each property
+        foreach ($properties as $property) {
+            if (array_key_exists($property, $data)) {
+                $this->data[$property] = $data[$property];
+            }
+        }
+        $this->key = $key;
+    }
+
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    public function getPath()
+    {
+        if ($this->data['path'] == '') {
+            return false;
+        }
+        // add a trailing slash if needed
+        if (!preg_match('#/$#', $this->data['path'])) {
+            $this->data['path'] .= '/';
+        }
+        $path = $this->data['path'];
+        // if path is relative, get full path
+        if ($this->data['path'][0] != '/' and $this->data['path'][1] != ':') {
+            $path = realpath($this->varPath.$this->data['path']).'/';
+        }
+        if (strstr($this->data['path'], './')) {
+            $path = realpath($this->data['path']).'/';
+        }
+        if (file_exists($path)) {
+            $this->data['path'] = $path;
+        } else {
+            return false;
+        }
+
+        return $this->data['path'];
+    }
+
+    public static function getProperties()
+    {
+        return self::$properties;
+    }
+
+    public function getRepoProperties()
+    {
+        return self::$properties;
+    }
+
+    public static function getPropertiesOptions()
+    {
+        return self::$propertiesOptions;
+    }
+
+    public function getData($key)
+    {
+        if (!array_key_exists($key, $this->data)) {
+            return null;
+        }
+
+        return $this->data[$key];
+    }
+
+    /**
+     * Update a repository in a jIniFilemodifier object
+     *
+     * @param array $data the repository data
+     * @param jIniFileModifier $ini the object to edit the ini file
+     *
+     * @return bool true if there is at least one valid data in $data
+     */
+
+    public function update($data, $ini)
+    {
+        // Set section
+        $section = 'repository:'.$this->key;
+
+        $modified = false;
+        // Modify the ini data for the repository
+        foreach ($data as $k => $v) {
+            if (in_array($k, self::getProperties())) {
+                // Set values in ini file
+                $ini->setValue($k, $v, $section);
+                // Modify lizmapConfigData
+                $this->data[$k] = $v;
+                $modified = true;
+            }
+        }
+
+        // Save the ini file
+        if ($modified) {
+            $ini->save();
+        }
+
+        return $modified;
+    }
+
+    public function getProject($key, $context, $services)
+    {
+        if (isset($this->projectInstances[$key])) {
+            return $this->projectInstances[$key];
+        }
+
+        try {
+            $proj = new project($key, $this, $context, $services);
+        } catch (\UnknownLizmapProjectException $e) {
+            throw $e;
+        } catch (\Exception $e) {
+            \jLog::logEx($e, 'error');
+            return null;
+        }
+
+        $this->projectInstances[$key] = $proj;
+
+        return $proj;
+    }
+
+    public function getProjects($context, $services)
+    {
+        $projects = array();
+        $dir = $this->getPath();
+
+        if (is_dir($dir)) {
+            if ($dh = opendir($dir)) {
+                $cfgFiles = array();
+                $qgsFiles = array();
+                while (($file = readdir($dh)) !== false) {
+                    if (substr($file, -3) == 'cfg') {
+                        $cfgFiles[] = $file;
+                    }
+                    if (substr($file, -3) == 'qgs') {
+                        $qgsFiles[] = $file;
+                    }
+                }
+                closedir($dh);
+
+                foreach ($qgsFiles as $qgsFile) {
+                    $proj = null;
+                    if (in_array($qgsFile.'.cfg', $cfgFiles)) {
+                        try {
+                            $proj = $this->getProject(substr($qgsFile, 0, -4), $context, $services);
+                            if ($proj != null) {
+                                $projects[] = $proj;
+                            }
+                        } catch (\UnknownLizmapProjectException $e) {
+                            \jLog::logEx($e, 'error');
+                        } catch (\Exception $e) {
+                            \jLog::logEx($e, 'error');
+                        }
+                    }
+                }
+            }
+        }
+
+        return $projects;
+    }
+}

--- a/lizmap/modules/lizmap/module.xml
+++ b/lizmap/modules/lizmap/module.xml
@@ -20,6 +20,7 @@
         <class name="lizmapLogConfig" file="classes/lizmapLogConfig.class.php"/>
         <class name="lizmapOGCRequest" file="classes/lizmapOGCRequest.class.php"/>
         <class name="qgisProject" file="classes/qgisProject.class.php"/>
+        <class name="qgisServer" file="classes/qgisServer.class.php"/>
         <class name="lizmapProject" file="classes/lizmapProject.class.php"/>
         <class name="lizmapProxy" file="classes/lizmapProxy.class.php"/>
         <class name="lizmapRepository" file="classes/lizmapRepository.class.php"/>

--- a/lizmap/modules/view/zones/ajax_view.zone.php
+++ b/lizmap/modules/view/zones/ajax_view.zone.php
@@ -36,7 +36,7 @@ class ajax_viewZone extends jZone
             if (jAcl2::check('lizmap.repositories.view', $r)) {
                 $lrep = lizmap::getRepository($r);
                 $mrep = new lizmapMainViewItem($r, $lrep->getData('label'));
-                $lprojects = $lrep->getProjects();
+                $lprojects = $lrep->getProjects(lizmap::getAppContext(), lizmap::getServices());
                 foreach ($lprojects as $p) {
                     if (!$p->checkAcl()) {
                         continue;

--- a/lizmap/modules/view/zones/main_view.zone.php
+++ b/lizmap/modules/view/zones/main_view.zone.php
@@ -45,7 +45,7 @@ class main_viewZone extends jZone
             if (jAcl2::check('lizmap.repositories.view', $r)) {
                 $lrep = lizmap::getRepository($r);
                 $mrep = new lizmapMainViewItem($r, $lrep->getData('label'));
-                $lprojects = $lrep->getProjects();
+                $lprojects = $lrep->getProjects(lizmap::getAppContext(), lizmap::getServices());
 
                 // WMS GetCapabilities Url
                 $wmsGetCapabilitiesUrl = jAcl2::check(

--- a/tests/units/composer.json
+++ b/tests/units/composer.json
@@ -12,7 +12,8 @@
         "phpunit/phpunit": "^5.7.27"
     },
     "autoload": {
-        "classmap": ["../../lizmap/modules/lizmap/classes/" ]
+        "classmap": ["../../lizmap/modules/lizmap/classes/" ],
+        "psr-4": {"Lizmap\\": "../../lizmap/modules/lizmap/lib/"}
     },
     "minimum-stability": "stable"
 }


### PR DESCRIPTION
Moving lizmapRepository to namespace Lizmap\Project\ + marking lizmapRepository as deprecated.
The lizmapRepository class is still there to avoid breaking the API but it's now storing and using a Lizmap\Project\Repository.