### PR TITLE
[Bugfix] Attribute edition sets to null unedited fields

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisForm.class.php
+++ b/lizmap/modules/lizmap/classes/qgisForm.class.php
@@ -254,6 +254,20 @@ class qgisForm implements qgisFormControlsInterface
             $this->formControls[$fieldName] = $formControl;
         }
 
+        // Deactivate undisplayed fields in Drag and Drop form
+        $attributeEditorForm = $this->getAttributesEditorForm();
+        if ($attributeEditorForm) {
+            $attributeEditorFormFields = $attributeEditorForm->getFields();
+            if (count($attributeEditorFormFields) > 0) {
+                foreach ($this->formControls as $fieldName => $formControl) {
+                    if (in_array($fieldName, $attributeEditorFormFields)) {
+                        continue;
+                    }
+                    $form->setReadOnly($formControl->getControlName(), true);
+                }
+            }
+        }
+
         // Hide when no modify capabilities, only for UPDATE cases (  when $this->featureId control exists )
         if (!empty($featureId) && strtolower($capabilities->modifyAttribute) == 'false') {
             foreach ($toDeactivate as $de) {


### PR DESCRIPTION
To fix this issue, any fields not in QGIS Drag and Drop Form are deactivated.

Fixes #1994

* Funded by 3liz
