### PR TITLE
New config parameter to enable metrics

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmap.class.php
+++ b/lizmap/modules/lizmap/classes/lizmap.class.php
@@ -433,6 +433,10 @@ class lizmap
      */
     public static function logMetric($label, $start = 'index')
     {
+        if (!self::getServices()->areMetricsEnabled()) {
+            return;
+        }
+
         // Choose from when to calculate time: index, request or given $start
         if ($start == 'index') {
             $start = $_SERVER['LIZMAP_BEGIN_TIME'];

--- a/lizmap/modules/lizmap/classes/lizmapServices.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapServices.class.php
@@ -21,6 +21,8 @@ class lizmapServices
     /**
      * List of all properties of lizmapServices that should be retrieved
      * from lizmapConfig.ini.php or from the main configuration.
+     *
+     * These properties can be editable in the configuration form of Lizmap
      */
     private $properties = array(
         'appName',
@@ -56,10 +58,12 @@ class lizmapServices
         'adminSenderEmail',
         'adminSenderName',
         'googleAnalyticsID',
+        'metricsEnabled',
     );
 
     /**
-     * services properties to not display into the configuration form.
+     * services properties to not display into the configuration form,
+     * when hideSensitiveServicesProperties is set to 1.
      */
     private $sensitiveProperties = array(
         'qgisServerVersion',
@@ -89,13 +93,20 @@ class lizmapServices
         'proxyHttpBackend',
     );
 
+    /**
+     * List of properties that are not editable at all.
+     *
+     * @var string[]
+     */
     private $notEditableProperties = array(
         'cacheRedisKeyPrefixFlushMethod',
         'wmsServerHeaders',
+        'metricsEnabled',
     );
 
     /**
-     * List of properties mapped to a parameter of the main configuration of Jelix.
+     * List of properties mapped to a parameter of the main configuration
+     * of Jelix.
      *
      * @var array
      */
@@ -187,13 +198,18 @@ class lizmapServices
     // application id for google analytics
     public $googleAnalyticsID = '';
 
+    /**
+     * @var bool|int true/1 if metrics should be sent to the metric logger
+     */
+    private $metricsEnabled = false;
+
     protected $appContext;
 
     /**
      * constructor method.
      *
      * @param array  $readConfigPath the lizmapConfig ini file put in an array
-     * @param object  $globalConfig   the jelix configuration
+     * @param object $globalConfig   the jelix configuration
      * @param bool   $ldapEnabled    true if ldapdao module is enabled
      * @param string $varPath        the configuration files path given by jApp::varPath()
      * @param mixed  $appContext
@@ -272,6 +288,14 @@ class lizmapServices
     public function isLdapEnabled()
     {
         return $this->isUsingLdap;
+    }
+
+    /**
+     * @return bool|int
+     */
+    public function areMetricsEnabled()
+    {
+        return $this->metricsEnabled === true || $this->metricsEnabled === '1' || $this->metricsEnabled === 'true';
     }
 
     public function getProperties()

--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -457,12 +457,7 @@ class serviceCtrl extends jController
             }
         }
 
-        // log metric
-        $ser = lizmap::getServices();
-        $debug = $ser->debugMode;
-        if ($debug) {
-            lizmap::logMetric('LIZMAP_SERVICE_GETMAP');
-        }
+        lizmap::logMetric('LIZMAP_SERVICE_GETMAP');
 
         return $rep;
     }
@@ -794,12 +789,7 @@ class serviceCtrl extends jController
             }
         }
 
-        // log metric
-        $ser = lizmap::getServices();
-        $debug = $ser->debugMode;
-        if ($debug) {
-            lizmap::logMetric('LIZMAP_SERVICE_GETMAP');
-        }
+        lizmap::logMetric('LIZMAP_SERVICE_GETMAP');
 
         return $rep;
     }

--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -863,7 +863,16 @@ class WMSRequest extends OGCRequest
         return array($useCache, $wmsClient);
     }
 
-    public function getTileCache($params, $profile, $useCache, $forced, $debug)
+    /**
+     * @param array  $params
+     * @param string $profile
+     * @param bool   $useCache
+     * @param bool   $forced
+     * @param false  $debug    deprecated
+     *
+     * @return array|string
+     */
+    public function getTileCache($params, $profile, $useCache, $forced, $debug = false)
     {
         // Get cache if exists
         $keyParams = $params;
@@ -896,9 +905,7 @@ class WMSRequest extends OGCRequest
                     $mime = 'image/png';
                 }
 
-                if ($debug) {
-                    \lizmap::logMetric('LIZMAP_PROXY_HIT_CACHE');
-                }
+                \lizmap::logMetric('LIZMAP_PROXY_HIT_CACHE');
 
                 return array($tile, $mime, 200, true);
             }
@@ -939,7 +946,17 @@ class WMSRequest extends OGCRequest
         return array($params, $originalParams, $xFactor, $yFactor);
     }
 
