### PR TITLE
Fix logger: no more page processing interruption when it fails

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapServices.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapServices.class.php
@@ -193,7 +193,7 @@ class lizmapServices
      * constructor method.
      *
      * @param array  $readConfigPath the lizmapConfig ini file put in an array
-     * @param object  $globalConfig   the jelix configuration
+     * @param object $globalConfig   the jelix configuration
      * @param bool   $ldapEnabled    true if ldapdao module is enabled
      * @param string $varPath        the configuration files path given by jApp::varPath()
      * @param mixed  $appContext

--- a/lizmap/modules/lizmap/lib/Logger/Item.php
+++ b/lizmap/modules/lizmap/lib/Logger/Item.php
@@ -152,30 +152,26 @@ class Item
     {
         $dao = $this->appContext->getJelixDao('lizmap~logCounter', $profile);
 
-        if ($rec = $dao->getDistinctCounter($this->key, $repository, $project)) {
-            ++$rec->counter;
+        try {
+            if ($rec = $dao->getDistinctCounter($this->key, $repository, $project)) {
+                ++$rec->counter;
 
-            try {
                 $dao->update($rec);
-            } catch (\Exception $e) {
-                $this->appContext->logMessage('Error while updating a new line in log_counter :'.$e->getMessage());
-            }
-        } else {
-            $rec = $this->appContext->createDaoRecord('lizmap~logCounter', $profile);
-            $rec->key = $this->key;
-            if ($repository) {
-                $rec->repository = $repository;
-            }
-            if ($project) {
-                $rec->project = $project;
-            }
-            $rec->counter = 1;
+            } else {
+                $rec = $this->appContext->createDaoRecord('lizmap~logCounter', $profile);
+                $rec->key = $this->key;
+                if ($repository) {
+                    $rec->repository = $repository;
+                }
+                if ($project) {
+                    $rec->project = $project;
+                }
+                $rec->counter = 1;
 
-            try {
                 $dao->insert($rec);
-            } catch (\Exception $e) {
-                $this->appContext->logMessage('Error while inserting a new line in log_counter :'.$e->getMessage());
             }
+        } catch (\Exception $e) {
+            $this->appContext->logMessage('Error while increasing log counter:'.$e->getMessage());
         }
     }
 }


### PR DESCRIPTION
The call of the dao method getDistinctCounter may fail if the sqlite database is locked or else. The exception was not catched and stopped the processing of the page.

* Funded by 3Liz
