### PR TITLE
[BUGFIX] Get only projects metadata for the landing page

### DIFF
--- a/lizmap/modules/admin/classes/listProjectDatasource.class.php
+++ b/lizmap/modules/admin/classes/listProjectDatasource.class.php
@@ -22,13 +22,13 @@ class listProjectDatasource extends jFormsDynamicDatasource
         $criteria = $form->getData($this->criteriaFrom[0]);
         if ($criteria && array_key_exists($criteria, $this->data)) {
             $rep = lizmap::getRepository($criteria);
-            $projects = $rep->getProjects();
-            foreach ($projects as $p) {
-                $pOptions = $p->getOptions();
-                if (property_exists($pOptions, 'hideProject') && $pOptions->hideProject == 'True') {
+            // Get projects metadata
+            $metadata = $rep->getProjectsMetadata();
+            foreach ($metadata as $meta) {
+                if ($meta->getHidden()) {
                     continue;
                 }
-                $pdata[$p->getData('id')] = (string) $p->getData('title');
+                $pdata[$meta->getId()] = $meta->getTitle();
             }
         }
 

--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -139,6 +139,16 @@ class lizmapProject
         return $this->proj->getXmlLayer($layerId);
     }
 
+    /**
+     * Get the minimum needed project information for some pages (landing page, admin project listing).
+     *
+     * @return ProjectMetadata
+     */
+    public function getMetadata()
+    {
+        return $this->proj->getMetadata();
+    }
+
     public function findLayerByAnyName($name)
     {
         return $this->proj->findLayerByAnyName($name);

--- a/lizmap/modules/lizmap/classes/lizmapRepository.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapRepository.class.php
@@ -111,13 +111,36 @@ class lizmapRepository
         return $this->repo->update($data, $ini);
     }
 
-    public function getProject($key)
+    /**
+     * Get a project by key.
+     *
+     * @param string $key           the project key
+     * @param bool   $keepReference if we need to keep reference in projectInstances
+     *
+     * @return null|Project null if it does not exist
+     */
+    public function getProject($key, $keepReference = true)
     {
-        return $this->repo->getProject($key);
+        return $this->repo->getProject($key, $keepReference);
     }
 
+    /**
+     * Get the repository projects.
+     *
+     * @return Project[]
+     */
     public function getProjects()
     {
         return $this->repo->getProjects();
+    }
+
+    /**
+     * Get the repository projects metadata.
+     *
+     * @return ProjectMetadata[]
+     */
+    public function getProjectsMetadata()
+    {
+        return $this->repo->getProjectsMetadata();
     }
 }

--- a/lizmap/modules/lizmap/controllers/project.cmdline.php
+++ b/lizmap/modules/lizmap/controllers/project.cmdline.php
@@ -58,13 +58,13 @@ class projectCtrl extends jControllerCmdLine
         foreach ($repositories as $r) {
             $rep->addContent('Enter the repository '.$r."\n");
             $lrep = lizmap::getRepository($r);
-            $lprojects = $lrep->getProjects();
-
-            foreach ($lprojects as $p) {
-                $rep->addContent('Get the project '.$p->getData('id')."\n");
+            // Get projects metadata
+            $metadata = $lrep->getProjectsMetadata();
+            foreach ($metadata as $meta) {
+                $rep->addContent('Get the project '.$meta->getId()."\n");
                 // Get params
                 $params = array(
-                    'map' => $p->getRelativeQgisPath(),
+                    'map' => $meta->getMap(),
                     'service' => 'WMS',
                     'request' => 'GetCapabilities',
                 );
@@ -89,11 +89,11 @@ class projectCtrl extends jControllerCmdLine
                     ++$i;
                 }
                 if ($nb_500) {
-                    $rep->addContent($nb_500.' request(s) return error 500 for the project '.$p->getData('id')."\n");
+                    $rep->addContent($nb_500.' request(s) return error 500 for the project '.$meta->getId()."\n");
                 } elseif ($nb_400) {
-                    $rep->addContent($nb_400.' request(s) return error 400 for the project '.$p->getData('id')."\n");
+                    $rep->addContent($nb_400.' request(s) return error 400 for the project '.$meta->getId()."\n");
                 } else {
-                    $rep->addContent($nb_success.' request(s) return success for the project '.$p->getData('id')."\n");
+                    $rep->addContent($nb_success.' request(s) return success for the project '.$meta->getId()."\n");
                 }
             }
         }

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -467,6 +467,16 @@ class Project
         return $this->qgis->getData($key);
     }
 
