### PR TITLE
[Backport release_3_5] Docsstring: Add appContext param to QgisForm and QgisFormControl construct

### DIFF
--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -67,6 +67,7 @@ class QgisForm implements QgisFormControlsInterface
      * @param \jFormsBase                    $form
      * @param string                         $featureId
      * @param bool                           $loginFilteredOverride
+     * @param \AppContextInterface           $appContext
      *
      * @throws \Exception
      */

--- a/lizmap/modules/lizmap/lib/Form/QgisFormControl.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisFormControl.php
@@ -187,13 +187,13 @@ class QgisFormControl
      * Create an jForms control object based on a qgis edit widget.
      * And add it to the passed form.
      *
-     * @param string                    $ref                name of the control
+     * @param string                    $ref          name of the control
      * @param QgisFormControlProperties $properties
-     * @param jDbFieldProperties        $prop               Jelix object with field properties (datatype, required, etc.)
-     * @param array|object|string       $aliasXml           simplexml object corresponding to the QGIS alias for this field
-     * @param null|string               $defaultValue       the QGIS expression of the default value
-     * @param null|array                $constraints        the QGIS constraints
-     * @param object                    $rendererCategories simplexml object corresponding to the QGIS categories of the renderer
+     * @param jDbFieldProperties        $prop         Jelix object with field properties (datatype, required, etc.)
+     * @param array|object|string       $aliasXml     simplexml object corresponding to the QGIS alias for this field
+     * @param null|string               $defaultValue the QGIS expression of the default value
+     * @param null|array                $constraints  the QGIS constraints
+     * @param \AppContextInterface      $appContext
      */
     public function __construct($ref, $properties, $prop, $defaultValue, $constraints, App\AppContextInterface $appContext)
     {


### PR DESCRIPTION
The $appContext parameter was not described in the QgisForm and QgisFormControl constructor.

Manually backport #2464