### PR TITLE
Optimization : cache translate query

### DIFF
--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -128,7 +128,10 @@ class lizMapCtrl extends jController
 
         // the html response
         $rep = $this->getResponse('htmlmap');
-        $rep->addJSLink(jUrl::get('view~translate:index'));
+        // Get Lizmap version from project.xml
+        $xmlLoad = simplexml_load_file(jApp::appPath('project.xml'));
+        $version = (string) $xmlLoad->info->version;
+        $rep->addJSLink((jUrl::get('view~translate:index')).'?v='.$version.'&lang='.jApp::config()->locale);
 
         $this->repositoryKey = $lrep->getKey();
         $this->projectKey = $lproj->getKey();

--- a/lizmap/modules/view/controllers/translate.classic.php
+++ b/lizmap/modules/view/controllers/translate.classic.php
@@ -23,6 +23,7 @@ class translateCtrl extends jController
         $rep = $this->getResponse('binary');
         $rep->mimeType = 'text/javascript';
         $rep->doDownload = false;
+        $rep->setExpires('+1 year');
 
         $lang = $this->param('lang');
 


### PR DESCRIPTION
translate query is slow because it reads translations line by line.
It can be cached taking care of future invalidation with version and lang as URL parameters
