### PR TITLE
FixBug: mandatory relational value by default

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisForm.class.php
+++ b/lizmap/modules/lizmap/classes/qgisForm.class.php
@@ -1161,7 +1161,10 @@ class qgisForm implements qgisFormControlsInterface
             $dataSource = new jFormsStaticDatasource();
 
             // required
-            if (!$formControl->valueRelationData['allowNull']) {
+            if (array_key_exists('notNull', $formControl->valueRelationData)
+                and $formControl->valueRelationData['notNull']
+            ) {
+                jLog::log('notNull '.$formControl->valueRelationData['notNull'], 'error');
                 $formControl->ctrl->required = true;
             }
             // combobox
@@ -1173,7 +1176,7 @@ class qgisForm implements qgisFormControlsInterface
 
             // Add default empty value for required fields
             // Jelix does not do it, but we think it is better this way to avoid unwanted set values
-            if ($formControl->ctrl->required) {
+            if ($formControl->ctrl->required or $formControl->valueRelationData['allowNull']) {
                 $data[''] = '';
             }
 


### PR DESCRIPTION
<!-- Add "fix" in front of "#" if it fixes the ticket or do nothing to only mention it.

This PR will be harvested on changelog.lizmap.com if there is a "changelog" label.
Funded by NAME URL
-->
* In Lizmap 3.3.12-pre, there is a default relational value type field bug.
* This PR fix this bug
