### PR TITLE
Resurrect lizmapProxy and lizmapOGCRequest classes for modules compatibility

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -37,5 +37,6 @@
 ### Backend
 
 - Major refactoring of Lizmap source code done by @alagroy-42
+- Keep lizmapProxy and lizmapOGCRequest classes for modules compatibility
 - Upgrade Jelix to 1.6.32
 - Improve testings using Docker, Cypress, PHPUnit etc

--- a/lizmap/modules/lizmap/classes/lizmapOGCRequest.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapOGCRequest.class.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Manage OGC request.
+ *
+ * @author    3liz
+ * @copyright 2015-2021 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+/**
+ * dummy class for compatibility.
+ *
+ * @see \Lizmap\Request\OGCRequest
+ * @deprecated
+ */
+class lizmapOGCRequest extends \Lizmap\Request\OGCRequest
+{
+    /**
+     * constructor.
+     *
+     * @param lizmapProject $project    the project has a lizmapProject Class
+     * @param array         $params     the OGC request parameters array
+     * @param string        $requestXml the OGC XML Request as string
+     */
+    public function __construct($project, $params, $requestXml = null)
+    {
+        $this->project = $project;
+
+        $this->repository = $project->getRepository();
+
+        $this->services = lizmap::getServices();
+        $this->appContext = \Lizmap\Request\Proxy::getAppContext();
+
+        $params['map'] = $project->getRelativeQgisPath();
+        $this->params = \Lizmap\Request\Proxy::normalizeParams($params);
+        $this->requestXml = $requestXml;
+    }
+}

--- a/lizmap/modules/lizmap/classes/lizmapProxy.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProxy.class.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Proxy for map services.
+ *
+ * @author    3liz
+ * @copyright 2012-2021 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+/**
+ * dummy class for compatibility.
+ *
+ * @see \Lizmap\Request\Proxy
+ * @deprecated
+ */
+class lizmapProxy extends \Lizmap\Request\Proxy
+{
+}

--- a/lizmap/modules/lizmap/module.xml
+++ b/lizmap/modules/lizmap/module.xml
@@ -30,6 +30,9 @@
         <class name="qgisLayerDbFieldsInfo" file="classes/qgisLayerDbFieldsInfo.class.php"/>
         <class name="lizmapServices" file="classes/lizmapServices.class.php"/>
         <class name="qgisExpressionUtils" file="classes/qgisExpressionUtils.class.php"/>
+        <!-- legacy classes -->
+        <class name="lizmapProxy" file="classes/lizmapProxy.class.php"/>
+        <class name="lizmapOGCRequest" file="classes/lizmapOGCRequest.class.php"/>
         <namespacePathMap name="Lizmap" dir="lib"/>
     </autoload>
 </module>


### PR DESCRIPTION
Some modules, like cadastre and wps client, need lizmapProxy and lizmapOGCRequest.
These classes has been removed and replaced by namespace classes. To keep compatibility,
These classes has been resurrected to extends the new classes.