### PR TITLE
Fix regression in qgisFormControl constructor

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisFormControl.class.php
+++ b/lizmap/modules/lizmap/classes/qgisFormControl.class.php
@@ -308,7 +308,7 @@ class qgisFormControl
                         $markup = 'time';
                     }
                 }
-            } elseif (in_array($this->fieldEditType, $this->qgisEdittypeMap)) {
+            } elseif (array_key_exists($this->fieldEditType, $this->qgisEdittypeMap)) {
                 $markup = $this->qgisEdittypeMap[$this->fieldEditType]['jform']['markup'];
             } else {
                 $markup = 'input';


### PR DESCRIPTION
Followup bf4ded5

Use array_key_exists instead of in_array for key identification

Manually backport #2188 