### PR TITLE
Revert [Bugfix] Enclose primary keys in UPDATE RETURNING

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -815,10 +815,8 @@ class qgisVectorLayer extends qgisMapLayer
         $sql .= $uwhere;
 
         // Get select clause for primary keys (used when inserting data in postgresql)
-        $returnKeys = array();
-        foreach ($array_keys($pk) as $key) {
-            $returnKeys[] = $cnx->encloseName($key);
-        }
+        $returnKeys = array_keys($pk);
+
         $returnKeysString = implode(', ', $returnKeys);
         // For spatialite, we will run a complementary query to retrieve the pkeys
         if ($this->provider == 'postgres') {

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -816,7 +816,7 @@ class qgisVectorLayer extends qgisMapLayer
 
         // Get select clause for primary keys (used when inserting data in postgresql)
         $returnKeys = array();
-        foreach (array_keys($pk) as $key) {
+        foreach ($array_keys($pk) as $key) {
             $returnKeys[] = $cnx->encloseName($key);
         }
         $returnKeysString = implode(', ', $returnKeys);


### PR DESCRIPTION
The changes made to enclose primary keys in UPDATE RETURNING is not necessary in release_3_3 because it is done in `getPkWhereClause`

Fix regression introduced by #2014