### PR TITLE
[Fix] datasource w/o geom w/ service w/o sql (QGIS >= 3.16)

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -1,8 +1,15 @@
 # Changelog Lizmap 3.4
 
+## Version 3.4.4
+
+Release on 2021-05-xx
+
+- Fix QGIS >= 3.16 datasource compatibility
+- Fix Pre-generated cache is not used since Lizmap 3.4.1
+
 ## Version 3.4.3
 
-Release on 2021-03-xx
+Release on 2021-03-26
 
 - Fix form not displayed when editing an existing feature
 - Some fixes in the js to getprint
@@ -27,7 +34,6 @@ Release on 2021-02-25
 - Fix hide digitization tab for non geom layer
 - Hide label in legend for layers with single symbol rendering
 - Fix WMTS Request - use specific $wmsRequest parameters array
-- Fix Pre-generated cache is not used in Lizmap 3.4.1
 
 ## Version 3.4.1
 

--- a/lizmap/modules/lizmap/classes/qgisVectorLayerDatasource.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayerDatasource.class.php
@@ -28,19 +28,14 @@ class qgisVectorLayerDatasource
         'srid' => 'srid=([0-9]+) ',
         'type' => 'type=([a-zA-Z]+) ',
         'checkPrimaryKeyUnicity' => "checkPrimaryKeyUnicity='([0-1]+)' ",
-        'table' => ' table="(.+)" (\([^ ]+\) )?sql=',
-        'geocol' => '\(([^ ]+)\) sql=',
+        'table' => 'table="(.+?)"($|\s)',
+        'geocol' => '\(([^ ]+)\)',
         'sql' => ' sql=(.*)$',
     );
 
     protected $provider;
 
     protected $datasource;
-
-    // /!\ in table and geocol regex above, sql= will be removed when search for table or geocol
-    // to remove issues
-    // better would be to find a robust regex, but it is fragile
-    // See further down: "Avoid issue..."
 
     /**
      * constructor.
@@ -92,11 +87,7 @@ class qgisVectorLayerDatasource
         // For other parameters, use specific parameter regex
         $regex = $this->datasourceRegexes[$param];
 
-        // Avoid issue with sql not given (QGIS > 3.16)
-        if (!preg_match('# sql=#', $this->datasource) and in_array($param, array('table', 'geocol'))) {
-            $regex = preg_replace('# *sql=#', '', $regex);
-        }
-        $test = preg_match(
+        preg_match(
             '#'.$regex.'#s',
             $this->datasource,
             $result

--- a/tests/units/edition/qgisVectorLayerDatasourceTest.php
+++ b/tests/units/edition/qgisVectorLayerDatasourceTest.php
@@ -86,6 +86,35 @@ class qgisVectorLayerDatasourceTest extends PHPUnit_Framework_TestCase {
 
     }
 
+    
+    function testPostgresqlDatasourceWithoutGeometryWithServiceWithoutSql()
+    {
+        $provider = 'postgres';
+        $datasource = "dbname='test_dbname' service='test_service' sslmode=disable key='id' srid=2193 checkPrimaryKeyUnicity='1' table=\"public\".\"EditTest\"";
+
+        $element = new qgisVectorLayerDatasource($provider, $datasource);
+
+        $this->assertEquals('test_dbname', $element->getDatasourceParameter('dbname'));
+        $this->assertEquals('test_service', $element->getDatasourceParameter('service'));
+        $this->assertEquals('', $element->getDatasourceParameter('host'));
+        $this->assertEquals('', $element->getDatasourceParameter('port'));
+        $this->assertEquals('', $element->getDatasourceParameter('user'));
+        $this->assertEquals('', $element->getDatasourceParameter('password'));
+        $this->assertEquals('disable', $element->getDatasourceParameter('sslmode'));
+        $this->assertEquals('id', $element->getDatasourceParameter('key'));
+        $this->assertEquals('', $element->getDatasourceParameter('estimatedmetadata'));
+        $this->assertEquals('', $element->getDatasourceParameter('selectatid'));
+        $this->assertEquals('2193', $element->getDatasourceParameter('srid'));
+        $this->assertEquals('', $element->getDatasourceParameter('type'));
+        $this->assertEquals('1', $element->getDatasourceParameter('checkPrimaryKeyUnicity'));
+        $this->assertEquals('"public"."EditTest"', $element->getDatasourceParameter('table'));
+        $this->assertEquals('EditTest', $element->getDatasourceParameter('tablename'));
+        $this->assertEquals('public', $element->getDatasourceParameter('schema'));
+        $this->assertEquals('', $element->getDatasourceParameter('geocol'));
+        $this->assertEquals('', $element->getDatasourceParameter('sql'));
+    }
+
+
     function testPostgresDatasourceSimpleTableWithSql() {
         $provider = 'postgres';
         $datasource = "dbname='test_dbname' host=127.0.0.1 port=5432 user='test_user' password='test_password' sslmode=disable key='id_lieux' srid=2154 type=MultiPolygon checkPrimaryKeyUnicity='1' table=\"referentiel\".\"lieux\" (geom) sql=\"code_com\" = '010'";


### PR DESCRIPTION
Fix and add test.

@mdouchin  I've added a test which currently fail with this kind of datasource occuring with QGIS >= 3.16. See attachment for Lizmap project, `end2end_form_edition` can't be edited with 3.16 datasource.

before 3.16 : 
`<datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='1' table="tests_projects"."end2end_form_edition" sql=</datasource>`
after 3.16 : 
`<datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='1' table="tests_projects"."end2end_form_edition"</datasource>`


Related to https://github.com/3liz/lizmap-web-client/commit/508318f490dd21c74a55c196a0fdbbc81f4eee81

[end2end_form_edition_3_16.zip](https://github.com/3liz/lizmap-web-client/files/6182768/end2end_form_edition_3_16.zip)


