### PR TITLE
CFG - Make group_visibility an array instead of a string

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -1898,13 +1898,13 @@ class lizmapProject extends qgisProject
             if (!property_exists($obj, 'group_visibility')) {
                 continue;
             }
-            if ($obj->group_visibility === '') {
+            if (empty($obj->group_visibility)) {
                 unset($obj->group_visibility);
 
                 continue;
             }
-            // get group visibility as trimed array
-            $group_visibility = array_map('trim', explode(',', $obj->group_visibility));
+            // get group visibility as trimmed array
+            $group_visibility = array_map('trim', $obj->group_visibility);
             $layerToKeep = false;
             foreach ($userGroups as $group) {
                 if (in_array($group, $group_visibility)) {


### PR DESCRIPTION
<!---Thanks for your contribution and describing your PR.-->

## Description

* Ticket : #https://github.com/3liz/lizmap-plugin/issues/292
* CFG - Make group_visibility an array instead of a string
* Linked to https://github.com/3liz/lizmap-plugin/pull/293

