### PR TITLE
Add support for Drop-In lizmap configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,21 +248,6 @@ docker-release: check-factory
 docker-hub:
 	cd docker && $(FACTORY_SCRIPTS)/push-to-docker-hub.sh --clean
 
-LIZMAP_USER:=$(shell id -u)
-
-docker-run:
-	rm -rf $(shell pwd)/docker/.run
-	docker run -it --rm -p 9000:9000 \
-    -v $(shell pwd)/.run/config:/www/lizmap/var/config \
-    -v $(shell pwd)/.run/web:/www/lizmap/www \
-    -v $(shell pwd)/.run/log:/usr/local/var/log \
-    -v $(shell pwd)/.run/lizmap-theme-config:/www/lizmap/var/lizmap-theme-config \
-    -e LIZMAP_WMSSERVERURL=$(LIZMAP_WMSSERVERURL) \
-    -e LIZMAP_CACHEREDISHOST=$(LIZMAP_CACHEREDISHOST) \
-    -e LIZMAP_USER=$(LIZMAP_USER) \
-    -e LIZMAP_HOME=/srv/lizmap \
-    $(DOCKER_BUILDIMAGE) php-fpm
-
 php-cs-fixer-test:
 	php-cs-fixer fix --config=.php_cs.dist --allow-risky=yes --dry-run --diff
 

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -9,6 +9,9 @@ COMPOSER_VERSION:=2.0.8
 
 VERSION_TAG=$(COMPOSER_VERSION)-php$(PHP_VERSION)
 
+all: build
+	$(MAKE) -C .. docker-build docker-tag docker-clean
+
 image:
 	docker build --rm \
 		--build-arg="PHP_VERSION=$(PHP_VERSION)" \
@@ -30,4 +33,5 @@ build: image
 
 clean:
 	rm -rf $(WORKDIR)/.composer $(WORKDIR)/.npm
+
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG REGISTRY_PREFIX=''
 FROM ${REGISTRY_PREFIX}alpine:3
 MAINTAINER David Marteau <david.marteau@3liz.com>
-LABEL Description="Lizmap web client" Vendor="3liz.org"
+LABEL Description="Lizmap web client" Vendor="3liz.org" Version="21.05.0"
 
 RUN apk update && apk upgrade
 RUN apk --no-cache add git fcgi php7 php7-fpm \

--- a/docker/README.md
+++ b/docker/README.md
@@ -20,6 +20,8 @@ The container deploy one lizmap instance and may run php-fpm on commande line.
 - `LIZMAP_ADMIN_LOGIN`: Login of the admin user
 - `LIZMAP_ADMIN_EMAIL`: Email address of the admin user
 - `LIZMAP_ADMIN_DEFAULT_PASSWORD_SOURCE`: The password to set for the admin user. Cf [Admin Setup Section](#admin-setup)
+- `LIZMAP_LIZMAPCONFIG_INCLUDE`: Directory for `lizmapConfig` additional configuration. All `*.ini.php` files in this directory will be imported to `lizmapConfig.ini.php`.
+- `LIZMAP_LOCALCONFIG_INCLUDE`: Directory for `localConfig` additional configuration. All `*.ini.php` files in this directory will be imported to `localConfig.ini.php`.
 
 **Important**: `LIZMAP_HOME` is the prefix of the path towards lizmap web files (`lizmap/www`). This prefix
 must be identical to the one given in the nginx *root* directive, ex:

--- a/docker/lizmap-entrypoint.sh
+++ b/docker/lizmap-entrypoint.sh
@@ -33,6 +33,7 @@ else
 fi
 
 # Update localconfig and lizmapConfig
+echo "Updating configuration"
 update-config.php
 
 # Set up Configuration  

--- a/docker/update-config.php
+++ b/docker/update-config.php
@@ -2,6 +2,20 @@
 <?php
 require('/www/lib/jelix/utils/jIniFileModifier.class.php');
 
+
+function load_include_config($varname, $iniFileModifier)
+{
+    $includeConfigDir = getenv($varname);
+    if ($includeConfigDir !== false and is_dir($includeConfigDir)) {
+        echo("Checking for lizmap configuration files in ".$includeConfigDir."\n");
+        foreach (glob(rtrim($includeConfigDir,"/")."/*.ini.php") as $includeFile) {
+            echo("* Loading lizmap configuration: ".$includeFile."\n"); 
+            $includeConfig = new jIniFileModifier($includeFile);
+            $iniFileModifier->import($includeConfig);
+        }  
+    }  
+} 
+
 /**
  * lizmapConfig.ini.php
  */
@@ -23,6 +37,10 @@ foreach(array(
         $lizmapConfig->setValue($key, getenv($envValue), 'services');
     }
 }
+
+// DropIn capabilities: Merge all ini file in LIZMAP_LIZMAPCONFIG_INCLUDE
+load_include_config('LIZMAP_LIZMAPCONFIG_INCLUDE', $lizmapConfig);
+
 $lizmapConfig->save();
 
 /**
@@ -85,9 +103,10 @@ if (getenv('LIZMAP_THEME') !== false) {
     $localConfig->setValue('theme', getenv('LIZMAP_THEME'));
 }
 
+// DropIn capabilities: Merge all ini file in LIZMAP_LOCALCONFIG_INCLUDE
+load_include_config('LIZMAP_LOCALCONFIG_INCLUDE', $localConfig);
 
-// Update mail config
-
+// Do not break older install
 $mailConfigFile = '/srv/etc/mailconfig.ini';
 if (file_exists($mailConfigFile)) {
     $mailConfig = parse_ini_file($mailConfigFile, true);


### PR DESCRIPTION
## Support for drop-in configuration files in Lizmap docker image:

This PR add the capability to use drop-in config files that will merge to the lizmap configuration files at startup. It allows for customized local  persistent configuration which will be available at startup without the risk to be removed on container restart.

It allows for the container to provide its own set of configuration independently of the custom local configuration (modules configuration is a good exemple): it simplifies the the deployment of module configuration without  having to tamper with the main configuration files.

It use environment variables for defiining the directories to load files from. If defined, all files ending in `*.php.ini` are merged to the appropriate config file

## Changes

* Add `load_include_config` in `update-config.php`
* Use `LIZMAP_LOCALCONFIG_INCLUDE` env var for files merged to `localConfig.ini.php`
* Use `LIZMAP_LIZMAPCONFIG_INCLUDE` env var for files merged to `lizmapConfig.ini.php`

## Tests

Tested with [lizmap-docker-compose](https://github.com/3liz/lizmap-docker-compose)
