### PR TITLE
Fix regression in qgisFormControl constructor

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisFormControl.class.php
+++ b/lizmap/modules/lizmap/classes/qgisFormControl.class.php
@@ -310,7 +310,7 @@ class qgisFormControl
                         $markup = 'time';
                     }
                 }
-            } elseif (in_array($this->fieldEditType, $this->qgisEdittypeMap)) {
+            } elseif (array_key_exists($this->fieldEditType, $this->qgisEdittypeMap)) {
                 $markup = $this->qgisEdittypeMap[$this->fieldEditType]['jform']['markup'];
             } else {
                 $markup = 'input';


### PR DESCRIPTION
Followup bf4ded5

Use array_key_exists instead of in_array for key identification in array.

For users the issue was that the Hidden Field defined in QGIS Form is not hidden in Lizmap form.
Use form_edition_all_field_type to check it.