### PR TITLE
Fix visual blank line between map and right-dock

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -5,6 +5,7 @@
 Not released yet
 
 - Fix lizmap/install/set_rights.sh: some directories were missing
+- Fix visual blank line between the map and the right-dock
 
 
 ## Version 3.4.1

--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -1161,7 +1161,9 @@ transform: none !important;
 }
 
 #content.right-dock-visible #map-content{
-  margin-right:30%;
+  /* 30/100 is linked to #right-dock{width: 30%;}
+  TODO : avoid use of calc() and hard value */
+  margin-right: calc((100% - 30px)*30/100);
 }
 #content.mobile.right-dock-visible #map-content{
   margin-right:0px;


### PR DESCRIPTION
* Fix #2061
* Funded by 3Liz
@rldhont This can be easily tested editing CSS in this project : https://liz.lizmap.com/etrimaille/index.php/view/map/?repository=test&project=earthquake