### PR TITLE
[Bugfix] PostgreSQL typname can be _text

### DIFF
--- a/lizmap/modules/lizmap/lib/Form/QgisFormControl.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisFormControl.php
@@ -151,6 +151,7 @@ class QgisFormControl
         'varchar' => 'text',
         'bpchar' => 'text',
         'char' => 'text',
+        '_text' => 'text[]',
         'blob' => 'blob',
         'bytea' => 'blob',
         'geometry' => 'geometry',
@@ -185,7 +186,7 @@ class QgisFormControl
      *
      * @param string              $ref                name of the control
      * @param \SimpleXMLElement   $edittype           simplexml object corresponding to the QGIS edittype for this field
-     * @param object              $prop               Jelix object with field properties (datatype, required, etc.)
+     * @param jDbFieldProperties  $prop               Jelix object with field properties (datatype, required, etc.)
      * @param array|object|string $aliasXml           simplexml object corresponding to the QGIS alias for this field
      * @param null|string         $defaultValue       the QGIS expression of the default value
      * @param null|array          $constraints        the QGIS constraints


### PR DESCRIPTION
Fix Undefined index: _text in /srv/lzm/lizmap/modules/lizmap/lib/Form/QgisFormControl.php 201

When jelix retrives PostgreSQL fields info, the jDbFieldProperties type value comes from pgtype.typname and can be _text for text.

Fixing https://paste.sh/wELXEssH#2sMuGK8X5c82wOu61oyv8Fbz