### PR TITLE
Popup children fetchall

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -1,0 +1,9 @@
+# Changelog Lizmap 3.5
+
+## Version 3.5.0
+
+Not released yet
+
+### New JS events
+
+- `lizmappopupallchildrendisplayed` is raised when all children popups have been displayed

--- a/lizmap/modules/view/templates/popup.tpl
+++ b/lizmap/modules/view/templates/popup.tpl
@@ -1,5 +1,5 @@
 <div class="lizmapPopupSingleFeature">
-    <h4>{$layerTitle}</h4>
+    <h4 class="lizmapPopupTitle">{$layerTitle}</h4>
 
     <div class="lizmapPopupDiv">
     {$popupContent}

--- a/lizmap/www/assets/js/map.js
+++ b/lizmap/www/assets/js/map.js
@@ -3190,7 +3190,7 @@ var lizMap = function() {
                   clname = cleanName(configLayer.name);
                   configLayer.cleanname = clname;
                 }
-                var childPopup = $('<div class="lizmapPopupChildren ' + clname + '">' + popupChildData + '</div>');
+                var childPopup = $('<div class="lizmapPopupChildren ' + clname + '" data-layername="' + clname + '">' + popupChildData + '</div>');
 
                 //Manage if the user choose to create a table for children
                 if (configLayer.popupSource == 'qgis' &&

--- a/lizmap/www/assets/js/map.js
+++ b/lizmap/www/assets/js/map.js
@@ -3235,13 +3235,18 @@ var lizMap = function() {
 
                 parentDiv.append(childPopup);
 
-                // Trigger event
+                // Trigger event for single popup children
                 lizMap.events.triggerEvent(
                   "lizmappopupchildrendisplayed",
                   { 'html': childPopup.html() }
                 );
               }
             }
+            // Trigger event for all popup children
+            lizMap.events.triggerEvent(
+              "lizmappopupallchildrendisplayed",
+              { 'html': popupChildrenData }
+            );
           });
         });
       });

--- a/lizmap/www/assets/js/map.js
+++ b/lizmap/www/assets/js/map.js
@@ -3156,7 +3156,7 @@ var lizMap = function() {
                     );
 
                     // Keep `rConfigLayer` in array with same order that fetch queries
-                    // for later user when Promise.all resolves
+                    // for later user when Promise.allSettled resolves
                     rConfigLayerAll.push(rConfigLayer);
                     popupChidrenRequests.push(
                       fetch(service, {
@@ -3170,13 +3170,13 @@ var lizMap = function() {
               }
           }
 
-          // Execute promise all
-          Promise.all(popupChidrenRequests).then(popupChildrenData => {
+          // Fetch GetFeatureInfo query for every children popups
+          Promise.allSettled(popupChidrenRequests).then(popupChildrenData => {
 
             childPopupElements = [];
 
             for (let index = 0; index < popupChildrenData.length; index++) {
-              let popupChildData = popupChildrenData[index];
+              let popupChildData = popupChildrenData[index].value;
               
               var hasPopupContent = (!(!popupChildData || popupChildData == null || popupChildData == ''))
               if (hasPopupContent) {

--- a/lizmap/www/assets/js/map.js
+++ b/lizmap/www/assets/js/map.js
@@ -3172,6 +3172,9 @@ var lizMap = function() {
 
           // Execute promise all
           Promise.all(popupChidrenRequests).then(popupChildrenData => {
+
+            childPopupElements = [];
+
             for (let index = 0; index < popupChildrenData.length; index++) {
               let popupChildData = popupChildrenData[index];
               
@@ -3235,6 +3238,8 @@ var lizMap = function() {
 
                 parentDiv.append(childPopup);
 
+                childPopupElements.push(childPopup);
+
                 // Trigger event for single popup children
                 lizMap.events.triggerEvent(
                   "lizmappopupchildrendisplayed",
@@ -3245,7 +3250,10 @@ var lizMap = function() {
             // Trigger event for all popup children
             lizMap.events.triggerEvent(
               "lizmappopupallchildrendisplayed",
-              { 'html': popupChildrenData }
+              {
+                parentPopupElement: self.parents('.lizmapPopupSingleFeature'),
+                childPopupElements: childPopupElements
+              }
             );
           });
         });


### PR DESCRIPTION
Fetch all children popup instead of using jQuery post.
This allows having new `lizmappopupallchildrendisplayed` event launched when all children popup have been fetched.

* Funded by Grand Narbonne
