### PR TITLE
Command line to load QGIS project

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -46,7 +46,7 @@ New features:
 - improvement in Attribute Table view
   - a lizmap javascript script to show description labels instead of values in
     the attribute table for columns with ValueMap widget
-  - allow the use of the lizmap javascript script also for numeric columns 
+  - allow the use of the lizmap javascript script also for numeric columns
 - improvement in Timemanager
 - Atlas print in popup : you can now define values for custom fields
 ![Atlas print in popup](https://user-images.githubusercontent.com/2145040/92587962-a9721c00-f298-11ea-9d13-4b58d477986b.gif "Atlas print in popup")
@@ -60,6 +60,8 @@ New features:
   performed by Lizmap plugin as a QGIS Server plugin
 - Restrict filter by user on edition only, based on lizmap plugin config
 - Use QGIS expression in Lizmap edition, needs Lizmap plugin installed as a QGIS Server plugin
+- Command lines
+  - A command line to request project WMS GetCapabilities to put project in QGIS Server cache
 
 
 - Lizmap does not support anymore Internet Explorer (11 and lower)

--- a/lizmap/modules/lizmap/controllers/project.cmdline.php
+++ b/lizmap/modules/lizmap/controllers/project.cmdline.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * @author    your name
+ * @copyright 2020 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license    All rights reserved
+ */
+class projectCtrl extends jControllerCmdLine
+{
+    /**
+     * Options to the command line
+     *  'method_name' => array('-option_name' => true/false)
+     * true means that a value should be provided for the option on the command line.
+     */
+    protected $allowed_options = array(
+    );
+
+    /**
+     * Parameters for the command line
+     * 'method_name' => array('parameter_name' => true/false)
+     * false means that the parameter is optional. All parameters which follow an optional parameter
+     * is optional.
+     */
+    protected $allowed_parameters = array(
+        'load' => array(
+            'nb' => true,
+        ),
+    );
+
+    /**
+     * Help.
+     */
+    public $help = array(
+        'load' => 'Create repository
+    parameters:
+        nb             the number of loading iteration on each project
+    Use:
+        php lizmap/scripts/script.php lizmap~project:load nb
+        ',
+    );
+
+    public function load()
+    {
+        $rep = $this->getResponse(); // cmdline response by default
+
+        $nb = (int) $this->param('nb');
+        if (!$nb || $nb < 1) {
+            $rep->addContent("The number of loading iteration on each project has to be a number > 0!\n");
+            $rep->setExitCode(1);
+            return $rep;
+        }
+
+        $services = lizmap::getServices();
+        $wmsServerURL = $services->wmsServerURL;
+
+        $repositories = lizmap::getRepositoryList();
+        foreach ($repositories as $r) {
+            $rep->addContent("Enter the repository ".$r."\n");
+            $lrep = lizmap::getRepository($r);
+            $lprojects = $lrep->getProjects();
+
+            foreach ($lprojects as $p) {
+                $rep->addContent("Get the project ".$p->getData('id')."\n");
+                // Get params
+                $params = array(
+                    'map' => $p->getRelativeQgisPath(),
+                    'service' => 'WMS',
+                    'request' => 'GetCapabilities'
+                );
+
+                // Build http params
+                $bparams = http_build_query($params);
+
+                // Replace some chars (not needed in php 5.4, use the 4th parameter of http_build_query)
+                $a = array('+', '_', '.', '-');
+                $b = array('%20', '%5F', '%2E', '%2D');
+                $bparams = str_replace($a, $b, $bparams);
+
+                // Get URL
+                $url = $wmsServerURL.'?'.$bparams;
+
+                $nb_500 = 0;
+                $nb_400 = 0;
+                $nb_success = 0;
+
+                $i = 0;
+                while ($i < $nb) {
+                    // Get remote data
+                    list($data, $mime, $code) = lizmapProxy::getRemoteData($url);
+                    if (floor($code / 100) >= 5) {
+                        $nb_500 += 1;
+                    } else if (floor($code / 100) >= 4) {
+                        $nb_400 += 1;
+                    } else {
+                        $nb_success += 1;
+                    }
+                    $i += 1;
+                }
+                if ($nb_500) {
+                    $rep->addContent($nb_500." request(s) return error 500 for the project ".$p->getData('id')."\n");
+                } else if ($nb_400) {
+                    $rep->addContent($nb_400." request(s) return error 400 for the project ".$p->getData('id')."\n");
+                } else {
+                    $rep->addContent($nb_success." request(s) return success for the project ".$p->getData('id')."\n");
+                }
+            }
+        }
+        return $rep;
+    }
+}


### PR DESCRIPTION
## Description

A command line to request project WMS GetCapabilities to put project in QGIS Server cache.

The command line `php /srv/lizmap-web-client/lizmap/scripts/script.php lizmap~project:load 5` can be used in cron to be sure that lizmap project has been loaded by QGIS Server in Cache.

Funded by WPD