### PR TITLE
Fix bug of boolean checkbox when inserting

### DIFF
--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -716,8 +716,14 @@ class editionCtrl extends jController
         // And get returned primary key values
         $pkvals = null;
         if ($check) {
-            // Save to database with modified controls
-            $pkvals = $qgisForm->saveToDb($feature, $form->getModifiedControls());
+            // Check if featureId is null to get all controls or only modified controls
+            if ($this->featureId == null) {
+                // Save to database with all controls
+                $pkvals = $qgisForm->saveToDb($feature, $form->getControls());
+            } else {
+                // Save to database with modified controls
+                $pkvals = $qgisForm->saveToDb($feature, $form->getModifiedControls());
+            }
         }
 
         // Some errors where encoutered


### PR DESCRIPTION
<!-- Add "fix" in front of "#" if it fixes the ticket or do nothing to only mention it.

This PR will be harvested on changelog.lizmap.com if there is a "changelog" label.
Funded by NAME URL
-->
* Fix bug checkbox in the form. On insertion when the checkbox is not checked, Lizmap considers it as unmodified. On this PR I modified the edit.classic.php file when saving in the database, if featureId is null we get all the controls else if not null we get only the modified controls.
* Funded by 3liz
