### PR TITLE
fixing getXmlLayer2

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -1500,7 +1500,13 @@ class lizmapProject extends qgisProject
      */
     protected function getXmlLayer2($xml, $layerId)
     {
-        return $xml->xpath("//maplayer[id='${layerId}']");
+        $layerList = $xml->xpath("//maplayer");
+        foreach ($layerList as $layer) {
+            if ((string)$layer->id === $layerId) {
+                return $layer;
+            }
+        }
+        return null;
     }
 
     protected function readLocateByLayers($xml, $cfg)


### PR DESCRIPTION
Fixing a bug in getXmlLayer2 with a xpath query that was not compatible with QGIS Versions > 3