### PR TITLE
[Fix] Disable selection tool when mini-dock closed

### DIFF
--- a/assets/src/modules/SelectionTool.js
+++ b/assets/src/modules/SelectionTool.js
@@ -145,6 +145,11 @@ export default class SelectionTool {
             },
             'layerFilteredFeaturesChanged': () => {
                 mainEventDispatcher.dispatch('selectionTool.filteredFeaturesChanged');
+            },
+            minidockclosed: (event) => {
+                if (event.id === 'selectiontool'){
+                    mainLizmap.digitizing.toolSelected = 'deactivate';
+                }
             }
         });
     }


### PR DESCRIPTION
Fix #2093
* Funded by 3Liz
