### PR TITLE
Fix potential issues when calling OGC requests with unexpected method

### DIFF
--- a/lizmap/modules/dataviz/classes/datavizPlot.class.php
+++ b/lizmap/modules/dataviz/classes/datavizPlot.class.php
@@ -460,7 +460,8 @@ class datavizPlot
             }
 
             $wfsrequest = new \Lizmap\Request\WFSRequest($this->lproj, $wfsparams, lizmap::getServices(), lizmap::getAppContext());
-            $wfsresponse = $wfsrequest->getfeature();
+            // FIXME no support of the case where $wfsresponse is the content of serviceException?
+            $wfsresponse = $wfsrequest->process();
             $features = null;
 
             // Check data

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -270,7 +270,8 @@ class editionCtrl extends jController
             );
 
             $wfsrequest = new \Lizmap\Request\WFSRequest($this->project, $wfsparams, lizmap::getServices(), lizmap::getAppContext());
-            $wfsresponse = $wfsrequest->getfeature();
+            // FIXME no support of the case where $wfsresponse is the content of serviceException?
+            $wfsresponse = $wfsrequest->process();
             if (property_exists($wfsresponse, 'data')) {
                 $data = $wfsresponse->data;
                 if (property_exists($wfsresponse, 'file') and $wfsresponse->file and is_file($data)) {

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -428,6 +428,9 @@ class Project
         return $this->key;
     }
 
+    /**
+     * @return Repository
+     */
     public function getRepository()
     {
         return $this->repository;

--- a/lizmap/modules/lizmap/lib/Request/OGCRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/OGCRequest.php
@@ -26,14 +26,29 @@ abstract class OGCRequest
      */
     protected $project;
 
+    /**
+     * @var \Lizmap\Project\Repository
+     */
     protected $repository;
 
+    /**
+     * @var array
+     */
     protected $params;
 
+    /**
+     * @var null|string
+     */
     protected $requestXml;
 
+    /**
+     * @var \lizmapServices
+     */
     protected $services;
 
+    /**
+     * @var string selector of a template
+     */
     protected $tplExceptions;
 
     protected $appContext;
@@ -122,8 +137,11 @@ abstract class OGCRequest
     public function process()
     {
         $req = $this->param('request');
-        if ($req && method_exists($this, $req)) {
-            return $this->{$req}();
+        if ($req) {
+            $reqMeth = 'process_'.$req;
+            if (method_exists($this, $reqMeth)) {
+                return $this->{$reqMeth}();
+            }
         }
 
         if (!$req) {
@@ -197,22 +215,19 @@ abstract class OGCRequest
     protected function serviceException($code = 400)
     {
         $messages = \jMessage::getAll();
-        $mime = 'text/plain';
-        if (!$messages) {
-            $data = '';
-        } else {
-            if (is_array($messages)) {
-                $data = '';
-            } else {
-                $data = implode('\n', $messages);
-            }
-        }
 
         if ($this->tplExceptions !== null) {
             $mime = 'text/xml';
             $tpl = new \jTpl();
             $tpl->assign('messages', $messages);
             $data = $tpl->fetch($this->tplExceptions);
+        } else {
+            $mime = 'text/plain';
+            if (is_array($messages) && count($messages)) {
+                $data = implode('\n', $messages);
+            } else {
+                $data = '';
+            }
         }
         \jMessage::clearAll();
 
@@ -229,7 +244,7 @@ abstract class OGCRequest
      *
      * @return array['code', 'mime', 'data', 'cached'] The request result with HTTP code, response mime-type and response data
      */
-    protected function getcapabilities()
+    protected function process_getcapabilities()
     {
         $appContext = $this->appContext;
         // Get cached session

--- a/lizmap/modules/lizmap/lib/Request/WFSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WFSRequest.php
@@ -111,7 +111,7 @@ class WFSRequest extends OGCRequest
     /**
      * @see https://en.wikipedia.org/wiki/Web_Feature_Service#Static_Interfaces.
      */
-    protected function getcapabilities()
+    protected function process_getcapabilities()
     {
         $version = $this->param('version');
         // force version if not defined
@@ -119,7 +119,7 @@ class WFSRequest extends OGCRequest
             $this->params['version'] = '1.3.0';
         }
 
-        $result = parent::getcapabilities();
+        $result = parent::process_getcapabilities();
 
         $data = $result->data;
         if (empty($data) || floor($result->code / 100) >= 4) {
@@ -166,7 +166,7 @@ class WFSRequest extends OGCRequest
     /**
      * @see https://en.wikipedia.org/wiki/Web_Feature_Service#Static_Interfaces.
      */
-    public function describefeaturetype()
+    protected function process_describefeaturetype()
     {
         // Extensions to get aliases and type
         $returnJson = (strtolower($this->param('outputformat', '')) == 'json');
@@ -224,7 +224,7 @@ class WFSRequest extends OGCRequest
     /**
      * @see https://en.wikipedia.org/wiki/Web_Feature_Service#Static_Interfaces.
      */
-    public function getfeature()
+    protected function process_getfeature()
     {
         if ($this->requestXml !== null) {
             return $this->getfeatureQgis();
@@ -299,7 +299,7 @@ class WFSRequest extends OGCRequest
      *
      * @see https://en.wikipedia.org/wiki/Web_Feature_Service#Static_Interfaces
      */
-    public function getfeatureQgis()
+    protected function getfeatureQgis()
     {
         // Else pass query to QGIS Server
         // Get remote data
@@ -522,7 +522,7 @@ class WFSRequest extends OGCRequest
      * https://en.wikipedia.org/wiki/Web_Feature_Service#Static_Interfaces
      * Queries The PostGreSQL Server for getFeature.
      */
-    public function getfeaturePostgres()
+    protected function getfeaturePostgres()
     {
         $params = $this->parameters();
 

--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -103,14 +103,14 @@ class WMSRequest extends OGCRequest
     /**
      * @see https://en.wikipedia.org/wiki/Web_Map_Service#Requests.
      */
-    protected function getcapabilities()
+    protected function process_getcapabilities()
     {
         $version = $this->param('version');
         // force version if noy defined
         if (!$version) {
             $this->params['version'] = '1.3.0';
         }
-        $result = parent::getcapabilities();
+        $result = parent::process_getcapabilities();
 
         $data = $result->data;
         if (empty($data) or floor($result->code / 100) >= 4) {
@@ -188,7 +188,7 @@ class WMSRequest extends OGCRequest
         );
     }
 
-    protected function getcontext()
+    protected function process_getcontext()
     {
         // Get remote data
         $response = $this->request();
@@ -210,7 +210,7 @@ class WMSRequest extends OGCRequest
         );
     }
 
-    protected function getschemaextension()
+    protected function process_getschemaextension()
     {
         $data = '<?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:wms="http://www.opengis.net/wms" xmlns:qgs="http://www.qgis.org/wms" targetNamespace="http://www.qgis.org/wms" elementFormDefault="qualified" version="1.0.0">
@@ -231,7 +231,7 @@ class WMSRequest extends OGCRequest
     /**
      * @see https://en.wikipedia.org/wiki/Web_Map_Service#Requests.
      */
-    protected function getmap()
+    protected function process_getmap()
     {
         if (!$this->checkMaximumWidthHeight()) {
             \jMessage::add('The requested map size is too large', 'Size error');
@@ -274,12 +274,12 @@ class WMSRequest extends OGCRequest
     /**
      * @see https://en.wikipedia.org/wiki/Web_Map_Service#Requests.
      */
-    protected function getlegendgraphic()
+    protected function process_getlegendgraphic()
     {
-        return $this->getlegendgraphics();
+        return $this->process_getlegendgraphics();
     }
 
-    protected function getlegendgraphics()
+    protected function process_getlegendgraphics()
     {
         $layers = $this->param('Layers', $this->param('Layer', ''));
         $layers = explode(',', $layers);
@@ -305,7 +305,7 @@ class WMSRequest extends OGCRequest
     /**
      * @see https://en.wikipedia.org/wiki/Web_Map_Service#Requests.
      */
-    protected function getfeatureinfo()
+    protected function process_getfeatureinfo()
     {
         $queryLayers = $this->param('query_layers');
         // QUERY_LAYERS is mandatory
@@ -402,7 +402,7 @@ class WMSRequest extends OGCRequest
         );
     }
 
-    protected function getprint()
+    protected function process_getprint()
     {
         // Get remote data
         $response = $this->request(true);
@@ -415,7 +415,7 @@ class WMSRequest extends OGCRequest
         );
     }
 
-    protected function getprintatlas()
+    protected function process_getprintatlas()
     {
         // Trigger optional actions by other modules
         // For example, cadastre module can create a file
@@ -437,7 +437,7 @@ class WMSRequest extends OGCRequest
         );
     }
 
-    protected function getstyles()
+    protected function process_getstyles()
     {
 
         // Get remote data

--- a/lizmap/modules/lizmap/lib/Request/WMTSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMTSRequest.php
@@ -34,7 +34,7 @@ class WMTSRequest extends OGCRequest
     /**
      * @see https://en.wikipedia.org/wiki/Web_Map_Tile_Service#Requests.
      */
-    protected function getcapabilities()
+    protected function process_getcapabilities()
     {
         $tileCapabilities = null;
 
@@ -83,7 +83,7 @@ class WMTSRequest extends OGCRequest
     /**
      * @see https://en.wikipedia.org/wiki/Web_Map_Tile_Service#Requests.
      */
-    public function gettile()
+    protected function process_gettile()
     {
         //\jLog::log('GetTile '.http_build_query($this->params));
         // Get the layer

--- a/tests/units/classes/Request/ClassesForTests.php
+++ b/tests/units/classes/Request/ClassesForTests.php
@@ -59,7 +59,7 @@ class WMTSRequestForTest extends WMTSRequest
 {
     public function getCapabilitiesForTests()
     {
-        return $this->getcapabilities();
+        return $this->process_getcapabilities();
     }
 }
 
@@ -129,7 +129,7 @@ class WMSRequestForTests extends WMSRequest
 {
     public function getContextForTests()
     {
-        return $this->getcontext();
+        return $this->process_getcontext();
     }
 
     public function checkMaximumWidthHeightForTests()

--- a/tests/units/classes/Request/OGCRequestTest.php
+++ b/tests/units/classes/Request/OGCRequestTest.php
@@ -72,9 +72,9 @@ class OGCRequestTest extends TestCase
             'request' => 'getcapabilities'
         );
         $ogc = $this->getMockBuilder(OGCRequestForTest::class)
-            ->setMethods(['getcapabilities'])
+            ->setMethods(['process_getcapabilities'])
             ->setConstructorArgs([new ProjectForOGC(), $params, null, new testContext()])->getMock();
-        $ogc->expects($this->once())->method('getcapabilities');
+        $ogc->expects($this->once())->method('process_getcapabilities');
         $ogc->process();
         $params = array(
             'service' => 'WMS',


### PR DESCRIPTION
Even if the request type name is checked into service.classic.php, when we used one of the OGC requests object independently, it could be processed with the name of any methods of the object.

Only methods corresponding to the request should be able to be executed. This is why I choose the solution to prefix these methods, so no other methods can be executed.

This naming allows too to identify easily methods of request types.

* Funded by 3liz
