### PR TITLE
Allow new OpenLayers Map to be used on top of OL2 one

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -11,6 +11,7 @@
 ### Changed
 
 - Replace OpenLayers 2 overviewmap by OL6 one. Overviewmap now zoom in/out with main map.
+- Allow new OpenLayers Map to be used on top of OL2 one
 - Update OpenLayers to 6.5
 
 ### Fixed

--- a/assets/src/components/MousePosition.js
+++ b/assets/src/components/MousePosition.js
@@ -99,12 +99,20 @@ export default class MousePosition extends HTMLElement {
         if (evt == null) {
             return;
         }else{
-            const { lon, lat } = mainLizmap.lizmap3.map.getLonLatFromPixel(evt.xy);
+            let lon,lat;
+            // OL2
+            if(evt.xy){
+                ({ lon, lat } = mainLizmap.lizmap3.map.getLonLatFromPixel(evt.xy));
+            } else if (evt.pixel){ //OL6
+                [lon, lat ] = mainLizmap.map.getCoordinateFromPixel(evt.pixel);
+            }
 
-            this._longitude = lon;
-            this._latitude = lat;
+            if(lon && lat){
+                this._longitude = lon;
+                this._latitude = lat;
 
-            this.redraw(lon, lat);
+                this.redraw(lon, lat);
+            }
         }
     }
 
@@ -205,12 +213,20 @@ export default class MousePosition extends HTMLElement {
         this.displayUnit = this._qgisProjectProjectionUnits;
 
         // Listen to mousemove event
+        // OL2
         mainLizmap.lizmap3.map.events.register('mousemove', this, this._mousemove);
+        // OL6
+        // mainLizmap.map._olMap.on('pointermove', (evt) => this._mousemove(evt));
+        mainLizmap.map._olMap.on('pointermove', (evt) => this._mousemove(evt));
+
         // First render
         render(this.mainTemplate(null, null), this);
     }
 
     disconnectedCallback() {
+        // OL2
         mainLizmap.lizmap3.map.events.unregister('mousemove', this, this._mousemove);
+        // OL6
+        mainLizmap.map._olMap.un('pointermove', (evt) => this._mousemove(evt));
     }
 }

--- a/assets/src/modules/Layers.js
+++ b/assets/src/modules/Layers.js
@@ -1,0 +1,51 @@
+import { mainLizmap } from './Globals.js';
+
+import { Vector as VectorSource } from 'ol/source';
+import { Vector as VectorLayer } from 'ol/layer';
+
+import WKT from 'ol/format/WKT';
+
+export default class Layers {
+
+    constructor() {}
+
+    /**
+     * Add a vector layer from a WKT.
+     * @param {string} wkt WKT in EPSG:4326 projection
+     * @memberof Layers
+     */
+    addLayerFromWKT(wkt){
+        if(!wkt){return;}
+
+        const format = new WKT();
+        const feature = format.readFeature(wkt, {
+            dataProjection: 'EPSG:4326',
+            featureProjection: mainLizmap.projection,
+        });
+
+        const vector = new VectorLayer({
+            source: new VectorSource({
+                features: [feature],
+            }),
+        });
+
+        mainLizmap.map._olMap.addLayer(vector);
+
+        return vector;
+    }
+
+    /**
+     * Removes the given layer from the map.
+     * @param {import("ol/layer/Base").default} layer OL layer to remove
+     * @memberof Layers
+     */
+    removeLayer(layer){
+        if (!layer){return;}
+
+        for (const _layer of mainLizmap.map._olMap.getLayers().getArray()) {
+            if (_layer === layer) {
+                mainLizmap.map._olMap.removeLayer(layer);
+            }
+        }
+    }
+}

--- a/assets/src/modules/Lizmap.js
+++ b/assets/src/modules/Lizmap.js
@@ -47,6 +47,13 @@ export default class Lizmap {
         });
     }
 
+    /**
+     * @param {Boolean} mode - switch new OL map on top of OL2 one
+     */
+    set newOlMap(mode){
+        document.getElementById('newOlMap').style.zIndex = mode ? 750 : 'auto';
+    }
+
     get lizmap3() {
         return this._lizmap3;
     }

