### PR TITLE
Run refreshDatatableSize after button Refresh was pressed or when a dock is oppened or closed

### DIFF
--- a/lizmap/www/assets/js/attributeTable.js
+++ b/lizmap/www/assets/js/attributeTable.js
@@ -526,6 +526,7 @@ var lizAttributeTable = function() {
                         getAttributeFeatureData( lname, dFilter, null, 'extent', function(someName, someNameFilter, someNameFeatures, someNameAliases){
                             buildLayerAttributeDatatable( someName, aTable, someNameFeatures, someNameAliases );
                             $('#attribute-layer-main-'+cleanName+' > div.attribute-layer-content').show();
+                            refreshDatatableSize('#attribute-layer-main-'+ cleanName);
                         });
 
                         return false;
@@ -3200,6 +3201,30 @@ var lizAttributeTable = function() {
                 bottomdocksizechanged: function(evt) {
                     var mycontainerId = $('#bottom-dock div.bottom-content.active div.attribute-layer-main').attr('id');
                     refreshDatatableSize('#'+mycontainerId);
+                },
+                dockopened: function(evt) {
+                    if($('#mapmenu li.attributeLayers').hasClass('active')){
+                        var mycontainerId = $('#bottom-dock div.bottom-content.active div.attribute-layer-main').attr('id');
+                        refreshDatatableSize('#'+mycontainerId);
+                    }
+                },
+                dockclosed: function(evt) {
+                    if($('#mapmenu li.attributeLayers').hasClass('active')){
+                        var mycontainerId = $('#bottom-dock div.bottom-content.active div.attribute-layer-main').attr('id');
+                        refreshDatatableSize('#'+mycontainerId);
+                    }
+                },
+                rightdockopened: function(evt) {
+                    if($('#mapmenu li.attributeLayers').hasClass('active')){
+                        var mycontainerId = $('#bottom-dock div.bottom-content.active div.attribute-layer-main').attr('id');
+                        refreshDatatableSize('#'+mycontainerId);
+                    }
+                },
+                rightdockclosed: function(evt) {
+                    if($('#mapmenu li.attributeLayers').hasClass('active')){
+                        var mycontainerId = $('#bottom-dock div.bottom-content.active div.attribute-layer-main').attr('id');
+                        refreshDatatableSize('#'+mycontainerId);
+                    }
                 }
 
             }); // lizMap.events.on end


### PR DESCRIPTION
Target version: LWC 3.4.4, LWC 3.5

If bottom dock is opened, when UI size is changed, columns width of active table will be recomputed.

Without this patch if we press on button `Refresh`  the width of table columns is resetting to 0. 

This commit will fix this.
