### PR TITLE
Fix: Call to undefined method lizmapWMSRequest::parameters()

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapOGCRequest.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapOGCRequest.class.php
@@ -66,6 +66,16 @@ class lizmapOGCRequest
         return $defaultValue;
     }
 
+    /**
+     * Gets the request parameters.
+     *
+     * @return array the request parameters
+     */
+    public function parameters()
+    {
+        return $this->params;
+    }
+
     public function process()
     {
         $req = $this->param('request');


### PR DESCRIPTION
Fixes #2277

* Funded by 3Liz