+    /**
+     * Get the minimum needed project information for some pages (landing page, admin project listing).
+     *
+     * @return ProjectMetadata
+     */
+    public function getMetadata()
+    {
+        return new ProjectMetadata($this);
+    }
+
     public function getProj4($authId)
     {
         return $this->qgis->getProj4($authId);

--- a/lizmap/modules/lizmap/lib/Project/ProjectMetadata.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectMetadata.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Get access to the Lizmap project metadata.
+ *
+ * @author    3liz
+ * @copyright 2012 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+namespace Lizmap\Project;
+
+class ProjectMetadata
+{
+    /**
+     * The project metadata.
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * Construct the object.
+     *
+     * @param Project $project The Lizmap project instance
+     */
+    public function __construct(Project $project)
+    {
+        $metadata = array(
+            'id' => $project->getData('id'),
+            'repository' => $project->getData('repository'),
+            'title' => $project->getData('title'),
+            'abstract' => $project->getData('abstract'),
+            'keywordList' => $project->getData('keywordList'),
+            'proj' => $project->getData('proj'),
+            'bbox' => $project->getData('bbox'),
+            'wmsGetCapabilitiesUrl' => $project->getData('wmsGetCapabilitiesUrl'),
+            'wmtsGetCapabilitiesUrl' => $project->getData('wmtsGetCapabilitiesUrl'),
+            'map' => $project->getRelativeQgisPath(),
+            'acl' => $project->checkAcl(),
+        );
+
+        $options = $project->getOptions();
+        $hideProject = (
+            $options && property_exists($options, 'hideProject') && $options->hideProject == 'True'
+        );
+        $metadata['hidden'] = $hideProject;
+
+        $this->data = $metadata;
+    }
+
+    /**
+     * Get the project id.
+     *
+     * @return string the project id
+     */
+    public function getId()
+    {
+        return $this->data['id'];
+    }
+
+    /**
+     * Get the project repository code.
+     *
+     * @return string the project repository code
+     */
+    public function getRepository()
+    {
+        return $this->data['repository'];
+    }
+
+    /**
+     * Get the project title.
+     *
+     * @return string the project title
+     */
+    public function getTitle()
+    {
+        return $this->data['title'];
+    }
+
+    /**
+     * Get the project abstract.
+     *
+     * @return string the project abstract
+     */
+    public function getAbstract()
+    {
+        return $this->data['abstract'];
+    }
+
+    /**
+     * Get the project map.
+     *
+     * @return string the project map
+     */
+    public function getMap()
+    {
+        return $this->data['map'];
+    }
+
+    /**
+     * Get the project hidden flag.
+     *
+     * @return bool True if the project must be hidden in the landing page
+     */
+    public function getHidden()
+    {
+        return $this->data['hidden'];
+    }
+
+    /**
+     * Get the project access rights for the authenticated or anonymous user.
+     *
+     * @return bool True if the user has the right to access the Lizmap project
+     */
+    public function getAcl()
+    {
+        return $this->data['acl'];
+    }
+
+    /**
+     * Get any project property.
+     *
+     * @param string $key The property to get
+     *
+     * @return the project title
+     */
+    public function getData($key)
+    {
+        if (array_key_exists($key, $this->data)) {
+            return $this->data[$key];
+        }
+
+        return null;
+    }
+}

--- a/lizmap/modules/view/zones/ajax_view.zone.php
+++ b/lizmap/modules/view/zones/ajax_view.zone.php
@@ -36,19 +36,28 @@ class ajax_viewZone extends jZone
             if (jAcl2::check('lizmap.repositories.view', $r)) {
                 $lrep = lizmap::getRepository($r);
                 $mrep = new lizmapMainViewItem($r, $lrep->getData('label'));
-                $lprojects = $lrep->getProjects();
-                foreach ($lprojects as $p) {
-                    if (!$p->checkAcl()) {
+                $metadata = $lrep->getProjectsMetadata();
+                foreach ($metadata as $meta) {
+                    // Avoid project with no access rights
+                    if (!$meta->getAcl()) {
                         continue;
                     }
+
+                    // Hide project with option "hideProject"
+                    if ($meta->getHidden()) {
+                        continue;
+                    }
+
+                    // Add item
                     $mrep->childItems[] = new lizmapMainViewItem(
-                        $p->getData('id'),
-                        $p->getData('title'),
-                        $p->getData('abstract'),
-                        $p->getData('proj'),
-                        $p->getData('bbox'),
-                        jUrl::getFull('view~map:index', array('repository' => $p->getData('repository'), 'project' => $p->getData('id'))),
-                        jUrl::getFull('view~media:illustration', array('repository' => $p->getData('repository'), 'project' => $p->getData('id'))),
+                        $meta->getId(),
+                        $meta->getTitle(),
+                        $meta->getAbstract(),
+                        $meta->getData('keywordList'),
+                        $meta->getData('proj'),
+                        $meta->getData('bbox'),
+                        jUrl::getFull('view~map:index', array('repository' => $meta->getRepository(), 'project' => $meta->getId())),
+                        jUrl::getFull('view~media:illustration', array('repository' => $meta->getRepository(), 'project' => $meta->getId())),
                         0,
                         $r,
                         'map'

--- a/lizmap/modules/view/zones/main_view.zone.php
+++ b/lizmap/modules/view/zones/main_view.zone.php
@@ -45,7 +45,6 @@ class main_viewZone extends jZone
             if (jAcl2::check('lizmap.repositories.view', $r)) {
                 $lrep = lizmap::getRepository($r);
                 $mrep = new lizmapMainViewItem($r, $lrep->getData('label'));
-                $lprojects = $lrep->getProjects();
 
                 // WMS GetCapabilities Url
                 $wmsGetCapabilitiesUrl = jAcl2::check(
@@ -54,35 +53,33 @@ class main_viewZone extends jZone
                 );
                 $wmtsGetCapabilitiesUrl = $wmsGetCapabilitiesUrl;
 
-                foreach ($lprojects as $p) {
-                    $pOptions = $p->getOptions();
-                    // Hide project with option "hideProject"
-                    if (property_exists($pOptions, 'hideProject')
-                        && $pOptions->hideProject == 'True'
-                    ) {
+                $metadata = $lrep->getProjectsMetadata();
+                foreach ($metadata as $meta) {
+                    // Avoid project with no access rights
+                    if (!$meta->getAcl()) {
                         continue;
                     }
 
-                    // Hide project with no acl
-                    if (!$p->checkAcl()) {
+                    // Hide project with option "hideProject"
+                    if ($meta->getHidden()) {
                         continue;
                     }
 
                     // Get project information
                     if ($wmsGetCapabilitiesUrl) {
-                        $wmsGetCapabilitiesUrl = $p->getData('wmsGetCapabilitiesUrl');
-                        $wmtsGetCapabilitiesUrl = $p->getData('wmtsGetCapabilitiesUrl');
+                        $wmsGetCapabilitiesUrl = $meta->getData('wmsGetCapabilitiesUrl');
+                        $wmtsGetCapabilitiesUrl = $meta->getData('wmtsGetCapabilitiesUrl');
                     }
-                    if ($lrep->getKey().'~'.$p->getData('id') != $excludedProject) {
+                    if ($lrep->getKey().'~'.$meta->getId() != $excludedProject) {
                         $mrep->childItems[] = new lizmapMainViewItem(
-                            $p->getData('id'),
-                            $p->getData('title'),
-                            $p->getData('abstract'),
-                            $p->getData('keywordList'),
-                            $p->getData('proj'),
-                            $p->getData('bbox'),
-                            jUrl::get('view~map:index', array('repository' => $p->getData('repository'), 'project' => $p->getData('id'))),
-                            jUrl::get('view~media:illustration', array('repository' => $p->getData('repository'), 'project' => $p->getData('id'))),
+                            $meta->getId(),
+                            $meta->getTitle(),
+                            $meta->getAbstract(),
+                            $meta->getData('keywordList'),
+                            $meta->getData('proj'),
+                            $meta->getData('bbox'),
+                            jUrl::get('view~map:index', array('repository' => $meta->getRepository(), 'project' => $meta->getId())),
+                            jUrl::get('view~media:illustration', array('repository' => $meta->getRepository(), 'project' => $meta->getId())),
                             0,
                             $r,
                             'map',
@@ -93,7 +90,7 @@ class main_viewZone extends jZone
                           $this->_tpl->assign('auth_url_return', jUrl::get('view~map:index',
                             array(
                               "repository"=>$lrep->getKey(),
-                              "project"=>$p->getData('id'),
+                              "project"=>$meta->getId(),
                             )
                           ) );*/
                     }


### PR DESCRIPTION
This will lower the memory usage when listing all projects information when building the landing page (or listing the projects of a repository). Fix #2191 

* Ticket : #2191
* Funded by 3liz