--- a/assets/src/modules/Lizmap.js
+++ b/assets/src/modules/Lizmap.js
@@ -1,11 +1,12 @@
-import Map from '../modules/Map.js';
-import Edition from '../modules/Edition.js';
-import Geolocation from '../modules/Geolocation.js';
-import GeolocationSurvey from '../modules/GeolocationSurvey.js';
-import SelectionTool from '../modules/SelectionTool.js';
-import Digitizing from '../modules/Digitizing.js';
-import Snapping from '../modules/Snapping.js';
-import Draw from '../modules/interaction/Draw.js';
+import Map from './Map.js';
+import Edition from './Edition.js';
+import Geolocation from './Geolocation.js';
+import GeolocationSurvey from './GeolocationSurvey.js';
+import SelectionTool from './SelectionTool.js';
+import Digitizing from './Digitizing.js';
+import Snapping from './Snapping.js';
+import Draw from './interaction/Draw.js';
+import Layers from './Layers.js';
 
 import { get as getProjection } from 'ol/proj';
 import { register } from 'ol/proj/proj4';
@@ -45,6 +46,7 @@ export default class Lizmap {
                 this.digitizing = new Digitizing();
                 this.snapping = new Snapping();
                 this.draw = new Draw();
+                this.layers = new Layers();
             }
         });
     }

--- a/assets/src/modules/Lizmap.js
+++ b/assets/src/modules/Lizmap.js
@@ -5,6 +5,7 @@ import GeolocationSurvey from '../modules/GeolocationSurvey.js';
 import SelectionTool from '../modules/SelectionTool.js';
 import Digitizing from '../modules/Digitizing.js';
 import Snapping from '../modules/Snapping.js';
+import Draw from '../modules/interaction/Draw.js';
 
 import { get as getProjection } from 'ol/proj';
 import { register } from 'ol/proj/proj4';
@@ -43,6 +44,7 @@ export default class Lizmap {
                 this.selectionTool = new SelectionTool();
                 this.digitizing = new Digitizing();
                 this.snapping = new Snapping();
+                this.draw = new Draw();
             }
         });
     }

--- a/assets/src/modules/Map.js
+++ b/assets/src/modules/Map.js
@@ -2,40 +2,85 @@ import { mainLizmap, mainEventDispatcher } from '../modules/Globals.js';
 import olMap from 'ol/Map';
 import View from 'ol/View';
 
