### PR TITLE
[Bugfix] Get form modified controls

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisForm.class.php
+++ b/lizmap/modules/lizmap/classes/qgisForm.class.php
@@ -545,10 +545,11 @@ class qgisForm implements qgisFormControlsInterface
      * Save the form to the database.
      *
      * @param null|mixed $feature
+     * @param array      $modifiedControls
      *
      * @return array|false|int value of primary key or false if an error occured
      */
-    public function saveToDb($feature = null)
+    public function saveToDb($feature = null, $modifiedControls = array())
     {
         if (!$this->dbFieldsInfo) {
             throw new Exception('Save to database can\'t be done for the layer "'.$this->layer->getName().'"!');
@@ -569,13 +570,10 @@ class qgisForm implements qgisFormControlsInterface
         $dataFields = $this->dbFieldsInfo->dataFields;
         $geometryColumn = $this->dbFieldsInfo->geometryColumn;
 
-        // Get list of fields diplayed in form
+        // Get list of modified fields
         // can be an empty list
-        $formFields = array();
-        $attributeEditorForm = $this->getAttributesEditorForm();
-        if ($attributeEditorForm) {
-            $formFields = $attributeEditorForm->getFields();
-        }
+        $modifiedFields = array_keys($modifiedControls);
+        jLog::log(implode(', ', $modifiedFields), 'error');
 
         // Get list of fields which are not primary keys
         $fields = array();
@@ -601,8 +599,8 @@ class qgisForm implements qgisFormControlsInterface
             // For other column than geometry does not add it
             // if it's column not in form
             if ($fieldName != $geometryColumn
-                && count($formFields) != 0
-                && !in_array($fieldName, $formFields)) {
+                && count($modifiedFields) != 0
+                && !in_array($fieldName, $modifiedFields)) {
                 continue;
             }
 

--- a/lizmap/modules/lizmap/classes/qgisForm.class.php
+++ b/lizmap/modules/lizmap/classes/qgisForm.class.php
@@ -573,7 +573,6 @@ class qgisForm implements qgisFormControlsInterface
         // Get list of modified fields
         // can be an empty list
         $modifiedFields = array_keys($modifiedControls);
-        jLog::log(implode(', ', $modifiedFields), 'error');
 
         // Get list of fields which are not primary keys
         $fields = array();

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -867,7 +867,7 @@ class qgisVectorLayer extends qgisMapLayer
 
             return $pkvals;
         } catch (Exception $e) {
-            jLog::log('SQL = '.$sql);
+            jLog::log('SQL = '.$sql, 'error');
 
             throw $e;
         }

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -604,6 +604,13 @@ class editionCtrl extends jController
         $eventParams['qgisForm'] = $qgisForm;
         jEvent::notify('LizmapEditionSaveGetQgisForm', $eventParams);
 
+        // SELECT data from the database and set the form data accordingly
+        // to check modified fields
+        if ($this->featureId) {
+            $form = $qgisForm->setFormDataFromFields($this->featureData->features[0]);
+        }
+        // Track modified records
+        $form->initModifiedControlsList();
         // Get data from the request and set the form controls data accordingly
         $form->initFromRequest();
 
@@ -637,7 +644,8 @@ class editionCtrl extends jController
             if ($this->featureId) {
                 $feature = $this->featureData->features[0];
             }
-            $pkvals = $qgisForm->saveToDb($feature);
+            // Save to database with modified controls
+            $pkvals = $qgisForm->saveToDb($feature, $form->getModifiedControls());
         }
 
         // Some errors where encoutered


### PR DESCRIPTION
## Description

We have an issue in the way lizmap managed editable fields when the form is applied.

This commit try to indentified only modified fields even if the fields is hidden or not used in the drag and drop form.

Funded by Conseil Départemental des Pyrénées Atlantiques