### PR TITLE
[GH Action] PHPStan setup

### DIFF
--- a/.github/workflows/php-stan.yml
+++ b/.github/workflows/php-stan.yml
@@ -44,5 +44,3 @@ jobs:
       - name: Run PHPStan
         run: phpstan analyse -c ../phpstan.neon
 
-      # - name: PHPStan
-      #   uses: chindit/actions-phpstan@master


### PR DESCRIPTION
This PR introduces PHPStan as a github Action to staticly analize the php code on each PR/push on master.
Some errors are fixed, the others are in #2024.

The rule level is set to 0 (the minimum) for now, we can increase it progressively once each level is fixed.

@Gustry we have the choice between using [this action](https://github.com/chindit/actions-phpstan) or [this one](https://github.com/shivammathur/setup-php#phpstan) (that we already use to install dependencies), which one do you think is best ?