### PR TITLE
Refactor some Project and ProjectConfig usage, and fix some cache issues

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapTiler.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapTiler.class.php
@@ -171,8 +171,8 @@ class lizmapTiler
     /**
      * Get a list of tileMatrixSet.
      *
-     * @param mixed $project
-     * @param mixed $wms_xml
+     * @param \Lizmap\Project\Project $project
+     * @param mixed                   $wms_xml
      */
     public static function getTileMatrixSetList($project, $wms_xml)
     {
@@ -220,9 +220,10 @@ class lizmapTiler
             $rootExtent[3] = $geoExtent[3];
         }
 
-        $opt = $project->getOptions();
-        $scales = array_merge(array(), $opt->mapScales);
+        $scales = array_merge(array(), $project->getOption('mapScales'));
         rsort($scales);
+
+        $projection = $project->getOption('projection');
 
         $tileMatrixSetList = array();
         foreach ($rootLayer[0]->CRS as $CRS) {
@@ -282,11 +283,11 @@ class lizmapTiler
                 $tileMatrixSet->extent = $extent;
                 $tileMatrixSet->tileMatrixList = $tileMatrixList;
                 $tileMatrixSetList[] = $tileMatrixSet;
-            } elseif ($CRS == $opt->projection->ref) {
+            } elseif ($CRS == $projection->ref) {
                 $proj4 = new Proj4php();
-                Proj4php::$defs[$CRS] = $opt->projection->proj4;
+                Proj4php::$defs[$CRS] = $projection->proj4;
                 $sourceProj = new Proj4phpProj('EPSG:4326', $proj4);
-                $destProj = new Proj4phpProj($opt->projection->ref, $proj4);
+                $destProj = new Proj4phpProj($projection->ref, $proj4);
 
                 $sourceMinPt = new proj4phpPoint($rootExtent[0], $rootExtent[1]);
                 $destMinPt = $proj4->transform($sourceProj, $destProj, $sourceMinPt);
@@ -296,7 +297,7 @@ class lizmapTiler
 
                 $extent = array($destMinPt->x, $destMinPt->y, $destMaxPt->x, $destMaxPt->y);
 
-                preg_match('/ \+units=(?P<unit>\w+) /', $opt->projection->proj4, $matches);
+                preg_match('/ \+units=(?P<unit>\w+) /', $projection->proj4, $matches);
                 $unit = $matches['unit'];
 
                 //$res = 0.28E-3 * $scales[0] / $METERS_PER_INCH / $INCHES_PER_UNIT[ $unit ];
@@ -421,8 +422,7 @@ class lizmapTiler
             $rootExtent[3] = $geoExtent[3];
         }
 
-        $opt = $project->getOptions();
-        $scales = array_merge(array(), $opt->mapScales);
+        $scales = array_merge(array(), $project->getOption('mapScales'));
         rsort($scales);
 
         $layers = $project->getLayers();
@@ -492,9 +492,9 @@ class lizmapTiler
             'y' => $layerExtent[3],
         );
 
-        $opt = $project->getOptions();
+        $projection = $project->getOption('projection');
         $proj4 = new Proj4php();
