### PR TITLE
Fix form init modified controls list management

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisForm.class.php
+++ b/lizmap/modules/lizmap/classes/qgisForm.class.php
@@ -631,10 +631,18 @@ class qgisForm implements qgisFormControlsInterface
         }
 
         if (count($fields) == 0) {
-            jLog::log('Not enough capabilities for this layer ! SQL cannot be constructed: no fields available !', 'error');
-            $this->form->setErrorOn($geometryColumn, jLocale::get('view~edition.message.error.save').' '.jLocale::get('view~edition.message.error.save.fields'));
-
-            throw new Exception(jLocale::get('view~edition.link.error.sql'));
+            if ($insertAction) {
+                // For insertion, one field has to be set
+                jLog::log('Error in form, SQL cannot be constructed: no fields available for insert !', 'error');
+                $this->form->setErrorOn($geometryColumn, jLocale::get('view~edition.message.error.save').' '.jLocale::get('view~edition.message.error.save.fields'));
+                // do not throw an exception to let the user update the form
+                jLog::log(jLocale::get('view~edition.link.error.sql'), 'error');
+                return false;
+            } else {
+                // For update, nothing has changed so nothing to do except close form
+                jLog::log('SQL cannot be constructed: no fields available for update !', 'error');
+                return true;
+            }
         }
 
         $form = $this->form;

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -606,13 +606,22 @@ class editionCtrl extends jController
 
         // SELECT data from the database and set the form data accordingly
         // or reset form controls data to null to check modified fields
+        // and save default data
+        $defaultFormData = array();
         if ($this->featureId) {
             $form = $qgisForm->setFormDataFromFields($this->featureData->features[0]);
         } else {
+            $defaultFormData = $form->getAllData();
             $form = $qgisForm->resetFormData();
         }
         // Track modified records
         $form->initModifiedControlsList();
+        // Apply default data to get save it
+        foreach( $defaultFormData as $ref => $val ) {
+            if ( $val !== null ) {
+                $form->setdata($ref, $val);
+            }
+        }
         // Get data from the request and set the form controls data accordingly
         $form->initFromRequest();
 


### PR DESCRIPTION
* Apply default value after initModifiedControlsList to be saved in database
* Fix when no fields modified
  * If it's an insert return false and reopen the form
  * If it's an update return true to close the form and do not execute an SQL UPDATE.

* Funded by Terre de Provence Agglomération
