### PR TITLE
QgisForm* namespace + Jelix uncontextualization

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisAttributeEditorElement.class.php
+++ b/lizmap/modules/lizmap/classes/qgisAttributeEditorElement.class.php
@@ -29,7 +29,7 @@ class qgisAttributeEditorElement
     protected $childrenAfterTab = array();
 
     public function __construct(
-        qgisFormControlsInterface $formControls,
+        Lizmap\Form\QgisFormControlsInterface $formControls,
         SimpleXMLElement $node,
         $parentId,
         $idx = 0,

--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -64,7 +64,7 @@ class QgisForm implements QgisFormControlsInterface
      * qgisForm constructor.
      *
      * @param qgisMapLayer|qgisVectorLayer $layer
-     * @param \jFormsBase                   $form
+     * @param \jFormsBase                  $form
      * @param string                       $featureId
      * @param bool                         $loginFilteredOverride
      *
@@ -419,7 +419,7 @@ class QgisForm implements QgisFormControlsInterface
     }
 
     /**
-     * @return \jFormsPlugin[]
+     * @return array
      */
     public function getFormPlugins()
     {
@@ -849,7 +849,7 @@ class QgisForm implements QgisFormControlsInterface
     }
 
     /**
-     * @param \jFormsBase    $form
+     * @param \jFormsBase   $form
      * @param string        $ref
      * @param jDbConnection $cnx
      */

--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Create and set jForms form based on QGIS vector layer.
+ * Create and set \jForms form based on QGIS vector layer.
  *
  * @author    3liz
  * @copyright 2017 3liz
@@ -9,7 +9,10 @@
  *
  * @license Mozilla Public License : http://www.mozilla.org/MPL/
  */