-        Proj4php::$defs[$opt->projection->ref] = $opt->projection->proj4;
+        Proj4php::$defs[$projection->ref] = $projection->proj4;
         $sourceProj = new Proj4phpProj('EPSG:4326', $proj4);
 
         $tileMatrixSetLinkList = array();

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -1031,11 +1031,7 @@ class qgisVectorLayer extends qgisMapLayer
     public function isEditable()
     {
         $layerName = $this->name;
-        $eLayers = $this->project->getEditionLayers();
-        if (!property_exists($eLayers, $layerName)) {
-            return false;
-        }
-        $eLayer = $eLayers->{$layerName};
+        $eLayer = $this->project->getEditionLayerByName($layerName);
         if ($eLayer->capabilities->modifyGeometry != 'True'
            && $eLayer->capabilities->modifyAttribute != 'True'
            && $eLayer->capabilities->deleteFeature != 'True'

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -1229,10 +1229,9 @@ class editionCtrl extends jController
         $layerName2 = $layer2->getName();
 
         // verifying layers in attribute config
-        $pConfig = $lproj->getFullCfg();
         if (!$lproj->hasAttributeLayers()
-            or !property_exists($pConfig->attributeLayers, $layerName1)
-            or !property_exists($pConfig->attributeLayers, $layerName2)
+            or !$lproj->hasAttributeLayersForLayer($layerName1)
+            or !$lproj->hasAttributeLayersForLayer($layerName2)
         ) {
             jMessage::add(jLocale::get('view~edition.link.error.not.attribute.layer'), 'error');
 

--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -1522,47 +1522,43 @@ class QgisForm implements QgisFormControlsInterface
 
         // Optionnaly add a filter parameter
         $lproj = $this->layer->getProject();
-        $pConfig = $lproj->getFullCfg();
+        $loginFilteredConfig = $lproj->getLoginFilteredConfig($layername);
 
-        if ($pConfig->loginFilteredLayers) {
-            if (property_exists($pConfig->loginFilteredLayers, $layername)) {
-                $v = '';
-                $where = '';
-                $type = 'groups';
-                $attribute = $pConfig->loginFilteredLayers->{$layername}->filterAttribute;
+        if ($loginFilteredConfig) {
+            $type = 'groups';
+            $attribute = $loginFilteredConfig->filterAttribute;
 
-                // check filter type
-                if (property_exists($pConfig->loginFilteredLayers->{$layername}, 'filterPrivate')
-                     && $pConfig->loginFilteredLayers->{$layername}->filterPrivate == 'True') {
-                    $type = 'login';
-                }
+            // check filter type
+            if (property_exists($loginFilteredConfig, 'filterPrivate')
+                 && $loginFilteredConfig->filterPrivate == 'True') {
+                $type = 'login';
+            }
 
-                // Check if a user is authenticated
-                $isConnected = $this->appContext->userIsConnected();
-                $cnx = $this->appContext->getDbConnection($this->layer->getId());
-                if ($isConnected) {
-                    $user = $this->appContext->getUserSession();
-                    $login = $user->login;
-                    if ($type == 'login') {
-                        $where = ' "'.$attribute."\" IN ( '".$login."' , 'all' )";
-                    } else {
-                        $userGroups = $this->appContext->aclUserGroupsId();
-                        // Set XML Filter if getFeature request
-                        $flatGroups = implode("' , '", $userGroups);
-                        $where = ' "'.$attribute."\" IN ( '".$flatGroups."' , 'all' )";
-                    }
+            // Check if a user is authenticated
+            $isConnected = $this->appContext->userIsConnected();
+            $cnx = $this->appContext->getDbConnection($this->layer->getId());
+            if ($isConnected) {
+                $user = $this->appContext->getUserSession();
+                $login = $user->login;
+                if ($type == 'login') {
+                    $where = ' "'.$attribute."\" IN ( '".$login."' , 'all' )";
                 } else {
-                    // The user is not authenticated: only show data with attribute = 'all'
-                    $where = ' "'.$attribute.'" = '.$cnx->quote('all');
+                    $userGroups = $this->appContext->aclUserGroupsId();
+                    // Set XML Filter if getFeature request
+                    $flatGroups = implode("' , '", $userGroups);
+                    $where = ' "'.$attribute."\" IN ( '".$flatGroups."' , 'all' )";
                 }
-                // Set filter when multiple layers concerned
-                if ($where) {
-                    return array(
-                        'where' => $where,
-                        'type' => $type,
-                        'attribute' => $attribute,
-                    );
-                }
+            } else {
+                // The user is not authenticated: only show data with attribute = 'all'
+                $where = ' "'.$attribute.'" = '.$cnx->quote('all');
+            }
+            // Set filter when multiple layers concerned
+            if ($where) {
+                return array(
+                    'where' => $where,
+                    'type' => $type,
+                    'attribute' => $attribute,
+                );
             }
         }
 

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -157,11 +157,6 @@ class Project
     protected $options;
 
     /**
-     * @var mixed
-     */
-    protected $cfgContent;
-
-    /**
      * @var array List of cached properties
      */
     protected static $cachedProperties = array(
@@ -179,7 +174,6 @@ class Project
         'useLayerIDs',
         'layers',
         'data',
-        'cfgContent',
         'options',
         'QgisProjectVersion',
     );

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -324,7 +324,7 @@ class Project
     protected function readProject($key, Repository $rep)
     {
         $qgsXml = $this->qgis;
-        $configOptions = $this->cfg->getProperty('options');
+        $configOptions = $this->cfg->getOptions();
 
         $this->options = $configOptions;
         // Complete data
@@ -589,9 +589,24 @@ class Project
         return $this->properties;
     }
 
+    /**
+     * @return object
+     *
+     * @deprecated use getOption() instead
+     */
     public function getOptions()
     {
-        return $this->cfg->getProperty('options');
+        return $this->cfg->getOptions();
+    }
+
+    /**
+     * @param string $name the option name
+     *
+     * @return null|mixed
+     */
+    public function getOption($name)
+    {
+        return $this->cfg->getOption($name);
     }
 
     public function getLayers()
@@ -708,9 +723,10 @@ class Project
 
     public function hasAtlasEnabled()
     {
-        $options = $this->getOptions();
+        $atlasEnabled = $this->cfg->getOption('atlasEnabled');
         $atlas = $this->cfg->getProperty('atlas');
-        if ((property_exists($options, 'atlasEnabled') && $options->atlasEnabled == 'True') // Legacy LWC < 3.4 (only one layer)
+
+        if (($atlasEnabled == 'True') // Legacy LWC < 3.4 (only one layer)
             || ($atlas && property_exists($atlas, 'layers') && count((array) $atlas->layers) > 0)) { // Multiple atlas
             return true;
         }
@@ -1292,16 +1308,17 @@ class Project
             'location' => 'dock',
             'theme' => 'dark',
         );
-        $options = $this->getOptions();
-        if ($options && property_exists($options, 'datavizLocation')
-            && in_array($options->datavizLocation, array('dock', 'bottomdock', 'right-dock'))
+        $optionDatavizLocation = $this->cfg->getOption('datavizLocation');
+        if (in_array(
+            $optionDatavizLocation,
+            array('dock', 'bottomdock', 'right-dock')
+        )
         ) {
-            $config['dataviz']['location'] = $options->datavizLocation;
+            $config['dataviz']['location'] = $optionDatavizLocation;
         }
-        if (property_exists($options, 'theme')
-            and in_array($options->theme, array('dark', 'light'))
-        ) {
-            $config['dataviz']['theme'] = $options->theme;
+        $theme = $this->cfg->getOption('theme');
+        if (in_array($theme, array('dark', 'light'))) {
+            $config['dataviz']['theme'] = $theme;
         }
 
         return $config;
@@ -1312,7 +1329,6 @@ class Project
      */
     public function needsGoogle()
     {
-        $configOptions = $this->getOptions();
         $googleProps = array(
             'googleStreets',
             'googleSatellite',
@@ -1321,12 +1337,14 @@ class Project
         );
 
         foreach ($googleProps as $google) {
-            if (property_exists($configOptions, $google) && $this->optionToBoolean($configOptions->{$google})) {
+            $value = $this->cfg->getOption($google);
+            if ($value !== null && $this->optionToBoolean($value)) {
                 return true;
             }
         }
+        $externalSearch = $this->cfg->getOption('externalSearch');
 
-        return property_exists($configOptions, 'externalSearch') && $configOptions->externalSearch == 'google';
+        return $externalSearch == 'google';
     }
 
     /**
@@ -1334,10 +1352,9 @@ class Project
      */
     public function getGoogleKey()
     {
-        $configOptions = $this->getOptions();
-        $gKey = '';
-        if (property_exists($configOptions, 'googleKey')) {
-            $gKey = $configOptions->googleKey;
+        $gKey = $this->cfg->getOption('googleKey');
+        if ($gKey === null) {
+            $gKey = '';
         }
 
         return $gKey;
@@ -1346,8 +1363,8 @@ class Project
     protected function readPrintCapabilities(QgisProject $qgsLoad)
     {
         $printTemplates = array();
-        $options = $this->getOptions();
-        if ($options && property_exists($options, 'print') && $options->print == 'True') {
+        $print = $this->cfg->getOption('print');
+        if ($print == 'True') {
             $printTemplates = $qgsLoad->getPrintTemplates();
         }
 
@@ -1778,7 +1795,7 @@ class Project
     }
 
     /**
-     * @throws jExceptionSelector
+     * @throws \jExceptionSelector
      *
      * @return \lizmapMapDockItem[]
      */
@@ -1858,19 +1875,17 @@ class Project
     }
 
     /**
-     * @throws jException
-     * @throws jExceptionSelector
+     * @throws \jException
+     * @throws \jExceptionSelector
      *
      * @return \lizmapMapDockItem[]
      */
     public function getDefaultMiniDockable()
     {
         $dockable = array();
-        $configOptions = $this->getOptions();
         $bp = $this->appContext->appConfig()->urlengine['basePath'];
 
         if ($this->hasAttributeLayers()) {
-            $tpl = new \jTpl();
             // Add layer-export attribute to lizmap-selection-tool component if allowed
             $layerExport = $this->appContext->aclCheck('lizmap.tools.layer.export', $this->repository->getKey()) ? 'layer-export' : '';
             $dock = new \lizmapMapDockItem(
@@ -1895,8 +1910,7 @@ class Project
             );
         }
 
-        if (property_exists($configOptions, 'geolocation')
-            && $configOptions->geolocation == 'True') {
+        if ($this->cfg->getOption('geolocation') == 'True') {
             $tpl = new \jTpl();
             $tpl->assign('hasEditionLayers', $this->hasEditionLayersForCurrentUser());
             $dockable[] = new \lizmapMapDockItem(
@@ -1907,8 +1921,7 @@ class Project
             );
         }
 
-        if (property_exists($configOptions, 'print')
-            && $configOptions->print == 'True') {
+        if ($this->cfg->getOption('print') == 'True') {
             $tpl = new \jTpl();
             $dockable[] = new \lizmapMapDockItem(
                 'print',
@@ -1918,8 +1931,7 @@ class Project
             );
         }
 
-        if (property_exists($configOptions, 'measure')
-            && $configOptions->measure == 'True') {
+        if ($this->cfg->getOption('measure') == 'True') {
             $tpl = new \jTpl();
             $dockable[] = new \lizmapMapDockItem(
                 'measure',
@@ -1993,8 +2005,7 @@ class Project
             );
         }
 
-        if (property_exists($configOptions, 'draw')
-            && $configOptions->draw == 'True') {
+        if ($this->cfg->getOption('draw') == 'True') {
             $tpl = new \jTpl();
             $dockable[] = new \lizmapMapDockItem(
                 'draw',
@@ -2008,7 +2019,7 @@ class Project
     }
 
     /**
-     * @throws jExceptionSelector
+     * @throws \jExceptionSelector
      *
      * @return \lizmapMapDockItem[]
      */
@@ -2040,15 +2051,14 @@ class Project
      */
     public function checkAcl()
     {
-        $options = $this->getOptions();
-
         // Check right on repository
         if (!$this->appContext->aclCheck('lizmap.repositories.view', $this->repository->getKey())) {
             return false;
         }
 
         // Check acl option is configured in project config
-        if (!property_exists($options, 'acl') || !is_array($options->acl) || empty($options->acl)) {
+        $aclGroups = $this->cfg->getOption('acl');
+        if ($aclGroups === null || !is_array($aclGroups) || empty($aclGroups)) {
             return true;
         }
 
@@ -2058,7 +2068,6 @@ class Project
         }
 
         // Check if configured groups white list and authenticated user groups list intersects
-        $aclGroups = $options->acl;
         $userGroups = $this->appContext->aclUserGroupsId();
         if (array_intersect($aclGroups, $userGroups)) {
             return true;
@@ -2084,15 +2093,13 @@ class Project
             return false;
         }
 
-        $options = $this->getOptions();
-
         // Check acl option is configured in project config
-        if (!property_exists($options, 'acl') || !is_array($options->acl) || empty($options->acl)) {
+        $aclGroups = $this->cfg->getOption('acl');
+        if ($aclGroups === null || !is_array($aclGroups) || empty($aclGroups)) {
             return true;
         }
 
         // Check if configured groups white list and authenticated user groups list intersects
-        $aclGroups = $options->acl;
         $userGroups = $this->appContext->aclGroupsIdByUser($login);
         if (array_intersect($aclGroups, $userGroups)) {
             return true;

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -371,21 +371,12 @@ class Project
         $this->qgis->setPropertiesAfterRead($this->cfg);
 
         $this->printCapabilities = $this->readPrintCapabilities($qgsXml);
+        $this->cfg->setPrintCapabilities($this->printCapabilities);
         $this->locateByLayers = $this->readLocateByLayers($qgsXml, $this->cfg);
         $this->editionLayers = $this->readEditionLayers($qgsXml);
         $this->layersOrder = $this->readLayersOrder($qgsXml);
+        $this->cfg->setLayersOrder($this->layersOrder);
         $this->attributeLayers = $this->readAttributeLayers($qgsXml, $this->cfg);
-
-        $props = array(
-            'printCapabilities',
-            'locateByLayers',
-            'editionLayers',
-            'layersOrder',
-            'attributeLayers',
-        );
-        foreach ($props as $prop) {
-            $this->cfg->setProperty($prop, $this->{$prop});
-        }
 
         $this->qgis->readEditionForms($this->getEditionLayers(), $this);
     }
@@ -611,7 +602,7 @@ class Project
 
     public function getLayers()
     {
-        return $this->cfg->getProperty('layers');
+        return $this->cfg->getLayers();
     }
 
     /**
@@ -688,7 +679,7 @@ class Project
 
     public function hasLocateByLayer()
     {
-        $locate = $this->cfg->getProperty('locateByLayer');
+        $locate = $this->cfg->getLocateByLayer();
         if ($locate && count((array) $locate)) {
             return true;
         }
@@ -698,7 +689,7 @@ class Project
 
     public function hasFormFilterLayers()
     {
-        $form = $this->cfg->getProperty('formFilterLayers');
+        $form = $this->cfg->getFormFilterLayers();
         if ($form && count((array) $form)) {
             return true;
         }
@@ -708,12 +699,12 @@ class Project
 
     public function getFormFilterLayersConfig()
     {
-        return $this->cfg->getProperty('formFilterLayers');
+        return $this->cfg->getFormFilterLayers();
     }
 
     public function hasTimemanagerLayers()
     {
-        $timeManager = $this->cfg->getProperty('timemanagerLayers');
+        $timeManager = $this->cfg->getTimemanagerLayers();
         if ($timeManager && count((array) $timeManager)) {
             return true;
         }
@@ -724,7 +715,7 @@ class Project
     public function hasAtlasEnabled()
     {
         $atlasEnabled = $this->cfg->getOption('atlasEnabled');
-        $atlas = $this->cfg->getProperty('atlas');
+        $atlas = $this->cfg->getAtlas();
 
         if (($atlasEnabled == 'True') // Legacy LWC < 3.4 (only one layer)
             || ($atlas && property_exists($atlas, 'layers') && count((array) $atlas->layers) > 0)) { // Multiple atlas
@@ -746,7 +737,7 @@ class Project
 
     public function hasTooltipLayers()
     {
-        $tooltip = $this->cfg->getProperty('tooltipLayers');
+        $tooltip = $this->cfg->getTooltipLayers();
         if ($tooltip && count((array) $tooltip)) {
             return true;
         }
@@ -756,7 +747,7 @@ class Project
 
     public function hasAttributeLayers($onlyDisplayedLayers = false)
     {
-        $attributeLayers = $this->cfg->getProperty('attributeLayers');
+        $attributeLayers = $this->cfg->getAttributeLayers();
         if ($attributeLayers) {
             $hasDisplayedLayer = !$onlyDisplayedLayers;
             if ($onlyDisplayedLayers) {
@@ -779,7 +770,7 @@ class Project
 
     public function hasAttributeLayersForLayer($layerName)
     {
-        $attributeLayers = $this->cfg->getProperty('attributeLayers');
+        $attributeLayers = $this->cfg->getAttributeLayers();
 
         return property_exists($attributeLayers, $layerName);
     }
@@ -985,9 +976,12 @@ class Project
         return $this->editionLayersForCurrentUser;
     }
 
+    /**
+     * @return object
+     */
     public function getEditionLayers()
     {
-        return $this->cfg->getProperty('editionLayers');
+        return $this->cfg->getEditionLayers();
     }
 
     /**
@@ -1056,7 +1050,7 @@ class Project
      */
     public function hasLoginFilteredLayers()
     {
-        $login = (array) $this->cfg->getProperty('loginFilteredLayers');
+        $login = (array) $this->cfg->getLoginFilteredLayers();
         if ($login && count((array) $login)) {
             return true;
         }
@@ -1077,7 +1071,7 @@ class Project
             $ln = $layerByTypeName->name;
         }
 
-        $login = $this->cfg->getProperty('loginFilteredLayers');
+        $login = $this->cfg->getLoginFilteredLayers();
         if (!$login || !property_exists($login, $ln)) {
             return null;
         }
@@ -1204,7 +1198,7 @@ class Project
      */
     public function getDatavizLayersConfig()
     {
-        $datavizLayers = $this->cfg->getProperty('datavizLayers');
+        $datavizLayers = $this->cfg->getDatavizLayers();
         if (!$datavizLayers) {
             return false;
         }
@@ -1373,31 +1367,35 @@ class Project
 
     protected function readLocateByLayers(QgisProject $xml, ProjectConfig $cfg)
     {
-        $locateByLayer = $cfg->getProperty('locateByLayer');
+        $locateByLayer = $cfg->getLocateByLayer();
         if ($locateByLayer) {
             // The method takes a reference
             $xml->readLocateByLayers($locateByLayer);
-            // so we can modify it here
-            $this->cfg->setProperty('locateByLayer', $locateByLayer);
         }
 
         return $locateByLayer;
     }
 
+    /**
+     * @return object
+     */
     protected function readFormFilterLayers(QgisProject $xml, ProjectConfig $cfg)
     {
-        $formFilterLayers = $cfg->getProperty('formFilterLayer');
+        $formFilterLayers = $cfg->getFormFilterLayers();
 
         if (!$formFilterLayers) {
-            $formFilterLayers = array();
+            $formFilterLayers = new \stdClass();
         }
 
         return $formFilterLayers;
     }
 
+    /**
+     * @return object
+     */
     protected function readEditionLayers(QgisProject $xml)
     {
-        $editionLayers = $this->getEditionLayers();
+        $editionLayers = $this->cfg->getEditionLayers();
 
         if ($editionLayers) {
             // Check ability to load spatialite extension
@@ -1409,27 +1407,29 @@ class Project
             if (!$spatialiteExt) {
                 $this->appContext->logMessage('Spatialite is not available', 'error');
                 $xml->readEditionLayers($editionLayers);
-                // so we can ste the data here
-                $this->cfg->setProperty('EditionLayers', $editionLayers);
             }
         } else {
-            $editionLayers = array();
+            $editionLayers = new \stdClass();
         }
+        $this->cfg->setEditionLayers($editionLayers);
 
         return $editionLayers;
     }
 
+    /**
+     * @return object
+     */
     protected function readAttributeLayers(QgisProject $xml, ProjectConfig $cfg)
     {
-        $attributeLayers = $cfg->getProperty('attributeLayers');
+        $attributeLayers = $cfg->getAttributeLayers();
 
         if ($attributeLayers) {
             // method takes a reference
             $xml->readAttributeLayers($attributeLayers);
             // so we can modify data here
-            $this->cfg->setProperty('attributeLayers', $attributeLayers);
+            $cfg->setAttributeLayers($attributeLayers);
         } else {
-            $attributeLayers = array();
+            $attributeLayers = new \stdClass();
         }
 
         return $attributeLayers;
@@ -1437,7 +1437,6 @@ class Project
 
     /**
      * @param \SimpleXMLElement $xml
-     * @param $cfg
      *
      * @return int[]
      */
@@ -1446,6 +1445,11 @@ class Project
         return $this->qgis->readLayersOrder($xml, $this->getLayers());
     }
 
+    /**
+     * @param string $layerId
+     *
+     * @return null|string
+     */
     public function getLayerNameByIdFromConfig($layerId)
     {
         return $this->qgis->getLayerNameByIdFromConfig($layerId, $this->layers);

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -582,7 +582,7 @@ class Project
     /**
      * @return object
      *
-     * @deprecated use getOption() instead
+     * @deprecated use getOption() or getBooleanOption() instead
      */
     public function getOptions()
     {
@@ -597,6 +597,18 @@ class Project
     public function getOption($name)
     {
         return $this->cfg->getOption($name);
+    }
+
+    /**
+     * Retrieve the given option as a boolean value.
+     *
+     * @param string $name the option name
+     *
+     * @return null|bool true if the option value is 'True', null if it does not exist
+     */
+    public function getBooleanOption($name)
+    {
+        return $this->cfg->getBooleanOption($name);
     }
 
     public function getLayers()
@@ -713,10 +725,10 @@ class Project
 
     public function hasAtlasEnabled()
     {
-        $atlasEnabled = $this->cfg->getOption('atlasEnabled');
+        $atlasEnabled = $this->cfg->getBooleanOption('atlasEnabled');
         $atlas = $this->cfg->getAtlas();
 
-        if (($atlasEnabled == 'True') // Legacy LWC < 3.4 (only one layer)
+        if ($atlasEnabled // Legacy LWC < 3.4 (only one layer)
             || ($atlas && property_exists($atlas, 'layers') && count((array) $atlas->layers) > 0)) { // Multiple atlas
             return true;
         }
@@ -1330,11 +1342,11 @@ class Project
         );
 
         foreach ($googleProps as $google) {
-            $value = $this->cfg->getOption($google);
-            if ($value !== null && $this->optionToBoolean($value)) {
+            if ($this->cfg->getBooleanOption($google)) {
                 return true;
             }
         }
+
         $externalSearch = $this->cfg->getOption('externalSearch');
 
         return $externalSearch == 'google';
@@ -1356,8 +1368,7 @@ class Project
     protected function readPrintCapabilities(QgisProject $qgsLoad)
     {
         $printTemplates = array();
-        $print = $this->cfg->getOption('print');
-        if ($print == 'True') {
+        if ($this->cfg->getBooleanOption('print')) {
             $printTemplates = $qgsLoad->getPrintTemplates();
         }
 
@@ -1913,7 +1924,7 @@ class Project
             );
         }
 
-        if ($this->cfg->getOption('geolocation') == 'True') {
+        if ($this->cfg->getBooleanOption('geolocation')) {
             $tpl = new \jTpl();
             $tpl->assign('hasEditionLayers', $this->hasEditionLayersForCurrentUser());
             $dockable[] = new \lizmapMapDockItem(
@@ -1924,7 +1935,7 @@ class Project
             );
         }
 
-        if ($this->cfg->getOption('print') == 'True') {
+        if ($this->cfg->getBooleanOption('print')) {
             $tpl = new \jTpl();
             $dockable[] = new \lizmapMapDockItem(
                 'print',
@@ -1934,7 +1945,7 @@ class Project
             );
         }
 
-        if ($this->cfg->getOption('measure') == 'True') {
+        if ($this->cfg->getBooleanOption('measure')) {
             $tpl = new \jTpl();
             $dockable[] = new \lizmapMapDockItem(
                 'measure',
@@ -2008,7 +2019,7 @@ class Project
             );
         }
 
-        if ($this->cfg->getOption('draw') == 'True') {
+        if ($this->cfg->getBooleanOption('draw')) {
             $tpl = new \jTpl();
             $dockable[] = new \lizmapMapDockItem(
                 'draw',

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -743,20 +743,29 @@ class Project
         $attributeLayers = $this->cfg->getProperty('attributeLayers');
         if ($attributeLayers) {
             $hasDisplayedLayer = !$onlyDisplayedLayers;
-            foreach ($attributeLayers as $key => $obj) {
-                if ($onlyDisplayedLayers
-                    && (!property_exists($obj, 'hideLayer')
-                    || strtolower($obj->hideLayer) != 'true')
-                ) {
-                    $hasDisplayedLayer = true;
+            if ($onlyDisplayedLayers) {
+                foreach ($attributeLayers as $key => $obj) {
+                    if (!property_exists($obj, 'hideLayer')
+                        || strtolower($obj->hideLayer) != 'true'
+                    ) {
+                        $hasDisplayedLayer = true;
+                    }
                 }
             }
+
             if (count((array) $attributeLayers) && $hasDisplayedLayer) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    public function hasAttributeLayersForLayer($layerName)
+    {
+        $attributeLayers = $this->cfg->getProperty('attributeLayers');
+
+        return property_exists($attributeLayers, $layerName);
     }
 
     public function hasFtsSearches()
@@ -1757,7 +1766,11 @@ class Project
     }
 
     /**
+     * access to configuration raw content.
+     *
      * @return object
+     *
+     * @deprecated Don't access directly to configuration, use Project methods
      */
     public function getFullCfg()
     {

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -247,21 +247,27 @@ class Project
             $this->readProject($key, $rep);
 
             // set project data in cache
+            $dataProj = array();
             foreach (self::$cachedProperties as $prop) {
                 if (isset($this->{$prop}) && !empty($this->{$prop})) {
-                    $data[$prop] = $this->{$prop};
+                    $dataProj[$prop] = $this->{$prop};
                 }
             }
-            $data = array_merge($data, $this->qgis->getCacheData($data), $this->cfg->getCacheData($data));
+
+            $data = array(
+                'project' => $dataProj,
+                'qgis' => $this->qgis->getCacheData(),
+                'cfg' => $this->cfg->getCacheData(),
+            );
             $this->cacheHandler->storeProjectData($data);
         } else {
             foreach (self::$cachedProperties as $prop) {
-                if (array_key_exists($prop, $data)) {
-                    $this->{$prop} = $data[$prop];
+                if (array_key_exists($prop, $data['project'])) {
+                    $this->{$prop} = $data['project'][$prop];
                 }
             }
             $rewriteCache = false;
-            foreach ($this->layers as $index => $layer) {
+            foreach ($data['qgis']['layers'] as $index => $layer) {
                 if (array_key_exists('embedded', $layer)
                     && $layer['embedded'] == '1'
                     && $layer['qgsmtime'] < filemtime($layer['file'])
@@ -272,8 +278,7 @@ class Project
                     $newLayer['file'] = $layer['file'];
                     $newLayer['embedded'] = 1;
                     $newLayer['projectPath'] = $layer['projectPath'];
-                    $this->layers[$index] = $newLayer;
-                    $data['layers'][$index] = $newLayer;
+                    $data['qgis']['layers'][$index] = $newLayer;
                     $rewriteCache = true;
                 }
             }
@@ -282,13 +287,13 @@ class Project
             }
 
             try {
-                $this->cfg = new ProjectConfig($file.'.cfg', $data);
+                $this->cfg = new ProjectConfig($file.'.cfg', $data['cfg']);
             } catch (UnknownLizmapProjectException $e) {
                 throw $e;
             }
 
             try {
-                $this->qgis = new QgisProject($file, $services, $appContext, $data);
+                $this->qgis = new QgisProject($file, $services, $appContext, $data['qgis']);
             } catch (UnknownLizmapProjectException $e) {
                 throw $e;
             }
@@ -1446,7 +1451,7 @@ class Project
      */
     public function getLayerNameByIdFromConfig($layerId)
     {
-        return $this->qgis->getLayerNameByIdFromConfig($layerId, $this->layers);
+        return $this->qgis->getLayerNameByIdFromConfig($layerId, $this->cfg->getLayers());
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -107,17 +107,17 @@ class Project
     protected $layersOrder = array();
 
     /**
-     * @var array
+     * @var object
      */
     protected $printCapabilities = array();
 
     /**
-     * @var array
+     * @var object
      */
     protected $locateByLayer = array();
 
     /**
-     * @var array
+     * @var object
      */
     protected $formFilterLayers = array();
 
@@ -132,7 +132,7 @@ class Project
     protected $editionLayersForCurrentUser;
 
     /**
-     * @var array
+     * @var object
      */
     protected $attributeLayers = array();
 
@@ -371,7 +371,7 @@ class Project
 
         $this->printCapabilities = $this->readPrintCapabilities($qgsXml);
         $this->cfg->setPrintCapabilities($this->printCapabilities);
-        $this->locateByLayers = $this->readLocateByLayers($qgsXml, $this->cfg);
+        $this->locateByLayer = $this->readLocateByLayer($qgsXml, $this->cfg);
         $this->editionLayers = $this->readEditionLayers($qgsXml);
         $this->layersOrder = $this->readLayersOrder($qgsXml);
         $this->cfg->setLayersOrder($this->layersOrder);
@@ -1375,12 +1375,12 @@ class Project
         return $printTemplates;
     }
 
-    protected function readLocateByLayers(QgisProject $xml, ProjectConfig $cfg)
+    protected function readLocateByLayer(QgisProject $xml, ProjectConfig $cfg)
     {
         $locateByLayer = $cfg->getLocateByLayer();
         if ($locateByLayer) {
             // The method takes a reference
-            $xml->readLocateByLayers($locateByLayer);
+            $xml->readLocateByLayer($locateByLayer);
         }
 
         return $locateByLayer;

--- a/lizmap/modules/lizmap/lib/Project/ProjectCache.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectCache.php
@@ -51,7 +51,7 @@ class ProjectCache
      * So you'll be sure that the cache will be updated when Lizmap code source
      * is updated on a server
      */
-    const CACHE_FORMAT_VERSION = 2;
+    const CACHE_FORMAT_VERSION = 3;
 
     /**
      * Initialize the cache of a Qgis project.

--- a/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
@@ -128,12 +128,11 @@ class ProjectConfig
     /**
      * Return the properties to store in the cache.
      *
-     * @param mixed $data
-     *
      * @return object
      */
-    public function getCacheData($data)
+    public function getCacheData()
     {
+        $data = array();
         foreach (self::$cachedProperties as $prop) {
             $data[$prop] = $this->{$prop};
         }
@@ -157,6 +156,9 @@ class ProjectConfig
         $this->layersOrder = $layersOrder;
     }
 
+    /**
+     * @return object
+     */
     public function getLayers()
     {
         return $this->layers;

--- a/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
@@ -5,16 +5,6 @@ namespace Lizmap\Project;
 class ProjectConfig
 {
     /**
-     * @var object
-     */
-    protected $cfgContent;
-
-    /**
-     * @var ProjectCache
-     */
-    protected $cacheHandler;
-
-    /**
      * @var int[] keys are layer name
      */
     protected $layersOrder = array();
@@ -81,31 +71,36 @@ class ProjectConfig
 
     protected static $cachedProperties = array(
         'layersOrder',
+        'printCapabilities',
         'locateByLayer',
         'formFilterLayers',
         'editionLayers',
         'attributeLayers',
-        'cfgContent',
+        'layers',
         'options',
+        'timemanagerLayers',
+        'atlas',
+        'tooltipLayers',
+        'loginFilteredLayers',
+        'datavizLayers',
     );
 
     public function __construct($cfgFile, $data = null)
     {
         if ($data === null) {
             $fileContent = file_get_contents($cfgFile);
-            $this->cfgContent = json_decode($fileContent);
-            if ($this->cfgContent === null) {
+            $data = json_decode($fileContent);
+            if ($data === null) {
                 throw new UnknownLizmapProjectException('The file '.$cfgFile.' cannot be decoded.');
             }
-        } else {
-            foreach ($data as $prop => $value) {
-                if (in_array($prop, self::$cachedProperties)) {
-                    // if ($prop == 'cfgContent') {
-                    //     $this->{$prop} = json_decode(json_encode($value));
+        }
 
-                    //     continue;
-                    // }
-                    $this->{$prop} = $value;
+        foreach (self::$cachedProperties as $prop) {
+            if (isset($data->{$prop})) {
+                $this->{$prop} = $data->{$prop};
+            } else {
+                if ($prop != 'layersOrder') {
+                    $this->{$prop} = new \stdClass();
                 }
             }
         }
@@ -121,13 +116,13 @@ class ProjectConfig
     }
 
     /**
-     * Return the config file as an array.
+     * Return the config content.
      *
      * @return object
      */
     public function getConfigContent()
     {
-        return $this->cfgContent;
+        return (object) get_object_vars($this);
     }
 
     /**
@@ -135,21 +130,15 @@ class ProjectConfig
      *
      * @param mixed $data
      *
-     * @return array
+     * @return object
      */
     public function getCacheData($data)
     {
         foreach (self::$cachedProperties as $prop) {
-            if (!isset($this->{$prop}) || isset($data[$prop])) {
-                continue;
-                // }
-            // if ($prop == 'cfgContent') {
-            //     $data['cfgContent'] = json_decode(json_encode($this->cfgContent), true);
-            }
             $data[$prop] = $this->{$prop};
         }
 
-        return $data;
+        return (object) $data;
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
@@ -460,6 +460,22 @@ class ProjectConfig
     }
 
     /**
+     * Retrieve the given option as a boolean value.
+     *
+     * @param string $name option name
+     *
+     * @return null|bool true if the option value is 'True', null if it does not exist
+     */
+    public function getBooleanOption($name)
+    {
+        if (property_exists($this->options, $name)) {
+            return strtolower($this->options->{$name}) == 'true';
+        }
+
+        return null;
+    }
+
+    /**
      * @return object
      */
     public function getPrintCapabilities()

--- a/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
@@ -394,4 +394,26 @@ class ProjectConfig
 
         return false;
     }
+
+    /**
+     * @return mixed
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return null|mixed
+     */
+    public function getOption($name)
+    {
+        if (property_exists($this->options, $name)) {
+            return $this->options->{$name};
+        }
+
+        return null;
+    }
 }

--- a/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
@@ -15,9 +15,9 @@ class ProjectConfig
     protected $cacheHandler;
 
     /**
-     * @var mixed
+     * @var int[] keys are layer name
      */
-    protected $layersOrder;
+    protected $layersOrder = array();
 
     /**
      * @var mixed
@@ -43,6 +43,36 @@ class ProjectConfig
      * @var object
      */
     protected $attributeLayers;
+
+    /**
+     * @var object
+     */
+    protected $layers;
+
+    /**
+     * @var object
+     */
+    protected $timemanagerLayers;
+
+    /**
+     * @var object
+     */
+    protected $atlas;
+
+    /**
+     * @var object
+     */
+    protected $tooltipLayers;
+
+    /**
+     * @var object
+     */
+    protected $loginFilteredLayers;
+
+    /**
+     * @var object
+     */
+    protected $datavizLayers;
 
     /**
      * @var mixed
@@ -87,7 +117,7 @@ class ProjectConfig
      */
     public function getData()
     {
-        return $this->cfgContent;
+        return $this->getConfigContent();
     }
 
     /**
@@ -123,51 +153,75 @@ class ProjectConfig
     }
 
     /**
-     * Return the value of a given property.
-     *
-     * @param string $propName The property to get
+     * @return int[] keys are layer name
      */
-    public function getProperty($propName)
+    public function getLayersOrder()
     {
-        if (property_exists($this, $propName) && isset($this->{$propName})) {
-            return $this->{$propName};
-        }
-        if (property_exists($this->cfgContent, $propName)) {
-            return $this->cfgContent->{$propName};
+        return $this->layersOrder;
+    }
+
+    /**
+     * @param int[] $layersOrder
+     */
+    public function setLayersOrder($layersOrder)
+    {
+        $this->layersOrder = $layersOrder;
+    }
+
+    public function getLayers()
+    {
+        return $this->layers;
+    }
+
+    public function getLayer($layerName)
+    {
+        if (property_exists($this->layers, $layerName)) {
+            return $this->layers->{$layerName};
         }
 
         return null;
     }
 
-    public function setProperty($prop, $value)
+    /**
+     * @param string $layerName
+     * @param object $layer
+     */
+    public function setLayer($layerName, $layer)
     {
-        if (property_exists($this, $prop)) {
-            $this->{$prop} = $value;
-        }
-        if (property_exists($this->cfgContent, $prop)) {
-            $this->cfgContent->{$prop} = $value;
+        $this->layers->{$layerName} = $layer;
+    }
+
+    public function removeLayer($layerName)
+    {
+        if (property_exists($this->layers, $layerName)) {
+            unset($this->layers->{$layerName});
         }
     }
 
-    public function unsetProperty($propName, $propName2 = '', $propName3 = '')
+    public function getAttributeLayers()
     {
-        $rootProp = $this->cfgContent;
-        if (in_array($propName, self::$cachedProperties)) {
-            $rootProp = $this;
-        }
-        if (isset($rootProp->{$propName}) && $propName2 == '') {
-            unset($rootProp->{$propName});
-        } elseif (isset($rootProp->{$propName})
-                  && property_exists($rootProp->{$propName}, $propName2)
-                  && $propName3 == ''
-        ) {
-            unset($rootProp->{$propName}->{$propName2});
-        } elseif (isset($rootProp->{$propName})
-                  && property_exists($rootProp->{$propName}, $propName2)
-                  && property_exists($rootProp->{$propName}->{$propName2}, $propName3)
-        ) {
-            unset($rootProp->{$propName}->{$propName2}->{$propName3});
-        }
+        return $this->attributeLayers;
+    }
+
+    public function setAttributeLayers($attributeLayers)
+    {
+        $this->attributeLayers = $attributeLayers;
+    }
+
+    /**
+     * @return object
+     */
+    public function getLocateByLayer()
+    {
+        return $this->locateByLayer;
+    }
+
+    /**
+     * @param object $locateByLayer
+     */
+    public function setLocateByLayer($locateByLayer)
+    {
+        $this->locateByLayer = $locateByLayer;
     }
 
     /**
@@ -180,7 +234,7 @@ class ProjectConfig
     public function findLayerByAnyName($name)
     {
         // name null or empty string
-        if ($name == null || empty($name) || !isset($this->cfgContent->layers)) {
+        if ($name == null || empty($name) || !isset($this->layers)) {
             return null;
         }
 
@@ -220,8 +274,8 @@ class ProjectConfig
             return null;
         }
 
-        if (property_exists($this->cfgContent->layers, $name)) {
-            return $this->cfgContent->layers->{$name};
+        if (property_exists($this->layers, $name)) {
+            return $this->layers->{$name};
         }
 
         return null;
@@ -239,7 +293,7 @@ class ProjectConfig
             return null;
         }
 
-        foreach ($this->cfgContent->layers as $layer) {
+        foreach ($this->layers as $layer) {
             if (!property_exists($layer, 'shortname')) {
                 continue;
             }
@@ -263,7 +317,7 @@ class ProjectConfig
             return null;
         }
 
-        foreach ($this->cfgContent->layers as $layer) {
+        foreach ($this->layers as $layer) {
             if (!property_exists($layer, 'title')) {
                 continue;
             }
@@ -287,7 +341,7 @@ class ProjectConfig
             return null;
         }
 
-        foreach ($this->cfgContent->layers as $layer) {
+        foreach ($this->layers as $layer) {
             if (!property_exists($layer, 'id')) {
                 continue;
             }
@@ -312,11 +366,11 @@ class ProjectConfig
         }
 
         // typeName is layerName
-        if (property_exists($this->cfgContent->layers, $typeName)) {
-            return $this->cfgContent->layers->{$typeName};
+        if (property_exists($this->layers, $typeName)) {
+            return $this->layers->{$typeName};
         }
         // typeName is cleanName or shortName
-        foreach ($this->cfgContent->layers as $layer) {
+        foreach ($this->layers as $layer) {
             if (str_replace(' ', '_', $layer->name) == $typeName) {
                 return $layer;
             }
@@ -332,19 +386,19 @@ class ProjectConfig
     }
 
     /**
-     * @return object[] layer names => layers
+     * @return object {layer names : layers}
      */
     public function getEditionLayers()
     {
-        if ($this->editionLayers) {
-            return (array) $this->editionLayers;
-        }
+        return $this->editionLayers;
+    }
 
-        if (isset($this->cfgContent->editionLayers)) {
-            return (array) $this->cfgContent->editionLayers;
-        }
-
-        return array();
+    /**
+     * @param object $editionLayers
+     */
+    public function setEditionLayers($editionLayers)
+    {
+        $this->editionLayers = $editionLayers;
     }
 
     public function getEditionLayerByName($name)
@@ -380,15 +434,12 @@ class ProjectConfig
         return null;
     }
 
+    /**
+     * @return bool
+     */
     public function hasEditionLayers()
     {
-        if ($this->editionLayers) {
-            return true;
-        }
-
-        if (isset($this->cfgContent->editionLayers)
-            && $this->cfgContent->editionLayers
-        ) {
+        if (count((array) $this->editionLayers)) {
             return true;
         }
 
@@ -415,5 +466,60 @@ class ProjectConfig
         }
 
         return null;
+    }
+
+    /**
+     * @return object
+     */
+    public function getPrintCapabilities()
+    {
+        return $this->printCapabilities;
+    }
+
+    public function setPrintCapabilities($printCapabilities)
+    {
+        $this->printCapabilities = $printCapabilities;
+    }
+
+    public function getFormFilterLayers()
+    {
+        return $this->formFilterLayers;
+    }
+
+    public function getTimemanagerLayers()
+    {
+        return $this->timemanagerLayers;
+    }
+
+    /**
+     * @return object
+     */
+    public function getAtlas()
+    {
+        return $this->atlas;
+    }
+
+    /**
+     * @return object
+     */
+    public function getTooltipLayers()
+    {
+        return $this->tooltipLayers;
+    }
+
+    /**
+     * @return object
+     */
+    public function getLoginFilteredLayers()
+    {
+        return $this->loginFilteredLayers;
+    }
+
+    /**
+     * @return object
+     */
+    public function getDatavizLayers()
+    {
+        return $this->datavizLayers;
     }
 }

--- a/lizmap/modules/lizmap/lib/Project/ProjectMetadata.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectMetadata.php
@@ -42,11 +42,8 @@ class ProjectMetadata
             'acl' => $project->checkAcl(),
         );
 
-        $options = $project->getOptions();
-        $hideProject = (
-            $options && property_exists($options, 'hideProject') && $options->hideProject == 'True'
-        );
-        $metadata['hidden'] = $hideProject;
+        $hideProject = $project->getOption('hideProject');
+        $metadata['hidden'] = ($hideProject == 'True');
 
         $this->data = $metadata;
     }

--- a/lizmap/modules/lizmap/lib/Project/ProjectMetadata.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectMetadata.php
@@ -42,8 +42,7 @@ class ProjectMetadata
             'acl' => $project->checkAcl(),
         );
 
-        $hideProject = $project->getOption('hideProject');
-        $metadata['hidden'] = ($hideProject == 'True');
+        $metadata['hidden'] = $project->getBooleanOption('hideProject');
 
         $this->data = $metadata;
     }

--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -866,7 +866,7 @@ class QgisProject
     /**
      * @param object $locateByLayer
      */
-    public function readLocateByLayers($locateByLayer)
+    public function readLocateByLayer($locateByLayer)
     {
         // collect layerIds
         $locateLayerIds = array();

--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -127,8 +127,9 @@ class QgisProject
         $this->path = $file;
     }
 
-    public function getCacheData($data)
+    public function getCacheData()
     {
+        $data = array();
         foreach (self::$cachedProperties as $prop) {
             if (!isset($this->{$prop}) || isset($data[$prop])) {
                 continue;
@@ -597,7 +598,7 @@ class QgisProject
 
     /**
      * @param string $layerId
-     * @param mixed  $layers
+     * @param object $layers
      *
      * @return null|string
      */

--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -114,12 +114,9 @@ class lizMapCtrl extends jController
             return $rep;
         }
 
-        $pOptions = $lproj->getOptions();
         // Redirect if project is hidden (lizmap plugin option)
         if (!$this->forceHiddenProjectVisible) {
-            if (property_exists($pOptions, 'hideProject')
-                && $pOptions->hideProject == 'True'
-            ) {
+            if ($lproj->getOption('hideProject') == 'True') {
                 jMessage::add(jLocale::get('view~default.project.access.denied'), 'error');
 
                 return $rep;
@@ -254,8 +251,7 @@ class lizMapCtrl extends jController
             $rep->addJSLink($bp.'assets/js/atlas.js');
 
             // Add CSS
-            $options = $lproj->getOptions();
-            $atlasWidth = $options->atlasMaxWidth;
+            $atlasWidth = $lproj->getOption('atlasMaxWidth');
             $cssContent = '';
             $cssContent .= "#content.atlas-visible:not(.mobile) #right-dock {width: ${atlasWidth}%; max-width: ${atlasWidth}%;}";
             $cssContent .= "#content.atlas-visible:not(.mobile) #map-content {margin-right: ${atlasWidth}%;}";
@@ -441,9 +437,7 @@ class lizMapCtrl extends jController
         $mapMenuCss = '';
         $h = $this->intParam('h', 1);
         if ($h == 0
-            or (property_exists($pOptions, 'hideHeader')
-                && $pOptions->hideHeader == 'True'
-            )
+            || $lproj->getOption('hideHeader') == 'True'
         ) {
             $h = 0;
             $rep->addStyle('#body', 'padding-top:0px;');
@@ -453,10 +447,7 @@ class lizMapCtrl extends jController
         // menu = left vertical menu with icons
         $m = $this->intParam('m', 1);
         if ($m == 0
-            or (
-              property_exists($pOptions, 'hideMenu')
-              && $pOptions->hideMenu == 'True'
-            )
+            || $lproj->getOption('hideMenu') == 'True'
         ) {
             $m = 0;
             $rep->addStyle('#mapmenu', 'display:none !important; width:0px;');
@@ -468,10 +459,7 @@ class lizMapCtrl extends jController
         // legend = legend open at startup
         $l = $this->intParam('l', 1);
         if ($l == 0
-            || (
-                property_exists($pOptions, 'hideLegend')
-                && $pOptions->hideLegend == 'True'
-            )
+            || $lproj->getOption('hideLegend') == 'True'
         ) {
             $l = 0;
             //~ $rep->addStyle('#dock', 'display:none;');
@@ -489,10 +477,7 @@ class lizMapCtrl extends jController
         // navbar
         $n = $this->intParam('n', 1);
         if ($n == 0
-            or (
-                property_exists($pOptions, 'hideNavbar')
-                && $pOptions->hideNavbar == 'True'
-            )
+            || $lproj->getOption('hideNavbar') == 'True'
         ) {
             $rep->addStyle('#navbar', 'display:none !important;');
         }
@@ -500,10 +485,7 @@ class lizMapCtrl extends jController
         // overview-box = scale & overview
         $o = $this->intParam('o', 1);
         if ($o == 0
-            || (
-                property_exists($pOptions, 'hideOverview')
-                && $pOptions->hideOverview == 'True'
-            )
+            || $lproj->getOption('hideOverview') == 'True'
         ) {
             $rep->addStyle('#overview-box', 'display:none !important;');
         }
@@ -514,9 +496,7 @@ class lizMapCtrl extends jController
         }
 
         // Hide groups checkboxes
-        if (property_exists($pOptions, 'hideGroupCheckbox')
-            && $pOptions->hideGroupCheckbox == 'True'
-        ) {
+        if ($lproj->getOption('hideGroupCheckbox') == 'True') {
             $rep->addStyle('#switcher-layers button[name="group"]', 'display:none !important;');
         }
 

--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -116,7 +116,7 @@ class lizMapCtrl extends jController
 
         // Redirect if project is hidden (lizmap plugin option)
         if (!$this->forceHiddenProjectVisible) {
-            if ($lproj->getOption('hideProject') == 'True') {
+            if ($lproj->getBooleanOption('hideProject')) {
                 jMessage::add(jLocale::get('view~default.project.access.denied'), 'error');
 
                 return $rep;
@@ -437,7 +437,7 @@ class lizMapCtrl extends jController
         $mapMenuCss = '';
         $h = $this->intParam('h', 1);
         if ($h == 0
-            || $lproj->getOption('hideHeader') == 'True'
+            || $lproj->getBooleanOption('hideHeader')
         ) {
             $h = 0;
             $rep->addStyle('#body', 'padding-top:0px;');
@@ -447,7 +447,7 @@ class lizMapCtrl extends jController
         // menu = left vertical menu with icons
         $m = $this->intParam('m', 1);
         if ($m == 0
-            || $lproj->getOption('hideMenu') == 'True'
+            || $lproj->getBooleanOption('hideMenu')
         ) {
             $m = 0;
             $rep->addStyle('#mapmenu', 'display:none !important; width:0px;');
@@ -459,7 +459,7 @@ class lizMapCtrl extends jController
         // legend = legend open at startup
         $l = $this->intParam('l', 1);
         if ($l == 0
-            || $lproj->getOption('hideLegend') == 'True'
+            || $lproj->getBooleanOption('hideLegend')
         ) {
             $l = 0;
             //~ $rep->addStyle('#dock', 'display:none;');
@@ -477,7 +477,7 @@ class lizMapCtrl extends jController
         // navbar
         $n = $this->intParam('n', 1);
         if ($n == 0
-            || $lproj->getOption('hideNavbar') == 'True'
+            || $lproj->getBooleanOption('hideNavbar')
         ) {
             $rep->addStyle('#navbar', 'display:none !important;');
         }
@@ -485,7 +485,7 @@ class lizMapCtrl extends jController
         // overview-box = scale & overview
         $o = $this->intParam('o', 1);
         if ($o == 0
-            || $lproj->getOption('hideOverview') == 'True'
+            || $lproj->getBooleanOption('hideOverview')
         ) {
             $rep->addStyle('#overview-box', 'display:none !important;');
         }
@@ -496,7 +496,7 @@ class lizMapCtrl extends jController
         }
 
         // Hide groups checkboxes
-        if ($lproj->getOption('hideGroupCheckbox') == 'True') {
+        if ($lproj->getBooleanOption('hideGroupCheckbox')) {
             $rep->addStyle('#switcher-layers button[name="group"]', 'display:none !important;');
         }
 

--- a/lizmap/modules/view/zones/map_headermenu.zone.php
+++ b/lizmap/modules/view/zones/map_headermenu.zone.php
@@ -46,10 +46,10 @@ class map_headermenuZone extends jZone
 
         try {
             $lproj = lizmap::getProject($repository.'~'.$project);
-            $configOptions = $lproj->getOptions();
+            $externalSearch = $lproj->getOption('externalSearch');
 
-            if (property_exists($configOptions, 'externalSearch')) {
-                $assign['externalSearch'] = $configOptions->externalSearch;
+            if ($externalSearch !== null) {
+                $assign['externalSearch'] = $externalSearch;
             }
         } catch (UnknownLizmapProjectException $e) {
             jLog::logEx($e, 'error');

--- a/lizmap/modules/view/zones/map_menu.zone.php
+++ b/lizmap/modules/view/zones/map_menu.zone.php
@@ -38,22 +38,19 @@ class map_menuZone extends jZone
         try {
             $lproj = lizmap::getProject($repository.'~'.$project);
 
-            if ($lproj->getOption('measure') == 'True'
-            ) {
+            if ($lproj->getBooleanOption('measure')) {
                 $assign['measure'] = true;
             }
 
             $assign['locate'] = $lproj->hasLocateByLayer();
 
-            if ($lproj->getOption('print') == 'True'
-            ) {
+            if ($lproj->getBooleanOption('print')) {
                 $assign['print'] = true;
             }
 
             $assign['edition'] = $lproj->hasEditionLayersForCurrentUser();
 
-            if ($lproj->getOption('geolocation') == 'True'
-            ) {
+            if ($lproj->getBooleanOption('geolocation')) {
                 $assign['geolocation'] = true;
             }
 

--- a/lizmap/modules/view/zones/map_menu.zone.php
+++ b/lizmap/modules/view/zones/map_menu.zone.php
@@ -37,26 +37,22 @@ class map_menuZone extends jZone
 
         try {
             $lproj = lizmap::getProject($repository.'~'.$project);
-            $configOptions = $lproj->getOptions();
 
-            if (property_exists($configOptions, 'measure')
-                && $configOptions->measure == 'True'
+            if ($lproj->getOption('measure') == 'True'
             ) {
                 $assign['measure'] = true;
             }
 
             $assign['locate'] = $lproj->hasLocateByLayer();
 
-            if (property_exists($configOptions, 'print')
-                && $configOptions->print == 'True'
+            if ($lproj->getOption('print') == 'True'
             ) {
                 $assign['print'] = true;
             }
 
             $assign['edition'] = $lproj->hasEditionLayersForCurrentUser();
 
-            if (property_exists($configOptions, 'geolocation')
-                && $configOptions->geolocation == 'True'
+            if ($lproj->getOption('geolocation') == 'True'
             ) {
                 $assign['geolocation'] = true;
             }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,11 +12,6 @@ parameters:
       # This error is normal, the undefined variables are dynamically assigned.
       message: '#Undefined variable: #'
       path: lizmap/modules/lizmap/lib/Request/WMTSRequest.php
-    -
-      # Same false positive
-      message: '#Access to an undefined property#'
-      path: lizmap/modules/lizmap/lib/Project/Project.php
     - "#Inner named functions are not supported by PHPStan\\. Consider refactoring to an anonymous function\\, class method\\, or a top-level-defined function\\.#"
   paths:
     - lizmap/modules
-  

--- a/tests/units/classes/Project/ProjectConfigTest.php
+++ b/tests/units/classes/Project/ProjectConfigTest.php
@@ -79,7 +79,7 @@ class projectConfigTest extends TestCase
     {
         $testCfg = new Project\ProjectConfig(null, $layers);
         if ($layerName) {
-            $this->assertSame($testCfg->getProperty('layers')->{$layerName}, $testCfg->findLayerByAnyName($key));
+            $this->assertSame($testCfg->getLayer($layerName), $testCfg->findLayerByAnyName($key));
         } else {
             $this->assertNull($testCfg->findLayerByAnyName($key));
         }
@@ -88,9 +88,8 @@ class projectConfigTest extends TestCase
     public function getEditionLayerByNameData()
     {
         $file = __DIR__.'/Ressources/montpellier.qgs.cfg';
-        $json = json_decode(file_get_contents($file));
-        $eLayer = array('editionLayers' => $json->editionLayers);
-        $eLayerNull = array('editionLayers' => null);
+        $eLayer = json_decode(file_get_contents($file));
+        $eLayerNull = (object) array('editionLayers' => null);
 
         return array(
             array($eLayer, 'tramstop'),
@@ -109,7 +108,7 @@ class projectConfigTest extends TestCase
     {
         $testCfg = new Project\ProjectConfig(null, $eLayers);
         if ($name) {
-            $this->assertSame($testCfg->getProperty('editionLayers')->{$name}, $testCfg->getEditionLayerByName($name));
+            $this->assertSame($eLayers->editionLayers->{$name}, $testCfg->getEditionLayerByName($name));
         } else {
             $this->assertNull($testCfg->getEditionLayerByName($name));
         }
@@ -118,8 +117,7 @@ class projectConfigTest extends TestCase
     public function getEditionLayerByLayerIdData()
     {
         $file = __DIR__.'/Ressources/montpellier.qgs.cfg';
-        $json = json_decode(file_get_contents($file));
-        $eLayer = array('editionLayers' => $json->editionLayers);
+        $eLayer = json_decode(file_get_contents($file));
         $eLayerNull = array('editionLayers' => null);
 
         return array(
@@ -142,7 +140,7 @@ class projectConfigTest extends TestCase
     {
         $testCfg = new Project\ProjectConfig(null, $eLayers);
         if ($eLayerName) {
-            $this->assertSame($testCfg->getProperty('editionLayers')->{$eLayerName}, $testCfg->getEditionLayerByLayerId($id));
+            $this->assertSame($eLayers->editionLayers->$eLayerName, $testCfg->getEditionLayerByLayerId($id));
         } else {
             $this->assertNull($testCfg->getEditionLayerByLayerId($id));
         }

--- a/tests/units/classes/Project/ProjectConfigTest.php
+++ b/tests/units/classes/Project/ProjectConfigTest.php
@@ -147,4 +147,44 @@ class projectConfigTest extends TestCase
             $this->assertNull($testCfg->getEditionLayerByLayerId($id));
         }
     }
+
+    public function getOptionsValues()
+    {
+        return array(
+            array('mapScales', [
+                1000,
+                2500,
+                5000,
+                10000,
+                25000,
+                50000,
+                100000,
+                150000
+            ]),
+            array('minScale', 1000),
+            array('maxScale', 150000),
+            array('initialExtent',  [
+                417006.613738,
+                5394910.3409,
+                447158.048911,
+                5414844.99481
+            ]),
+            array('osmMapnik', "True"),
+            array('measure', "True"),
+            array('atlasDuration', 5),
+        );
+    }
+
+    /**
+     * @dataProvider getOptionsValues
+     *
+     * @param mixed $option
+     * @param mixed $expectedValue
+     */
+    public function testGetOption($option, $expectedValue)
+    {
+        $file = __DIR__.'/Ressources/montpellier.qgs.cfg';
+        $testCfg = new Project\ProjectConfig($file);
+        $this->assertEquals($expectedValue, $testCfg->getOption($option));
+    }
 }

--- a/tests/units/classes/Project/ProjectConfigTest.php
+++ b/tests/units/classes/Project/ProjectConfigTest.php
@@ -11,10 +11,20 @@ class projectConfigTest extends TestCase
     public function getConstructData()
     {
         $file = __DIR__.'/Ressources/events.qgs.cfg';
+        $json = json_decode(file_get_contents($file));
 
+        $expected = clone $json;
+        $expected->layersOrder = array ();
+        $expected->printCapabilities = new stdClass();
+
+        $expected->editionLayers = new stdClass();
+        $expected->timemanagerLayers = new stdClass();
+        $expected->atlas = new stdClass();
+        $expected->tooltipLayers = new stdClass();
+        $expected->loginFilteredLayers = new stdClass();
         return array(
-            array(null, json_decode(file_get_contents($file))),
-            array(array('cfgContent' => json_decode(file_get_contents($file))), json_decode(file_get_contents($file))),
+            array(null, $expected),
+            array($json, $expected),
         );
     }
 
@@ -27,6 +37,7 @@ class projectConfigTest extends TestCase
     public function testConstruct($data, $expectedData)
     {
         $file = __DIR__.'/Ressources/events.qgs.cfg';
+
         $testCfg = new Project\ProjectConfig($file, $data);
         $this->assertEquals($expectedData, $testCfg->getConfigContent());
     }
@@ -34,17 +45,14 @@ class projectConfigTest extends TestCase
     public function testConstructCache()
     {
         $file = __DIR__.'/Ressources/events.qgs.cfg';
-        $json = json_decode(file_get_contents($file));
-        $data = array('cfgContent' => $json);
-        foreach ($json as $key => $prop) {
-            $data[$key] = $json->{$key};
-        }
+        $data = json_decode(file_get_contents($file));
         $cachedProperties = array('layersOrder', 'locateByLayer', 'formFilterLayers', 'editionLayers',
-            'attributeLayers', 'cfgContent', 'options', 'layers', );
+            'attributeLayers', 'options', 'layers', );
         $testCfg = new Project\ProjectConfig($file, $data);
         foreach ($cachedProperties as $prop) {
-            if (array_key_exists($prop, $data)) {
-                $this->assertEquals($data[$prop], $testCfg->getProperty($prop), 'failed Prop = '.$prop);
+            if (property_exists($data, $prop)) {
+                $meth = 'get'.ucfirst($prop);
+                $this->assertEquals($data->$prop, $testCfg->$meth(), 'failed Prop = '.$prop);
             }
         }
     }
@@ -52,9 +60,8 @@ class projectConfigTest extends TestCase
     public function getFindLayerData()
     {
         $file = __DIR__.'/Ressources/events.qgs.cfg';
-        $json = json_decode(file_get_contents($file));
-        $layers = array('cfgContent' => (object) array('layers' => $json->layers));
-        $layersNull = array('cfgContent' => (object) array('layers' => null));
+        $layers = json_decode(file_get_contents($file));
+        $layersNull = (object) array('layers' => null);
 
         return array(
             array($layers, 'events_4c3b47b8_3939_4c8c_8e91_55bdb13a2101', 'montpellier_events'),

--- a/tests/units/classes/Project/ProjectConfigTest.php
+++ b/tests/units/classes/Project/ProjectConfigTest.php
@@ -192,4 +192,14 @@ class projectConfigTest extends TestCase
         $testCfg = new Project\ProjectConfig($file);
         $this->assertEquals($expectedValue, $testCfg->getOption($option));
     }
+
+    /**
+     */
+    public function testGetBooleanOption()
+    {
+        $file = __DIR__.'/Ressources/events.qgs.cfg';
+        $testCfg = new Project\ProjectConfig($file);
+        $this->assertTrue($testCfg->getBooleanOption('atlasHighlightGeometry'));
+        $this->assertNull($testCfg->getBooleanOption('atlasEnabled'));
+    }
 }

--- a/tests/units/classes/Project/ProjectTest.php
+++ b/tests/units/classes/Project/ProjectTest.php
@@ -20,7 +20,7 @@ class ProjectTest extends TestCase
         $rep = new Project\Repository('key', array(), null, null, null);
         $proj = new ProjectForTests();
         $cfg = json_decode(file_get_contents(__DIR__.'/Ressources/readProject.qgs.cfg'));
-        $config = new Project\ProjectConfig('', array('cfgContent' => $cfg, 'options' => $cfg->options));
+        $config = new Project\ProjectConfig('', $cfg);
         $proj->setCfg($config);
         $proj->setQgis($qgis_default);
         $proj->setRepo($rep);
@@ -132,7 +132,7 @@ class ProjectTest extends TestCase
      */
     public function testHasAttributeLayer($only, $attributeLayers, $expectedReturn)
     {
-        $config = new Project\ProjectConfig(null, array('attributeLayers' => $attributeLayers));
+        $config = new Project\ProjectConfig(null, (object)array('attributeLayers' => $attributeLayers));
         $proj = new ProjectForTests();
         $proj->setCfg($config);
         $this->assertEquals($expectedReturn, $proj->hasAttributeLayers($only));
@@ -205,7 +205,7 @@ class ProjectTest extends TestCase
         foreach ($editionLayers as $key => $obj) {
             $eLayers->{$key} = clone $obj;
         }
-        $config = new Project\ProjectConfig(null, array('editionLayers' => $eLayers));
+        $config = new Project\ProjectConfig(null, (object) array('editionLayers' => $eLayers));
         $rep = new Project\Repository(null, array(), null, null, null);
         $context = new ContextForTests();
         $context->setResult($acl);
@@ -252,7 +252,9 @@ class ProjectTest extends TestCase
      */
     public function testGetLoginFilteredConfig($lfLayers, $layers, $ln, $expectedLn)
     {
-        $config = new Project\ProjectConfig(null, array('cfgContent' => (object) array('loginFilteredLayers' => $lfLayers, 'layers' => $layers)));
+        $config = new Project\ProjectConfig(null, (object) array(
+            'loginFilteredLayers' => $lfLayers,
+            'layers' => $layers));
         $proj = new ProjectForTests();
         $proj->setCfg($config);
         $this->assertEquals($expectedLn, $proj->getLoginFilteredConfig($ln));
@@ -286,8 +288,11 @@ class ProjectTest extends TestCase
     public function testGetLoginFilters($aclData, $expectedFilters)
     {
         $file = __DIR__.'/Ressources/montpellier_filtered.qgs.cfg';
+        $json = json_decode(file_get_contents($file));
         $expectedFilters = array(
-            'edition_line' => array_merge(json_decode(file_get_contents($file), true)['loginFilteredLayers']['edition_line'], array('layername' => 'edition_line', 'filter' => $expectedFilters)),
+            'edition_line' => array_merge((array)$json->loginFilteredLayers->edition_line,
+                                          array('layername' => 'edition_line',
+                                                'filter' => $expectedFilters)),
         );
         $config = new Project\ProjectConfig($file);
         $context = new ContextForTests();
@@ -343,7 +348,7 @@ class ProjectTest extends TestCase
      */
     public function testGoogle($options, $needGoogle, $gKey)
     {
-        $config = new Project\ProjectConfig(null, array('options' => $options));
+        $config = new Project\ProjectConfig(null, (object) array('options' => $options));
         $proj = new ProjectForTests();
         $proj->setCfg($config);
         $this->assertEquals($needGoogle, $proj->needsGoogle());
@@ -400,7 +405,7 @@ class ProjectTest extends TestCase
         $rep = new Project\Repository('key', array(), null, null, null);
         $context = new ContextForTests();
         $context->setResult($aclData);
-        $config = new Project\ProjectConfig(null, array('options' => $options));
+        $config = new Project\ProjectConfig(null, (object)array('options' => $options));
         $proj = new ProjectForTests($context);
         $proj->setRepo($rep);
         $proj->setCfg($config);

--- a/tests/units/classes/Project/QgisProjectTest.php
+++ b/tests/units/classes/Project/QgisProjectTest.php
@@ -223,7 +223,7 @@ class QgisProjectTest extends TestCase
         $testProj = new qgisProjectForTests();
         $testProj->setXml(simplexml_load_file(__DIR__.'/Ressources/opacity.qgs'));
         $testProj->setLayerOpacityForTest($cfg);
-        $this->assertEquals($expectedLayer, $cfg->getProperty('layers'));
+        $this->assertEquals($expectedLayer, $cfg->getLayers());
     }
 
     public function getLayerData()
@@ -371,7 +371,7 @@ class QgisProjectTest extends TestCase
         $testProj->setXml(simplexml_load_file($file));
         $cfg = new Project\ProjectConfig(null, array('cfgContent' => (object) array('layers' => (object) $layers)));
         $testProj->setShortNamesForTest($cfg);
-        $layer = $cfg->getProperty('layers');
+        $layer = $cfg->getLayers();
         if ($sname) {
             $this->assertEquals($sname, $layer->{$lname}->shortname);
         } else {

--- a/tests/units/classes/Project/QgisProjectTest.php
+++ b/tests/units/classes/Project/QgisProjectTest.php
@@ -219,7 +219,7 @@ class QgisProjectTest extends TestCase
         $json = json_decode(file_get_contents($file));
         $expectedLayer = clone $json->layers;
         $expectedLayer->montpellier_events->opacity = (float) 0.85;
-        $cfg = new Project\ProjectConfig(null, array('cfgContent' => (object) array('layers' => $json->layers)));
+        $cfg = new Project\ProjectConfig(null, (object) array('layers' => $json->layers));
         $testProj = new qgisProjectForTests();
         $testProj->setXml(simplexml_load_file(__DIR__.'/Ressources/opacity.qgs'));
         $testProj->setLayerOpacityForTest($cfg);
@@ -369,7 +369,7 @@ class QgisProjectTest extends TestCase
         );
         $testProj = new qgisProjectForTests();
         $testProj->setXml(simplexml_load_file($file));
-        $cfg = new Project\ProjectConfig(null, array('cfgContent' => (object) array('layers' => (object) $layers)));
+        $cfg = new Project\ProjectConfig(null, (object) array('layers' => (object) $layers));
         $testProj->setShortNamesForTest($cfg);
         $layer = $cfg->getLayers();
         if ($sname) {


### PR DESCRIPTION
There are duplicated content into ProjectConfig which makes its code complex: there is property having the raw content of the cfg file, and other properties that have also some content of this cfg file. 

Moreover, sometimes some code are retrieving the raw content (`getFullCfg`) to access to values, whereas there is a `getProperty` method for that. Using the raw content force the calling call to "know" the structure of the raw content. ProjectConfig should provide some methods to avoid this issue, and to abstract the structure of the cfg file.

So this patch remove the use of `getFullCfg()`, `getOptions` and `getProperties` (on Project or ProjectConfig), and replace them by getter methods that are ease the retrieval of desired values. There are not anymore duplicated content into ProjectConfig, and the content of the cache is lighter.

This refactoring helps me to find the bug in the code for the issue #2153. See the last commit of the patch. It fixes also #2438.

* Funded by 3liz
