### PR TITLE
API - Factorize ACL checks about edition layers

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -241,12 +241,22 @@ class lizmapProject
 
     public function hasEditionLayers()
     {
-        return $this->proj->hasEditionLayers();
+        return $this->proj->hasEditionLayersForCurrentUser();
+    }
+
+    public function hasEditionLayersForCurrentUser()
+    {
+        return $this->proj->hasEditionLayersForCurrentUser();
     }
 
     public function getEditionLayers()
     {
         return $this->proj->getEditionLayers();
+    }
+
+    public function getEditionLayersForCurrentUser()
+    {
+        return $this->proj->getEditionLayersForCurrentUser();
     }
 
     public function findEditionLayerByName($name)
@@ -257,7 +267,7 @@ class lizmapProject
     /**
      * @param $layerId
      *
-     * @return null|array
+     * @return null|object
      */
     public function findEditionLayerByLayerId($layerId)
     {

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -1047,14 +1047,45 @@ class qgisVectorLayer extends qgisMapLayer
         return true;
     }
 
+    /**
+     * @return bool
+     */
+    public function canCurrentUserEdit()
+    {
+        $eLayer = $this->project->getEditionLayerByName($this->name);
+
+        return $this->project->checkEditionLayerAcl($eLayer);
+    }
+
+    /**
+     * @return null|object the edition layer object
+     *
+     * @deprecated return the edition layer object to be compatible with external
+     *  modules. It will returns the capabilities object in the future.
+     *  Use getRealEditionCapabilities() for the moment.
+     * @see getRealEditionCapabilities()
+     */
     public function getEditionCapabilities()
     {
-        $layerName = $this->name;
-        $eLayers = $this->project->getEditionLayers();
-        if (!property_exists($eLayers, $layerName)) {
-            return null;
+        return $this->project->getEditionLayerByName($this->name);
+    }
+
+    /**
+     * @return object the capabilities object
+     */
+    public function getRealEditionCapabilities()
+    {
+        $eLayer = $this->project->getEditionLayerByName($this->name);
+        if (property_exists($eLayer, 'capabilities')) {
+            return $eLayer->capabilities;
         }
 
-        return $eLayers->{$layerName};
+        return (object) array(
+            'createFeature' => 'False',
+            'allow_without_geom' => 'False',
+            'modifyAttribute' => 'False',
+            'modifyGeometry' => 'False',
+            'deleteFeature' => 'False',
+        );
     }
 }

--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -97,8 +97,7 @@ class QgisForm implements QgisFormControlsInterface
         $this->appContext = $appContext;
         $this->dbFieldsInfo = $dbFieldsInfo;
 
-        $eCapabilities = $layer->getEditionCapabilities();
-        $capabilities = $eCapabilities->capabilities;
+        $capabilities = $layer->getRealEditionCapabilities();
         $dataFields = $dbFieldsInfo->dataFields;
         $toDeactivate = array();
         $toSetReadOnly = array();
@@ -486,7 +485,7 @@ class QgisForm implements QgisFormControlsInterface
         $check = $form->check();
 
         // Geom check
