### PR TITLE
adding confirm on 'delete group' admin action

### DIFF
--- a/lib/jelix-admin-modules/jacl2db_admin/locales/en_EN/acl2.UTF-8.properties
+++ b/lib/jelix-admin-modules/jacl2db_admin/locales/en_EN/acl2.UTF-8.properties
@@ -18,6 +18,7 @@ rename.button=Rename
 new.name.label=New name:
 delete.group=Delete a group
 delete.button=Delete
+delete.button.confirm.label = Do you want to delete this group ?
 setdefault.button=Set default groups
 has.rights.on.resources = This user has rights on some resources
 see.rights.on.resources = See this rights

--- a/lib/jelix-admin-modules/jacl2db_admin/locales/en_GB/acl2.UTF-8.properties
+++ b/lib/jelix-admin-modules/jacl2db_admin/locales/en_GB/acl2.UTF-8.properties
@@ -28,6 +28,7 @@ message.group.rename.ok=Group renamed
 # form to remove a group
 delete.group=Delete a group
 delete.button=Delete
+delete.button.confirm.label = Do you want to delete this group ?
 message.group.delete.ok=Group deleted
 message.group.delete.error.noacl.yourself=The group cannot be deleted, else you couldn't manage rights
 message.group.delete.error.noacl.anybody=The group cannot be deleted, else nobody couldn't manage rights

--- a/lib/jelix-admin-modules/jacl2db_admin/locales/en_US/acl2.UTF-8.properties
+++ b/lib/jelix-admin-modules/jacl2db_admin/locales/en_US/acl2.UTF-8.properties
@@ -28,6 +28,7 @@ message.group.rename.ok=Group renamed
 # form to remove a group
 delete.group=Delete a group
 delete.button=Delete
+delete.button.confirm.label = Do you want to delete this group ?
 message.group.delete.ok=Group deleted
 message.group.delete.error.noacl.yourself=The group cannot be deleted, else you couldn't manage rights
 message.group.delete.error.noacl.anybody=The group cannot be deleted, else nobody couldn't manage rights

--- a/lib/jelix-admin-modules/jacl2db_admin/locales/fr_FR/acl2.UTF-8.properties
+++ b/lib/jelix-admin-modules/jacl2db_admin/locales/fr_FR/acl2.UTF-8.properties
@@ -28,6 +28,7 @@ message.group.rename.ok = Le groupe a été renommé avec succès
 # form to remove a group
 delete.group = Supprimer un groupe
 delete.button = Supprimer
+delete.button.confirm.label = Voulez vous supprimer ce groupe ?
 message.group.delete.ok = Le groupe a été effacé avec succès
 message.group.delete.error.noacl.yourself=Le groupe ne peut être supprimé, sinon vous ne pourrez plus gérer les droits
 message.group.delete.error.noacl.anybody=Le groupe ne peut être supprimé, sinon personne ne pourra plus gérer les droits

--- a/lib/jelix-admin-modules/jacl2db_admin/templates/groups_edit.tpl
+++ b/lib/jelix-admin-modules/jacl2db_admin/templates/groups_edit.tpl
@@ -53,7 +53,7 @@
     {/foreach}
      </select>
 
-    <input type="submit" value="{@jacl2db_admin~acl2.delete.button@}" />
+    <input type="submit" value="{@jacl2db_admin~acl2.delete.button@}" onclick="return confirm(`{@jacl2db_admin~acl2.delete.button.confirm.label@}`);"/>
 </fieldset>
 </form>
 {/ifacl2}

--- a/lizmap/var/themes/default/jacl2db_admin/groups_edit.tpl
+++ b/lizmap/var/themes/default/jacl2db_admin/groups_edit.tpl
@@ -83,7 +83,7 @@
   </div>
 
   <div class="form-actions">
-    <input type="submit" value="{@jacl2db_admin~acl2.delete.button@}" class="btn"/>
+    <input type="submit" value="{@jacl2db_admin~acl2.delete.button@}" onclick="return confirm(`{@jacl2db_admin~acl2.delete.button.confirm.label@}`);" class="btn"/>
   </div>
 </fieldset>
 </form>


### PR DESCRIPTION
<!---Thanks for your contribution and describing your PR.-->

## Description

*  Ticket : #1793
*  Adding a confirm dialog box before deletion of a group by an admin.
