### PR TITLE
Fix: WMTS GetTile request with 0 as parameter value

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/WMTSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMTSRequest.php
@@ -98,8 +98,8 @@ class WMTSRequest extends OGCRequest
 
         foreach ($params as $var => $param) {
             ${$var} = $this->param($param);
-            if (!${$var}) {
-                \jMessage::add('The parameter '.$var.' is mandatory!', 'MissingParameter');
+            if (${$var} === '' || ${$var} === null) {
+                \jMessage::add('The parameter '.$param.' is mandatory!', 'MissingParameter');
 
                 return $this->serviceException();
             }


### PR DESCRIPTION
The WMTS GetTile request with TILEMATRIX=0&TILEROW=0&TILECOL=0 returned
```
<ows:ExceptionReport xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd" version="1.0.0" xml:lang="en">
<ows:Exception exceptionCode="MissingParameter">
<ows:ExceptionText>The parameter TileMatrixId is mandatory!</ows:ExceptionText>
</ows:Exception>
</ows:ExceptionReport>
```
Even if the tileMatrixId 0 is a valid value.

<!-- Add "fix" in front of "#" if it fixes the ticket or do nothing to only mention it.

This PR will be harvested on changelog.lizmap.com if there is a "changelog" label.
Funded by NAME URL
-->
* Ticket : #
* Funded by
