### PR TITLE
[Bugfix] Regression - Edition - Geometry is not retrieved and saved

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisForm.class.php
+++ b/lizmap/modules/lizmap/classes/qgisForm.class.php
@@ -263,7 +263,14 @@ class qgisForm implements qgisFormControlsInterface
                     if (in_array($fieldName, $attributeEditorFormFields)) {
                         continue;
                     }
-                    $form->setReadOnly($formControl->getControlName(), true);
+                    if ($formControl->ctrl->type == 'hidden') {
+                        continue;
+                    }
+                    $ctrlref = $formControl->getControlName();
+                    if (!$form->isActivated($ctrlref)) {
+                        continue;
+                    }
+                    $form->setReadOnly($ctrlref, true);
                 }
             }
         }


### PR DESCRIPTION
The #2013 to fix #1994 has introduced a regression in form edition.

When submitted the form, the geometry is not retrieved and saved. The form isdisplayed with an error message about geometry not submitted.

* Funded by 3liz