+import DragPan from "ol/interaction/DragPan";
+import { defaults as defaultInteractions } from 'ol/interaction.js';
+import { Kinetic } from "ol";
+
 /** Class initializing Openlayers Map. */
 export default class Map {
 
     constructor() {
         this._olMap = new olMap({
             controls: [], // disable default controls
+            interactions: defaultInteractions({
+                dragPan: false
+            }).extend([new DragPan({ kinetic: new Kinetic(0, 0, 0) })]),
             view: new View({
-                center: [0, 0],
-                zoom: 2,
-                projection: mainLizmap.projection === 'EPSG:900913' ? 'EPSG:3857' : mainLizmap.projection
+                resolutions: mainLizmap.lizmap3.map.baseLayer.resolutions,
+                constrainResolution: true,
+                center: this._lizmap3Center,
+                projection: mainLizmap.projection === 'EPSG:900913' ? 'EPSG:3857' : mainLizmap.projection,
+                enableRotation: false,
+                extent: mainLizmap.lizmap3.map.restrictedExtent.toArray(),
+                constrainOnlyCenter: true // allow view outside the restricted extent when zooming
             }),
             target: 'newOlMap'
         });
 
+        // Sync new OL view with OL2 view
+        mainLizmap.lizmap3.map.events.on({
+            moveend: () => {
+                // Sync center
+                this._olMap.getView().animate({
+                    center: this._lizmap3Center,
+                    duration: 0
+                });
+
+                mainEventDispatcher.dispatch('map.moveend');
+            },
+            zoomstart: (evt) => {
+                // Sync zoom level
+                this._olMap.getView().animate({
+                    zoom: evt.zoom,
+                    duration: 0
+                });
+
+                mainEventDispatcher.dispatch('map.zoomstart');
+            },
+            zoomend: () => {
+                mainEventDispatcher.dispatch('map.zoomend');
+            }
+        });
+
+        // Sync OL2 view with new OL view
+        this._olMap.on('pointerdrag', () => {
+            mainLizmap.lizmap3.map.setCenter(
+                this._olMap.getView().getCenter(),
+                null,
+                true // avoid many WMS request in OL2 map and also movestart/end events.
+            );
+        });
+
+        // TODO: we need a OL6 movestart or zoomstart event giving the target zoom
+        // to sync OL2 zoom without waiting moveend event as done with OL2 zoomstart
+        // This would avoid a visual shift between OL2 and OL6 when zooming
         this._olMap.on('moveend', () => {
-            mainLizmap.lizmap3.map.setCenter(this._olMap.getView().getCenter());
+            // This refresh OL2 layers
+            mainLizmap.lizmap3.map.zoomToExtent(this._olMap.getView().calculateExtent(), true);
         });
 
         // Init view
         this.syncNewOLwithOL2View();
+    }
 
-        // Listen to old map events to dispatch new ones
-        mainLizmap.lizmap3.map.events.on({
-            moveend: () => {
-                this.syncNewOLwithOL2View();
-
-                mainEventDispatcher.dispatch('map.moveend');
-            },
-            zoomend: () => {
-                this.syncNewOLwithOL2View();
-
-                mainEventDispatcher.dispatch('map.zoomend');
-            }
-        });
+    /**
+     * Returns Lizmap 3 map center
+     * @readonly
+     * @memberof Map
+     * @returns {[Number, Number]} lon, lat coords
+     */
+    get _lizmap3Center(){
+        return [mainLizmap.lizmap3.map.getCenter().lon, mainLizmap.lizmap3.map.getCenter().lat];
     }
 
     /**
@@ -43,9 +88,10 @@ export default class Map {
      * @memberof Map
      */
     syncNewOLwithOL2View(){
-        this._olMap.getView().setResolution(mainLizmap.lizmap3.map.getResolution());
-
-        const lizmap3Center = mainLizmap.lizmap3.map.getCenter();
-        this._olMap.getView().setCenter([lizmap3Center.lon, lizmap3Center.lat]);
+        this._olMap.getView().animate({
+            center: this._lizmap3Center,
+            zoom: mainLizmap.lizmap3.map.getZoom(),
+            duration: 0
+        });
     }
 }

--- a/assets/src/modules/Map.js
+++ b/assets/src/modules/Map.js
@@ -3,6 +3,7 @@ import olMap from 'ol/Map';
 import View from 'ol/View';
 
 import DragPan from "ol/interaction/DragPan";
+import MouseWheelZoom from "ol/interaction/MouseWheelZoom";
 import { defaults as defaultInteractions } from 'ol/interaction.js';
 import { Kinetic } from "ol";
 
