### PR TITLE
Add Romanian translation for dataTables

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -5,6 +5,7 @@
 Not released yet
 
 - Fix: multiple selection edition w/ text field. Values can be integer but also string
+- Translation: add Romamian for dataTables (contribution from @ygorigor)
 
 ## Version 3.4.4
 

--- a/lizmap/www/assets/js/dataTables/ro_RO.json
+++ b/lizmap/www/assets/js/dataTables/ro_RO.json
@@ -1,0 +1,23 @@
+{
+    "sEmptyTable":     "Nu există date disponibile în tabel",
+    "sInfo":           "Afișare _START_ - _END_ din _TOTAL_ înregistrări.",
+    "sInfoEmpty":      "Afișare 0 - 0 din 0 înregistrări",
+    "sInfoFiltered":   "(filtrat din _MAX_ înregistrări totale)",
+    "sInfoPostFix":    "",
+    "sInfoThousands":  ",",
+    "sLengthMenu":     "Afișare _MENU_ înregistrări",
+    "sLoadingRecords": "Se încarcă...",
+    "sProcessing":     "Se procesează...",
+    "sSearch":         "Căutare:",
+    "sZeroRecords":    "Nu au fost găsite înregistrări care să se potrivească",
+    "oPaginate": {
+        "sFirst":    "Prima",
+        "sLast":     "Ultima",
+        "sNext":     "Următoarea",
+        "sPrevious": "Precedenta"
+    },
+    "oAria": {
+        "sSortAscending":  ": activați pentru a sorta coloana în ordine crescătoare",
+        "sSortDescending": ": activați pentru a sorta coloana în ordine descrescătoare"
+    }
+}


### PR DESCRIPTION
Target: LWC 3.6, 3.5, 3.4
