### PR TITLE
Fix scale values to match those defined in plugin

### DIFF
--- a/assets/src/components/Scaleline.js
+++ b/assets/src/components/Scaleline.js
@@ -7,11 +7,18 @@ export default class Scaleline extends HTMLElement {
     }
 
     connectedCallback() {
+
+        // DPI is adjusted here because this commit https://github.com/openlayers/openlayers/commit/857f4e01ac9c6c27d83f7cc1f5eda86c53405228
+        // has not been released yet. Also we use 25.40005080010160020 as it is more precise
+        // TODO : Change this value when commit released and Lizmap up to date with OL 6
+        const ADJUSTED_DPI = (96 * 1000) / (25.40005080010160020 * 39.37);
+
         this._olScaleline = new ScaleLine({
             target: this,
             minWidth: 76,
             bar: true,
-            text: true
+            text: true,
+            dpi: ADJUSTED_DPI
         });
 
         mainLizmap.map._olMap.addControl(

--- a/assets/src/modules/Lizmap.js
+++ b/assets/src/modules/Lizmap.js
@@ -30,6 +30,11 @@ export default class Lizmap {
                 }
                 register(proj4);
 
+                // Override getPointResolution method to always return resolution
+                // without taking care of geodesic adjustment as it can be confusing for user to not have rounded scales
+                (getProjection(this.projection)).setGetPointResolution((resolution) => resolution);
+                (getProjection(this.config.options.qgisProjectProjection.ref)).setGetPointResolution((resolution) => resolution);
+
                 // Create Lizmap modules
                 this.map = new Map();
                 this.edition = new Edition();

--- a/assets/src/modules/Map.js
+++ b/assets/src/modules/Map.js
@@ -27,8 +27,7 @@ export default class Map {
             view: new View({
                 center: [0, 0],
                 zoom: 2,
-                projection: mainLizmap.projection,
-                constrainResolution: true
+                projection: mainLizmap.projection
             }),
             target: 'newOlMap'
         });


### PR DESCRIPTION
Scales are those defined in Lizmap plugin when there is no EPSG:3857 base layers defined
Fix #1938

* Funded by 3Liz