-        $allow_without_geom = $this->layer->getEditionCapabilities()->capabilities->allow_without_geom;
+        $allow_without_geom = $this->layer->getRealEditionCapabilities()->allow_without_geom;
         if (strtolower($allow_without_geom) == 'false' && $geometryColumn != '' && $form->getData($geometryColumn) == '') {
             $check = false;
             $form->setErrorOn($geometryColumn, $this->appContext->getLocale('view~edition.message.error.no.geometry'));
@@ -772,8 +771,7 @@ class QgisForm implements QgisFormControlsInterface
 
     protected function getFieldList($geometryColumn, $insertAction, $modifiedControls)
     {
-        $eCapabilities = $this->layer->getEditionCapabilities();
-        $capabilities = $eCapabilities->capabilities;
+        $capabilities = $this->layer->getRealEditionCapabilities();
 
         $dataFields = $this->dbFieldsInfo->dataFields;
 

--- a/lizmap/modules/lizmap/lib/Form/QgisFormControl.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisFormControl.php
@@ -406,6 +406,12 @@ class QgisFormControl
 
     protected static function buildEditTypeMap()
     {
+        if (self::$qgisEdittypeMap['builded']) {
+            // as self::$qgisEdittypeMap is static, it may already exists
+            // if a QgisFormControl has already been instanciated
+            return;
+        }
+
         // Add new editTypes naming convention since QGIS 2.4
         self::$qgisEdittypeMap['LineEdit'] = self::$qgisEdittypeMap[0];
         self::$qgisEdittypeMap['UniqueValues'] = self::$qgisEdittypeMap[2];

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -159,7 +159,7 @@ class Project
     /**
      * @var array List of cached properties
      */
-    protected $cachedProperties = array(
+    protected static $cachedProperties = array(
         'WMSInformation',
         'canvasColor',
         'allProj4',
@@ -248,7 +248,7 @@ class Project
             $this->readProject($key, $rep);
 
             // set project data in cache
-            foreach ($this->cachedProperties as $prop) {
+            foreach (self::$cachedProperties as $prop) {
                 if (isset($this->{$prop}) && !empty($this->{$prop})) {
                     $data[$prop] = $this->{$prop};
                 }
@@ -256,7 +256,7 @@ class Project
             $data = array_merge($data, $this->qgis->getCacheData($data), $this->cfg->getCacheData($data));
             $this->cacheHandler->storeProjectData($data);
         } else {
-            foreach ($this->cachedProperties as $prop) {
+            foreach (self::$cachedProperties as $prop) {
                 if (array_key_exists($prop, $data)) {
                     $this->{$prop} = $data[$prop];
                 }
@@ -365,19 +365,23 @@ class Project
 
         $this->qgis->setPropertiesAfterRead($this->cfg);
 
+        $this->printCapabilities = $this->readPrintCapabilities($qgsXml);
+        $this->locateByLayers = $this->readLocateByLayers($qgsXml, $this->cfg);
+        $this->editionLayers = $this->readEditionLayers($qgsXml);
+        $this->layersOrder = $this->readLayersOrder($qgsXml);
+        $this->attributeLayers = $this->readAttributeLayers($qgsXml, $this->cfg);
+
         $props = array(
             'printCapabilities',
             'locateByLayers',
-            // 'formFilterLayers',
             'editionLayers',
             'layersOrder',
             'attributeLayers',
         );
         foreach ($props as $prop) {
-            $method = 'read'.ucfirst($prop);
-            $this->{$prop} = $this->{$method}($qgsXml, $this->cfg);
             $this->cfg->setProperty($prop, $this->{$prop});
         }
+
         $this->qgis->readEditionForms($this->getEditionLayers(), $this);
     }
 
@@ -1188,7 +1192,7 @@ class Project
         return $gKey;
     }
 
-    protected function readPrintCapabilities(QgisProject $qgsLoad, ProjectConfig $cfg)
+    protected function readPrintCapabilities(QgisProject $qgsLoad)
     {
         $printTemplates = array();
         $options = $this->getOptions();
@@ -1223,7 +1227,7 @@ class Project
         return $formFilterLayers;
     }
 
-    protected function readEditionLayers(QgisProject $xml, ProjectConfig $cfg)
+    protected function readEditionLayers(QgisProject $xml)
     {
         $editionLayers = $this->getEditionLayers();
 
@@ -1269,7 +1273,7 @@ class Project
      *
      * @return int[]
      */
-    protected function readLayersOrder(QgisProject $xml, ProjectConfig $cfg)
+    protected function readLayersOrder(QgisProject $xml)
     {
         return $this->qgis->readLayersOrder($xml, $this->getLayers());
     }

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -127,6 +127,11 @@ class Project
     protected $editionLayers = array();
 
     /**
+     * @var null|object[] layer names => layers
+     */
+    protected $editionLayersForCurrentUser;
+
+    /**
      * @var array
      */
     protected $attributeLayers = array();
@@ -815,45 +820,144 @@ class Project
         );
     }
 
+    /**
+     * same as hasEditionLayersForCurrentUser.
+     *
+     * @return bool
+     *
+     * @deprecated will returns all edition layers, regarding ACL
+     */
     public function hasEditionLayers()
     {
-        $editionLayers = $this->cfg->getProperty('editionLayers');
-        if ($editionLayers) {
-            if (!$this->appContext->aclCheck('lizmap.tools.edition.use', $this->repository->getKey())) {
-                return false;
+        return $this->hasEditionLayersForCurrentUser();
+    }
+
+    public function hasEditionLayersForCurrentUser()
+    {
+        if ($this->editionLayersForCurrentUser === null) {
+            $this->readEditionLayersForCurrentUser();
+        }
+
+        if (count($this->editionLayersForCurrentUser) != 0) {
+            return true;
+        }
+
+        return false;
+    }
+
+    protected function readEditionLayersForCurrentUser()
+    {
+        if (!$this->cfg->hasEditionLayers()) {
+            $this->editionLayersForCurrentUser = array();
+
+            return;
+        }
+
+        if (!$this->appContext->aclCheck('lizmap.tools.edition.use', $this->repository->getKey())) {
+            $this->editionLayersForCurrentUser = array();
+
+            return;
+        }
+
+        $editionLayers = $this->cfg->getEditionLayers();
+        $this->editionLayersForCurrentUser = array();
+        $isAdmin = $this->appContext->aclCheck('lizmap.admin.repositories.delete');
+        $userGroups = $this->appContext->aclUserGroupsId();
+
+        foreach ($editionLayers as $key => $eLayer) {
+            if ($this->_checkEditionLayerAcl($eLayer, $isAdmin, $userGroups)) {
+                $this->editionLayersForCurrentUser[$key] = $eLayer;
             }
-            $count = 0;
-            foreach ($editionLayers as $key => $eLayer) {
-                // Check if user groups intersects groups allowed by project editor
-                // If user is admin, no need to check for given groups
-                if (property_exists($eLayer, 'acl') && $eLayer->acl) {
-                    // Check if configured groups white list and authenticated user groups list intersects
-                    $editionGroups = $eLayer->acl;
-                    $editionGroups = array_map('trim', explode(',', $editionGroups));
-                    if (is_array($editionGroups) && count($editionGroups) > 0) {
-                        $userGroups = $this->appContext->aclUserGroupsId();
-                        if (array_intersect($editionGroups, $userGroups) || $this->appContext->aclCheck('lizmap.admin.repositories.delete')) {
-                            // User group(s) correspond to the groups given for this edition layer
-                            // or user is admin
-                            ++$count;
-                            $this->cfg->unsetProperty('editionLayers', $key, 'acl');
-                        } else {
-                            // No match found, we deactivate the edition layer
-                            $this->cfg->unsetProperty('editionLayers', $key);
-                        }
-                    }
-                } else {
-                    ++$count;
-                }
-            }
-            if ($count != 0) {
+        }
+    }
+
+    /**
+     * Indicate if the edition layer can be edit by the current user.
+     *
+     * @param object $eLayer edition layer object
+     */
+    public function checkEditionLayerAcl($eLayer)
+    {
+        $isAdmin = $this->appContext->aclCheck('lizmap.admin.repositories.delete');
+        $userGroups = $this->appContext->aclUserGroupsId();
+
+        return $this->_checkEditionLayerAcl($eLayer, $isAdmin, $userGroups);
+    }
+
+    /**
+     * @param object   $eLayer     the edition layer
+     * @param bool     $isAdmin
+     * @param string[] $userGroups
+     *
+     * @return bool
+     */
+    protected function _checkEditionLayerAcl($eLayer, $isAdmin, $userGroups)
+    {
+        // Check if user groups intersects groups allowed by project editor
+        // If user is admin, no need to check for given groups
+        if (property_exists($eLayer, 'acl') && $eLayer->acl) {
+            // Check if configured groups white list and authenticated user
+            // groups list intersects
+            $editionGroups = preg_split('/\\s*,\\s*/', $eLayer->acl);
+            if ($isAdmin || ($editionGroups
+                             && array_intersect($editionGroups, $userGroups))) {
+                // User group(s) correspond to the groups given for this edition layer
+                // or user is admin: we take the layer.
+                unset($eLayer->acl);
+
                 return true;
             }
 
             return false;
         }
 
-        return false;
+        return true;
+    }
+
+    /**
+     * @param $layerName
+     *
+     * @return null|object the layer or null if does not exist
+     */
+    public function getEditionLayerForCurrentUser($layerName)
+    {
+        if ($this->editionLayersForCurrentUser !== null) {
+            // we already read all edition layers, just pick the corresponding one
+            if (isset($this->editionLayersForCurrentUser[$layerName])) {
+                return $this->editionLayersForCurrentUser[$layerName];
+            }
+
+            return null;
+        }
+
+        // we didn't yet retrieve all edition layer. Just pick and check the
+        // given edition layer. We do not call readEditionLayersForCurrentUser
+        // because we may need only the given layer during the php request process
+        // and we don't want to spend time on all others layers
+
+        $layer = $this->cfg->getEditionLayerByName($layerName);
+        if (!$layer) {
+            return null;
+        }
+
+        if (!$this->appContext->aclCheck('lizmap.tools.edition.use', $this->repository->getKey())) {
+            return null;
+        }
+
+        if ($this->checkEditionLayerAcl($layer)) {
+            return $layer;
+        }
+
+        return null;
+    }
+
+    public function getEditionLayersForCurrentUser()
+    {
+        if ($this->editionLayersForCurrentUser === null) {
+            $this->readEditionLayersForCurrentUser();
+        }
+
+        return $this->editionLayersForCurrentUser;
     }
 
     public function getEditionLayers()
@@ -861,27 +965,65 @@ class Project
         return $this->cfg->getProperty('editionLayers');
     }
 
-    public function findEditionLayerByName($name)
+    /**
+     * Return the given edition layer, whether the user has the right to edit
+     * or not.
+     *
+     * @param $layerName
+     */
+    public function getEditionLayerByName($layerName)
     {
-        if (!$this->hasEditionLayers()) {
+        $eLayers = $this->getEditionLayers();
+        if (!property_exists($eLayers, $layerName)) {
             return null;
         }
 
-        return $this->cfg->getEditionLayerByName($name);
+        return $eLayers->{$layerName};
     }
 
     /**
-     * @param $layerId
+     * Return the given edition layer if it exists and if the
+     * current user can edit it.
      *
-     * @return null|array
+     * Similar to getEditionLayerForCurrentUser except that
+     * findEditionLayerByName loads alls edition layers if not already done.
+     * Use it in a layers loop instead of getEditionLayerForCurrentUser.
+     *
+     * @param $name
+     *
+     * @return null|object
      */
-    public function findEditionLayerByLayerId($layerId)
+    public function findEditionLayerByName($name)
     {
-        if (!$this->hasEditionLayers()) {
+        if (!$this->hasEditionLayersForCurrentUser()) {
             return null;
         }
 
-        return $this->cfg->getEditionLayerByLayerId($layerId);
+        return $this->getEditionLayerForCurrentUser($name);
+    }
+
+    /**
+     * Return the given edition layer if it exists and if the
+     * current user can edit it.
+     *
+     * notice: it checks all edition layers.
+     *
+     * @param $layerId
+     *
+     * @return null|object
+     */
+    public function findEditionLayerByLayerId($layerId)
+    {
+        if (!$this->hasEditionLayersForCurrentUser()) {
+            return null;
+        }
+
+        $layer = $this->cfg->getEditionLayerByLayerId($layerId);
+        if ($layer && $this->checkEditionLayerAcl($layer)) {
+            return $layer;
+        }
+
+        return null;
     }
 
     /**
@@ -1284,8 +1426,6 @@ class Project
     }
 
     /**
-     * @deprecated
-     *
      * @param mixed $name
      */
     public function findLayerByAnyName($name)
@@ -1294,8 +1434,6 @@ class Project
     }
 
     /**
-     * @deprecated
-     *
      * @param mixed $name
      */
     public function findLayerByName($name)
@@ -1304,8 +1442,6 @@ class Project
     }
 
     /**
-     * @deprecated
-     *
      * @param mixed $shortName
      */
     public function findLayerByShortName($shortName)
@@ -1314,8 +1450,6 @@ class Project
     }
 
     /**
-     * @deprecated
-     *
      * @param mixed $title
      */
     public function findLayerByTitle($title)
@@ -1324,8 +1458,6 @@ class Project
     }
 
     /**
-     * @deprecated
-     *
      * @param mixed $layerId
      */
     public function findLayerByLayerId($layerId)
@@ -1334,8 +1466,6 @@ class Project
     }
 
     /**
-     * @deprecated
-     *
      * @param mixed $typeName
      */
     public function findLayerByTypeName($typeName)
@@ -1699,7 +1829,7 @@ class Project
             2
         );
 
-        if ($this->hasEditionLayers()) {
+        if ($this->hasEditionLayersForCurrentUser()) {
             $tpl = new \jTpl();
             $dockable[] = new \lizmapMapDockItem(
                 'edition',
@@ -1755,7 +1885,7 @@ class Project
         if (property_exists($configOptions, 'geolocation')
             && $configOptions->geolocation == 'True') {
             $tpl = new \jTpl();
-            $tpl->assign('hasEditionLayers', $this->hasEditionLayers());
+            $tpl->assign('hasEditionLayers', $this->hasEditionLayersForCurrentUser());
             $dockable[] = new \lizmapMapDockItem(
                 'geolocation',
                 $this->appContext->getLocale('view~map.geolocate.navbar.title'),

--- a/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
@@ -25,22 +25,22 @@ class ProjectConfig
     protected $printCapabilities;
 
     /**
-     * @var mixed
+     * @var object
      */
     protected $locateByLayer;
 
     /**
-     * @var mixed
+     * @var object
      */
     protected $formFilterLayers;
 
     /**
-     * @var mixed
+     * @var object
      */
     protected $editionLayers;
 
     /**
-     * @var mixed
+     * @var object
      */
     protected $attributeLayers;
 
@@ -157,9 +157,15 @@ class ProjectConfig
         }
         if (isset($rootProp->{$propName}) && $propName2 == '') {
             unset($rootProp->{$propName});
-        } elseif (isset($rootProp->{$propName}) && property_exists($rootProp->{$propName}, $propName2) && $propName3 == '') {
+        } elseif (isset($rootProp->{$propName})
+                  && property_exists($rootProp->{$propName}, $propName2)
+                  && $propName3 == ''
+        ) {
             unset($rootProp->{$propName}->{$propName2});
-        } elseif (isset($rootProp->{$propName}) && property_exists($rootProp->{$propName}, $propName2) && property_exists($rootProp->{$propName}->{$propName2}, $propName3)) {
+        } elseif (isset($rootProp->{$propName})
+                  && property_exists($rootProp->{$propName}, $propName2)
+                  && property_exists($rootProp->{$propName}->{$propName2}, $propName3)
+        ) {
             unset($rootProp->{$propName}->{$propName2}->{$propName3});
         }
     }
@@ -168,6 +174,8 @@ class ProjectConfig
      * Call every findLayerBy function to get a layer.
      *
      * @param string $name The name, shortname, typename, id or title of the layer to get
+     *
+     * @see findLayerByName, findLayerByShortName, findLayerByTypeName, findLayerByLayerId, findLayerByTitle
      */
     public function findLayerByAnyName($name)
     {
@@ -176,7 +184,6 @@ class ProjectConfig
             return null;
         }
 
-        $layer = null;
         $methods = array(
             // Get by name ie as written in QGIS Desktop legend
             'Name',
@@ -324,6 +331,22 @@ class ProjectConfig
         return null;
     }
 
+    /**
+     * @return object[] layer names => layers
+     */
+    public function getEditionLayers()
+    {
+        if ($this->editionLayers) {
+            return (array) $this->editionLayers;
+        }
+
+        if (isset($this->cfgContent->editionLayers)) {
+            return (array) $this->cfgContent->editionLayers;
+        }
+
+        return array();
+    }
+
     public function getEditionLayerByName($name)
     {
         $editionLayers = $this->editionLayers;
@@ -337,7 +360,7 @@ class ProjectConfig
     /**
      * @param $layerId
      *
-     * @return null|array
+     * @return null|object
      */
     public function getEditionLayerByLayerId($layerId)
     {
@@ -355,5 +378,20 @@ class ProjectConfig
         }
 
         return null;
+    }
+
+    public function hasEditionLayers()
+    {
+        if ($this->editionLayers) {
+            return true;
+        }
+
+        if (isset($this->cfgContent->editionLayers)
+            && $this->cfgContent->editionLayers
+        ) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
@@ -49,7 +49,7 @@ class ProjectConfig
      */
     protected $options;
 
-    protected $cachedProperties = array(
+    protected static $cachedProperties = array(
         'layersOrder',
         'locateByLayer',
         'formFilterLayers',
@@ -69,7 +69,7 @@ class ProjectConfig
             }
         } else {
             foreach ($data as $prop => $value) {
-                if (in_array($prop, $this->cachedProperties)) {
+                if (in_array($prop, self::$cachedProperties)) {
                     // if ($prop == 'cfgContent') {
                     //     $this->{$prop} = json_decode(json_encode($value));
 
@@ -109,7 +109,7 @@ class ProjectConfig
      */
     public function getCacheData($data)
     {
-        foreach ($this->cachedProperties as $prop) {
+        foreach (self::$cachedProperties as $prop) {
             if (!isset($this->{$prop}) || isset($data[$prop])) {
                 continue;
                 // }
@@ -152,7 +152,7 @@ class ProjectConfig
     public function unsetProperty($propName, $propName2 = '', $propName3 = '')
     {
         $rootProp = $this->cfgContent;
-        if (in_array($propName, $this->cachedProperties)) {
+        if (in_array($propName, self::$cachedProperties)) {
             $rootProp = $this;
         }
         if (isset($rootProp->{$propName}) && $propName2 == '') {

--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -373,7 +373,7 @@ class QgisProject
             }
         }
         //unset cache for editionLayers
-        $eLayers = $cfg->getProperty('editionLayers');
+        $eLayers = $cfg->getEditionLayers();
         $layers = $cfg->getProperty('layers');
         if ($eLayers) {
             foreach ($eLayers as $key => $obj) {

--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -84,8 +84,17 @@ class QgisProject
     /**
      * @var array List of cached properties
      */
-    protected $cachedProperties = array('WMSInformation', 'canvasColor', 'allProj4',
-        'relations', 'themes', 'useLayerIDs', 'layers', 'data', 'qgisProjectVersion', );
+    protected static $cachedProperties = array(
+        'WMSInformation',
+        'canvasColor',
+        'allProj4',
+        'relations',
+        'themes',
+        'useLayerIDs',
+        'layers',
+        'data',
+        'qgisProjectVersion',
+    );
 
     /**
      * @var App\AppContextInterface
@@ -106,7 +115,7 @@ class QgisProject
             // have a kind of lock to avoid this issue.
             $this->readXmlProject($file);
         } else {
-            foreach ($this->cachedProperties as $prop) {
+            foreach (self::$cachedProperties as $prop) {
                 if (array_key_exists($prop, $data)) {
                     $this->{$prop} = $data[$prop];
                 }
@@ -120,7 +129,7 @@ class QgisProject
 
     public function getCacheData($data)
     {
-        foreach ($this->cachedProperties as $prop) {
+        foreach (self::$cachedProperties as $prop) {
             if (!isset($this->{$prop}) || isset($data[$prop])) {
                 continue;
             }

--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -151,7 +151,7 @@ class lizMapCtrl extends jController
         $bp = $confUrlEngine['basePath'];
 
         // Add the jForms js
-        if ($lproj->hasEditionLayers()) {
+        if ($lproj->hasEditionLayersForCurrentUser()) {
             $lang = jLocale::getCurrentLang();
             $www = $confUrlEngine['jelixWWWPath'];
 

--- a/lizmap/modules/view/zones/map_menu.zone.php
+++ b/lizmap/modules/view/zones/map_menu.zone.php
@@ -53,7 +53,7 @@ class map_menuZone extends jZone
                 $assign['print'] = true;
             }
 
-            $assign['edition'] = $lproj->hasEditionLayers();
+            $assign['edition'] = $lproj->hasEditionLayersForCurrentUser();
 
             if (property_exists($configOptions, 'geolocation')
                 && $configOptions->geolocation == 'True'

--- a/tests/units/classes/Project/ProjectTest.php
+++ b/tests/units/classes/Project/ProjectTest.php
@@ -212,8 +212,8 @@ class ProjectTest extends TestCase
         $proj = new ProjectForTests($context);
         $proj->setRepo($rep);
         $proj->setCfg($config);
-        $this->assertEquals($expectedRet, $proj->hasEditionLayers());
-        $eLayer = $proj->getEditionLayers();
+        $this->assertEquals($expectedRet, $proj->hasEditionLayersForCurrentUser());
+        $eLayer = $proj->getEditionLayersForCurrentUser();
         foreach ($unset as $key => $value) {
             if ($value) {
                 $this->assertFalse(isset($eLayer->{$key}));

--- a/tests/units/testslib/QgisLayerForTests.php
+++ b/tests/units/testslib/QgisLayerForTests.php
@@ -59,6 +59,15 @@ class QgisLayerForTests extends qgisVectorLayer
         return (object) array('capabilities' => null);
     }
 
+    public function getRealEditionCapabilities()
+    {
+        if (isset($this->eCapabilities)) {
+            return $this->eCapabilities->capabilities;
+        }
+
+        return null;
+    }
+
     public function getDbFieldValues($feature)
     {
         return $this->dbFieldValues;


### PR DESCRIPTION
The code to do some ACL checks for edition layers is duplicated at several place (including in at least the address module). This patch reorganize the code so we now have new methods on Project to manipulate edition layers. There is for example the method `canCurrentUserEdit` that could be used into the address module.

This patch improve also the memory usage of classes that have some properties like `cachedProperties` that could be `static`.


* Funded by 3Liz
