### PR TITLE
Docker: configure log metrics

### DIFF
--- a/dev/Makefile
+++ b/dev/Makefile
@@ -9,10 +9,12 @@ COMPOSER_VERSION:=2.0.8
 
 VERSION_TAG=$(COMPOSER_VERSION)-php$(PHP_VERSION)
 
-all: build
-	$(MAKE) -C .. docker-build docker-tag docker-clean
+all: build image
 
 image:
+	$(MAKE) -C .. docker-build docker-tag docker-clean
+
+builder:
 	docker build --rm \
 		--build-arg="PHP_VERSION=$(PHP_VERSION)" \
 		--build-arg="COMPOSER_VERSION=$(COMPOSER_VERSION)" \
@@ -21,7 +23,7 @@ image:
 
 WORKDIR=$(realpath ..)
 
-build: image
+build: builder
 	mkdir -p $(WORKDIR)/.composer $(WORKDIR)/.npm
 	docker run --rm -it --user $$(id -u):$$(id -g) \
 		--workdir /build \

--- a/docker/update-config.php
+++ b/docker/update-config.php
@@ -2,7 +2,6 @@
 <?php
 require('/www/lib/jelix/utils/jIniFileModifier.class.php');
 
-
 function load_include_config($varname, $iniFileModifier)
 {
     $includeConfigDir = getenv($varname);
@@ -15,6 +14,19 @@ function load_include_config($varname, $iniFileModifier)
         }  
     }  
 } 
+
+/** 
+ * mainconfig.ini.php
+ */
+$mainconfig = new jIniFileModifier('/www/lizmap/var/config/mainconfig.ini.php');
+
+// Configure metric logger
+$logger_metric = getenv('LIZMAP_LOGMETRICS');
+if ($logger_metric !== false) {
+    $mainconfig->setValue('metric', $logger_metric, 'logger');
+}
+
+$mainconfig->save();
 
 /**
  * lizmapConfig.ini.php
@@ -40,6 +52,11 @@ foreach(array(
 
 // DropIn capabilities: Merge all ini file in LIZMAP_LIZMAPCONFIG_INCLUDE
 load_include_config('LIZMAP_LIZMAPCONFIG_INCLUDE', $lizmapConfig);
+
+// Enable metrics
+if ($logger_metric !== false) {
+    $lizmapConfig->setValue('metricsEnabled', 1, 'services');
+} 
 
 $lizmapConfig->save();
 


### PR DESCRIPTION
## Enable configuration for log metrics in docker

If `LIZMAP_LOGMETRICS` env var is set then use the value as metrics logger and enable metric logging.
