### PR TITLE
[Bugfix] Tab content is not visible on mobile screen

### DIFF
--- a/lizmap/www/assets/js/edition.js
+++ b/lizmap/www/assets/js/edition.js
@@ -1523,7 +1523,11 @@ OpenLayers.Geometry.pointOnSegment = function(point, segment) {
                 }
             }
             // Check li (tabs) visibility
-            if (form.children('ul.nav-tabs').find('li:visible').length == 0 ) {
+            var visibleTabs = form.children('ul.nav-tabs').find('li').filter(
+                function(){
+                    return $(this).css('display') !== 'none';
+                });
+            if (visibleTabs.length == 0 ) {
                 // No tabs visible, hide the tab content
                 $('#'+form.attr('id')+'-tab-content').hide();
             } else {


### PR DESCRIPTION
Fixes #2019 Tab content is not visible using Edition on Android (Lizmap 3.4.0)

The way lizmap checks the edition form tab visibility was not the right way. Lizmap checks visibility instead of checks if tab has not display:none

* Funded by 3liz

To test in a desktop browser:
* [ ] Go to a map with creation capabilities and a form with QGIS Drag an Drop form configuration and tabs
* [ ] Activate mobile display
* [ ] Reload the page to get the mobile UI
* [ ] Go to Edition and click on Add
* [ ] Go to Edition to display the form and check that the form content is well displayed