### PR TITLE
Fix: Add hash in custom assets querystring

### DIFF
--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -404,6 +404,7 @@ class lizMapCtrl extends jController
                                     array(
                                         'repository' => $lrep->getKey(),
                                         'project' => $project,
+                                        'mtime' => filemtime($filename),
                                         'path' => $jsRelPath,
                                     )
                                 );


### PR DESCRIPTION
Add file modification time in custom assets querystring.
It busts cache and avoid user to force reload (ctrl + F5) to have fresh assets.

* Fix #2373 
* Funded by 3Liz
