### PR TITLE
Dataviz resizePlot on docks opened or closed

### DIFF
--- a/lizmap/www/assets/js/dataviz/dataviz.js
+++ b/lizmap/www/assets/js/dataviz/dataviz.js
@@ -357,9 +357,15 @@ var lizDataviz = function() {
                 if ( $.inArray(e.id, ['dataviz', 'popup']) > -1 ) {
                     resizePlot(id);
                 }
+                if($('#mapmenu li.dataviz').hasClass('active')){
+                    resizePlot(id);
+                }
             },
             rightdockopened: function(e) {
                 if ( $.inArray(e.id, ['dataviz', 'popup']) > -1 ) {
+                    resizePlot(id);
+                }
+                if($('#mapmenu li.dataviz').hasClass('active')){
                     resizePlot(id);
                 }
             },
@@ -370,6 +376,16 @@ var lizDataviz = function() {
             },
             bottomdocksizechanged: function(e) {
                 if($('#mapmenu li.dataviz').hasClass('active')  || $('#mapmenu li.popup').hasClass('active')){
+                    resizePlot(id);
+                }
+            },
+            dockclosed: function(e) {
+                if($('#mapmenu li.dataviz').hasClass('active')){
+                    resizePlot(id);
+                }
+            },
+            rightdockclosed: function(e) {
+                if($('#mapmenu li.dataviz').hasClass('active')){
                     resizePlot(id);
                 }
             }

--- a/lizmap/www/assets/js/dataviz/dataviz.js
+++ b/lizmap/www/assets/js/dataviz/dataviz.js
@@ -388,6 +388,11 @@ var lizDataviz = function() {
                 if($('#mapmenu li.dataviz').hasClass('active')){
                     resizePlot(id);
                 }
+            },
+            lizmapswitcheritemselected: function(e){
+                if($('#mapmenu li.dataviz').hasClass('active')){
+                    resizePlot(id);
+                }
             }
 
         });


### PR DESCRIPTION
Target version: LWC 3.4.4, LWC 3.5

If a dock with some plots is displayed, when another dock is opened the plots will be resized