-class qgisForm implements qgisFormControlsInterface
+
+namespace Lizmap\Form;
+
+class QgisForm implements QgisFormControlsInterface
 {
     /**
      * @var qgisMapLayer|qgisVectorLayer
@@ -17,7 +20,7 @@ class qgisForm implements qgisFormControlsInterface
     protected $layer;
 
     /**
-     * @var jFormsBase
+     * @var \jFormsBase
      */
     protected $form;
 
@@ -27,7 +30,7 @@ class qgisForm implements qgisFormControlsInterface
     protected $form_name;
 
     /**
-     * @var null|qgisAttributeEditorElement the qgis form element
+     * @var null|\qgisAttributeEditorElement the qgis form element
      */
     protected $attributeEditorForm;
 
@@ -49,37 +52,37 @@ class qgisForm implements qgisFormControlsInterface
     /** @var qgisFormControl[] */
     protected $formControls = array();
 
-    /** @var jFormsPlugin[] */
+    /** @var \jFormsPlugin[] */
     protected $formPlugins = array();
 
     /**
      * qgisForm constructor.
      *
      * @param qgisMapLayer|qgisVectorLayer $layer
-     * @param jFormsBase                   $form
+     * @param \jFormsBase                   $form
      * @param string                       $featureId
      * @param bool                         $loginFilteredOverride
      *
-     * @throws Exception
+     * @throws \Exception
      */
     public function __construct($layer, $form, $featureId, $loginFilteredOverride)
     {
         if ($layer->getType() != 'vector') {
-            throw new Exception('The layer "'.$layer->getName().'" is not a vector layer!');
+            throw new \Exception('The layer "'.$layer->getName().'" is not a vector layer!');
         }
         if (!$layer->isEditable()) {
-            throw new Exception('The layer "'.$layer->getName().'" is not an editable vector layer!');
+            throw new \Exception('The layer "'.$layer->getName().'" is not an editable vector layer!');
         }
 
         //Get the fields info
         $dbFieldsInfo = $layer->getDbFieldsInfo();
         // verifying db fields info
         if (!$dbFieldsInfo) {
-            throw new Exception('Can\'t get Db fields information for the layer "'.$layer->getName().'"!');
+            throw new \Exception('Can\'t get Db fields information for the layer "'.$layer->getName().'"!');
         }
 
         if (count($dbFieldsInfo->primaryKeys) == 0) {
-            throw new Exception('The layer "'.$layer->getName().'" has no primary keys. The edition tool needs a primary key on the table to be defined.');
+            throw new \Exception('The layer "'.$layer->getName().'" has no primary keys. The edition tool needs a primary key on the table to be defined.');
         }
 
         $this->layer = $layer;
@@ -228,7 +231,7 @@ class qgisForm implements qgisFormControlsInterface
             } elseif ($formControl->isUploadControl()) {
                 // Add Hidden Control for upload
                 // help to retrieve file path
-                $hiddenCtrl = new jFormsControlHidden($fieldName.'_hidden');
+                $hiddenCtrl = new \jFormsControlHidden($fieldName.'_hidden');
                 $form->addControl($hiddenCtrl);
                 $toDeactivate[] = $formControl->getControlName();
             } elseif ($formControl->fieldEditType === 'Color') {
@@ -301,7 +304,7 @@ class qgisForm implements qgisFormControlsInterface
         $attributeEditorForm = $this->getAttributesEditorForm();
         if ($attributeEditorForm) {
             $groupVisibilities = $attributeEditorForm->getGroupVisibilityExpressions();
-            $qgis_groupDependencies = qgisExpressionUtils::getCriteriaFromExpressions($groupVisibilities);
+            $qgis_groupDependencies = \qgisExpressionUtils::getCriteriaFromExpressions($groupVisibilities);
             $privateData['qgis_groupDependencies'] = array_intersect($qgis_groupDependencies, array_keys($this->dbFieldsInfo->dataFields));
         } else {
             $privateData['qgis_groupDependencies'] = array();
@@ -337,7 +340,7 @@ class qgisForm implements qgisFormControlsInterface
             }
         }
         // Evaluate the expression by qgis
-        $results = qgisExpressionUtils::evaluateExpressions(
+        $results = \qgisExpressionUtils::evaluateExpressions(
             $this->layer,
             array(
                 $fieldName => $expression,
@@ -380,7 +383,7 @@ class qgisForm implements qgisFormControlsInterface
     }
 
     /**
-     * @return null|qgisAttributeEditorElement
+     * @return null|\qgisAttributeEditorElement
      */
     public function getAttributesEditorForm()
     {
@@ -396,7 +399,7 @@ class qgisForm implements qgisFormControlsInterface
         if ($_editorlayout && $_editorlayout[0] == 'tablayout') {
             $_attributeEditorForm = $layerXml->xpath('attributeEditorForm');
             if ($_attributeEditorForm && count($_attributeEditorForm)) {
-                $attributeEditorForm = new qgisAttributeEditorElement($this, $_attributeEditorForm[0], $this->form_name);
+                $attributeEditorForm = new \qgisAttributeEditorElement($this, $_attributeEditorForm[0], $this->form_name);
             }
         }
 
@@ -410,7 +413,7 @@ class qgisForm implements qgisFormControlsInterface
     }
 
     /**
-     * @return jFormsPlugin[]
+     * @return \jFormsPlugin[]
      */
     public function getFormPlugins()
     {
@@ -418,7 +421,7 @@ class qgisForm implements qgisFormControlsInterface
     }
 
     /**
-     * List of field name for a jForms form.
+     * List of field name for a \jForms form.
      *
      * @return string[]
      */
@@ -430,7 +433,7 @@ class qgisForm implements qgisFormControlsInterface
     }
 
     /**
-     * @return jFormsBase
+     * @return \jFormsBase
      */
     public function getForm()
     {
@@ -502,9 +505,9 @@ class qgisForm implements qgisFormControlsInterface
                     $path = explode('/', $value);
                     $filename = array_pop($path);
                     $filename = preg_replace('#_|-#', ' ', $filename);
-                    $ctrl->itemsNames['keep'] = jLocale::get('view~edition.upload.choice.keep').' '.$filename;
-                    $ctrl->itemsNames['update'] = jLocale::get('view~edition.upload.choice.update');
-                    $ctrl->itemsNames['delete'] = jLocale::get('view~edition.upload.choice.delete').' '.$filename;
+                    $ctrl->itemsNames['keep'] = \jLocale::get('view~edition.upload.choice.keep').' '.$filename;
+                    $ctrl->itemsNames['update'] = \jLocale::get('view~edition.upload.choice.update');
+                    $ctrl->itemsNames['delete'] = \jLocale::get('view~edition.upload.choice.delete').' '.$filename;
                 }
                 $form->setData($ref.'_hidden', $value);
             } else {
@@ -529,7 +532,7 @@ class qgisForm implements qgisFormControlsInterface
         $modifyGeometry = $this->layer->getEditionCapabilities()->capabilities->modifyGeometry;
         if (strtolower($modifyGeometry) == 'true' && $form->getData($geometryColumn) == '') {
             $check = false;
-            $form->setErrorOn($geometryColumn, jLocale::get('view~edition.message.error.no.geometry'));
+            $form->setErrorOn($geometryColumn, \jLocale::get('view~edition.message.error.no.geometry'));
         }
 
         // Get values and form fields
@@ -559,7 +562,7 @@ class qgisForm implements qgisFormControlsInterface
                 continue;
             }
             // Control is an upload control
-            if ($jCtrl instanceof jFormsControlUpload) {
+            if ($jCtrl instanceof \jFormsControlUpload) {
                 $values[$fieldName] = $this->processUploadedFile($form, $fieldName, $cnx);
             } else {
 
@@ -591,7 +594,7 @@ class qgisForm implements qgisFormControlsInterface
                 'geometry' => null,
                 'properties' => $values,
             );
-            $results = qgisExpressionUtils::evaluateExpressions(
+            $results = \qgisExpressionUtils::evaluateExpressions(
                 $this->layer,
                 $constraintExpressions,
                 $form_feature
@@ -610,7 +613,7 @@ class qgisForm implements qgisFormControlsInterface
                 if ($constraints['exp_desc'] !== '') {
                     $form->setErrorOn($fieldName, $constraints['exp_desc']);
                 } else {
-                    $form->setErrorOn($fieldName, jLocale::get('view~edition.message.error.constraint', array($constraints['exp_value'])));
+                    $form->setErrorOn($fieldName, \jLocale::get('view~edition.message.error.constraint', array($constraints['exp_value'])));
                 }
                 $check = false;
             }
@@ -629,7 +632,7 @@ class qgisForm implements qgisFormControlsInterface
     public function saveToDb($feature = null)
     {
         if (!$this->dbFieldsInfo) {
-            throw new Exception('Save to database can\'t be done for the layer "'.$this->layer->getName().'"!');
+            throw new \Exception('Save to database can\'t be done for the layer "'.$this->layer->getName().'"!');
         }
 
         // Update or Insert
@@ -688,10 +691,10 @@ class qgisForm implements qgisFormControlsInterface
         }
 
         if (count($fields) == 0) {
-            jLog::log('Not enough capabilities for this layer ! SQL cannot be constructed: no fields available !', 'error');
-            $this->form->setErrorOn($geometryColumn, jLocale::get('view~edition.message.error.save').' '.jLocale::get('view~edition.message.error.save.fields'));
+            \jLog::log('Not enough capabilities for this layer ! SQL cannot be constructed: no fields available !', 'error');
+            $this->form->setErrorOn($geometryColumn, \jLocale::get('view~edition.message.error.save').' '.\jLocale::get('view~edition.message.error.save.fields'));
 
-            throw new Exception(jLocale::get('view~edition.link.error.sql'));
+            throw new \Exception(\jLocale::get('view~edition.link.error.sql'));
         }
 
         $form = $this->form;
@@ -705,7 +708,7 @@ class qgisForm implements qgisFormControlsInterface
                 continue;
             }
             // Control is an upload control
-            if ($jCtrl instanceof jFormsControlUpload) {
+            if ($jCtrl instanceof \jFormsControlUpload) {
                 $values[$ref] = $this->processUploadedFile($form, $ref, $cnx);
 
                 continue;
@@ -730,7 +733,7 @@ class qgisForm implements qgisFormControlsInterface
                 case 'geometry':
                     try {
                         $value = $this->layer->getGeometryAsSql($value);
-                    } catch (Exception $e) {
+                    } catch (\Exception $e) {
                         $form->setErrorOn($geometryColumn, $e->getMessage());
 
                         return false;
@@ -808,7 +811,7 @@ class qgisForm implements qgisFormControlsInterface
                 'tablename' => $dtParams->tablename,
                 'schema' => $dtParams->schema,
             );
-            $event = jEvent::notify('LizmapEditionFeaturePreUpdateInsert', $eventParams);
+            $event = \jEvent::notify('LizmapEditionFeaturePreUpdateInsert', $eventParams);
             $additionnalValues = $event->getResponseByKey('values');
             if ($additionnalValues !== null) {
                 foreach ($additionnalValues as $additionnalValue) {
@@ -825,13 +828,13 @@ class qgisForm implements qgisFormControlsInterface
 
             // event to execute additional process on updated/inserted data
             $eventParams['pkVal'] = $pkVal;
-            jEvent::notify('LizmapEditionFeaturePostUpdateInsert', $eventParams);
+            \jEvent::notify('LizmapEditionFeaturePostUpdateInsert', $eventParams);
 
             return $pkVal;
-        } catch (Exception $e) {
-            $form->setErrorOn($geometryColumn, jLocale::get('view~edition.message.error.save'));
-            jLog::log('An error has been raised when saving form data edition to db : ', 'error');
-            jLog::logEx($e, 'error');
+        } catch (\Exception $e) {
+            $form->setErrorOn($geometryColumn, \jLocale::get('view~edition.message.error.save'));
+            \jLog::log('An error has been raised when saving form data edition to db : ', 'error');
+            \jLog::logEx($e, 'error');
 
             return false;
         }
@@ -840,7 +843,7 @@ class qgisForm implements qgisFormControlsInterface
     }
 
     /**
-     * @param jFormsBase    $form
+     * @param \jFormsBase    $form
      * @param string        $ref
      * @param jDbConnection $cnx
      */
@@ -857,7 +860,7 @@ class qgisForm implements qgisFormControlsInterface
         $targetFullPath = $repPath.$targetPath;
         // Else use given root, but only if it is a child or brother of the repository path
         if (!empty($this->formControls[$ref]->DefaultRoot)) {
-            jFile::createDir($repPath.$this->formControls[$ref]->DefaultRoot); // Need to create it to then make the realpath checks
+            \jFile::createDir($repPath.$this->formControls[$ref]->DefaultRoot); // Need to create it to then make the realpath checks
             if (
                 (substr(realpath($repPath.$this->formControls[$ref]->DefaultRoot), 0, strlen(realpath($repPath))) === realpath($repPath))
                 or
@@ -923,7 +926,7 @@ class qgisForm implements qgisFormControlsInterface
     public function deleteFromDb($feature)
     {
         if (!$this->dbFieldsInfo) {
-            throw new Exception('Delete from database can\'t be done for the layer "'.$this->layer->getName().'"!');
+            throw new \Exception('Delete from database can\'t be done for the layer "'.$this->layer->getName().'"!');
         }
 
         $loginFilteredLayers = $this->filterDataByLogin($this->layer->getName());
@@ -939,7 +942,7 @@ class qgisForm implements qgisFormControlsInterface
             'loginFilteredLayers' => $loginFilteredLayers,
             'pkVal' => $this->layer->getPrimaryKeyValues($feature),
         );
-        $event = jEvent::notify('LizmapEditionFeaturePreDelete', $eventParams);
+        $event = \jEvent::notify('LizmapEditionFeaturePreDelete', $eventParams);
         if ($event->allResponsesByKeyAreTrue('deleteIsAlreadyDone')) {
             return 1;
         }
@@ -947,7 +950,7 @@ class qgisForm implements qgisFormControlsInterface
             return 0;
         }
         $result = $this->layer->deleteFeature($feature, $loginFilteredLayers);
-        jEvent::notify('LizmapEditionFeaturePostDelete', $eventParams);
+        \jEvent::notify('LizmapEditionFeaturePostDelete', $eventParams);
 
         return $result;
     }
@@ -955,7 +958,7 @@ class qgisForm implements qgisFormControlsInterface
     /**
      * Dynamically update form by modifying the filter by login control.
      *
-     * @return jFormsBase modified form
+     * @return \jFormsBase modified form
      */
     public function updateFormByLogin()
     {
@@ -972,14 +975,14 @@ class qgisForm implements qgisFormControlsInterface
             }
 
             // Check if a user is authenticated
-            if (!jAuth::isConnected()) {
+            if (!\jAuth::isConnected()) {
                 $form->setData($attribute, 'all');
                 $form->setReadOnly($attribute, true);
 
                 return $form;
             }
 
-            $user = jAuth::getUserSession();
+            $user = \jAuth::getUserSession();
             if (!$this->loginFilteredOverride) {
                 $value = null;
                 if ($oldCtrl != null) {
@@ -992,16 +995,16 @@ class qgisForm implements qgisFormControlsInterface
                     $data[$user->login] = $user->login;
                     $value = $user->login;
                 } else {
-                    $userGroups = jAcl2DbUserGroup::getGroups();
+                    $userGroups = \jAcl2DbUserGroup::getGroups();
                     foreach ($userGroups as $uGroup) {
                         if ($uGroup != 'users' and substr($uGroup, 0, 7) != '__priv_') {
                             $data[$uGroup] = $uGroup;
                         }
                     }
                 }
-                $dataSource = new jFormsStaticDatasource();
+                $dataSource = new \jFormsStaticDatasource();
                 $dataSource->data = $data;
-                $ctrl = new jFormsControlMenulist($attribute);
+                $ctrl = new \jFormsControlMenulist($attribute);
                 $ctrl->required = true;
                 if ($oldCtrl != null) {
                     $ctrl->label = $oldCtrl->label;
@@ -1022,11 +1025,11 @@ class qgisForm implements qgisFormControlsInterface
 
                 $data = array();
                 if ($type == 'login') {
-                    $plugin = jApp::coord()->getPlugin('auth');
+                    $plugin = \jApp::coord()->getPlugin('auth');
                     if ($plugin->config['driver'] == 'Db') {
                         $authConfig = $plugin->config['Db'];
-                        $dao = jDao::get($authConfig['dao'], $authConfig['profile']);
-                        $cond = jDao::createConditions();
+                        $dao = \jDao::get($authConfig['dao'], $authConfig['profile']);
+                        $cond = \jDao::createConditions();
                         $cond->addItemOrder('login', 'asc');
                         $us = $dao->findBy($cond);
                         foreach ($us as $u) {
@@ -1034,7 +1037,7 @@ class qgisForm implements qgisFormControlsInterface
                         }
                     }
                 } else {
-                    $gp = jAcl2DbUserGroup::getGroupList();
+                    $gp = \jAcl2DbUserGroup::getGroupList();
                     foreach ($gp as $g) {
                         if ($g->id_aclgrp != 'users') {
                             $data[$g->id_aclgrp] = $g->id_aclgrp;
@@ -1042,9 +1045,9 @@ class qgisForm implements qgisFormControlsInterface
                     }
                 }
                 $data['all'] = 'all';
-                $dataSource = new jFormsStaticDatasource();
+                $dataSource = new \jFormsStaticDatasource();
                 $dataSource->data = $data;
-                $ctrl = new jFormsControlMenulist($attribute);
+                $ctrl = new \jFormsControlMenulist($attribute);
                 $ctrl->required = true;
                 if ($oldCtrl != null) {
                     $ctrl->label = $oldCtrl->label;
@@ -1082,13 +1085,13 @@ class qgisForm implements qgisFormControlsInterface
             $data[$v] = $v;
         }
 
-        $dataSource = new jFormsStaticDatasource();
+        $dataSource = new \jFormsStaticDatasource();
 
         // required
         if (array_key_exists('notNull', $formControl->uniqueValuesData)
             and $formControl->uniqueValuesData['notNull']
         ) {
-            jLog::log('notNull '.$formControl->uniqueValuesData['notNull'], 'error');
+            \jLog::log('notNull '.$formControl->uniqueValuesData['notNull'], 'error');
             $formControl->ctrl->required = true;
         }
         // combobox
@@ -1225,7 +1228,7 @@ class qgisForm implements qgisFormControlsInterface
 
         $wfsData = $result->data;
         if (property_exists($result, 'file') and $result->file and is_file($wfsData)) {
-            $wfsData = jFile::read($wfsData);
+            $wfsData = \jFile::read($wfsData);
         }
         $mime = $result->mime;
 
@@ -1242,7 +1245,7 @@ class qgisForm implements qgisFormControlsInterface
                     $data[(string) $feat->properties->{$keyColumn}] = $feat->properties->{$valueColumn};
                 }
             }
-            $dataSource = new jFormsStaticDatasource();
+            $dataSource = new \jFormsStaticDatasource();
 
             // required
             if (!$formControl->valueRelationData['allowNull']) {
@@ -1382,12 +1385,12 @@ class qgisForm implements qgisFormControlsInterface
         }
 
         // Perform request
-        $wfsRequest = new lizmapWFSRequest($project, $params);
+        $wfsRequest = new \lizmapWFSRequest($project, $params);
         $result = $wfsRequest->process();
 
         $wfsData = $result->data;
         if (property_exists($result, 'file') and $result->file and is_file($wfsData)) {
-            $wfsData = jFile::read($wfsData);
+            $wfsData = \jFile::read($wfsData);
         }
         $mime = $result->mime;
 
@@ -1404,7 +1407,7 @@ class qgisForm implements qgisFormControlsInterface
                     $data[(string) $feat->properties->{$referencedField}] = $feat->properties->{$previewField};
                 }
             }
-            $dataSource = new jFormsStaticDatasource();
+            $dataSource = new \jFormsStaticDatasource();
 
             // required
             if (!$formControl->relationReferenceData['allowNull']) {
@@ -1470,15 +1473,15 @@ class qgisForm implements qgisFormControlsInterface
                 }
 
                 // Check if a user is authenticated
-                $isConnected = jAuth::isConnected();
-                $cnx = jDb::getConnection($this->layer->getId());
+                $isConnected = \jAuth::isConnected();
+                $cnx = \jDb::getConnection($this->layer->getId());
                 if ($isConnected) {
-                    $user = jAuth::getUserSession();
+                    $user = \jAuth::getUserSession();
                     $login = $user->login;
                     if ($type == 'login') {
                         $where = ' "'.$attribute."\" IN ( '".$login."' , 'all' )";
                     } else {
-                        $userGroups = jAcl2DbUserGroup::getGroups();
+                        $userGroups = \jAcl2DbUserGroup::getGroups();
                         // Set XML Filter if getFeature request
                         $flatGroups = implode("' , '", $userGroups);
                         $where = ' "'.$attribute."\" IN ( '".$flatGroups."' , 'all' )";

--- a/lizmap/modules/lizmap/lib/Form/QgisFormControl.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisFormControl.php
@@ -9,12 +9,15 @@
  *
  * @license Mozilla Public License : http://www.mozilla.org/MPL/
  */
-class qgisFormControl
+
+namespace Lizmap\Form;
+
+class QgisFormControl
 {
     public $ref = '';
 
     /**
-     * @var jFormsControl
+     * @var\jFormsControl
      */
     public $ctrl;
 
@@ -242,7 +245,7 @@ class qgisFormControl
             $this->rendererCategories = $rendererCategories;
 
             // Get qgis edittype data
-            if ($this->edittype && ($this->edittype instanceof SimpleXMLElement)) {
+            if ($this->edittype && ($this->edittype instanceof \SimpleXMLElement)) {
                 // New QGIS 2.4 edittypes : use widgetv2type property
                 if (property_exists($this->edittype->attributes(), 'widgetv2type')) {
                     $this->widgetv2configAttr = $this->edittype->widgetv2config->attributes();
@@ -315,9 +318,9 @@ class qgisFormControl
         // Create the control
         switch ($markup) {
             case 'input':
-                $this->ctrl = new jFormsControlInput($this->ref);
+                $this->ctrl = new \jFormsControlInput($this->ref);
                 if ($this->fieldEditType === 15) {
-                    $this->ctrl->datatype = new jDatatypeDecimal();
+                    $this->ctrl->datatype = new \jDatatypeDecimal();
                     $attributes = $this->edittype->attributes();
                     if (property_exists($attributes, 'min')) {
                         $this->ctrl->datatype->addFacet('minValue', (float) $attributes->min);
@@ -327,7 +330,7 @@ class qgisFormControl
                     }
                 } elseif ($this->fieldEditType === 'Range' ||
                          $this->fieldEditType === 'EditRange') {
-                    $this->ctrl->datatype = new jDatatypeDecimal();
+                    $this->ctrl->datatype = new \jDatatypeDecimal();
                     $attributes = $this->widgetv2configAttr;
                     if (property_exists($attributes, 'Min')) {
                         $this->ctrl->datatype->addFacet('minValue', (float) $attributes->Min);
@@ -340,59 +343,59 @@ class qgisFormControl
                 break;
 
             case 'menulist':
-                $this->ctrl = new jFormsControlMenulist($this->ref);
+                $this->ctrl = new\jFormsControlMenulist($this->ref);
                 $this->fillControlDatasource();
 
                 break;
 
             case 'checkboxes':
-                $this->ctrl = new jFormsControlCheckboxes($this->ref);
+                $this->ctrl = new\jFormsControlCheckboxes($this->ref);
                 $this->fillControlDatasource();
 
                 break;
 
             case 'hidden':
-                $this->ctrl = new jFormsControlHidden($this->ref);
+                $this->ctrl = new\jFormsControlHidden($this->ref);
 
                 break;
 
             case 'checkbox':
-                $this->ctrl = new jFormsControlCheckbox($this->ref);
+                $this->ctrl = new\jFormsControlCheckbox($this->ref);
                 $this->fillCheckboxValues();
 
                 break;
 
             case 'textarea':
-                $this->ctrl = new jFormsControlTextarea($this->ref);
+                $this->ctrl = new\jFormsControlTextarea($this->ref);
 
                 break;
 
             case 'htmleditor':
-                $this->ctrl = new jFormsControlHtmlEditor($this->ref);
+                $this->ctrl = new\jFormsControlHtmlEditor($this->ref);
 
                 break;
 
             case 'date':
-                $this->ctrl = new jFormsControlDate($this->ref);
+                $this->ctrl = new\jFormsControlDate($this->ref);
 
                 break;
 
             case 'datetime':
-                $this->ctrl = new jFormsControlDatetime($this->ref);
+                $this->ctrl = new\jFormsControlDatetime($this->ref);
 
                 break;
 
             case 'time':
-                //$this->ctrl = new jFormsControlDatetime($this->ref);
-                $this->ctrl = new jFormsControlInput($this->ref);
+                //$this->ctrl = new\jFormsControlDatetime($this->ref);
+                $this->ctrl = new\jFormsControlInput($this->ref);
 
                 break;
 
             case 'upload':
-                $choice = new jFormsControlChoice($this->ref.'_choice');
+                $choice = new\jFormsControlChoice($this->ref.'_choice');
                 $choice->createItem('keep', 'keep');
                 $choice->createItem('update', 'update');
-                $upload = new jFormsControlUpload($this->ref);
+                $upload = new\jFormsControlUpload($this->ref);
                 if ($this->fieldEditType === 'Photo') {
                     $upload->mimetype = array('image/jpg', 'image/jpeg', 'image/pjpeg', 'image/png', 'image/gif');
                     $upload->accept = 'image/jpg, image/jpeg, image/pjpeg, image/png, image/gif';
@@ -482,7 +485,7 @@ class qgisFormControl
                 break;
 
             default:
-                $this->ctrl = new jFormsControlInput($this->ref);
+                $this->ctrl = new\jFormsControlInput($this->ref);
 
                 break;
         }
@@ -497,7 +500,7 @@ class qgisFormControl
             // Checkbox should not be required
             $this->required = false;
             // Set control
-            $this->ctrl = new jFormsControlCheckbox($this->ref);
+            $this->ctrl = new\jFormsControlCheckbox($this->ref);
             // Check data list
             foreach ($data as $k => $v) {
                 $strK = strtolower($k);
@@ -523,7 +526,7 @@ class qgisFormControl
             if ($constraints['exp_desc'] !== '') {
                 $this->ctrl->hint = $constraints['exp_desc'];
             } else {
-                $this->ctrl->hint = jLocale::get('view~edition.message.hint.constraint', array($constraints['exp_value']));
+                $this->ctrl->hint = \jLocale::get('view~edition.message.hint.constraint', array($constraints['exp_value']));
             }
         }
     }
@@ -543,39 +546,39 @@ class qgisFormControl
         }
 
         // Data type
-        if ($this->ctrl->datatype instanceof jDatatypeString) {
-            // let's change datatype when control has the default one, jDatatypeString
-            // we don't want to change datatype that are specific to a control type, like in jFormsControlHtmlEditor,
-            // jFormsControlDate etc..
+        if ($this->ctrl->datatype instanceof \jDatatypeString) {
+            // let's change datatype when control has the default one, \jDatatypeString
+            // we don't want to change datatype that are specific to a control type, like in\jFormsControlHtmlEditor,
+            //\jFormsControlDate etc..
 
             switch ($this->fieldDataType) {
                 case 'integer':
-                    $this->ctrl->datatype = new jDatatypeInteger();
+                    $this->ctrl->datatype = new \jDatatypeInteger();
 
                     break;
 
                 case 'float':
-                    $this->ctrl->datatype = new jDatatypeDecimal();
+                    $this->ctrl->datatype = new \jDatatypeDecimal();
 
                     break;
 
                 case 'date':
-                    $this->ctrl->datatype = new jDatatypeDate();
+                    $this->ctrl->datatype = new \jDatatypeDate();
 
                     break;
 
                 case 'datetime':
-                    $this->ctrl->datatype = new jDatatypeDateTime();
+                    $this->ctrl->datatype = new \jDatatypeDateTime();
 
                     break;
 
                 case 'time':
-                    $this->ctrl->datatype = new jDatatypeTime();
+                    $this->ctrl->datatype = new \jDatatypeTime();
 
                     break;
 
                 case 'boolean':
-                    $this->ctrl->datatype = new jDatatypeBoolean();
+                    $this->ctrl->datatype = new \jDatatypeBoolean();
 
                     break;
             }
@@ -586,7 +589,7 @@ class qgisFormControl
             if (array_key_exists('readonly', $this->qgisEdittypeMap[$this->fieldEditType]['jform'])) {
                 $this->isReadOnly = true;
             }
-            if ($this->edittype && ($this->edittype instanceof SimpleXMLElement)) {
+            if ($this->edittype && ($this->edittype instanceof \SimpleXMLElement)) {
                 $isEditable = true;
                 // Also use "editable" property
                 if (property_exists($this->edittype->attributes(), 'editable')) {
@@ -649,7 +652,7 @@ class qgisFormControl
     {
 
         // Create a datasource for some types : menulist
-        $dataSource = new jFormsStaticDatasource();
+        $dataSource = new \jFormsStaticDatasource();
 
         // Create an array of data specific for the qgis edittype
         $data = array();
@@ -680,7 +683,7 @@ class qgisFormControl
                 if ($this->fieldEditType === 'UniqueValuesEditable') {
                     $this->uniqueValuesData['editable'] = true;
                 }
-                if (($this->edittype instanceof SimpleXMLElement) && $this->edittype->widgetv2config) {
+                if (($this->edittype instanceof \SimpleXMLElement) && $this->edittype->widgetv2config) {
                     $this->uniqueValuesData['notNull'] = filter_var($this->widgetv2configAttr->notNull, FILTER_VALIDATE_BOOLEAN);
                     $this->uniqueValuesData['editable'] = filter_var($this->widgetv2configAttr->Editable, FILTER_VALIDATE_BOOLEAN);
                 } elseif (is_object($this->edittype)) {
@@ -704,7 +707,7 @@ class qgisFormControl
 
                 break;
             case 'ValueMap':
-                if ($this->edittype instanceof SimpleXMLElement) {
+                if ($this->edittype instanceof \SimpleXMLElement) {
                     foreach ($this->edittype->widgetv2config->xpath('value') as $value) {
                         $k = (string) $value->attributes()->key;
                         $v = (string) $value->attributes()->value;
@@ -807,7 +810,7 @@ class qgisFormControl
                 $filterExpression = (string) $this->widgetv2configAttr->FilterExpression;
                 $useCompleter = filter_var($this->widgetv2configAttr->UseCompleter, FILTER_VALIDATE_BOOLEAN);
                 $fieldEditable = true;
-                if (($this->edittype instanceof SimpleXMLElement) && property_exists($this->widgetv2configAttr, 'fieldEditable')) {
+                if (($this->edittype instanceof \SimpleXMLElement) && property_exists($this->widgetv2configAttr, 'fieldEditable')) {
                     $fieldEditable = filter_var($this->widgetv2configAttr->fieldEditable, FILTER_VALIDATE_BOOLEAN);
                 } elseif (is_object($this->edittype) && property_exists($this->edittype, 'editable')) {
                     $fieldEditable = filter_var($this->edittype->editable, FILTER_VALIDATE_BOOLEAN);
@@ -834,7 +837,7 @@ class qgisFormControl
                 $MapIdentification = filter_var($this->widgetv2configAttr->MapIdentification, FILTER_VALIDATE_BOOLEAN);
                 $chainFilters = false;
                 $filters = array();
-                if (($this->edittype instanceof SimpleXMLElement)) {
+                if (($this->edittype instanceof \SimpleXMLElement)) {
                     if (property_exists($this->edittype->widgetv2config, 'FilterFields')) {
                         foreach ($this->edittype->widgetv2config->FilterFields->children('field') as $f) {
                             $filters[] = (string) $f->attributes()->name;

--- a/lizmap/modules/lizmap/lib/Form/QgisFormControl.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisFormControl.php
@@ -12,6 +12,8 @@
 
 namespace Lizmap\Form;
 
+use Lizmap\App;
+
 class QgisFormControl
 {
     public $ref = '';
@@ -171,6 +173,9 @@ class QgisFormControl
      */
     protected $widgetv2configAttr;
 
+    /** @var App\AppContextInterface */
+    protected $appContext;
+
     /**
      * Create an jForms control object based on a qgis edit widget.
      * And add it to the passed form.
@@ -183,7 +188,7 @@ class QgisFormControl
      * @param array               $constraints        the QGIS constraints
      * @param object              $rendererCategories simplexml object corresponding to the QGIS categories of the renderer
      */
-    public function __construct($ref, $edittype, $prop, $aliasXml = null, $defaultValue = null, $constraints = null, $rendererCategories = null)
+    public function __construct($ref, $edittype, $prop, $aliasXml = null, $defaultValue = null, $constraints = null, $rendererCategories = null, App\AppContextInterface $appContext)
     {
 
     // Add new editTypes naming convention since QGIS 2.4
@@ -215,6 +220,7 @@ class QgisFormControl
         // Set class attributes
         $this->ref = $ref;
         $this->fieldName = $ref;
+        $this->appContext = $appContext;
         if (is_string($aliasXml)) {
             $this->fieldAlias = $aliasXml;
         } elseif ($aliasXml and is_array($aliasXml) and count($aliasXml) != 0) {
@@ -343,59 +349,59 @@ class QgisFormControl
                 break;
 
             case 'menulist':
-                $this->ctrl = new\jFormsControlMenulist($this->ref);
+                $this->ctrl = new \jFormsControlMenulist($this->ref);
                 $this->fillControlDatasource();
 
                 break;
 
             case 'checkboxes':
-                $this->ctrl = new\jFormsControlCheckboxes($this->ref);
+                $this->ctrl = new \jFormsControlCheckboxes($this->ref);
                 $this->fillControlDatasource();
 
                 break;
 
             case 'hidden':
-                $this->ctrl = new\jFormsControlHidden($this->ref);
+                $this->ctrl = new \jFormsControlHidden($this->ref);
 
                 break;
 
             case 'checkbox':
-                $this->ctrl = new\jFormsControlCheckbox($this->ref);
+                $this->ctrl = new \jFormsControlCheckbox($this->ref);
                 $this->fillCheckboxValues();
 
                 break;
 
             case 'textarea':
-                $this->ctrl = new\jFormsControlTextarea($this->ref);
+                $this->ctrl = new \jFormsControlTextarea($this->ref);
 
                 break;
 
             case 'htmleditor':
-                $this->ctrl = new\jFormsControlHtmlEditor($this->ref);
+                $this->ctrl = new \jFormsControlHtmlEditor($this->ref);
 
                 break;
 
             case 'date':
-                $this->ctrl = new\jFormsControlDate($this->ref);
+                $this->ctrl = new \jFormsControlDate($this->ref);
 
                 break;
 
             case 'datetime':
-                $this->ctrl = new\jFormsControlDatetime($this->ref);
+                $this->ctrl = new \jFormsControlDatetime($this->ref);
 
                 break;
 
             case 'time':
-                //$this->ctrl = new\jFormsControlDatetime($this->ref);
-                $this->ctrl = new\jFormsControlInput($this->ref);
+                //$this->ctrl = new \jFormsControlDatetime($this->ref);
+                $this->ctrl = new \jFormsControlInput($this->ref);
 
                 break;
 
             case 'upload':
-                $choice = new\jFormsControlChoice($this->ref.'_choice');
+                $choice = new \jFormsControlChoice($this->ref.'_choice');
                 $choice->createItem('keep', 'keep');
                 $choice->createItem('update', 'update');
-                $upload = new\jFormsControlUpload($this->ref);
+                $upload = new \jFormsControlUpload($this->ref);
                 if ($this->fieldEditType === 'Photo') {
                     $upload->mimetype = array('image/jpg', 'image/jpeg', 'image/pjpeg', 'image/png', 'image/gif');
                     $upload->accept = 'image/jpg, image/jpeg, image/pjpeg, image/png, image/gif';
@@ -485,7 +491,7 @@ class QgisFormControl
                 break;
 
             default:
-                $this->ctrl = new\jFormsControlInput($this->ref);
+                $this->ctrl = new \jFormsControlInput($this->ref);
 
                 break;
         }
@@ -500,7 +506,7 @@ class QgisFormControl
             // Checkbox should not be required
             $this->required = false;
             // Set control
-            $this->ctrl = new\jFormsControlCheckbox($this->ref);
+            $this->ctrl = new \jFormsControlCheckbox($this->ref);
             // Check data list
             foreach ($data as $k => $v) {
                 $strK = strtolower($k);
@@ -526,7 +532,7 @@ class QgisFormControl
             if ($constraints['exp_desc'] !== '') {
                 $this->ctrl->hint = $constraints['exp_desc'];
             } else {
-                $this->ctrl->hint = \jLocale::get('view~edition.message.hint.constraint', array($constraints['exp_value']));
+                $this->ctrl->hint = $this->appContext->getLocale('view~edition.message.hint.constraint', array($constraints['exp_value']));
             }
         }
     }

--- a/lizmap/modules/lizmap/lib/Form/QgisFormControlsInterface.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisFormControlsInterface.php
@@ -7,7 +7,10 @@
  *
  * @license Mozilla Public License : http://www.mozilla.org/MPL/
  */
-interface qgisFormControlsInterface
+
+namespace Lizmap\Form;
+
+interface QgisFormControlsInterface
 {
     /**
      * @return qgisFormControl[]

--- a/lizmap/modules/lizmap/lib/Form/QgisFormValueRelationDynamicDatasource.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisFormValueRelationDynamicDatasource.php
@@ -1,8 +1,10 @@
 <?php
 
+namespace Lizmap\Form;
+
 require_once JELIX_LIB_PATH.'forms/jFormsDatasource.class.php';
 
-class qgisFormValueRelationDynamicDatasource extends jFormsDynamicDatasource
+class QgisFormValueRelationDynamicDatasource extends \jFormsDynamicDatasource
 {
     //protected $formid;
     protected $ref;
@@ -28,7 +30,7 @@ class qgisFormValueRelationDynamicDatasource extends jFormsDynamicDatasource
 
         $repository = $privateData['liz_repository'];
         $project = $privateData['liz_project'];
-        $lproj = lizmap::getProject($repository.'~'.$project);
+        $lproj = \lizmap::getProject($repository.'~'.$project);
 
         $layer = $lproj->getLayer($layerId);
 
@@ -41,7 +43,7 @@ class qgisFormValueRelationDynamicDatasource extends jFormsDynamicDatasource
                 if ($ref == $privateData['liz_geometryColumn']) {
                     // from wkt to geom
                     $wkt = trim($form->getData($ref));
-                    $geom = lizmapWkt::parse($wkt);
+                    $geom = \lizmapWkt::parse($wkt);
                 } else {
                     // properties
                     $values[$ref] = $form->getData($ref);
@@ -55,7 +57,7 @@ class qgisFormValueRelationDynamicDatasource extends jFormsDynamicDatasource
             );
 
             // Get Feature With Forms Scope
-            $features = qgisExpressionUtils::getFeatureWithFormScope($layer, $filterExpression, $form_feature, array($keyColumn, $valueColumn));
+            $features = \qgisExpressionUtils::getFeatureWithFormScope($layer, $filterExpression, $form_feature, array($keyColumn, $valueColumn));
             foreach ($features as $feat) {
                 if (property_exists($feat, 'properties')
                     and property_exists($feat->properties, $keyColumn)
@@ -80,12 +82,12 @@ class qgisFormValueRelationDynamicDatasource extends jFormsDynamicDatasource
             );
 
             // Perform request
-            $wfsRequest = new lizmapWFSRequest($lproj, $params);
+            $wfsRequest = new \lizmapWFSRequest($lproj, $params);
             $wfsResult = $wfsRequest->process();
 
             $data = $wfsResult->data;
             if (property_exists($wfsResult, 'file') and $wfsResult->file and is_file($data)) {
-                $data = jFile::read($data);
+                $data = \jFile::read($data);
             }
             $mime = $wfsResult->mime;
 
@@ -132,7 +134,7 @@ class qgisFormValueRelationDynamicDatasource extends jFormsDynamicDatasource
 
         $repository = $privateData['liz_repository'];
         $project = $privateData['liz_project'];
-        $lproj = lizmap::getProject($repository.'~'.$project);
+        $lproj = \lizmap::getProject($repository.'~'.$project);
 
         $layer = $lproj->getLayer($layerId);
 
@@ -161,19 +163,19 @@ class qgisFormValueRelationDynamicDatasource extends jFormsDynamicDatasource
         );
 
         // Perform request
-        $wfsRequest = new lizmapWFSRequest($lproj, $params);
+        $wfsRequest = new \lizmapWFSRequest($lproj, $params);
         $wfsResult = $wfsRequest->process();
 
         $data = $wfsResult->data;
         if (property_exists($wfsResult, 'file') and $wfsResult->file and is_file($data)) {
-            $data = jFile::read($data);
+            $data = \jFile::read($data);
         }
         $mime = $wfsResult->mime;
 
         if ($data && (strpos($mime, 'text/json') === 0 ||
                       strpos($mime, 'application/json') === 0 ||
                       strpos($mime, 'application/vnd.geo+json') === 0)) {
-            $json = json_decode($result->data);
+            $json = json_decode($wfsResult->data);
             // Get result from json
             $features = $json->features;
             foreach ($features as $feat) {

--- a/tests/units/edition/qgisAttributeFormTest.php
+++ b/tests/units/edition/qgisAttributeFormTest.php
@@ -1,38 +1,48 @@
 <?php
 
+use Lizmap\Form;
 
-class dummyQgisFormControls implements qgisFormControlsInterface {
-
+class dummyQgisFormControls implements Form\QgisFormControlsInterface
+{
     /**
      * @return qgisFormControl[]
      */
-    public function getQgisControls() {
-        return [];
+    public function getQgisControls()
+    {
+        return array();
     }
 
     /**
      * @param string $name
-     * @return qgisFormControl|null null if the control does not exists
+     *
+     * @return null|qgisFormControl null if the control does not exists
      */
-    public function getQgisControl($name) {
+    public function getQgisControl($name)
+    {
         return null;
     }
 
     /**
-     * Return the control name for the jForms form
+     * Return the control name for the jForms form.
+     *
      * @param string $name the name of the qgis control
-     * @return null|string  null if the control does not exist
+     *
+     * @return null|string null if the control does not exist
      */
-    public function getFormControlName($name) {
+    public function getFormControlName($name)
+    {
         return $name;
     }
-
 }
 
-class qgisAttributeFormTest extends PHPUnit_Framework_TestCase {
-
-
-    function testSimpleContainer() {
+/**
+ * @internal
+ * @coversNothing
+ */
+class qgisAttributeFormTest extends PHPUnit_Framework_TestCase
+{
+    public function testSimpleContainer()
+    {
         $xml = '<attributeEditorForm>
             <attributeEditorField showLabel="1" index="0" name="pkuid"/>
             <attributeEditorField showLabel="1" index="1" name="name"/>
@@ -40,7 +50,7 @@ class qgisAttributeFormTest extends PHPUnit_Framework_TestCase {
       </attributeEditorForm>';
         $sXml = simplexml_load_string($xml);
         $controls = new dummyQgisFormControls();
-        $element = new qgisAttributeEditorElement($controls, $sXml, 'foo', 0,0);
+        $element = new qgisAttributeEditorElement($controls, $sXml, 'foo', 0, 0);
 
         $this->assertEquals(3, count($element->getFields()));
 
@@ -95,10 +105,10 @@ class qgisAttributeFormTest extends PHPUnit_Framework_TestCase {
         $this->assertFalse($cc->hasChildren());
         $this->assertEquals('foo-2', $cc->getHtmlId());
         $this->assertEquals('foo', $cc->getParentId());
-
     }
 
-    function testSimpleGroupBox() {
+    public function testSimpleGroupBox()
+    {
         $xml = '<attributeEditorForm>
            <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Generic" groupBox="1" columnCount="0">
             <attributeEditorField showLabel="1" index="0" name="pkuid"/>
@@ -108,7 +118,7 @@ class qgisAttributeFormTest extends PHPUnit_Framework_TestCase {
       </attributeEditorForm>';
         $sXml = simplexml_load_string($xml);
         $controls = new dummyQgisFormControls();
-        $element = new qgisAttributeEditorElement($controls, $sXml, 'foo', 0,0);
+        $element = new qgisAttributeEditorElement($controls, $sXml, 'foo', 0, 0);
 
         $this->assertEquals(3, count($element->getFields()));
 
@@ -180,7 +190,8 @@ class qgisAttributeFormTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('foo-group0', $cc->getParentId());
     }
 
-    function testTabAttributesForm() {
+    public function testTabAttributesForm()
+    {
         $xml = '<attributeEditorForm>
         <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Description" groupBox="0" columnCount="0">
           <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Generic" groupBox="1" columnCount="0">
@@ -200,7 +211,7 @@ class qgisAttributeFormTest extends PHPUnit_Framework_TestCase {
       </attributeEditorForm>';
         $sXml = simplexml_load_string($xml);
         $controls = new dummyQgisFormControls();
-        $element = new qgisAttributeEditorElement($controls, $sXml, 'foo', 0,0);
+        $element = new qgisAttributeEditorElement($controls, $sXml, 'foo', 0, 0);
 
         $this->assertEquals(7, count($element->getFields()));
 
@@ -243,7 +254,6 @@ class qgisAttributeFormTest extends PHPUnit_Framework_TestCase {
         $this->assertFalse($cc->hasChildren());
         $this->assertEquals('foo-tab1-0', $cc->getHtmlId());
         $this->assertEquals('foo-tab1', $cc->getParentId());
-
 
         $tab = $element->getTabChildren()[0];
 
@@ -327,7 +337,6 @@ class qgisAttributeFormTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('foo-tab0-group0-2', $cc->getHtmlId());
         $this->assertEquals('foo-tab0-group0', $cc->getParentId());
 
-
         $cc = $tab2->getChildrenBeforeTab()[0];
 
         $this->assertEquals(0, count($cc->getChildrenBeforeTab()));
@@ -366,6 +375,5 @@ class qgisAttributeFormTest extends PHPUnit_Framework_TestCase {
         $this->assertFalse($cc->hasChildren());
         $this->assertEquals('foo-tab0-group1-2', $cc->getHtmlId());
         $this->assertEquals('foo-tab0-group1', $cc->getParentId());
-
     }
 }


### PR DESCRIPTION
Moving qgisForm * classes to namespace `Lizmap\Form` + changing some Jelix methods in appContext methods.
