### PR TITLE
[Bugfix] The landing page shouldn't show project when not available for groups ACL

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -2372,11 +2372,6 @@ class lizmapProject extends qgisProject
             return false;
         }
 
-        // Check user is admin -> ok, give permission
-        if (jAcl2::check('lizmap.admin.repositories.delete')) {
-            return true;
-        }
-
         // Check if configured groups white list and authenticated user groups list intersects
         $aclGroups = $this->cfg->options->acl;
         $userGroups = jAcl2DbUserGroup::getGroups();
@@ -2406,11 +2401,6 @@ class lizmapProject extends qgisProject
 
         // Check acl option is configured in project config
         if (!property_exists($this->cfg->options, 'acl') || !is_array($this->cfg->options->acl) || empty($this->cfg->options->acl)) {
-            return true;
-        }
-
-        // Check user is admin -> ok, give permission
-        if (jAcl2::checkByUser($login, 'lizmap.admin.repositories.delete')) {
             return true;
         }
 


### PR DESCRIPTION
fixes #2032
fixes #2012

The test is described in #2032 

* [ ] Given a project with fake groups : restrict, to, this, group
* [ ] The project is not visible in landing page for anonymous
* [ ] The project is not visible in landing page for a user not in admins group
* [ ] The project is not visible in landing page for a user in admins group
