### PR TITLE
Fix geobookmark sql: remove explicit public schema

### DIFF
--- a/lizmap/modules/lizmap/install/sql/lizgeobookmark.pgsql.sql
+++ b/lizmap/modules/lizmap/install/sql/lizgeobookmark.pgsql.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS public.geobookmark(
+CREATE TABLE IF NOT EXISTS geobookmark(
   id serial PRIMARY KEY,
   usr_login text NOT NULL,
   bname text NOT NULL,
@@ -7,13 +7,13 @@ CREATE TABLE IF NOT EXISTS public.geobookmark(
 );
 
 DROP INDEX IF EXISTS geobookmark_usr_login_idx;
-ALTER TABLE public.geobookmark
+ALTER TABLE geobookmark
 DROP CONSTRAINT IF EXISTS geobookmark_usr_login_fkey
 ;
 
-ALTER TABLE public.geobookmark
+ALTER TABLE geobookmark
 ADD CONSTRAINT geobookmark_usr_login_fkey FOREIGN KEY (usr_login)
 REFERENCES jlx_user (usr_login) MATCH SIMPLE
 ON UPDATE CASCADE ON DELETE CASCADE;
 
-CREATE INDEX geobookmark_usr_login_idx ON public.geobookmark( usr_login );
+CREATE INDEX geobookmark_usr_login_idx ON geobookmark( usr_login );


### PR DESCRIPTION
The table geobookmark should not be created explicitly into the public schema.

All Lizmap tables must be installed in the same schema, e.g. in the
first schema indicated into the search_path of the connection.

* Funded by 3Liz
