### PR TITLE
Fix qgisForm listener

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisForm.listener.php
+++ b/lizmap/modules/lizmap/classes/qgisForm.listener.php
@@ -15,6 +15,13 @@ class qgisFormListener extends jEventListener
     {
         $form = $event->getParam('form');
         $privateData = $form->getContainer()->privateData;
+        if (!$privateData ||
+            !array_key_exists('liz_repository', $privateData) ||
+            !array_key_exists('liz_project', $privateData) ||
+            !array_key_exists('liz_layerId', $privateData)) {
+            // it's not a QGIS Form
+            return;
+        }
 
         $repository = $privateData['liz_repository'];
         $project = $privateData['liz_project'];
@@ -22,8 +29,20 @@ class qgisFormListener extends jEventListener
         $featureId = $privateData['liz_featureId'];
 
         $lrep = lizmap::getRepository($repository);
+        if (!$lrep) {
+            // Unknown repository
+            return;
+        }
         $lproj = lizmap::getProject($repository.'~'.$project);
+        if (!$lproj) {
+            // Unknown project
+            return;
+        }
         $layer = $lproj->getLayer($layerId);
+        if (!$layer) {
+            // Unknown layer
+            return;
+        }
 
         $qgisForm = new qgisForm($layer, $form, $featureId, jAcl2::check('lizmap.tools.loginFilteredLayers.override', $lrep->getKey()));
     }


### PR DESCRIPTION
#  Description

The `qgisForm` listener does not check if the  provided form is a qgis one.
