### PR TITLE
[Bugfix] Cache does not work after authorization

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapProxy.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProxy.class.php
@@ -318,8 +318,18 @@ class lizmapProxy
 
         // Get cache if exists
         $keyParams = $params;
+        // Remove keys not necessary for cache
         if (array_key_exists('map', $keyParams)) {
             unset($keyParams['map']);
+        }
+        if (array_key_exists('lizmap_user', $keyParams)) {
+            unset($keyParams['lizmap_user']);
+        }
+        if (array_key_exists('lizmap_user_groups', $keyParams)) {
+            unset($keyParams['lizmap_user_groups']);
+        }
+        if (array_key_exists('lizmap_override_filter', $keyParams)) {
+            unset($keyParams['lizmap_override_filter']);
         }
         ksort($keyParams);
 


### PR DESCRIPTION
Auto-generated cache is not used

To get authentication control in QGIS Server, extra parameters are added to GetMap WMS URLs. These parameters has to be removed to build the key of the cache.

Fixes #1993

* Funded by
