### PR TITLE
[Bugfix] Impossible to upload a file in edition mode

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisForm.class.php
+++ b/lizmap/modules/lizmap/classes/qgisForm.class.php
@@ -590,24 +590,19 @@ class qgisForm implements qgisFormControlsInterface
             if ($jCtrl === null) {
                 continue;
             }
-            // Control is an upload control
-            if ($jCtrl instanceof jFormsControlUpload) {
-                $values[$fieldName] = $this->processUploadedFile($form, $fieldName, $cnx);
-            } else {
 
-                // Get and filter the posted data foreach form control
-                $value = $form->getData($fieldName);
+            // Get and filter the posted data foreach form control
+            $value = $form->getData($fieldName);
 
-                if (is_array($value)) {
-                    $value = '{'.implode(',', $value).'}';
-                }
-
-                if ($value === '') {
-                    $value = null;
-                }
-
-                $values[$fieldName] = $value;
+            if (is_array($value)) {
+                $value = '{'.implode(',', $value).'}';
             }
+
+            if ($value === '') {
+                $value = null;
+            }
+
+            $values[$fieldName] = $value;
 
             // Get expression constraint
             $constraints = $this->getConstraints($fieldName);


### PR DESCRIPTION
* fixes #1898

`qgisForm::processUploadedFile()` is called twice, once in `qgisForm::check()` and once in `qgisForm::saveToDb()`.

`qgisForm::processUploadedFile()` has not to be called in `qgisForm::check()`, it is called to get the value for checking constraints but it is not needed to process uploaded file.
