### PR TITLE
[Bugfix] WMS GetFeatureInfo Request can return XML

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -396,6 +396,8 @@ class WMSRequest extends OGCRequest
         if ($toHtml and preg_match('#/xml#', $mime)) {
             $rep .= $this->gfiXmlToHtml($data);
             $mime = 'text/html';
+        } else {
+            $rep .= $data;
         }
 
         return (object) array(


### PR DESCRIPTION
After refactoring, Lizmap was only able to return HTML for WMS GetFeatureInfo Request.