@@ -13,8 +14,12 @@ export default class Map {
         this._olMap = new olMap({
             controls: [], // disable default controls
             interactions: defaultInteractions({
-                dragPan: false
-            }).extend([new DragPan({ kinetic: new Kinetic(0, 0, 0) })]),
+                dragPan: false,
+                mouseWheelZoom: false
+            }).extend([
+                new DragPan({ kinetic: new Kinetic(0, 0, 0) }),
+                new MouseWheelZoom({ duration: 0 })
+            ]),
             view: new View({
                 resolutions: mainLizmap.lizmap3.map.baseLayer.resolutions,
                 constrainResolution: true,

--- a/assets/src/modules/Map.js
+++ b/assets/src/modules/Map.js
@@ -92,7 +92,7 @@ export default class Map {
      * Returns Lizmap 3 map center
      * @readonly
      * @memberof Map
-     * @returns {[Number, Number]} lon, lat coords
+     * @return {[number, number]} lon, lat coords
      */
     get _lizmap3Center(){
         return [mainLizmap.lizmap3.map.getCenter().lon, mainLizmap.lizmap3.map.getCenter().lat];
@@ -108,5 +108,14 @@ export default class Map {
             zoom: mainLizmap.lizmap3.map.getZoom(),
             duration: 0
         });
+    }
+
+    /**
+     * Get the coordinate for a given pixel array.
+     * @param {[number, number]} pixel Pixel.
+     * @return {[number, number]} The coordinate for the pixel position.
+     */
+    getCoordinateFromPixel(pixel){
+        return this._olMap.getCoordinateFromPixel(pixel);
     }
 }

--- a/assets/src/modules/interaction/Draw.js
+++ b/assets/src/modules/interaction/Draw.js
@@ -1,0 +1,86 @@
+import { mainLizmap, mainEventDispatcher } from '../Globals.js';
+
+import { Circle as CircleStyle, Fill, Stroke, Style } from 'ol/style';
+import { Vector as VectorSource } from 'ol/source';
+import { Vector as VectorLayer } from 'ol/layer';
+import { Draw as olDraw, Modify as olModify } from 'ol/interaction';
+
+export default class Draw {
+
+    constructor(){}
+
+    /**
+     * Initialize Draw based on new OL
+     * @param {string} [geomType="Point"] The geometry type. One of 'Point', 'LineString', 'LinearRing', 'Polygon', 'MultiPoint', 'MultiLineString', 'MultiPolygon', 'GeometryCollection', 'Circle'.
+     * @param {number} [maxFeatures=-1] Limit the draw to maxFeatures features
+     * @param {boolean} [modify=true] Allow to modify features after being drawn
+     * @memberof Draw
+     */
+    init(geomType = "Point", maxFeatures = -1, modify = true) {
+        if (this._drawSource){
+            this.clear();
+        }
+
+        mainLizmap.newOlMap = true;
+
+        this._drawSource = new VectorSource();
+
+        // Dispatch event when a feature is added
+        this._drawSource.on('addfeature', () => {
+            mainEventDispatcher.dispatch('draw.addFeature');
+        });
+
+        this._drawLayer = new VectorLayer({
+            source: this._drawSource,
+            style: new Style({
+                fill: new Fill({
+                    color: 'rgba(255, 255, 255, 0.2)',
+                }),
+                stroke: new Stroke({
+                    color: '#ffcc33',
+                    width: 2,
+                }),
+                image: new CircleStyle({
+                    radius: 7,
+                    fill: new Fill({
+                        color: '#ffcc33',
+                    }),
+                }),
+            }),
+        });
+
+        mainLizmap.map._olMap.addLayer(this._drawLayer);
+
+        this._drawInteraction = new olDraw({
+            source: this._drawSource,
+            type: geomType,
+        });
+
+        this._drawInteraction.on('drawend', () => {
+            // Limit the draw to maxFeatures features
+            if (maxFeatures !== -1 && this._drawSource.getFeatures().length === maxFeatures - 1) {
+                mainLizmap.map._olMap.removeInteraction(this._drawInteraction);
+            }
+        });
+
+        mainLizmap.map._olMap.addInteraction(this._drawInteraction);
+
+        if (modify) {
+            this._modifyInteraction = new olModify({ source: this._drawSource });
+            mainLizmap.map._olMap.addInteraction(this._modifyInteraction);
+        }
+    }
+
+    clear(){
+        this._drawSource.clear(true);
+    }
+
+    set visible(visible) {
+        this._drawLayer.setVisible(visible);
+        mainLizmap.newOlMap = visible;
+    }
+
+    get features(){
+        return this._drawSource.getFeatures();
+    }
+}


### PR DESCRIPTION
This PR allows to put new OpenLayers Map on top of OL2 one. Both maps are in sync (zoom and extent).
This allows to use new OpenLayers features and remove legacy OL2 ones step by step.
This PR also add some draw features with new OpenLayers.

* Funded by [CRIGE PACA](https://www.crige-paca.org/) and 3Liz
