### PR TITLE
Docker: change base image tag

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG REGISTRY_PREFIX=''
-FROM ${REGISTRY_PREFIX}alpine:3.11
+FROM ${REGISTRY_PREFIX}alpine:3
 MAINTAINER David Marteau <david.marteau@3liz.com>
 LABEL Description="Lizmap web client" Vendor="3liz.org"
 

--- a/docker/lizmap-entrypoint.sh
+++ b/docker/lizmap-entrypoint.sh
@@ -9,7 +9,7 @@ LIZMAP_ADMIN_EMAIL=${LIZMAP_ADMIN_EMAIL:-root@local.localhost}
 
 # php ini override
 if [ ! -z $PHP_INI ]; then
-    echo -e "$PHP_INI" > $PHP_INI_DIR/conf.d/lizmap-php-0.ini
+    echo -e "$PHP_INI" > $PHP_INI_DIR/conf.d/00_lizmap.ini
 fi
 
 # lizmapConfig.ini.php.dist


### PR DESCRIPTION
## Change base image tag from alpine:3.11 to alpine:3

Strict alpine version is too restrictive: it prevents CI builds to take into accounts custom infrastructure choices. 

## Follow convention for php override config name.

Change the name of the custom lizmap override config file dynamically created at startup from the PHP_INI env variable to follow convention.
