### PR TITLE
[tests] upgrade PHPUnit to 9.5.7

### DIFF
--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -243,7 +243,10 @@ class Project
             }
             $rewriteCache = false;
             foreach ($this->layers as $index => $layer) {
-                if (array_key_exists('embedded', $layer) && $layer['embedded'] == '1' && $layer['qgsmtime'] < filemtime($layer['file'])) {
+                if (array_key_exists('embedded', $layer)
+                    && $layer['embedded'] == '1'
+                    && $layer['qgsmtime'] < filemtime($layer['file'])
+                ) {
                     $qgsProj = new QgisProject($layer['file'], $services, $this->appContext);
                     $newLayer = $qgsProj->getLayerDefinition($layer['id']);
                     $newLayer['qsgmtime'] = filemtime($layer['file']);

--- a/tests/units/bootstrap.php
+++ b/tests/units/bootstrap.php
@@ -1,8 +1,6 @@
 <?php
 
 require_once(__DIR__.'/../../lizmap/application.init.php');
-require_once(LIB_PATH.'jelix-tests/classes/junittestcase.class.php');
-require_once(LIB_PATH.'jelix-tests/classes/junittestcasedb.class.php');
 
 
 spl_autoload_register(function($class) {

--- a/tests/units/classes/App/XmlToolsTest.php
+++ b/tests/units/classes/App/XmlToolsTest.php
@@ -58,7 +58,7 @@ class XmlToolsTest extends TestCase
         $this->assertTrue(!is_object($xml));
         $this->assertTrue(is_string($xml));
         $this->assertStringStartsNotWith('\n', $xml);
-        $this->assertContains('Fatal', $xml);
+        $this->assertStringContainsString('Fatal', $xml);
     }
 
     function testXmlFromFile() {
@@ -75,6 +75,6 @@ class XmlToolsTest extends TestCase
         $this->assertTrue(!is_object($xml));
         $this->assertTrue(is_string($xml));
         $this->assertStringStartsNotWith('\n', $xml);
-        $this->assertContains('Fatal', $xml);
+        $this->assertStringContainsString('Fatal', $xml);
     }
 }

--- a/tests/units/classes/Form/QgisFormTest.php
+++ b/tests/units/classes/Form/QgisFormTest.php
@@ -121,7 +121,7 @@ class QgisFormTest extends TestCase
         if (!$fields) {
             $this->expectException('Exception');
         }
-        $form = new QgisForm2ForTests($layer, new dummyForm(), null, false, $this->appContext, true);
+        $form = new QgisForm2ForTests($layer, new dummyForm(), null, false, $this->appContext);
         if ($fields) {
             $controls = $form->getQgisControls();
             $this->assertEquals(count((array) $fields), count($controls));

--- a/tests/units/classes/Log/ConfigTest.php
+++ b/tests/units/classes/Log/ConfigTest.php
@@ -1,5 +1,5 @@
 <?php
-
+use PHPUnit\Framework\TestCase;
 
 use Lizmap\Logger as Log;
 
@@ -7,11 +7,11 @@ use Lizmap\Logger as Log;
  * @internal
  * @coversNothing
  */
-class ConfigTest extends PHPUnit_Framework_TestCase
+class ConfigTest extends TestCase
 {
     protected $context;
 
-    public function setUp()
+    public function setUp() : void
     {
         if ($this->context) {
             return;

--- a/tests/units/classes/Log/ItemTest.php
+++ b/tests/units/classes/Log/ItemTest.php
@@ -7,7 +7,7 @@ class ItemTest extends TestCase
 {
     protected $context = null;
 
-    public function setUp()
+    public function setUp() : void
     {
         if (!$this->context) {
             $this->context = new ContextForTests();
@@ -94,12 +94,25 @@ class ItemTest extends TestCase
         ));
         $item = new Log\Item('test', array(), $context);
         $item->insertLogDetail($data);
+        $resultRecord = $context->getResult()['createDaoRecord'];
         if (!$data) {
+            $this->assertNull($resultRecord->key);
+            $this->assertNull($resultRecord->user);
+            $this->assertNull($resultRecord->content);
+            $this->assertNull($resultRecord->repository);
+            $this->assertNull($resultRecord->project);
+            $this->assertNull($resultRecord->ip);
+            $this->assertNull($resultRecord->email);
             return ;
         }
+
+
         foreach ($data as $key => $value) {
             if (in_array($key, $item->getRecordKeys())) {
-                $this->assertEquals($value, $context->getResult()['createDaoRecord']->$key);
+                $this->assertEquals($value, $resultRecord->$key);
+            }
+            else {
+                $this->assertFalse(isset($resultRecord->$key));
             }
         }
     }

--- a/tests/units/classes/Project/ProjectConfigTest.php
+++ b/tests/units/classes/Project/ProjectConfigTest.php
@@ -1,12 +1,12 @@
 <?php
-
+use PHPUnit\Framework\TestCase;
 use Lizmap\Project;
 
 /**
  * @internal
  * @coversNothing
  */
-class projectConfigTest extends PHPUnit_Framework_TestCase
+class projectConfigTest extends TestCase
 {
     public function getConstructData()
     {

--- a/tests/units/classes/Request/ProxyTest.php
+++ b/tests/units/classes/Request/ProxyTest.php
@@ -5,7 +5,7 @@ use Lizmap\Request;
 
 class ProxyTest extends TestCase
 {
-    public function setUp()
+    public function setUp() : void
     {
         $appContext = new ContextForTests();
         Request\Proxy::setServices(new lizmapServices(array(), (object)array(), false, '', $appContext));

--- a/tests/units/classes/lizmapRepositoryTest.php
+++ b/tests/units/classes/lizmapRepositoryTest.php
@@ -1,10 +1,10 @@
 <?php
-
+use PHPUnit\Framework\TestCase;
 /**
  * @internal
  * @coversNothing
  */
-class lizmapRepositoryTest extends PHPUnit_Framework_TestCase
+class lizmapRepositoryTest extends TestCase
 {
     public function getTestGetPathData()
     {

--- a/tests/units/classes/lizmapServicesTest.php
+++ b/tests/units/classes/lizmapServicesTest.php
@@ -1,10 +1,10 @@
 <?php
-
+use PHPUnit\Framework\TestCase;
 /**
  * @internal
  * @coversNothing
  */
-class lizmapServicesTest extends PHPUnit_Framework_TestCase
+class lizmapServicesTest extends TestCase
 {
     public function getContactEmail()
     {

--- a/tests/units/classes/lizmapWktTest.php
+++ b/tests/units/classes/lizmapWktTest.php
@@ -1,7 +1,7 @@
 <?php
+use PHPUnit\Framework\TestCase;
 
-
-class lizmapWktTest extends PHPUnit_Framework_TestCase {
+class lizmapWktTest extends TestCase {
 
     function testPoint() {
         $wkt = 'POINT (30 10)';

--- a/tests/units/classes/qgisExpressionUtilsTest.php
+++ b/tests/units/classes/qgisExpressionUtilsTest.php
@@ -1,7 +1,7 @@
 <?php
+use PHPUnit\Framework\TestCase;
 
-
-class qgisExpressionUtilsTest extends PHPUnit_Framework_TestCase {
+class qgisExpressionUtilsTest extends TestCase {
 
     function testCriteriaFromExpression() {
         $exp = '"name" IS NOT NULL AND "name" <> \'\'';

--- a/tests/units/composer.json
+++ b/tests/units/composer.json
@@ -8,8 +8,8 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
-        "phpunit/phpunit": "^5.7.27"
+        "php": ">=7.3.0",
+        "phpunit/phpunit": "^9.5.7"
     },
     "autoload": {
         "classmap": ["../../lizmap/modules/lizmap/classes/" ],

--- a/tests/units/edition/qgisAttributeFormTest.php
+++ b/tests/units/edition/qgisAttributeFormTest.php
@@ -1,5 +1,5 @@
 <?php
-
+use PHPUnit\Framework\TestCase;
 use Lizmap\Form;
 
 class dummyQgisFormControls implements Form\QgisFormControlsInterface
@@ -39,7 +39,7 @@ class dummyQgisFormControls implements Form\QgisFormControlsInterface
  * @internal
  * @coversNothing
  */
-class qgisAttributeFormTest extends PHPUnit_Framework_TestCase
+class qgisAttributeFormTest extends TestCase
 {
     public function testSimpleContainer()
     {

--- a/tests/units/edition/qgisVectorLayerDatasourceTest.php
+++ b/tests/units/edition/qgisVectorLayerDatasourceTest.php
@@ -1,6 +1,7 @@
 <?php
+use PHPUnit\Framework\TestCase;
 
-class qgisVectorLayerDatasourceTest extends PHPUnit_Framework_TestCase {
+class qgisVectorLayerDatasourceTest extends TestCase {
 
 
     function testPostgresqlDatasource() {


### PR DESCRIPTION
We have an old PHP Unit version compatible with PHP 5.6. As we won't support PHP 5.6, we can upgrade to PHP unit 9.5.7 which is compatible with PHP 7.3+

* Funded by 3Liz
