### PR TITLE
Remove wps module from docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,9 +3,6 @@ FROM ${REGISTRY_PREFIX}alpine:3.10
 MAINTAINER David Marteau <david.marteau@3liz.com>
 LABEL Description="Lizmap web client" Vendor="3liz.org"
 
-ARG lizmap_wps_version=master
-ARG lizmap_wps_git=https://github.com/3liz/lizmap-wps-web-client-module.git
-
 RUN apk update && apk upgrade
 RUN apk --no-cache add git fcgi php7 php7-fpm \
     php7-tokenizer \
@@ -41,11 +38,6 @@ RUN echo "installing lizmap from given package" \
     && mv lizmap_web_client /www \
     && mv /www/lizmap/var/config /www/lizmap/var/config.dist \
     && mv /www/lizmap/www /www/lizmap/www.dist
-
-# Install lizmap wps
-RUN git clone --branch $lizmap_wps_version --depth=1 $lizmap_wps_git lizmap-wps \
-    && mv lizmap-wps/wps /www/lizmap/lizmap-modules/wps \
-    && rm -rf lizmap-wps
 
 COPY factory.manifest /build.manifest
 COPY lizmapConfig.ini.php.dist localconfig.ini.php.dist /www/lizmap/var/config.dist/

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,4 @@
-# Lizmap web client Docker image with WPS support
+# Lizmap web client Docker image
 
 The container deploy one lizmap instance and may run php-fpm on commande line.
 (cf [docker/php](https://hub.docker.com/_/php/) )
@@ -6,7 +6,7 @@ The container deploy one lizmap instance and may run php-fpm on commande line.
 
 ## Configuration variables
 
-- LIZMAP\_WMSSERVERURL: URL of the OWS (WMS/WFS/WCS) service used by the WPS service 
+- LIZMAP\_WMSSERVERURL: URL of the OWS (WMS/WFS/WCS) service used
 - LIZMAP\_DEBUGMODE: Error level INFO/DEBUG/ERROR/WARNING
 - LIZMAP\_CACHESTORAGETYPE: Always Use 'redis'
 - LIZMAP\_CACHEREDISHOST: Redis host


### PR DESCRIPTION
The [WPS module](https://github.com/3liz/lizmap-wps-web-client-module) is still a work in progresse and should not be delivered with docker official lizmap image  since it may be cause of instability.

This PR remove installation of the wps module in the docker image. 

The wps configuration is kept atm since this is a conditional setup and not activated if there is no LIZMAP_WPS_URL defined.

