### PR TITLE
Fix: showFeatureCount reading

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -340,7 +340,7 @@ class lizmapProject extends qgisProject
             }
         }
 
-        $layersWithShowFeatureCount = $qgs_xml->xpath("//layer-tree-layer/customproperties/property[@key='showFeatureCount']/parent::*/parent::*");
+        $layersWithShowFeatureCount = $qgs_xml->xpath("//layer-tree-layer/customproperties/property[@key='showFeatureCount'][@value='1']/parent::*/parent::*");
         if ($layersWithShowFeatureCount && count($layersWithShowFeatureCount) > 0) {
             foreach ($layersWithShowFeatureCount as $layer) {
                 $name = (string) $layer['name'];


### PR DESCRIPTION
## Description

In the qgis project, the show feature count is describe as a custom property
```xml
<customproperties>
<property key="showFeatureCount" value="1"/>
</customproperties>
```

In old version the custom property was removed by QGIS when show feature count was deactivated. Now it seems that QGIS keep the custom property with 0 as value.

```xml
<customproperties>
<property key="showFeatureCount" value="0"/>
</customproperties>
```

Lizmap was looking that the custom property exists, the fix also check the value.

Funded by [Conseil Département du Calvados](https://www.calvados.fr)