-    protected function getImageData($data, $params, $originalParams, $xFactor, $yFactor, $debug)
+    /**
+     * @param string $data           data of the original image
+     * @param array  $params
+     * @param array  $originalParams
+     * @param float  $xFactor
+     * @param float  $yFactor
+     * @param false  $debug          deprecated
+     *
+     * @return false|string content of the image
+     */
+    protected function getImageData($data, $params, $originalParams, $xFactor, $yFactor, $debug = false)
     {
         $metatileBuffer = 5;
         // Save original content into an image var
@@ -980,9 +997,7 @@ class WMSRequest extends OGCRequest
         imagedestroy($original);
         imagedestroy($image);
 
-        if ($debug) {
-            \lizmap::logMetric('LIZMAP_PROXY_CROP_METATILE');
-        }
+        \lizmap::logMetric('LIZMAP_PROXY_CROP_METATILE');
 
         return $data;
     }
@@ -1007,9 +1022,6 @@ class WMSRequest extends OGCRequest
         $project = $lproj->getKey();
         $repository = $lrep->getKey();
 
-        // Change to true to put some information in debug files
-        $debug = $this->services->debugMode;
-
         // Read config file for the current project
         $layername = $params['layers'];
         $configLayers = $lproj->getLayers();
@@ -1029,14 +1041,12 @@ class WMSRequest extends OGCRequest
         // --> must be done after checking that parent project is involved
         $profile = Proxy::createVirtualProfile($repository, $project, $layers, $crs);
 
-        if ($debug) {
-            \lizmap::logMetric('LIZMAP_PROXY_READ_LAYER_CONFIG');
-        }
+        \lizmap::logMetric('LIZMAP_PROXY_READ_LAYER_CONFIG');
 
         list($useCache, $wmsClient) = $this->useCache($configLayer, $params, $profile);
         // Get cache if exists
 
-        $key = $this->getTileCache($params, $profile, $useCache, $forced, $debug);
+        $key = $this->getTileCache($params, $profile, $useCache, $forced);
         if (is_array($key)) {
             return $key;
         }
@@ -1067,9 +1077,7 @@ class WMSRequest extends OGCRequest
             Proxy::constructUrl($params, $this->services)
         );
 
-        if ($debug) {
-            \lizmap::logMetric('LIZMAP_PROXY_REQUEST_QGIS_MAP');
-        }
+        \lizmap::logMetric('LIZMAP_PROXY_REQUEST_QGIS_MAP');
 
         if ($useCache && !preg_match('/^image/', $mime)) {
             $useCache = false;
@@ -1080,7 +1088,7 @@ class WMSRequest extends OGCRequest
         if ($metatileSize && $useCache && $wmsClient == 'web'
             && extension_loaded('gd') && function_exists('gd_info')
         ) {
-            $data = $this->getImageData($data, $params, $originalParams, $xFactor, $yFactor, $debug);
+            $data = $this->getImageData($data, $params, $originalParams, $xFactor, $yFactor);
         }
 
         $_SESSION['LIZMAP_GETMAP_CACHE_STATUS'] = 'off';
@@ -1099,9 +1107,7 @@ class WMSRequest extends OGCRequest
                 $_SESSION['LIZMAP_GETMAP_CACHE_STATUS'] = 'write';
                 $cached = true;
 
-                if ($debug) {
-                    \lizmap::logMetric('LIZMAP_PROXY_WRITE_CACHE');
-                }
+                \lizmap::logMetric('LIZMAP_PROXY_WRITE_CACHE');
             } catch (\Exception $e) {
                 \jLog::logEx($e, 'error');
                 $cached = false;

--- a/tests/units/classes/lizmapServicesTest.php
+++ b/tests/units/classes/lizmapServicesTest.php
@@ -401,4 +401,39 @@ class lizmapServicesTest extends PHPUnit_Framework_TestCase
         }
         unset($testLizmapServices, $repo);
     }
+
+    public function getMetricsEnabled()
+    {
+        return array(
+            array(null, false),
+            array('', false),
+            array('1', true),
+            array('0', false),
+            array(true, true),
+            array(false, false),
+            array('bla', false),
+        );
+    }
+
+    /**
+     * @dataProvider getMetricsEnabled
+     *
+     * @param mixed $testValue
+     * @param mixed $expectedValue
+     */
+    public function testGetMetricsEnabled($testValue, $expectedValue)
+    {
+        $ini_tab = array('hideSensitiveServicesProperties' => '0',
+                         'services' => array(
+                             'appName' => 'Lizmap' ),
+        );
+
+        if ($testValue !== null) {
+            $ini_tab['services']['metricsEnabled'] = $testValue;
+        }
+
+        $testLizmapServices = new lizmapServices($ini_tab, (object) array(), true, '', null);
+        $this->assertEquals($expectedValue, $testLizmapServices->areMetricsEnabled());
+        unset($testLizmapServices);
+    }
 }


### PR DESCRIPTION
The debugMode parameter activates metrics, but also the logging of all
http requests to qgis. This is not what we would want. A new configuration
parameter `metricsEnabled` allow to enable only metrics, and
debugMode is not anymore used for metrics.

* Funded by 3liz
