### PR TITLE
Fix: Track fields changes for creation

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisForm.class.php
+++ b/lizmap/modules/lizmap/classes/qgisForm.class.php
@@ -384,7 +384,7 @@ class qgisForm implements qgisFormControlsInterface
     /**
      * Reset the form controls data to Null.
      *
-     * @return object the Jelix jForm object
+     * @return jFormsBase the Jelix jForm object
      */
     public function resetFormData()
     {
@@ -403,7 +403,7 @@ class qgisForm implements qgisFormControlsInterface
     /**
      * Set the form controls data from the database default value.
      *
-     * @return object the Jelix jForm object
+     * @return jFormsBase the Jelix jForm object
      */
     public function setFormDataFromDefault()
     {
@@ -439,7 +439,7 @@ class qgisForm implements qgisFormControlsInterface
      *
      * @param mixed $feature
      *
-     * @return object the Jelix jForm object
+     * @return jFormsBase the Jelix jForm object
      */
     public function setFormDataFromFields($feature)
     {

--- a/lizmap/modules/lizmap/classes/qgisForm.class.php
+++ b/lizmap/modules/lizmap/classes/qgisForm.class.php
@@ -382,6 +382,25 @@ class qgisForm implements qgisFormControlsInterface
     }
 
     /**
+     * Reset the form controls data to Null.
+     *
+     * @return object the Jelix jForm object
+     */
+    public function resetFormData()
+    {
+        if (!$this->dbFieldsInfo) {
+            return $this->form;
+        }
+
+        $form = $this->form;
+        $dataFields = $this->dbFieldsInfo->dataFields;
+        foreach ($dataFields as $ref => $prop) {
+            $form->setData($ref, Null);
+        }
+        return $form;
+    }
+
+    /**
      * Set the form controls data from the database default value.
      *
      * @return object the Jelix jForm object

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -280,9 +280,9 @@ class editionCtrl extends jController
             return $this->serviceAnswer();
         }
 
-        jForms::destroy('view~edition');
+        jForms::destroy('view~edition', $this->featureId);
         // Create form instance
-        $form = jForms::create('view~edition');
+        $form = jForms::create('view~edition', $this->featureId);
         $form->setData('liz_future_action', $this->param('liz_future_action', 'close'));
 
         // event to add custom field in the jForms form
@@ -605,9 +605,11 @@ class editionCtrl extends jController
         jEvent::notify('LizmapEditionSaveGetQgisForm', $eventParams);
 
         // SELECT data from the database and set the form data accordingly
-        // to check modified fields
+        // or reset form controls data to null to check modified fields
         if ($this->featureId) {
             $form = $qgisForm->setFormDataFromFields($this->featureData->features[0]);
+        } else {
+            $form = $qgisForm->resetFormData();
         }
         // Track modified records
         $form->initModifiedControlsList();


### PR DESCRIPTION
Add a method to reset form controls data before tracking form controls changes for creation feature.