### PR TITLE
[Bugfix] Admin export logs - No output with big logs table

### DIFF
--- a/lizmap/modules/admin/controllers/logs.classic.php
+++ b/lizmap/modules/admin/controllers/logs.classic.php
@@ -197,7 +197,7 @@ class logsCtrl extends jController
         $rep->doDownload = true;
         $rep->deleteFileAfterSending = true;
         $rep->fileName = $fileName;
-        $rep->outputFileName = 'lizmap_logs.csv';
+        $rep->outputFileName = 'lizmap_logs_'.date('YmdHi')'.csv';
 
         return $rep;
     }

--- a/lizmap/modules/admin/controllers/logs.classic.php
+++ b/lizmap/modules/admin/controllers/logs.classic.php
@@ -168,22 +168,36 @@ class logsCtrl extends jController
             $columns = array_keys($fetchArray);
         }
 
-        $rep = $this->getResponse('binary');
-        $rep->mimeType = 'text/csv';
-        $rep->addHttpHeader('charset', 'UTF-8');
-        $rep->doDownload = true;
-        $rep->fileName = 'lizmap_logs.csv';
+        # Create temp file
+        $tempPath = jApp::tempPath('export');
+        jFile::createDir($tempPath);
+        $fileName = tempnam($tempPath, 'lizmap_logs-');
 
-        $data = array();
-        $data[] = '"'.implode('";"', $columns).'"';
+        # Opening file
+        $fp = fopen($fileName, 'w');
+        # Adding encode utf8 to the file
+        fprintf($fp, chr(0xEF).chr(0xBB).chr(0xBF));
+        # Adding first CSV line
+        fputcsv($fp, $columns);
+        # Adding content
         foreach ($logs as $log) {
             $row = array();
             foreach ($columns as $column) {
                 $row[] = $log->{$column};
             }
-            $data[] = '"'.implode('";"', $row).'"';
+            fputcsv($fp, $row);
         }
-        $rep->content = implode("\r\n", $data);
+        # Closing file
+        fclose($fp);
+
+        # Create response
+        $rep = $this->getResponse('binary');
+        $rep->mimeType = 'text/csv';
+        $rep->addHttpHeader('charset', 'UTF-8');
+        $rep->doDownload = true;
+        $rep->deleteFileAfterSending = true;
+        $rep->fileName = $fileName;
+        $rep->outputFileName = 'lizmap_logs.csv';
 
         return $rep;
     }


### PR DESCRIPTION
If the lags table is too big, the controller does not build the output.

This commit fix it.
