### PR TITLE
Fix notice project

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -4,6 +4,11 @@ Changelog 3.2
 Version 3.2.18 (next)
 ---------------------
 
+- update locales
+- Upgrade the ldapdao module, to fix ldap connection management
+- Update IGN attribution
+- Fix a PHP notice about the existence of the hideLayer property
+
 Version 3.2.17
 ---------------------
 

--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -658,8 +658,10 @@ class lizmapProject extends qgisProject
             $hasDisplayedLayer = !$onlyDisplayedLayers;
             foreach ($this->cfg->attributeLayers as $key => $obj) {
                 ++$count;
-                if ($onlyDisplayedLayers && !property_exists($obj, 'hideLayer') ||
-                    strtolower($obj->hideLayer) != 'true') {
+                if ($onlyDisplayedLayers &&
+                    (!property_exists($obj, 'hideLayer') ||
+                     strtolower($obj->hideLayer) != 'true')
+                ) {
                     $hasDisplayedLayer = true;
                 }
             }


### PR DESCRIPTION
There are tons of logs about the code of `lizmapProject::hasAttributeLayers()`, because of the operator priority when $onlyDisplayedLayers is false, in this method.