### PR TITLE
[Feature] Get the GetFeatureInfo from QGIS Server with the QGIS Form

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -672,7 +672,7 @@ class WMSRequest extends OGCRequest
             // New option to choose the popup source : auto (=default), lizmap (=popupTemplate), qgis (=qgis maptip)
             $finalContent = $autoContent;
             if (property_exists($configLayer, 'popupSource')) {
-                if ($configLayer->popupSource == 'qgis' && $maptipValue) {
+                if (in_array($configLayer->popupSource, array('qgis', 'form')) && $maptipValue) {
                     $finalContent = $maptipValue;
                 }
                 if ($configLayer->popupSource == 'lizmap' && $templateConfigured) {

--- a/lizmap/www/assets/js/map.js
+++ b/lizmap/www/assets/js/map.js
@@ -3110,7 +3110,7 @@ var lizMap = function() {
                 var childPopup = $('<div class="lizmapPopupChildren ' + clname + '" data-layername="' + clname + '">' + popupChildData + '</div>');
 
                 //Manage if the user choose to create a table for children
-                if (configLayer.popupSource == 'qgis' &&
+                if (['qgis', 'form'].indexOf(configLayer.popupSource) !== -1 &&
                   childPopup.find('.lizmap_merged').length != 0) {
                   // save inputs
                   childPopup.find(".lizmapPopupDiv").each(function (i, e) {


### PR DESCRIPTION
* Funded by French Province Pyrénées-Atlantiques https://www.le64.fr/
* Based on Lizmap plugin changes https://github.com/3liz/lizmap-plugin/pull/341

A new popupSource is available in Lizmap Plugin: form
This configuration requested the Lizmap plugin server side to build the maptip HTML based on QGIS Form.
This configuration avoid to update the QGIS maptip with the QGIS Form.
So you can have a QGIS maptip and a Lizmap popup based on QGIS Form.
