### PR TITLE
Fix the form cache to avoid regression

### DIFF
--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -437,6 +437,7 @@ class serviceCtrl extends jController
             return $this->serviceException();
         }
 
+        /** @var jResponseBinary $rep */
         $rep = $this->getResponse('binary');
         $rep->setHttpStatus($result->code, '');
         $rep->mimeType = $result->mime;

--- a/lizmap/modules/lizmap/lib/App/JelixContext.php
+++ b/lizmap/modules/lizmap/lib/App/JelixContext.php
@@ -128,10 +128,12 @@ class JelixContext implements AppContextInterface
      * @param mixed  $value   The data to store in the cache
      * @param mixed  $ttl     data time expiration
      * @param string $profile the cache profile to use
+     *
+     * @return bool false if failure
      */
     public function setCache($key, $value, $ttl = null, $profile = '')
     {
-        \jCache::set($key, $value, $ttl, $profile);
+        return \jCache::set($key, $value, $ttl, $profile);
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -111,8 +111,8 @@ class QgisForm implements QgisFormControlsInterface
 
             $constraints = $this->getConstraints($fieldName);
 
-            if (property_exists($formInfos, $fieldName)) {
-                $formControl = new QgisFormControl($fieldName, $formInfos->{$fieldName}, $prop, $defaultValue, $constraints, $this->appContext);
+            if (isset($formInfos[$fieldName])) {
+                $formControl = new QgisFormControl($fieldName, $formInfos[$fieldName], $prop, $defaultValue, $constraints, $this->appContext);
             } else {
                 // The geometry field is not present in the .XML
                 $formControl = new QgisFormControl($fieldName, null, $prop, null, $constraints, $this->appContext);
@@ -252,6 +252,11 @@ class QgisForm implements QgisFormControlsInterface
         return null;
     }
 
+    /**
+     * @param QgisFormControl $formControl
+     * @param string          $fieldName
+     * @param \jFormsBase     $form
+     */
     protected function fillFormControl($formControl, $fieldName, $form)
     {
         if ($formControl->isUniqueValue()) {
@@ -454,10 +459,9 @@ class QgisForm implements QgisFormControlsInterface
                 $form->setData($ref.'_hidden', $value);
             } else {
                 if (in_array(strtolower($this->formControls[$ref]->fieldEditType), array('date', 'time', 'datetime'))) {
-                    $edittype = $this->formControls[$ref]->getEditType();
-                    if ($edittype && property_exists($edittype, 'options')
-                            && property_exists($edittype->options, 'field_format') && $value) {
-                        $format = $this->convertQgisFormatToPHP($edittype->options->field_format);
+                    $format = $this->formControls[$ref]->getEditAttribute('field_format');
+                    if ($format && $value) {
+                        $format = $this->convertQgisFormatToPHP($format);
                         $date = \DateTime::createFromFormat($format, $value);
                         if ($date) {
                             $value = $date->format('Y-m-d H:i:s');
@@ -832,10 +836,9 @@ class QgisForm implements QgisFormControlsInterface
         $convertDate = array('date', 'time', 'datetime');
 
         if (in_array(strtolower($this->formControls[$ref]->fieldEditType), $convertDate)) {
-            $edittype = $this->formControls[$ref]->getEditType();
-            if ($edittype && property_exists($edittype, 'options')
-                    && property_exists($edittype->options, 'field_format')) {
-                $value = $this->convertDateTimeToFormat($value, $edittype->options->field_format);
+            $format = $this->formControls[$ref]->getEditAttribute('field_format');
+            if ($format) {
+                $value = $this->convertDateTimeToFormat($value, $format);
             }
         }
 

--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -102,12 +102,10 @@ class QgisForm implements QgisFormControlsInterface
         $dataFields = $dbFieldsInfo->dataFields;
         $toDeactivate = array();
         $toSetReadOnly = array();
-        $formPath = $this->appContext->getFormPath();
-        $json = file_get_contents($formPath.$layer->getProject()->getKey().'.'.$layer->getId().'.form.json');
-        if (!$json) {
-            throw new \Exception('Can\'t read the Json form file, try to clear your cache and reload the page.');
-        }
-        $formInfos = json_decode($json);
+
+        $cacheHandler = $layer->getProject()->getCacheHandler();
+        $formInfos = $cacheHandler->getEditableLayerFormCache($layer->getId());
+
         foreach ($dataFields as $fieldName => $prop) {
             $defaultValue = $this->getDefaultValue($fieldName);
 
@@ -367,7 +365,7 @@ class QgisForm implements QgisFormControlsInterface
     /**
      * Reset the form controls data to Null.
      *
-     * @return jFormsBase the Jelix jForm object
+     * @return \jFormsBase the Jelix jForm object
      */
     public function resetFormData()
     {
@@ -387,7 +385,7 @@ class QgisForm implements QgisFormControlsInterface
     /**
      * Set the form controls data from the database default value.
      *
-     * @return jFormsBase the Jelix jForm object
+     * @return \jFormsBase the Jelix jForm object
      */
     public function setFormDataFromDefault()
     {
@@ -423,7 +421,7 @@ class QgisForm implements QgisFormControlsInterface
      *
      * @param mixed $feature
      *
-     * @return jFormsBase the Jelix jForm object
+     * @return \jFormsBase the Jelix jForm object
      */
     public function setFormDataFromFields($feature)
     {

--- a/lizmap/modules/lizmap/lib/Form/QgisFormControlProperties.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisFormControlProperties.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * Properties of a Form field.
+ *
+ * @author    3liz
+ * @copyright 2021 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+namespace Lizmap\Form;
+
+/**
+ * Properties of a Form field.
+ *
+ * These properties are set during the read of the QGIS file. Can be stored
+ * into a cache.
+ */
+class QgisFormControlProperties
+{
+    /**
+     * @var string
+     */
+    protected $name = '';
+
+    /**
+     * @var int|string
+     */
+    protected $fieldEditType;
+
+    /**
+     * @var array
+     */
+    protected $attributes = array();
+
+    /**
+     * @var bool
+     */
+    protected $editable = true;
+
+    /**
+     * @var string
+     */
+    protected $fieldAlias = '';
+
+    /**
+     * @var array
+     */
+    protected $rendererCategories = array();
+
+    protected $_IsMultiline = false;
+
+    protected $_UseHtml = false;
+
+    protected $markup = '';
+
+    /**
+     * @param string     $name
+     * @param int|string $fieldEditType
+     * @param mixed      $markup
+     */
+    public function __construct($name, $fieldEditType, $markup, array $attributes)
+    {
+        $this->name = $name;
+        $this->fieldEditType = $fieldEditType; // != '' ? $fieldEditType: 'undefined';
+        $this->markup = $markup;
+
+        foreach (array('IsMultiline', 'UseHtml') as $prop) {
+            if (isset($attributes[$prop])) {
+                $this->{'_'.$prop} = $attributes[$prop];
+                unset($attributes[$prop]);
+            }
+        }
+
+        // if one of these attributes is false, the control is not editable
+        foreach (array('editable', 'Editable', 'fieldEditable') as $prop) {
+            if (isset($attributes[$prop])) {
+                if (!$attributes[$prop]) {
+                    $this->editable = false;
+                }
+                unset($attributes[$prop]);
+            }
+        }
+
+        if (!isset($attributes['filters'])) {
+            $attributes['filters'] = array();
+        }
+        if (!isset($attributes['chainFilters'])) {
+            $attributes['chainFilters'] = false;
+        }
+
+        $this->attributes = $attributes;
+    }
+
+    /**
+     * The name of the control.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getFieldEditType()
+    {
+        return $this->fieldEditType;
+    }
+
+    /**
+     * @return array
+     */
+    public function getEditAttributes()
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * @param string $attrName
+     *
+     * @return null|mixed
+     */
+    public function getEditAttribute($attrName)
+    {
+        if (isset($this->attributes[$attrName])) {
+            return $this->attributes[$attrName];
+        }
+
+        return null;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEditable()
+    {
+        return $this->editable;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isMultiline()
+    {
+        return $this->_IsMultiline;
+    }
+
+    /**
+     * @return bool
+     */
+    public function useHtml()
+    {
+        return $this->_UseHtml;
+    }
+
+    public function getValueMap()
+    {
+        // for the case when it is stored into <edittype>
+        if (isset($this->attributes['valueMap'])
+            && is_array($this->attributes['valueMap'])
+        ) {
+            return $this->attributes['valueMap'];
+        }
+        // for the case when it is stored into <fieldConfiguration>
+        if (isset($this->attributes['map'])
+            && is_array($this->attributes['map'])
+        ) {
+            return $this->attributes['map'];
+        }
+
+        return array();
+    }
+
+    public function getValueRelationData()
+    {
+        return array(
+            'allowNull' => $this->getEditAttribute('AllowNull'),
+            'orderByValue' => $this->getEditAttribute('OrderByValue'),
+            'layer' => $this->getEditAttribute('Layer'),
+            'key' => $this->getEditAttribute('Key'),
+            'value' => $this->getEditAttribute('Value'),
+            'allowMulti' => $this->getEditAttribute('AllowMulti'),
+            'filterExpression' => $this->getEditAttribute('FilterExpression'),
+            'useCompleter' => $this->getEditAttribute('UseCompleter'),
+            'fieldEditable' => $this->isEditable(),
+        );
+    }
+
+    public function getRelationReference()
+    {
+        return array(
+            'allowNull' => $this->getEditAttribute('AllowNull'),
+            'orderByValue' => $this->getEditAttribute('OrderByValue'),
+            'relation' => $this->getEditAttribute('Relation'),
+            'mapIdentification' => $this->getEditAttribute('MapIdentification'),
+            'filters' => $this->getEditAttribute('filters'),
+            'chainFilters' => $this->getEditAttribute('chainFilters'),
+        );
+    }
+
+    public function setRendererCategories(array $rendererCategories)
+    {
+        $this->rendererCategories = $rendererCategories;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRendererCategories()
+    {
+        return $this->rendererCategories;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMarkup()
+    {
+        return $this->markup;
+    }
+
+    /**
+     * @param string $fieldAlias
+     */
+    public function setFieldAlias($fieldAlias)
+    {
+        $this->fieldAlias = $fieldAlias;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFieldAlias()
+    {
+        return $this->fieldAlias;
+    }
+}

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -204,9 +204,9 @@ class Project
     /**
      * constructor.
      *
-     * @param string                  $key        : the project name
-     * @param Repository              $rep        : the repository
-     * @param App\AppContextInterface $appContext the instance of jelixInfos
+     * @param string                  $key        the project name
+     * @param Repository              $rep        the repository
+     * @param App\AppContextInterface $appContext context
      */
     public function __construct($key, Repository $rep, App\AppContextInterface $appContext, \LizmapServices $services)
     {
@@ -224,8 +224,10 @@ class Project
         if (!file_exists($file.'.cfg')) {
             throw new UnknownLizmapProjectException('The lizmap config '.$file.'.cfg does not exist!');
         }
+        $qgsMtime = filemtime($file);
+        $qgsCfgMtime = filemtime($file.'.cfg');
 
-        $this->cacheHandler = new ProjectCache($file, $this->appContext);
+        $this->cacheHandler = new ProjectCache($file, $qgsMtime, $qgsCfgMtime, $this->appContext);
 
         $data = $this->cacheHandler->retrieveProjectData();
         if ($data === false) {

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -159,9 +159,25 @@ class Project
     /**
      * @var array List of cached properties
      */
-    protected $cachedProperties = array('WMSInformation', 'canvasColor', 'allProj4',
-        'relations', 'themes', 'layersOrder', 'printCapabilities', 'locateByLayer', 'formFilterLayers',
-        'editionLayers', 'attributeLayers', 'useLayerIDs', 'layers', 'data', 'cfgContent', 'options', 'QgisProjectVersion', );
+    protected $cachedProperties = array(
+        'WMSInformation',
+        'canvasColor',
+        'allProj4',
+        'relations',
+        'themes',
+        'layersOrder',
+        'printCapabilities',
+        'locateByLayer',
+        'formFilterLayers',
+        'editionLayers',
+        'attributeLayers',
+        'useLayerIDs',
+        'layers',
+        'data',
+        'cfgContent',
+        'options',
+        'QgisProjectVersion',
+    );
 
     /**
      * @var string
@@ -228,6 +244,8 @@ class Project
                 throw $e;
             }
             $this->readProject($key, $rep);
+
+            // set project data in cache
             foreach ($this->cachedProperties as $prop) {
                 if (isset($this->{$prop}) && !empty($this->{$prop})) {
                     $data[$prop] = $this->{$prop};
@@ -276,6 +294,14 @@ class Project
         }
 
         $this->path = $file;
+    }
+
+    /**
+     * @return ProjectCache
+     */
+    public function getCacheHandler()
+    {
+        return $this->cacheHandler;
     }
 
     public function clearCache()

--- a/lizmap/modules/lizmap/lib/Project/ProjectCache.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectCache.php
@@ -3,6 +3,7 @@
 namespace Lizmap\Project;
 
 use Lizmap\App;
+use Lizmap\Form\QgisFormControlProperties;
 
 class ProjectCache
 {
@@ -143,8 +144,8 @@ class ProjectCache
      * as the getEditableLayerFormCache method does not check the validity
      * of the cache.
      *
-     * @param string  $layerId
-     * @param array[] $formControls
+     * @param string                      $layerId
+     * @param QgisFormControlProperties[] $formControls
      */
     public function setEditableLayerFormCache($layerId, $formControls)
     {
@@ -162,7 +163,7 @@ class ProjectCache
      *
      * @throws \Exception
      *
-     * @return array[]
+     * @return QgisFormControlProperties[]
      */
     public function getEditableLayerFormCache($layerId)
     {

--- a/lizmap/modules/lizmap/lib/Project/ProjectCache.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectCache.php
@@ -35,12 +35,12 @@ class ProjectCache
     /**
      * @var int
      */
-    protected $qgsMtime;
+    protected $qgsMtime = 0;
 
     /**
      * @var int
      */
-    protected $qgsCfgMtime;
+    protected $qgsCfgMtime = 0;
 
     /**
      * version of the format of data stored in the cache.
@@ -58,16 +58,18 @@ class ProjectCache
      * The given Qgis file should exist, as well as the corresponding lizmap
      * cfg file.
      *
-     * @param string                  $file       The full path of the project
-     * @param App\AppContextInterface $appContext The interface to call Jelix
+     * @param string                  $file            The full path of the QGIS project file
+     * @param int                     $modifiedTime    Modification time of the file
+     * @param int                     $cfgModifiedTime Modification time of the lizmap configuration file for the QGIS project
+     * @param App\AppContextInterface $appContext      The interface to call Jelix
      */
-    public function __construct($file, App\AppContextInterface $appContext)
+    public function __construct($file, $modifiedTime, $cfgModifiedTime, App\AppContextInterface $appContext)
     {
         $this->file = $file;
         $this->appContext = $appContext;
         $this->fileKey = $this->appContext->normalizeCacheKey($file);
-        $this->qgsMtime = filemtime($this->file);
-        $this->qgsCfgMtime = filemtime($this->file.'.cfg');
+        $this->qgsMtime = $modifiedTime;
+        $this->qgsCfgMtime = $cfgModifiedTime;
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
@@ -49,8 +49,15 @@ class ProjectConfig
      */
     protected $options;
 
-    protected $cachedProperties = array('layersOrder', 'locateByLayer', 'formFilterLayers', 'editionLayers',
-        'attributeLayers', 'cfgContent', 'options', );
+    protected $cachedProperties = array(
+        'layersOrder',
+        'locateByLayer',
+        'formFilterLayers',
+        'editionLayers',
+        'attributeLayers',
+        'cfgContent',
+        'options',
+    );
 
     public function __construct($cfgFile, $data = null)
     {

--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -1516,95 +1516,110 @@ class QgisProject
         return $layers;
     }
 
-    protected function getValuesFromOptions($optionList, $name = true)
+    const MAP_VALUES_AS_VALUES = 0;
+    const MAP_VALUES_AS_KEYS = 1;
+    const MAP_ONLY_VALUES = 2;
+
+    /**
+     * @param \SimpleXMLElement $optionList
+     * @param int               $valuesExtraction one of MAP_* const
+     *
+     * @return array
+     */
+    protected function getValuesFromOptions($optionList, $valuesExtraction = 0)
     {
         $values = array();
 
         foreach ($optionList->Option as $v) {
-            if (!$name) {
+            if ($valuesExtraction == self::MAP_ONLY_VALUES) {
                 $values[] = (string) $v->attributes()->value;
+            } elseif ($valuesExtraction == self::MAP_VALUES_AS_VALUES) {
+                $values[(string) $v->attributes()->name] = (string) $v->attributes()->value;
             } else {
-                $values[] = (object) array(
-                    'key' => (string) $v->attributes()->name,
-                    'value' => (string) $v->attributes()->value,
-                );
+                $values[(string) $v->attributes()->value] = (string) $v->attributes()->name;
             }
-        }
-
-        if (count($values) == 1) {
-            return $values[0];
         }
 
         return $values;
     }
 
+    /**
+     * @param \SimpleXMLElement $layerXml
+     *
+     * @return Form\QgisFormControlProperties[]
+     */
     protected function getFieldConfiguration($layerXml)
     {
         $edittypes = array();
         $fieldConfiguration = $layerXml->fieldConfiguration;
-        $fields = $fieldConfiguration->xpath('field');
-        foreach ($fields as $key => $field) {
+        foreach ($fieldConfiguration->field as $key => $field) {
             $editWidget = $field->editWidget;
-            $fieldName = (string) $fields[$key]->attributes()->name;
+            $fieldName = (string) $field->attributes()->name;
             $fieldEditType = (string) $editWidget->attributes()->type;
             $options = $editWidget->config->Option;
-            $edittypes[$fieldName] = array();
+
             // Option + Attributes
             if (count((array) $options) > 2) {
                 \jLog::log('More than one Option found in the Qgis File for field '.$fieldName.', only the first will be read.', 'warning');
             }
-            $fieldEditOptions = array();
-            foreach ($options->Option as $option) {
-                if ((string) $option->attributes()->type === 'List') {
-                    $values = array();
-                    foreach ($option->Option as $l) {
-                        if ((string) $l->attributes()->type === 'Map') {
-                            $value = $this->getValuesFromOptions($l);
-                        } else {
-                            $value = $this->getValuesFromOptions($l, false);
-                        }
-                        if (is_array($value)) {
-                            $values = array_merge($values, $value);
-                        } else {
-                            $values[] = $value;
-                        }
-                    }
-                    $fieldEditOptions[(string) $option->attributes()->name] = $values;
-                // Option with list of values as Map
-                } elseif ((string) $option->attributes()->type === 'Map') {
-                    $fieldEditOptions[(string) $option->attributes()->name] = $this->getValuesFromOptions($option);
-
-                // Option with string list of values
-                } elseif ((string) $option->attributes()->type === 'StringList') {
-                    $fieldEditOptions[(string) $option->attributes()->name] = ${$this}->getValuesFromOptions($option, false);
-                // Simple option
-                } else {
-                    $fieldEditOptions[(string) $option->attributes()->name] = (string) $option->attributes()->value;
-                }
-            }
-
-            $edittype = array(
-                'type' => $fieldEditType,
-                'options' => (object) $fieldEditOptions,
-            );
+            $fieldEditOptions = $this->getFieldConfigurationOptions($options);
 
             // editable
             $editableFieldXml = $layerXml->xpath("editable/field[@name='${fieldName}']");
             if ($editableFieldXml && count($editableFieldXml)) {
-                $edittype['editable'] = (int) $editableFieldXml[0]->attributes()->editable;
+                $editable = (int) $editableFieldXml[0]->attributes()->editable;
             } else {
-                $edittype['editable'] = 1;
+                $editable = 1;
             }
+            $fieldEditOptions['editable'] = $editable;
 
-            $edittype = (object) $edittype;
-            $edittypes[$fieldName]['edittype'] = $edittype;
-            $edittypes[$fieldName]['widgetv2configAttr'] = $edittype->options;
-            $edittypes[$fieldName]['fieldEditType'] = $edittype->type;
+            $this->convertTypeOptions($fieldEditOptions);
+            $markup = $this->getMarkup($fieldEditType, $fieldEditOptions);
+            $control = new Form\QgisFormControlProperties($fieldName, $fieldEditType, $markup, $fieldEditOptions);
+            $edittypes[$fieldName] = $control;
         }
 
         return $edittypes;
     }
 
+    protected function getFieldConfigurationOptions(\SimpleXMLElement $options)
+    {
+        $fieldEditOptions = array();
+        foreach ($options->Option as $option) {
+            $optionName = (string) $option->attributes()->name;
+            $optionType = (string) $option->attributes()->type;
+
+            if ($optionType === 'List') {
+                $values = array();
+                foreach ($option->Option as $l) {
+                    if ((string) $l->attributes()->type === 'Map') {
+                        $values = array_merge($values, $this->getValuesFromOptions($l, self::MAP_VALUES_AS_KEYS));
+                    } else {
+                        $values[] = (string) $l->attributes()->value;
+                    }
+                }
+                $fieldEditOptions[$optionName] = $values;
+            // Option with list of values as Map
+            } elseif ($optionType === 'Map') {
+                $fieldEditOptions[$optionName] = $this->getValuesFromOptions($option);
+
+            // Option with string list of values
+            } elseif ($optionType === 'StringList') {
+                $fieldEditOptions[$optionName] = $this->getValuesFromOptions($option, self::MAP_ONLY_VALUES);
+            // Simple option
+            } else {
+                $fieldEditOptions[$optionName] = (string) $option->attributes()->value;
+            }
+        }
+
+        return $fieldEditOptions;
+    }
+
+    /**
+     * @param \SimpleXMLElement $layerXml
+     *
+     * @return Form\QgisFormControlProperties[]
+     */
     protected function getEditType($layerXml)
     {
         $edittypes = $layerXml->edittypes;
@@ -1615,39 +1630,148 @@ class QgisProject
                 continue;
             }
             $fieldName = (string) $edittype->attributes()->name;
-            $editTab[$fieldName] = array();
-            $editTab[$fieldName]['edittype'] = $edittype;
+            $attributes = array();
+
             // New QGIS 2.4 edittypes : use widgetv2type property
             if (property_exists($edittype->attributes(), 'widgetv2type')) {
-                $editTab[$fieldName]['widgetv2configAttr'] = $edittype->widgetv2config->attributes();
-                $editTab[$fieldName]['fieldEditType'] = (string) $edittype->attributes()->widgetv2type;
+                // translate the SimpleXmlElement containing attributes into an array
+                foreach ($edittype->widgetv2config->attributes() as $name => $value) {
+                    $attributes[$name] = (string) $value;
+                }
+                $fieldEditType = (string) $edittype->attributes()->widgetv2type;
+
+                $chainFilters = false;
+                $filters = array();
+                if (property_exists($edittype->widgetv2config, 'FilterFields')) {
+                    foreach ($edittype->widgetv2config->FilterFields->children('field') as $f) {
+                        $filters[] = (string) $f->attributes()->name;
+                    }
+                    $chainFilters = filter_var($edittype->widgetv2config->FilterFields->attributes()->ChainFilters, FILTER_VALIDATE_BOOLEAN);
+                }
+                $attributes['filters'] = $filters;
+                $attributes['chainFilters'] = $chainFilters;
             }
             // Before QGIS 2.4
             else {
-                $editTab[$fieldName]['fieldEditType'] = (int) $edittype->attributes()->type;
+                $fieldEditType = (int) $edittype->attributes()->type;
+                // convert edittype name to widgetv2type names
+                $convertName = array(
+                    'min' => 'Min',
+                    'max' => 'Max',
+                    'editable' => 'Editable',
+                    'checked' => 'CheckedState',
+                    'unchecked' => 'UncheckedState',
+                    'allowNull' => 'AllowNull',
+                    'orderByValue' => 'OrderByValue',
+                    'layer' => 'Layer',
+                    'key' => 'Key',
+                    'value' => 'Value',
+                    'allowMulti' => 'AllowMulti',
+                    'filterExpression' => 'FilterExpression',
+                );
+                // translate the SimpleXmlElement containing attributes into an array
+                foreach ($edittype->attributes() as $name => $value) {
+                    if (in_array($name, array('name', 'type'))) {
+                        continue;
+                    }
+                    if (isset($convertName[$name])) {
+                        $name = $convertName[$name];
+                    }
+                    $attributes[$name] = (string) $value;
+                }
             }
+
+            if ($fieldEditType === 3) {
+                $data = array();
+                foreach ($edittype->xpath('valuepair') as $valuepair) {
+                    $k = (string) $valuepair->attributes()->key;
+                    $v = (string) $valuepair->attributes()->value;
+                    $data[$v] = $k;
+                }
+                $attributes['valueMap'] = $data;
+            } elseif ($fieldEditType === 'ValueMap') {
+                $data = array();
+                foreach ($edittype->widgetv2config->xpath('value') as $value) {
+                    $k = (string) $value->attributes()->key;
+                    $v = (string) $value->attributes()->value;
+                    $data[$v] = $k;
+                }
+                $attributes['valueMap'] = $data;
+            }
+
+            $markup = $this->getMarkup($fieldEditType, $attributes);
+            $this->convertTypeOptions($attributes);
+            $control = new Form\QgisFormControlProperties($fieldName, $fieldEditType, $markup, $attributes);
+            $editTab[$fieldName] = $control;
         }
 
         return $editTab;
     }
 
-    protected function getMarkup($props)
+    protected static $optionTypes = array(
+        'Min' => 'f',
+        'Max' => 'f',
+        'Step' => 'i',
+        'Precision' => 'i',
+        'AllowMulti' => 'b',
+        'AllowNull' => 'b',
+        'UseCompleter' => 'b',
+        'DocumentViewer' => 'b',
+        'fieldEditable' => 'b',
+        'editable' => 'b',
+        'Editable' => 'b',
+        'notNull' => 'b',
+        'MapIdentification' => 'b',
+        'IsMultiline' => 'b',
+        'UseHtml' => 'b',
+        'field_iso_format' => 'b',
+    );
+
+    protected function convertTypeOptions(&$options)
+    {
+        foreach ($options as $name => $val) {
+            if (isset(self::$optionTypes[$name])) {
+                switch (self::$optionTypes[$name]) {
+                    case 'f':
+                        $options[$name] = (float) $val;
+
+                        break;
+
+                    case 'i':
+                        $options[$name] = (int) $val;
+
+                        break;
+
+                    case 'b':
+                        $options[$name] = filter_var($val, FILTER_VALIDATE_BOOLEAN);
+
+                        break;
+
+                }
+            }
+        }
+    }
+
+    /**
+     * @param int|string $fieldEditType
+     * @param array      $editAttributes attributes of widgetv2config
+     *
+     * @return string
+     */
+    protected function getMarkup($fieldEditType, $editAttributes)
     {
         $qgisEdittypeMap = Form\QgisFormControl::getEditTypeMap();
-        $edittype = $props['edittype'];
-        $fieldEditType = $props['fieldEditType'];
-        $widgetv2configAttr = $props['widgetv2configAttr'];
 
         if ($fieldEditType === 12) {
             $useHtml = 0;
-            if (property_exists($edittype->attributes(), 'UseHtml')) {
-                $useHtml = (int) filter_var((string) $edittype->attributes()->UseHtml, FILTER_VALIDATE_BOOLEAN);
+            if (array_key_exists('UseHtml', $editAttributes)) {
+                $useHtml = $editAttributes['UseHtml'];
             }
             $markup = $qgisEdittypeMap[$fieldEditType]['jform']['markup'][$useHtml];
         } elseif ($fieldEditType === 'TextEdit') {
             $isMultiLine = false;
-            if (property_exists($widgetv2configAttr, 'IsMultiline')) {
-                $isMultiLine = filter_var((string) $widgetv2configAttr->IsMultiline, FILTER_VALIDATE_BOOLEAN);
+            if (array_key_exists('IsMultiline', $editAttributes)) {
+                $isMultiLine = $editAttributes['IsMultiline'];
             }
 
             if (!$isMultiLine) {
@@ -1655,26 +1779,29 @@ class QgisProject
                 $markup = $qgisEdittypeMap[$fieldEditType]['jform']['markup'];
             } else {
                 $useHtml = 0;
-                if (property_exists($widgetv2configAttr, 'UseHtml')) {
-                    $useHtml = (int) filter_var((string) $widgetv2configAttr->UseHtml, FILTER_VALIDATE_BOOLEAN);
+                if (array_key_exists('UseHtml', $editAttributes)) {
+                    $useHtml = $editAttributes['UseHtml'];
                 }
                 $markup = $qgisEdittypeMap[$fieldEditType]['jform']['markup'][$useHtml];
             }
         } elseif ($fieldEditType === 5) {
             $markup = $qgisEdittypeMap[$fieldEditType]['jform']['markup'][0];
-        } elseif ($fieldEditType === 15) {
-            $allowMulti = (int) filter_var((string) $edittype->attributes()->allowMulti, FILTER_VALIDATE_BOOLEAN);
+        } elseif ($fieldEditType === 15 || $fieldEditType === 'ValueRelation') {
+            $allowMulti = false;
+            if (array_key_exists('AllowMulti', $editAttributes)) {
+                $allowMulti = $editAttributes['AllowMulti'];
+            }
             $markup = $qgisEdittypeMap[$fieldEditType]['jform']['markup'][$allowMulti];
         } elseif ($fieldEditType === 'Range' || $fieldEditType === 'EditRange') {
             $markup = $qgisEdittypeMap[$fieldEditType]['jform']['markup'][0];
         } elseif ($fieldEditType === 'SliderRange' || $fieldEditType === 'DialRange') {
             $markup = $qgisEdittypeMap[$fieldEditType]['jform']['markup'][1];
-        } elseif ($fieldEditType === 'ValueRelation') {
-            $allowMulti = (int) filter_var((string) $widgetv2configAttr->AllowMulti, FILTER_VALIDATE_BOOLEAN);
-            $markup = $qgisEdittypeMap[$fieldEditType]['jform']['markup'][$allowMulti];
         } elseif ($fieldEditType === 'DateTime') {
             $markup = 'date';
-            $display_format = $widgetv2configAttr->display_format;
+            $display_format = '';
+            if (array_key_exists('display_format', $editAttributes)) {
+                $display_format = $editAttributes['display_format'];
+            }
             // Use date AND time widget id type is DateTime and we find HH
             if (preg_match('#HH#i', $display_format)) {
                 $markup = 'datetime';
@@ -1701,16 +1828,14 @@ class QgisProject
      */
     public function readFormControls($layerXml, $layerId, $proj)
     {
-        $props = null;
-
         $layer = $this->getLayer($layerId, $proj);
         if ($layer->getType() !== 'vector') {
             return array();
         }
 
-        if ($layerXml->edittype && count($layerXml->edittypes)) {
+        if ($layerXml->edittypes && count($layerXml->edittypes->edittype)) {
             $props = $this->getEditType($layerXml);
-        } elseif ($layerXml->fieldConfiguration && count($layerXml->fieldConfiguration)) {
+        } elseif ($layerXml->fieldConfiguration /*&& count($layerXml->fieldConfiguration->field)*/) {
             $props = $this->getFieldConfiguration($layerXml);
         } else {
             return array();
@@ -1721,32 +1846,28 @@ class QgisProject
         $categoriesXml = $layerXml->xpath('renderer-v2/categories');
         if ($categoriesXml && count($categoriesXml) != 0) {
             $categoriesXml = $categoriesXml[0];
-            $data = array();
+            $categories = array();
             foreach ($categoriesXml as $category) {
-                $k = (string) $category->attributes()->label;
+                $l = (string) $category->attributes()->label;
                 $v = (string) $category->attributes()->value;
-                $data[$v] = $k;
+                $categories[$v] = $l;
             }
-            asort($data);
+            asort($categories);
         } else {
-            $data = null;
+            $categories = array();
         }
 
         foreach ($props as $fieldName => $prop) {
             $alias = null;
-            if ($prop['fieldEditType'] === '') {
-                $prop['fieldEditType'] = 'undefined';
-            }
             if ($aliases && array_key_exists($fieldName, $aliases)) {
                 $alias = $aliases[$fieldName];
             }
             if ($alias && is_array($alias) && count($alias)) {
-                $props[$fieldName]['fieldAlias'] = (string) $alias[0]->attributes()->name;
+                $prop->setFieldAlias((string) $alias[0]->attributes()->name);
             } elseif (is_string($alias) || $alias && count($alias)) {
-                $props[$fieldName]['fieldAlias'] = $alias;
+                $prop->setFieldAlias($alias);
             }
-            $props[$fieldName]['markup'] = $this->getMarkup($prop);
-            $props[$fieldName]['rendererCategories'] = $data;
+            $props[$fieldName]->setRendererCategories($categories);
         }
 
         return $props;

--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -949,7 +949,7 @@ class QgisProject
             }
             $layerXmlZero = $layerXml[0];
             $formControls = $this->readFormControls($layerXmlZero, $obj->layerId, $proj);
-            file_put_contents($this->appContext->getFormPath().$proj->getKey().'.'.$obj->layerId.'.form.json', json_encode($formControls, JSON_PRETTY_PRINT));
+            $proj->getCacheHandler()->setEditableLayerFormCache($obj->layerId, $formControls);
         }
     }
 

--- a/lizmap/modules/lizmap/lib/Request/OGCRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/OGCRequest.php
@@ -252,7 +252,7 @@ abstract class OGCRequest
                $this->project->getRepository()->getKey().'-'.
                $this->project->getKey().'-'.
                $this->param('service').'-getcapabilities';
-        if ($appContext->UserisConnected()) {
+        if ($appContext->UserIsConnected()) {
             $juser = $appContext->getUserSession();
             $key .= '-'.$juser->login;
         }

--- a/lizmap/modules/lizmap/lib/Request/OGCRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/OGCRequest.php
@@ -108,7 +108,7 @@ abstract class OGCRequest
     {
         $appContext = $this->appContext;
         // Check if a user is authenticated
-        if (!$appContext->UserisConnected()) {
+        if (!$appContext->UserIsConnected()) {
             // return parameters with empty user param
             return array_merge($this->params, array(
                 'Lizmap_User' => '',
@@ -251,6 +251,8 @@ abstract class OGCRequest
     {
         $appContext = $this->appContext;
         // Get cached session
+        // the cache should be unique between each user/service because the
+        // request content depends on rights of the user
         $key = session_id().'-'.$this->param('service');
         if ($appContext->UserIsConnected()) {
             $juser = $appContext->getUserSession();

--- a/lizmap/var/config/mainconfig.ini.php
+++ b/lizmap/var/config/mainconfig.ini.php
@@ -292,6 +292,7 @@ view.access=1
 ldapdao.installparam=noconfigfile
 multiauth.installparam="noconfigfile;localconfig"
 
+ldapdao.path="app:vendor/jelix/ldapdao-module/ldapdao"
 [mailLogger]
 email="root@localhost"
 emailHeaders="Content-Type: text/plain; charset=UTF-8\nFrom: webmaster@yoursite.com\nX-Mailer: Jelix\nX-Priority: 1 (Highest)\n"

--- a/tests/docker-conf/phpfpm/localconfig.ini.php
+++ b/tests/docker-conf/phpfpm/localconfig.ini.php
@@ -43,3 +43,5 @@ auth = file
 [jcommunity]
 registrationEnabled=off
 
+[error_handling]
+messageLogFormat = "[%code%]\t%msg%\n  %file%\t%line%\n %url%\n %params%\n ref:%referer%\n%trace%\n\n"

--- a/tests/units/classes/Form/QgisFormControlTest.php
+++ b/tests/units/classes/Form/QgisFormControlTest.php
@@ -13,33 +13,56 @@ class QgisFormControlTest extends TestCase
 {
     public function testSetControlMainProperties()
     {
-        $control = new QgisFormControlForTests();
         $ctrl = new \jFormsControlInput('test');
         $ctrl->datatype = new \jDatatypeDecimal();
+
+
+        $control = new QgisFormControlForTests();
+        $properties = new \Lizmap\Form\QgisFormControlProperties(
+            'test',
+            'Immutable',
+            'intput',
+            array(
+                'Editable' => true
+            )
+        );
         $control->fieldDataType = 'Immutable';
-        $control->fieldEditType = 'Immutable';
-        $control->edittype = (object) array('editable' => 2);
         $control->isReadOnly = false;
         $control->required = true;
         $control->ctrl = $ctrl;
-        $control->setControlMainPropertiesForTests();
+        $control->setControlMainPropertiesForTests($properties);
         $this->assertTrue($control->isReadOnly);
         $this->assertFalse($control->required);
-        $control->ctrl->datatype = new \jDatatypeString('test');
+
+        $control->ctrl->datatype = new \jDatatypeString();
+        $properties = new \Lizmap\Form\QgisFormControlProperties(
+            'test',
+            'TextEdit',
+            'intput',
+            array(
+                'Editable' => false
+            )
+        );
         $control->fieldDataType = 'date';
-        $control->fieldEditType = 'TextEdit';
         $control->isReadOnly = false;
-        $control->edittype = (object) array('editable' => 0);
-        $control->setControlMainPropertiesForTests();
+        $control->setControlMainPropertiesForTests($properties);
         $this->assertTrue($control->isReadOnly);
         $this->assertFalse($control->required);
         $this->assertInstanceOf(jDatatypeDate::class, $control->ctrl->datatype);
-        $control->ctrl->datatype = new \jDatatypeString('test');
+
+        $properties = new \Lizmap\Form\QgisFormControlProperties(
+            'test',
+            'TextEdit',
+            'intput',
+            array(
+                'Editable' => true
+            )
+        );
+        $control->ctrl->datatype = new \jDatatypeString();
         $control->fieldDataType = 'float';
         $control->isReadOnly = false;
         $control->required = true;
-        $control->edittype = (object) array('editable' => 5);
-        $control->setControlMainPropertiesForTests();
+        $control->setControlMainPropertiesForTests($properties);
         $this->assertFalse($control->isReadOnly);
         $this->assertTrue($control->required);
         $this->assertTrue($control->ctrl->required);
@@ -123,16 +146,15 @@ class QgisFormControlTest extends TestCase
             'notNull' => True,
         );
         # QGIS properties
-        $properties = (object) array(
-            'markup' => 'input',
-            'fieldEditType' => 'TextEdit',
-            'widgetv2configAttr' => (object) array(
-                'IsMultiline' => '0',
-                'UseHtml' => '0',
-            ),
-            'edittype' => (object) array(
-                'editable' => 1,
-            ),
+        $properties = new \Lizmap\Form\QgisFormControlProperties(
+            'id',
+            'TextEdit',
+            'input',
+            array(
+                'IsMultiline' => false,
+                'UseHtml' => false,
+                'Editable' => true
+            )
         );
         # QGIS Constraints
         # constraints is the number of contraints, 0 for no constraints
@@ -156,7 +178,16 @@ class QgisFormControlTest extends TestCase
         $this->assertFalse($control->required);
 
         # QGIS properties - not editable
-        $properties->edittype->editable = 0;
+        $properties = new \Lizmap\Form\QgisFormControlProperties(
+            'id',
+            'TextEdit',
+            'input',
+            array(
+                'IsMultiline' => false,
+                'UseHtml' => false,
+                'Editable' => false
+            )
+        );
         $control = new QgisFormControl('id', $properties, $prop, null, $constraints, $appContext);
         $this->assertTrue($control->isReadOnly);
         $this->assertFalse($control->required);
@@ -172,16 +203,15 @@ class QgisFormControlTest extends TestCase
             'notNull' => False,
         );
         # QGIS properties
-        $properties = (object) array(
-            'markup' => 'input',
-            'fieldEditType' => 'TextEdit',
-            'widgetv2configAttr' => (object) array(
-                'IsMultiline' => '0',
-                'UseHtml' => '0',
-            ),
-            'edittype' => (object) array(
-                'editable' => 1,
-            ),
+        $properties = new \Lizmap\Form\QgisFormControlProperties(
+            'label',
+            'TextEdit',
+            'input',
+            array(
+                'IsMultiline' => false,
+                'UseHtml' => false,
+                'Editable' => true
+            )
         );
         # QGIS Constraints
         # constraints is the number of contraints, 0 for no constraints
@@ -223,7 +253,16 @@ class QgisFormControlTest extends TestCase
         # DB properties - Text
         $prop->notNull = False;
         # QGIS properties
-        $properties->edittype->editable = 0;
+        $properties = new \Lizmap\Form\QgisFormControlProperties(
+            'label',
+            'TextEdit',
+            'input',
+            array(
+                'IsMultiline' => false,
+                'UseHtml' => false,
+                'Editable' => false
+            )
+        );
         # QGIS constraints
         $constraints['constraints'] = 0;
         $constraints['notNull'] = False;
@@ -242,13 +281,14 @@ class QgisFormControlTest extends TestCase
             'notNull' => True,
         );
         # QGIS properties
-        $properties = (object) array(
-            'markup' => 'checkbox',
-            'fieldEditType' => 'CheckBox',
-            'widgetv2configAttr' => (object) array(
-                'CheckedState' => '',
-                'UncheckedState' => '',
-            ),
+        $properties = new \Lizmap\Form\QgisFormControlProperties(
+            'checked',
+            'CheckBox',
+            'checkbox',
+            array(
+                'CheckedState' => 't',
+                'UncheckedState' => 'f',
+            )
         );
         # QGIS Constraints
         $constraints = array(
@@ -272,8 +312,15 @@ class QgisFormControlTest extends TestCase
         # DB properties - int
         $prop->type = 'int';
         # QGIS properties
-        $properties->widgetv2configAttr->CheckedState = '1';
-        $properties->widgetv2configAttr->UncheckedState = '0';
+        $properties = new \Lizmap\Form\QgisFormControlProperties(
+            'checked',
+            'CheckBox',
+            'checkbox',
+            array(
+                'CheckedState' => '1',
+                'UncheckedState' => '0',
+            )
+        );
 
         $control = new QgisFormControl('checked', $properties, $prop, null, $constraints, $appContext);
         $this->assertEquals($control->fieldDataType, 'integer');
@@ -283,8 +330,15 @@ class QgisFormControlTest extends TestCase
         # DB properties - text
         $prop->type = 'text';
         # QGIS properties
-        $properties->widgetv2configAttr->CheckedState = 'y';
-        $properties->widgetv2configAttr->UncheckedState = 'n';
+        $properties = new \Lizmap\Form\QgisFormControlProperties(
+            'checked',
+            'CheckBox',
+            'checkbox',
+            array(
+                'CheckedState' => 'y',
+                'UncheckedState' => 'n',
+            )
+        );
 
         $control = new QgisFormControl('checked', $properties, $prop, null, $constraints, $appContext);
         $this->assertEquals($control->fieldDataType, 'text');
@@ -295,21 +349,20 @@ class QgisFormControlTest extends TestCase
         $prop->type = 'boolean';
         $prop->notNull = True;
         # QGIS properties
-        $properties->markup = 'menulist';
-        $properties->fieldEditType = 'ValueMap';
-        $properties->widgetv2configAttr = (object) array(
-            'map' => null,
+        $properties = new \Lizmap\Form\QgisFormControlProperties(
+            'checked',
+            'ValueMap',
+            'menulist',
+            array(
+                'valueMap' => array(
+                     'true' => 'Yes',
+                     'false' => 'No',
+                     '{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}' => '<NULL>',
+                ),
+                'Editable' => 1
+            )
         );
-        $properties->widgetv2configAttr->map = array(
-            (object) array('key'=>'Yes', 'value'=>'true'),
-            (object) array('key'=>'No', 'value'=>'false'),
-            (object) array('key'=>'<NULL>', 'value'=>'{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}'),
-        );
-        $properties->edittype = (object) array(
-            'editable' => 1,
-            'options' => (object) array('map' => null),
-        );
-        $properties->edittype->options->map = $properties->widgetv2configAttr->map;
+
         $control = new QgisFormControl('checked', $properties, $prop, null, $constraints, $appContext);
         $this->assertEquals($control->fieldDataType, 'boolean');
         $this->assertEquals($control->fieldEditType, 'CheckBox');

--- a/tests/units/classes/Form/QgisFormTest.php
+++ b/tests/units/classes/Form/QgisFormTest.php
@@ -55,18 +55,19 @@ class QgisFormTest extends TestCase
 {
     protected $appContext;
 
-    public function setUpEnv($file, $fields)
+    protected function setUpEnv($projectKey, $layerId, $fields)
     {
-        $ids = explode('.', $file);
         $appContext = new ContextForTests();
         $appContext->setResult(array('path' => __DIR__.'/forms/'));
         $this->appContext = $appContext;
+        $appContext->setCache('/test.qgs.layer-line-form', json_decode(file_get_contents(__DIR__.'/forms/montpellier.line.form.json')), null, 'qgisprojects');
+        $appContext->setCache('/test.qgs.layer-date-form', json_decode(file_get_contents(__DIR__.'/forms/test.date.form.json')), null, 'qgisprojects');
         $layer = new QgisLayerForTests();
         $layer->fields = $fields;
-        $layer->setId($ids[1]);
-        $proj = new ProjectForTests();
-        $proj->setRepo(new \Lizmap\Project\Repository('key', array(), null, null, null));
-        $proj->setKey($ids[0]);
+        $layer->setId($layerId);
+        $proj = new ProjectForTests($appContext);
+        $proj->setRepo(new \Lizmap\Project\Repository('key', array(), null, null, $appContext));
+        $proj->setKey($projectKey);
         $layer->setProject($proj);
         return $layer;
     }
@@ -103,9 +104,9 @@ class QgisFormTest extends TestCase
         );
 
         return array(
-            array('test.date.form.json', $fields),
-            array('montpellier.line.form.json', $fields2),
-            array('not.existing.form.php', null),
+            array('test','date', $fields),
+            array('montpellier','line', $fields2),
+            array('not','existing', null),
         );
     }
 
@@ -115,9 +116,9 @@ class QgisFormTest extends TestCase
      * @param mixed $file
      * @param mixed $fields
      */
-    public function testContruct($file, $fields)
+    public function testConstruct($projectKey, $layer, $fields)
     {
-        $layer = $this->setUpEnv($file, $fields);
+        $layer = $this->setUpEnv($projectKey, $layer, $fields);
         if (!$fields) {
             $this->expectException('Exception');
         }

--- a/tests/units/classes/Form/QgisFormTest.php
+++ b/tests/units/classes/Form/QgisFormTest.php
@@ -60,8 +60,8 @@ class QgisFormTest extends TestCase
         $appContext = new ContextForTests();
         $appContext->setResult(array('path' => __DIR__.'/forms/'));
         $this->appContext = $appContext;
-        $appContext->setCache('/test.qgs.layer-line-form', json_decode(file_get_contents(__DIR__.'/forms/montpellier.line.form.json')), null, 'qgisprojects');
-        $appContext->setCache('/test.qgs.layer-date-form', json_decode(file_get_contents(__DIR__.'/forms/test.date.form.json')), null, 'qgisprojects');
+        $appContext->setCache('/test.qgs.layer-line-form', $this->readFormCache(__DIR__.'/forms/montpellier.line.form.json'), null, 'qgisprojects');
+        $appContext->setCache('/test.qgs.layer-date-form', $this->readFormCache(__DIR__.'/forms/test.date.form.json'), null, 'qgisprojects');
         $layer = new QgisLayerForTests();
         $layer->fields = $fields;
         $layer->setId($layerId);
@@ -71,6 +71,27 @@ class QgisFormTest extends TestCase
         $layer->setProject($proj);
         return $layer;
     }
+
+    protected function readFormCache($file)
+    {
+        $formCache = json_decode(file_get_contents($file), true);
+        $properties = array();
+        foreach($formCache as $ref => $props) {
+            $prop = new \Lizmap\Form\QgisFormControlProperties(
+                $ref,
+                $props['fieldEditType'],
+                $props['markup'],
+                $props['editAttr']
+            );
+            if (isset($props['rendererCategories'])) {
+                $prop->setRendererCategories($props['rendererCategories']);
+            }
+            $properties[$ref] = $prop;
+        }
+        return $properties;
+    }
+
+
 
     public function getConstructData()
     {

--- a/tests/units/classes/Form/forms/montpellier.line.form.json
+++ b/tests/units/classes/Form/forms/montpellier.line.form.json
@@ -1,13 +1,10 @@
 {
     "pkuid": {
-        "edittype": {
-            "type": "Hidden",
-            "options": {},
-            "editable": 1
+        "editAttr": {
+            "Editable": true,
+            "fieldAlias": ""
         },
-        "widgetv2configAttr": {},
         "fieldEditType": "Hidden",
-        "fieldAlias": "",
         "markup": "hidden",
         "rendererCategories": {
             "3": "difficult",
@@ -16,20 +13,13 @@
         }
     },
     "label": {
-        "edittype": {
-            "type": "TextEdit",
-            "options": {
-                "IsMultiline": "0",
-                "UseHtml": "0"
-            },
-            "editable": 1
-        },
-        "widgetv2configAttr": {
-            "IsMultiline": "0",
-            "UseHtml": "0"
+        "editAttr": {
+            "IsMultiline": false,
+            "UseHtml": false,
+            "Editable": true,
+            "fieldAlias": ""
         },
         "fieldEditType": "TextEdit",
-        "fieldAlias": "",
         "markup": "input",
         "rendererCategories": {
             "3": "difficult",
@@ -38,20 +28,13 @@
         }
     },
     "description": {
-        "edittype": {
-            "type": "TextEdit",
-            "options": {
-                "IsMultiline": "1",
-                "UseHtml": "0"
-            },
-            "editable": 1
-        },
-        "widgetv2configAttr": {
-            "IsMultiline": "1",
-            "UseHtml": "0"
+        "editAttr": {
+            "IsMultiline": true,
+            "UseHtml": false,
+            "Editable": true,
+            "fieldAlias": ""
         },
         "fieldEditType": "TextEdit",
-        "fieldAlias": "",
         "markup": "textarea",
         "rendererCategories": {
             "3": "difficult",
@@ -60,14 +43,11 @@
         }
     },
     "difficulty": {
-        "edittype": {
-            "type": "Classification",
-            "options": {},
-            "editable": 1
+        "editAttr": {
+            "Editable": true,
+            "fieldAlias": ""
         },
-        "widgetv2configAttr": {},
         "fieldEditType": "Classification",
-        "fieldAlias": "",
         "markup": "menulist",
         "rendererCategories": {
             "3": "difficult",

--- a/tests/units/classes/Form/forms/test.date.form.json
+++ b/tests/units/classes/Form/forms/test.date.form.json
@@ -1,38 +1,25 @@
 {
     "pkuid": {
-        "edittype": {
-            "type": "TextEdit",
-            "options": {},
-            "editable": 1
+        "editAttr": {
+            "editable": 1,
+            "fieldAlias": ""
         },
-        "widgetv2configAttr": {},
         "fieldEditType": "TextEdit",
-        "fieldAlias": "",
         "markup": "input",
-        "rendererCategories": null
+        "rendererCategories": []
     },
     "customdate": {
-        "edittype": {
-            "type": "DateTime",
-            "options": {
-                "allow_null": "true",
-                "calendar_popup": "true",
-                "display_format": "MM-d-yy",
-                "field_format": "MM-d-yy",
-                "field_iso_format": "false"
-            },
-            "editable": 1
-        },
-        "widgetv2configAttr": {
-            "allow_null": "true",
+        "editAttr": {
+            "AllowNull": "true",
             "calendar_popup": "true",
             "display_format": "MM-d-yy",
             "field_format": "MM-d-yy",
-            "field_iso_format": "false"
+            "field_iso_format": false,
+            "Editable": true,
+            "fieldAlias": ""
         },
         "fieldEditType": "DateTime",
-        "fieldAlias": "",
         "markup": "date",
-        "rendererCategories": null
+        "rendererCategories": []
     }
 }

--- a/tests/units/classes/Project/ProjectTest.php
+++ b/tests/units/classes/Project/ProjectTest.php
@@ -64,9 +64,9 @@ class ProjectTest extends TestCase
     public function getRelativeQgisPathData()
     {
         return array(
-            array('', null, '/srv/lzm/absolute/path', '/srv/lzm/absolute/path'),
-            array('1', '/srv/lzm/repo/root/path', '/srv/lzm/repo/root/path/project.qgs', 'project.qgs'),
-            array('1', '/srv/lzm/repo/root/path', '/srv/lzm/not/the/same/project.qgs', '/srv/lzm/not/the/same/project.qgs'),
+            array('',   null,                      '/srv/lzm/absolute/path',              '/srv/lzm/absolute/path'),
+            array('1',  '/srv/lzm/repo/root/path', '/srv/lzm/repo/root/path/project.qgs', 'project.qgs'),
+            array('1', '/srv/lzm/repo/root/path',  '/srv/lzm/not/the/same/project.qgs',   '/srv/lzm/not/the/same/project.qgs'),
         );
     }
 
@@ -88,7 +88,7 @@ class ProjectTest extends TestCase
         $proj = new ProjectForTests();
         $proj->setRepo(new Project\Repository(null, array('path' => ''), null, null, null));
         $proj->setServices($services);
-        $proj->setFile($file);
+        $proj->setFile($file, 0, 0);
         $path = $proj->getRelativeQgisPath();
         $this->assertEquals($expectedPath, $path);
     }

--- a/tests/units/classes/Project/QgisProjectTest.php
+++ b/tests/units/classes/Project/QgisProjectTest.php
@@ -420,19 +420,15 @@ class QgisProjectTest extends TestCase
         $this->assertTrue(is_array($props));
         $this->assertCount(9, $props);
         $this->assertTrue(array_key_exists('name', $props));
+
         $prop = $props['name'];
-        $this->assertTrue(array_key_exists('fieldEditType', $prop));
-        $this->assertEquals($prop['fieldEditType'], 'TextEdit');
-        $this->assertTrue(array_key_exists('edittype', $prop));
-        $this->assertTrue(array_key_exists('widgetv2configAttr', $prop));
-        $this->assertTrue(property_exists($prop['widgetv2configAttr'], 'IsMultiline'));
-        $this->assertEquals($prop['widgetv2configAttr']->IsMultiline, '0');
-        $this->assertTrue(property_exists($prop['widgetv2configAttr'], 'UseHtml'));
-        $this->assertEquals($prop['widgetv2configAttr']->UseHtml, '0');
+        $this->assertEquals($prop->getFieldEditType(), 'TextEdit');
+        $this->assertFalse($prop->isMultiline());
+        $this->assertFalse($prop->useHtml());
         $this->assertTrue(array_key_exists('wkt', $props));
+
         $prop = $props['wkt'];
-        $this->assertTrue(array_key_exists('fieldEditType', $prop));
-        $this->assertEquals($prop['fieldEditType'], 'Hidden');
+        $this->assertEquals($prop->getFieldEditType(), 'Hidden');
     }
 
     public function testGetFieldConfiguration() {
@@ -497,21 +493,15 @@ class QgisProjectTest extends TestCase
         $this->assertTrue(is_array($props));
         $this->assertCount(5, $props);
         $this->assertTrue(array_key_exists('name', $props));
+
         $prop = $props['name'];
-        $this->assertTrue(array_key_exists('fieldEditType', $prop));
-        $this->assertEquals($prop['fieldEditType'], 'TextEdit');
-        $this->assertTrue(array_key_exists('widgetv2configAttr', $prop));
-        $this->assertTrue(array_key_exists('edittype', $prop));
-        $this->assertTrue(property_exists($prop['edittype'], 'options'));
-        $options = $prop['edittype']->options;
-        $this->assertTrue(property_exists($options, 'IsMultiline'));
-        $this->assertEquals($options->IsMultiline, '0');
-        $this->assertTrue(property_exists($options, 'UseHtml'));
-        $this->assertEquals($options->UseHtml, '0');
+        $this->assertEquals($prop->getFieldEditType(), 'TextEdit');
+        $this->assertFalse($prop->isMultiline());
+        $this->assertFalse($prop->useHtml());
         $this->assertTrue(array_key_exists('wkt', $props));
+
         $prop = $props['wkt'];
-        $this->assertTrue(array_key_exists('fieldEditType', $prop));
-        $this->assertEquals($prop['fieldEditType'], 'Hidden');
+        $this->assertEquals($prop->getFieldEditType(), 'Hidden');
 
         # TextEdit widget editable
         $xmlStr = '
@@ -543,31 +533,20 @@ class QgisProjectTest extends TestCase
         $props = $testProj->getFieldConfigurationForTest($xml);
         $this->assertTrue(is_array($props));
         $this->assertCount(2, $props);
+
         $this->assertTrue(array_key_exists('id', $props));
         $prop = $props['id'];
-        $this->assertTrue(array_key_exists('fieldEditType', $prop));
-        $this->assertEquals($prop['fieldEditType'], 'TextEdit');
-        $this->assertTrue(array_key_exists('widgetv2configAttr', $prop));
-        $this->assertTrue(array_key_exists('edittype', $prop));
-        $this->assertTrue(property_exists($prop['edittype'], 'options'));
-        $options = $prop['edittype']->options;
-        $this->assertFalse(property_exists($options, 'IsMultiline'));
-        $this->assertFalse(property_exists($options, 'UseHtml'));
-        $this->assertTrue(array_key_exists('widgetv2configAttr', $prop));
-        $this->assertTrue(array_key_exists('edittype', $prop));
-        $this->assertTrue(property_exists($prop['edittype'], 'editable'));
-        $this->assertEquals($prop['edittype']->editable, 0);
+        $this->assertEquals($prop->getFieldEditType(), 'TextEdit');
+        $this->assertFalse($prop->isMultiline());
+        $this->assertFalse($prop->useHtml());
+        $this->assertFalse($prop->isEditable());
+
         $this->assertTrue(array_key_exists('label', $props));
         $prop = $props['label'];
-        $this->assertEquals($prop['fieldEditType'], 'TextEdit');
-        $this->assertTrue(array_key_exists('widgetv2configAttr', $prop));
-        $this->assertTrue(array_key_exists('edittype', $prop));
-        $this->assertTrue(property_exists($prop['edittype'], 'options'));
-        $options = $prop['edittype']->options;
-        $this->assertFalse(property_exists($options, 'IsMultiline'));
-        $this->assertFalse(property_exists($options, 'UseHtml'));
-        $this->assertTrue(property_exists($prop['edittype'], 'editable'));
-        $this->assertEquals($prop['edittype']->editable, 1);
+        $this->assertEquals($prop->getFieldEditType(), 'TextEdit');
+        $this->assertFalse($prop->isMultiline());
+        $this->assertFalse($prop->useHtml());
+        $this->assertTrue($prop->isEditable());
 
         # DateTime widget
         $xmlStr = '
@@ -595,16 +574,14 @@ class QgisProjectTest extends TestCase
         $this->assertTrue(is_array($props));
         $this->assertCount(1, $props);
         $this->assertTrue(array_key_exists('date', $props));
+
         $prop = $props['date'];
-        $this->assertEquals($prop['fieldEditType'], 'DateTime');
-        $this->assertTrue(array_key_exists('widgetv2configAttr', $prop));
-        $this->assertTrue(array_key_exists('edittype', $prop));
-        $this->assertTrue(property_exists($prop['edittype'], 'options'));
-        $options = $prop['edittype']->options;
+        $this->assertEquals($prop->getFieldEditType(), 'DateTime');
+        $options = (object) $prop->getEditAttributes();
         $this->assertTrue(property_exists($options, 'field_format'));
         $this->assertEquals($options->field_format, 'yyyy-MM-dd');
         $this->assertTrue(property_exists($options, 'field_iso_format'));
-        $this->assertEquals($options->field_iso_format, 'false');
+        $this->assertFalse($options->field_iso_format);
 
         # Classification widget
         $xmlStr = '
@@ -626,8 +603,9 @@ class QgisProjectTest extends TestCase
         $this->assertTrue(is_array($props));
         $this->assertCount(1, $props);
         $this->assertTrue(array_key_exists('type', $props));
+
         $prop = $props['type'];
-        $this->assertEquals($prop['fieldEditType'], 'Classification');
+        $this->assertEquals($prop->getFieldEditType(), 'Classification');
 
         # DateTime widget
         $xmlStr = '
@@ -658,11 +636,9 @@ class QgisProjectTest extends TestCase
         $this->assertCount(1, $props);
         $this->assertTrue(array_key_exists('photo', $props));
         $prop = $props['photo'];
-        $this->assertEquals($prop['fieldEditType'], 'ExternalResource');
-        $this->assertTrue(array_key_exists('widgetv2configAttr', $prop));
-        $this->assertTrue(array_key_exists('edittype', $prop));
-        $this->assertTrue(property_exists($prop['edittype'], 'options'));
-        $options = $prop['edittype']->options;
+        $this->assertEquals($prop->getFieldEditType(), 'ExternalResource');
+
+        $options = (object) $prop->getEditAttributes();
         $this->assertTrue(property_exists($options, 'FileWidgetFilter'));
         $this->assertEquals($options->FileWidgetFilter, 'Images (*.gif *.jpeg *.jpg *.png)');
 
@@ -689,13 +665,8 @@ class QgisProjectTest extends TestCase
         $this->assertCount(1, $props);
         $this->assertTrue(array_key_exists('author', $props));
         $prop = $props['author'];
-        $this->assertEquals($prop['fieldEditType'], 'UniqueValues');
-        $this->assertTrue(array_key_exists('widgetv2configAttr', $prop));
-        $this->assertTrue(array_key_exists('edittype', $prop));
-        $this->assertTrue(property_exists($prop['edittype'], 'options'));
-        $options = $prop['edittype']->options;
-        $this->assertTrue(property_exists($options, 'Editable'));
-        $this->assertEquals($options->Editable, '1');
+        $this->assertEquals($prop->getFieldEditType(), 'UniqueValues');
+        $this->assertTrue($prop->isEditable());
 
         # CheckBox widget
         $xmlStr = '
@@ -721,11 +692,9 @@ class QgisProjectTest extends TestCase
         $this->assertCount(1, $props);
         $this->assertTrue(array_key_exists('checked', $props));
         $prop = $props['checked'];
-        $this->assertEquals($prop['fieldEditType'], 'CheckBox');
-        $this->assertTrue(array_key_exists('widgetv2configAttr', $prop));
-        $this->assertTrue(array_key_exists('edittype', $prop));
-        $this->assertTrue(property_exists($prop['edittype'], 'options'));
-        $options = $prop['edittype']->options;
+        $this->assertEquals($prop->getFieldEditType(), 'CheckBox');
+
+        $options = (object) $prop->getEditAttributes();
         $this->assertTrue(property_exists($options, 'CheckedState'));
         $this->assertEquals($options->CheckedState, '1');
         $this->assertTrue(property_exists($options, 'UncheckedState'));
@@ -761,11 +730,10 @@ class QgisProjectTest extends TestCase
         $this->assertCount(1, $props);
         $this->assertTrue(array_key_exists('tram_id', $props));
         $prop = $props['tram_id'];
-        $this->assertEquals($prop['fieldEditType'], 'ValueRelation');
-        $this->assertTrue(array_key_exists('widgetv2configAttr', $prop));
-        $this->assertTrue(array_key_exists('edittype', $prop));
-        $this->assertTrue(property_exists($prop['edittype'], 'options'));
-        $options = $prop['edittype']->options;
+        $this->assertEquals($prop->getFieldEditType(), 'ValueRelation');
+
+
+        $options = (object) $prop->getEditAttributes();
         $this->assertTrue(property_exists($options, 'Layer'));
         $this->assertEquals($options->Layer, 'tramway20150328114206278');
         $this->assertTrue(property_exists($options, 'Key'));
@@ -773,9 +741,9 @@ class QgisProjectTest extends TestCase
         $this->assertTrue(property_exists($options, 'Value'));
         $this->assertEquals($options->Value, 'test');
         $this->assertTrue(property_exists($options, 'AllowMulti'));
-        $this->assertEquals($options->AllowMulti, '0');
+        $this->assertFalse($options->AllowMulti);
         $this->assertTrue(property_exists($options, 'AllowNull'));
-        $this->assertEquals($options->AllowNull, '1');
+        $this->assertTrue($options->AllowNull);
         $this->assertTrue(property_exists($options, 'OrderByValue'));
         $this->assertEquals($options->OrderByValue, '1');
         $this->assertTrue(property_exists($options, 'FilterExpression'));
@@ -814,11 +782,9 @@ class QgisProjectTest extends TestCase
         $this->assertCount(1, $props);
         $this->assertTrue(array_key_exists('code_with_geom_exp', $props));
         $prop = $props['code_with_geom_exp'];
-        $this->assertEquals($prop['fieldEditType'], 'ValueRelation');
-        $this->assertTrue(array_key_exists('widgetv2configAttr', $prop));
-        $this->assertTrue(array_key_exists('edittype', $prop));
-        $this->assertTrue(property_exists($prop['edittype'], 'options'));
-        $options = $prop['edittype']->options;
+        $this->assertEquals($prop->getFieldEditType(), 'ValueRelation');
+
+        $options = (object) $prop->getEditAttributes();
         $this->assertTrue(property_exists($options, 'FilterExpression'));
         $this->assertEquals($options->FilterExpression, 'intersects(@current_geometry , $geometry)');
 
@@ -850,22 +816,20 @@ class QgisProjectTest extends TestCase
         $this->assertCount(1, $props);
         $this->assertTrue(array_key_exists('integer_field', $props));
         $prop = $props['integer_field'];
-        $this->assertTrue(array_key_exists('fieldEditType', $prop));
-        $this->assertEquals($prop['fieldEditType'], 'Range');
-        $this->assertTrue(array_key_exists('widgetv2configAttr', $prop));
-        $this->assertTrue(array_key_exists('edittype', $prop));
-        $this->assertTrue(property_exists($prop['edittype'], 'options'));
-        $options = $prop['edittype']->options;
+
+        $this->assertEquals($prop->getFieldEditType(), 'Range');
+
+        $options = (object) $prop->getEditAttributes();
         $this->assertTrue(property_exists($options, 'AllowNull'));
-        $this->assertEquals($options->AllowNull, 'true');
+        $this->assertTrue($options->AllowNull);
         $this->assertTrue(property_exists($options, 'Max'));
-        $this->assertEquals($options->Max, '2147483647');
+        $this->assertEquals($options->Max, 2147483647);
         $this->assertTrue(property_exists($options, 'Min'));
-        $this->assertEquals($options->Min, '-2147483648');
+        $this->assertEquals($options->Min, -2147483648);
         $this->assertTrue(property_exists($options, 'Precision'));
-        $this->assertEquals($options->Precision, '0');
+        $this->assertEquals($options->Precision, 0);
         $this->assertTrue(property_exists($options, 'Step'));
-        $this->assertEquals($options->Step, '1');
+        $this->assertEquals($options->Step, 1);
         $this->assertTrue(property_exists($options, 'Style'));
         $this->assertEquals($options->Style, 'SpinBox');
 
@@ -901,21 +865,19 @@ class QgisProjectTest extends TestCase
         $this->assertTrue(is_array($props));
         $this->assertCount(1, $props);
         $this->assertTrue(array_key_exists('boolean_nullable', $props));
+
         $prop = $props['boolean_nullable'];
-        $this->assertTrue(array_key_exists('fieldEditType', $prop));
-        $this->assertEquals($prop['fieldEditType'], 'ValueMap');
-        $this->assertTrue(array_key_exists('widgetv2configAttr', $prop));
-        $this->assertTrue(property_exists($prop['widgetv2configAttr'], 'map'));
-        $this->assertCount(3, $prop['widgetv2configAttr']->map);
-        $this->assertTrue(array_key_exists('edittype', $prop));
-        $this->assertTrue(property_exists($prop['widgetv2configAttr']->map[0], 'key'));
-        $this->assertTrue(property_exists($prop['widgetv2configAttr']->map[0], 'value'));
-        $this->assertTrue(property_exists($prop['edittype'], 'options'));
-        $options = $prop['edittype']->options;
+
+        $this->assertEquals($prop->getFieldEditType(), 'ValueMap');
+        $options = (object) $prop->getEditAttributes();
         $this->assertTrue(property_exists($options, 'map'));
         $this->assertCount(3, $options->map);
-        $this->assertTrue(property_exists($options->map[0], 'key'));
-        $this->assertTrue(property_exists($options->map[0], 'value'));
+        $expectedOptions = array(
+            '{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}' => '<NULL>',
+            'true' => 'True',
+            'false' => 'False',
+        );
+        $this->assertEquals($expectedOptions, $options->map);
 
         $xmlStr = '
         <maplayer>
@@ -949,16 +911,18 @@ class QgisProjectTest extends TestCase
         $this->assertCount(1, $props);
         $this->assertTrue(array_key_exists('code_for_drill_down_exp', $props));
         $prop = $props['code_for_drill_down_exp'];
-        $this->assertTrue(array_key_exists('fieldEditType', $prop));
-        $this->assertEquals($prop['fieldEditType'], 'ValueMap');
-        $this->assertTrue(array_key_exists('widgetv2configAttr', $prop));
-        $this->assertTrue(array_key_exists('edittype', $prop));
-        $this->assertTrue(property_exists($prop['edittype'], 'options'));
-        $options = $prop['edittype']->options;
+
+        $this->assertEquals($prop->getFieldEditType(), 'ValueMap');
+
+        $options = (object) $prop->getEditAttributes();
         $this->assertTrue(property_exists($options, 'map'));
         $this->assertCount(3, $options->map);
-        $this->assertTrue(property_exists($options->map[0], 'key'));
-        $this->assertTrue(property_exists($options->map[0], 'value'));
+        $expectedOptions = array(
+            'A' => 'Zone A',
+            'B' => 'Zone B',
+            '{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}' => 'No Zone',
+        );
+        $this->assertEquals($expectedOptions, $options->map);
 
         # no edit widget type
         $xmlStr = '
@@ -981,11 +945,25 @@ class QgisProjectTest extends TestCase
         $this->assertCount(1, $props);
         $this->assertTrue(array_key_exists('label', $props));
         $prop = $props['label'];
-        $this->assertEquals($prop['fieldEditType'], '');
+        $this->assertEquals($prop->getFieldEditType(), '');
     }
 
     public function testGetValuesFromOptions() {
         $testProj = new qgisProjectForTests();
+
+        $xmlStr = '
+          <Option type="Map">
+            <Option value="0" type="QString" name="IsMultiline"/>
+            <Option value="0" type="QString" name="UseHtml"/>
+          </Option>
+        ';
+        $xml = simplexml_load_string($xmlStr);
+        $options = $testProj->getFieldConfigurationOptionsForTest($xml);
+        $expectedOptions = array(
+            'IsMultiline' => '0',
+            'UseHtml' => '0',
+        );
+        $this->assertEquals($expectedOptions, $options);
 
         $xmlStr = '
               <Option type="Map">
@@ -998,10 +976,29 @@ class QgisProjectTest extends TestCase
         $options = $testProj->getValuesFromOptionsForTest($xml);
         $this->assertTrue(is_array($options));
         $this->assertCount(2, $options);
-        $this->assertTrue(property_exists($options[0], 'key'));
-        $this->assertTrue(property_exists($options[0], 'value'));
+        $expectedOptions = array(
+            'IsMultiline' =>'false',
+            'UseHtml' =>'false',
+        );
+        $this->assertEquals($expectedOptions, $options);
 
         $xmlStr = '
+              <Option type="Map">
+                <Option value="A" type="QString" name="Zone A"/>
+              </Option>
+        ';
+        $xml = simplexml_load_string($xmlStr);
+
+        $options = $testProj->getValuesFromOptionsForTest($xml);
+        $this->assertTrue(is_array($options));
+        $this->assertCount(1, $options);
+        $expectedOptions = array(
+            'Zone A' =>'A'
+        );
+        $this->assertEquals($expectedOptions, $options);
+
+        $xmlStr = '
+           <Option type="Map">
            <Option type="List" name="map">
              <Option type="Map">
                <Option value="A" type="QString" name="Zone A"/>
@@ -1013,14 +1010,19 @@ class QgisProjectTest extends TestCase
                <Option value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" type="QString" name="No Zone"/>
              </Option>
            </Option>
+           </Option>
         ';
         $xml = simplexml_load_string($xmlStr);
-
-        $options = $testProj->getValuesFromOptionsForTest($xml, false);
+        $options = $testProj->getFieldConfigurationOptionsForTest($xml);
         $this->assertTrue(is_array($options));
-        $this->assertCount(3, $options);
-        $this->assertTrue(property_exists($options[0], 'key'));
-        $this->assertTrue(property_exists($options[0], 'value'));
+        $expectedOptions = array(
+            'map' => array(
+                'A' => 'Zone A',
+                'B' => 'Zone B',
+                '{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}' => 'No Zone',
+            )
+        );
+        $this->assertEquals($expectedOptions, $options);
     }
 
     public function testGetMarkup() {
@@ -1043,8 +1045,7 @@ class QgisProjectTest extends TestCase
         $xml = simplexml_load_string($xmlStr);
         $props = $testProj->getFieldConfigurationForTest($xml);
         $this->assertTrue(array_key_exists('label', $props));
-        $markup = $testProj->getMarkupForTest($props['label']);
-        $this->assertEquals($markup, '');
+        $this->assertEquals($props['label']->getMarkup(), '');
 
         # TextEdit widget
         $xmlStr = '
@@ -1063,8 +1064,7 @@ class QgisProjectTest extends TestCase
         $xml = simplexml_load_string($xmlStr);
         $props = $testProj->getFieldConfigurationForTest($xml);
         $this->assertTrue(array_key_exists('label', $props));
-        $markup = $testProj->getMarkupForTest($props['label']);
-        $this->assertEquals($markup, 'input');
+        $this->assertEquals($props['label']->getMarkup(), 'input');
 
         $xmlStr = '
         <maplayer>
@@ -1085,8 +1085,7 @@ class QgisProjectTest extends TestCase
         $xml = simplexml_load_string($xmlStr);
         $props = $testProj->getFieldConfigurationForTest($xml);
         $this->assertTrue(array_key_exists('label', $props));
-        $markup = $testProj->getMarkupForTest($props['label']);
-        $this->assertEquals($markup, 'input');
+        $this->assertEquals($props['label']->getMarkup(), 'input');
 
         $xmlStr = '
         <maplayer>
@@ -1107,8 +1106,7 @@ class QgisProjectTest extends TestCase
         $xml = simplexml_load_string($xmlStr);
         $props = $testProj->getFieldConfigurationForTest($xml);
         $this->assertTrue(array_key_exists('label', $props));
-        $markup = $testProj->getMarkupForTest($props['label']);
-        $this->assertEquals($markup, 'textarea');
+        $this->assertEquals($props['label']->getMarkup(), 'textarea');
 
         # Range widget
         $xmlStr = '
@@ -1134,8 +1132,7 @@ class QgisProjectTest extends TestCase
         $xml = simplexml_load_string($xmlStr);
         $props = $testProj->getFieldConfigurationForTest($xml);
         $this->assertTrue(array_key_exists('integer_field', $props));
-        $markup = $testProj->getMarkupForTest($props['integer_field']);
-        $this->assertEquals($markup, 'input');
+        $this->assertEquals($props['integer_field']->getMarkup(), 'input');
 
         # DateTime widget
         $xmlStr = '
@@ -1160,8 +1157,7 @@ class QgisProjectTest extends TestCase
         $xml = simplexml_load_string($xmlStr);
         $props = $testProj->getFieldConfigurationForTest($xml);
         $this->assertTrue(array_key_exists('date', $props));
-        $markup = $testProj->getMarkupForTest($props['date']);
-        $this->assertEquals($markup, 'date');
+        $this->assertEquals($props['date']->getMarkup(), 'date');
 
         # CheckBox widget
         $xmlStr = '
@@ -1183,8 +1179,7 @@ class QgisProjectTest extends TestCase
         $xml = simplexml_load_string($xmlStr);
         $props = $testProj->getFieldConfigurationForTest($xml);
         $this->assertTrue(array_key_exists('checked', $props));
-        $markup = $testProj->getMarkupForTest($props['checked']);
-        $this->assertEquals($markup, 'checkbox');
+        $this->assertEquals($props['checked']->getMarkup(), 'checkbox');
 
         # ValueRelation widget
         $xmlStr = '
@@ -1212,8 +1207,7 @@ class QgisProjectTest extends TestCase
         $xml = simplexml_load_string($xmlStr);
         $props = $testProj->getFieldConfigurationForTest($xml);
         $this->assertTrue(array_key_exists('tram_id', $props));
-        $markup = $testProj->getMarkupForTest($props['tram_id']);
-        $this->assertEquals($markup, 'menulist');
+        $this->assertEquals($props['tram_id']->getMarkup(), 'menulist');
 
         $xmlStr = '
         <maplayer>
@@ -1240,8 +1234,7 @@ class QgisProjectTest extends TestCase
         $xml = simplexml_load_string($xmlStr);
         $props = $testProj->getFieldConfigurationForTest($xml);
         $this->assertTrue(array_key_exists('tram_id', $props));
-        $markup = $testProj->getMarkupForTest($props['tram_id']);
-        $this->assertEquals($markup, 'menulist');
+        $this->assertEquals($props['tram_id']->getMarkup(), 'menulist');
 
         $xmlStr = '
         <maplayer>
@@ -1268,8 +1261,7 @@ class QgisProjectTest extends TestCase
         $xml = simplexml_load_string($xmlStr);
         $props = $testProj->getFieldConfigurationForTest($xml);
         $this->assertTrue(array_key_exists('tram_id', $props));
-        $markup = $testProj->getMarkupForTest($props['tram_id']);
-        $this->assertEquals($markup, 'checkboxes');
+        $this->assertEquals($props['tram_id']->getMarkup(), 'checkboxes');
 
         $xmlStr = '
         <maplayer>
@@ -1296,8 +1288,7 @@ class QgisProjectTest extends TestCase
         $xml = simplexml_load_string($xmlStr);
         $props = $testProj->getFieldConfigurationForTest($xml);
         $this->assertTrue(array_key_exists('tram_id', $props));
-        $markup = $testProj->getMarkupForTest($props['tram_id']);
-        $this->assertEquals($markup, 'checkboxes');
+        $this->assertEquals($props['tram_id']->getMarkup(), 'checkboxes');
 
         # ValueMap widget
         $xmlStr = '
@@ -1328,8 +1319,7 @@ class QgisProjectTest extends TestCase
         $xml = simplexml_load_string($xmlStr);
         $props = $testProj->getFieldConfigurationForTest($xml);
         $this->assertTrue(array_key_exists('boolean_nullable', $props));
-        $markup = $testProj->getMarkupForTest($props['boolean_nullable']);
-        $this->assertEquals($markup, 'menulist');
+        $this->assertEquals($props['boolean_nullable']->getMarkup(), 'menulist');
 
         $xmlStr = '
         <maplayer>
@@ -1359,7 +1349,6 @@ class QgisProjectTest extends TestCase
         $xml = simplexml_load_string($xmlStr);
         $props = $testProj->getFieldConfigurationForTest($xml);
         $this->assertTrue(array_key_exists('code_for_drill_down_exp', $props));
-        $markup = $testProj->getMarkupForTest($props['code_for_drill_down_exp']);
-        $this->assertEquals($markup, 'menulist');
+        $this->assertEquals($props['code_for_drill_down_exp']->getMarkup(), 'menulist');
     }
 }

--- a/tests/units/testslib/ContextForTests.php
+++ b/tests/units/testslib/ContextForTests.php
@@ -6,6 +6,8 @@ class ContextForTests implements AppContextInterface
 {
     protected $result = array();
 
+    protected $cache = array();
+
     public function appConfig()
     {
     }
@@ -73,6 +75,19 @@ class ContextForTests implements AppContextInterface
 
     public function getCache($key, $profile = '')
     {
+        if ($profile == '') {
+            $profile = 'default';
+        }
+
+        if (isset($this->cache[$profile][$key])) {
+            return $this->cache[$profile][$key];
+        }
+        return null;
+    }
+
+    public function getAllCacheForTests()
+    {
+        return $this->cache;
     }
 
     public function getCacheDriver($profile)
@@ -86,18 +101,31 @@ class ContextForTests implements AppContextInterface
 
     public function normalizeCacheKey($key)
     {
+        return $key;
     }
 
     public function setCache($key, $value, $ttl = null, $profile = '')
     {
+        if ($profile == '') {
+            $profile = 'default';
+        }
+        $this->cache[$profile][$key] = $value;
     }
 
     public function clearCache($key, $profile = '')
     {
+        if ($profile == '') {
+            $profile = 'default';
+        }
+        unset($this->cache[$profile]);
     }
 
     public function flushCache($profile = '')
     {
+        if ($profile == '') {
+            $profile = 'default';
+        }
+        unset($this->cache[$profile]);
     }
     
     public function logMessage($message, $cat = 'default')

--- a/tests/units/testslib/ProjectForTests.php
+++ b/tests/units/testslib/ProjectForTests.php
@@ -1,16 +1,17 @@
 <?php
 
 use Lizmap\Project;
+use Lizmap\Project\ProjectCache;
 
 class ProjectForTests extends Project\Project
 {
     public function __construct($appContext = null)
     {
-        if ($appContext) {
-            $this->appContext = $appContext;
-        } else {
-            $this->appContext = new ContextForTests();
+        if (!$appContext) {
+            $appContext = new ContextForTests();
         }
+        $this->appContext = $appContext;
+        $this->cacheHandler = new ProjectCache('/test.qgs', time(), time(), $this->appContext);
     }
 
     public function setRepo($rep)
@@ -38,9 +39,10 @@ class ProjectForTests extends Project\Project
         $this->services = $services;
     }
 
-    public function setFile($file)
+    public function setFile($file, $modifiedTime, $cfgModifiedTime)
     {
         $this->file = $file;
+        $this->cacheHandler = new ProjectCache($file, $modifiedTime, $cfgModifiedTime, $this->appContext);
     }
 
     public function readProjectForTest($key, $rep)

--- a/tests/units/testslib/QgisFormControlForTests.php
+++ b/tests/units/testslib/QgisFormControlForTests.php
@@ -1,6 +1,7 @@
 <?php
 
 use Lizmap\Form\QgisFormControl;
+use Lizmap\Form\QgisFormControlProperties;
 
 class QgisFormControlForTests extends QgisFormControl
 {
@@ -11,8 +12,13 @@ class QgisFormControlForTests extends QgisFormControl
         self::buildEditTypeMap();
     }
 
-    public function setControlMainPropertiesForTests()
+
+    /**
+     * @param QgisFormControlProperties $properties
+     */
+    public function setControlMainPropertiesForTests($properties)
     {
+        $this->setProperties($properties);
         $this->setControlMainProperties();
     }
 }

--- a/tests/units/testslib/QgisProjectForTests.php
+++ b/tests/units/testslib/QgisProjectForTests.php
@@ -89,13 +89,13 @@ class QgisProjectForTests extends QgisProject
         return $this->getFieldConfiguration($layerXml);
     }
 
-    public function getValuesFromOptionsForTest($optionList, $name = true)
+    public function getValuesFromOptionsForTest($optionList, $valuesExtract = 0)
     {
-        return $this->getValuesFromOptions($optionList, $name = true);
+        return $this->getValuesFromOptions($optionList, $valuesExtract);
     }
 
-    public function getMarkupForTest($props)
+    public function getFieldConfigurationOptionsForTest($optionList)
     {
-        return $this->getMarkup($props);
+        return $this->getFieldConfigurationOptions($optionList);
     }
 }


### PR DESCRIPTION
In 3.5, we put form properties into a cache, in order to avoid to load the qgis file when we need to edit a SIG feature.

However, there are some issues that causes some regressions and issues. This patch brings these improvements:

* the form properties are now stored into the same cache backend as  the one used to cache project properties, instead of storing into some JSON files somewhere into the lizmap directories. 
    * So when flushing the main cache, forms caches will be also deleted.
    * using the` jCache` backend allow to store PHP objects. So when loading the cache, we don't have an untyped object, but we could have objects having our own classes.
* refactor `QgisFormControl`, so it does not deal anymore with XML and `SimpleXml` objects. It is now the responsability to `QgisProject` to read form properties from the XML, and to generate some new `QgisFormControlProperties` object that are stored into the form cache. `QgisFormControl` use  a `QgisFormControlProperties` object to access to editing properties. 

* Funded by 3Liz
