### PR TITLE
[Bugfix] With lizmap plugin server side, override login by filter is not respected

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapOGCRequest.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapOGCRequest.class.php
@@ -132,18 +132,22 @@ class lizmapOGCRequest
     {
         // Check if a user is authenticated
         if (!jAuth::isConnected()) {
-            // return empty header array
+            // return parameters with empty user param
             return array_merge($this->params, array(
                 'Lizmap_User' => '',
                 'Lizmap_User_Groups' => '',
             ));
         }
+
+        // Provide user and groups to lizmap plugin access control
         $user = jAuth::getUserSession();
         $userGroups = jAcl2DbUserGroup::getGroups();
+        $loginFilteredOverride = jAcl2::check('lizmap.tools.loginFilteredLayers.override', $this->repository->getKey());
 
         return array_merge($this->params, array(
             'Lizmap_User' => $user->login,
             'Lizmap_User_Groups' => implode(', ', $userGroups),
+            'Lizmap_Override_Filter' => $loginFilteredOverride,
         ));
     }
 

--- a/lizmap/modules/lizmap/classes/lizmapProxy.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProxy.class.php
@@ -141,6 +141,9 @@ class lizmapProxy
             self::userHttpHeader(),
             $options['headers']
         );
+        if (isset($options['loginFilteredOverride'])) {
+            $options['headers']['X-Lizmap-Override-Filter'] = $options['loginFilteredOverride'];
+        }
 
         // Initialize responses
         $http_code = null;
@@ -269,9 +272,14 @@ class lizmapProxy
     {
         // Check if a user is authenticated
         if (!jAuth::isConnected()) {
-            // return empty header array
-            return array();
+            // return headers with empty user header
+            return array(
+                'X-Lizmap-User' => '',
+                'X-Lizmap-User-Groups' => '',
+            );
         }
+
+        // Provide user and groups to lizmap plugin access control
         $user = jAuth::getUserSession();
         $userGroups = jAcl2DbUserGroup::getGroups();
 


### PR DESCRIPTION
The lizmapOGCRequest does not check if the user has the right to override the login by filter.

If the user has the right to override the login by filter, lizmap has to send it to QGIS Server with an extra parameters `LIZMAP_OVERRIDE_FILTER`.

* Funded by Grand Narbonne
