### PR TITLE
Action - Improvements in Lizmap Web Client action module

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -20,12 +20,14 @@
 - Overviewmap now zoom in/out with main map. Replace OpenLayers 2 overviewmap by the OpenLayers 6 one.
 - Allow new OpenLayers Map to be used on top of OL2 one
 - Update OpenLayers to 6.5
+- Action popup module has been improved with new options: confirm property, display a message if configured, raise a JS event with the returned result.
 
 ### Fixed
 
 ### New JS events
 
 - `lizmappopupallchildrendisplayed` is raised when all children popups have been displayed
+- `actionResultReceived` is raised when a popup action result is returned
 
 ### Backend
 


### PR DESCRIPTION
* Remove useless JS code which sent the action `options` parameters (they are retrieved safely by the PHP back-end)
* When the result GeoJSON contains a field `message`, it is displayed in Lizmap message bar at the same time the received geometry is drawn
* A new action property `confirm` allows the editor to have a confirm message displayed with its text content before performing the action
* A new Lizmap event `actionResultReceived` is triggered when the action result is received with the action properties and the returned GeoJSON feature
* Documentation has been improved.

* Funded by SNCF Réseau Grand-Est
