### PR TITLE
Cleanup of Project and ProjectConfig classes

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -25,8 +25,6 @@ class lizmapProject
      */
     protected $proj;
 
-    const CACHE_FORMAT_VERSION = 1;
-
     /**
      * constructor.
      *

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -68,38 +68,9 @@ class Project
     protected $data = array();
 
     /**
-     * Version of QGIS which wrote the project.
-     *
-     * @var null|int
-     */
-    protected $QgisProjectVersion;
-
-    /**
      * @var array contains WMS info
      */
     protected $WMSInformation;
-
-    /**
-     * @var string
-     */
-    protected $canvasColor = '';
-
-    /**
-     * @var array authid => proj4
-     */
-    protected $allProj4 = array();
-
-    /**
-     * @var array for each referenced layer, there is an item
-     *            with referencingLayer, referencedField, referencingField keys.
-     *            There is also a 'pivot' key
-     */
-    protected $relations = array();
-
-    /**
-     * @var array list of themes
-     */
-    protected $themes = array();
 
     /**
      * @var array list of layer orders: layer name => order
@@ -142,29 +113,10 @@ class Project
     protected $useLayerIDs = false;
 
     /**
-     * @var array
-     */
-    protected $layers = array();
-
-    /**
-     * @var null
-     */
-    protected $xml;
-
-    /**
-     * @var array
-     */
-    protected $options;
-
-    /**
      * @var array List of cached properties
      */
     protected static $cachedProperties = array(
         'WMSInformation',
-        'canvasColor',
-        'allProj4',
-        'relations',
-        'themes',
         'layersOrder',
         'printCapabilities',
         'locateByLayer',
@@ -172,10 +124,7 @@ class Project
         'editionLayers',
         'attributeLayers',
         'useLayerIDs',
-        'layers',
         'data',
-        'options',
-        'QgisProjectVersion',
     );
 
     /**
@@ -184,16 +133,6 @@ class Project
     private $spatialiteExt;
 
     protected $path;
-
-    /**
-     * version of the format of data stored in the cache.
-     *
-     * This number should be increased each time you change the structure of the
-     * properties of QgisProject (ex: adding some new data properties into the $layers).
-     * So you'll be sure that the cache will be updated when Lizmap code source
-     * is updated on a server
-     */
-    const CACHE_FORMAT_VERSION = 1;
 
     /**
      * @var ProjectCache
@@ -331,7 +270,6 @@ class Project
         $qgsXml = $this->qgis;
         $configOptions = $this->cfg->getOptions();
 
-        $this->options = $configOptions;
         // Complete data
         $this->data['repository'] = $rep->getKey();
         $this->data['id'] = $key;

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -283,12 +283,10 @@ class Project
 
         $this->qgis->setPropertiesAfterRead($this->cfg);
 
-        $this->printCapabilities = $this->readPrintCapabilities($qgsXml);
-        $this->cfg->setPrintCapabilities($this->printCapabilities);
+        $this->readPrintCapabilities($qgsXml);
         $this->readLocateByLayer($qgsXml, $this->cfg);
         $this->readEditionLayers($qgsXml);
         $this->layersOrder = $this->readLayersOrder($qgsXml);
-        $this->cfg->setLayersOrder($this->layersOrder);
         $this->readAttributeLayers($qgsXml, $this->cfg);
 
         $this->qgis->readEditionForms($this->getEditionLayers(), $this);

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -234,7 +234,13 @@ class Project
             // read it and construct the cache at the same time. We should
             // have a kind of lock to avoid this issue.
             try {
-                $this->cfg = new ProjectConfig($file.'.cfg');
+                $fileContent = file_get_contents($file.'.cfg');
+                $cfgContent = json_decode($fileContent);
+                if ($cfgContent === null) {
+                    throw new UnknownLizmapProjectException('The file '.$file.'.cfg cannot be decoded.');
+                }
+
+                $this->cfg = new ProjectConfig($cfgContent);
             } catch (UnknownLizmapProjectException $e) {
                 throw $e;
             }
@@ -287,7 +293,7 @@ class Project
             }
 
             try {
-                $this->cfg = new ProjectConfig($file.'.cfg', $data['cfg']);
+                $this->cfg = new ProjectConfig($data['cfg']);
             } catch (UnknownLizmapProjectException $e) {
                 throw $e;
             }

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -88,11 +88,6 @@ class Project
     protected $editionLayersForCurrentUser;
 
     /**
-     * @var object
-     */
-    protected $attributeLayers = array();
-
-    /**
      * @var bool
      */
     protected $useLayerIDs = false;
@@ -104,7 +99,6 @@ class Project
         'WMSInformation',
         'layersOrder',
         'printCapabilities',
-        'attributeLayers',
         'useLayerIDs',
         'data',
     );
@@ -301,7 +295,7 @@ class Project
         $this->readEditionLayers($qgsXml);
         $this->layersOrder = $this->readLayersOrder($qgsXml);
         $this->cfg->setLayersOrder($this->layersOrder);
-        $this->attributeLayers = $this->readAttributeLayers($qgsXml, $this->cfg);
+        $this->readAttributeLayers($qgsXml, $this->cfg);
 
         $this->qgis->readEditionForms($this->getEditionLayers(), $this);
     }
@@ -1327,23 +1321,13 @@ class Project
         }
     }
 
-    /**
-     * @return object
-     */
     protected function readAttributeLayers(QgisProject $xml, ProjectConfig $cfg)
     {
         $attributeLayers = $cfg->getAttributeLayers();
 
         if ($attributeLayers) {
-            // method takes a reference
             $xml->readAttributeLayers($attributeLayers);
-            // so we can modify data here
-            $cfg->setAttributeLayers($attributeLayers);
-        } else {
-            $attributeLayers = new \stdClass();
         }
-
-        return $attributeLayers;
     }
 
     /**
@@ -1434,8 +1418,6 @@ class Project
 
         // set printTemplates in config
         $configJson->printTemplates = $this->printCapabilities;
-        // Update attributeLayers with attributetableconfig
-        $configJson->attributeLayers = $this->attributeLayers;
 
         // Remove FTP remote directory
         if (property_exists($configJson->options, 'remoteDir')) {

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -85,16 +85,6 @@ class Project
     /**
      * @var object
      */
-    protected $locateByLayer = array();
-
-    /**
-     * @var object
-     */
-    protected $formFilterLayers = array();
-
-    /**
-     * @var object
-     */
     protected $editionLayers = array();
 
     /**
@@ -119,8 +109,6 @@ class Project
         'WMSInformation',
         'layersOrder',
         'printCapabilities',
-        'locateByLayer',
-        'formFilterLayers',
         'editionLayers',
         'attributeLayers',
         'useLayerIDs',
@@ -315,7 +303,7 @@ class Project
 
         $this->printCapabilities = $this->readPrintCapabilities($qgsXml);
         $this->cfg->setPrintCapabilities($this->printCapabilities);
-        $this->locateByLayer = $this->readLocateByLayer($qgsXml, $this->cfg);
+        $this->readLocateByLayer($qgsXml, $this->cfg);
         $this->editionLayers = $this->readEditionLayers($qgsXml);
         $this->layersOrder = $this->readLayersOrder($qgsXml);
         $this->cfg->setLayersOrder($this->layersOrder);
@@ -1323,25 +1311,8 @@ class Project
     {
         $locateByLayer = $cfg->getLocateByLayer();
         if ($locateByLayer) {
-            // The method takes a reference
             $xml->readLocateByLayer($locateByLayer);
         }
-
-        return $locateByLayer;
-    }
-
-    /**
-     * @return object
-     */
-    protected function readFormFilterLayers(QgisProject $xml, ProjectConfig $cfg)
-    {
-        $formFilterLayers = $cfg->getFormFilterLayers();
-
-        if (!$formFilterLayers) {
-            $formFilterLayers = new \stdClass();
-        }
-
-        return $formFilterLayers;
     }
 
     /**
@@ -1477,13 +1448,6 @@ class Project
 
         // set printTemplates in config
         $configJson->printTemplates = $this->printCapabilities;
-
-        // Update locate by layer with vecctorjoins
-        $configJson->locateByLayer = $this->locateByLayer;
-
-        // Update filter form layers with vecctorjoins
-        $configJson->formFilterLayers = $this->formFilterLayers;
-
         // Update attributeLayers with attributetableconfig
         $configJson->attributeLayers = $this->attributeLayers;
 

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -88,18 +88,12 @@ class Project
     protected $editionLayersForCurrentUser;
 
     /**
-     * @var bool
-     */
-    protected $useLayerIDs = false;
-
-    /**
      * @var array List of cached properties
      */
     protected static $cachedProperties = array(
         'WMSInformation',
         'layersOrder',
         'printCapabilities',
-        'useLayerIDs',
         'data',
     );
 
@@ -1464,7 +1458,7 @@ class Project
         if ($themes) {
             $configJson->themes = $themes;
         }
-        if ($this->useLayerIDs) {
+        if ($this->qgis->isUsingLayerIDs()) {
             $configJson->options->useLayerIDs = 'True';
         }
 

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -83,11 +83,6 @@ class Project
     protected $printCapabilities = array();
 
     /**
-     * @var object
-     */
-    protected $editionLayers = array();
-
-    /**
      * @var null|object[] layer names => layers
      */
     protected $editionLayersForCurrentUser;
@@ -109,7 +104,6 @@ class Project
         'WMSInformation',
         'layersOrder',
         'printCapabilities',
-        'editionLayers',
         'attributeLayers',
         'useLayerIDs',
         'data',
@@ -304,7 +298,7 @@ class Project
         $this->printCapabilities = $this->readPrintCapabilities($qgsXml);
         $this->cfg->setPrintCapabilities($this->printCapabilities);
         $this->readLocateByLayer($qgsXml, $this->cfg);
-        $this->editionLayers = $this->readEditionLayers($qgsXml);
+        $this->readEditionLayers($qgsXml);
         $this->layersOrder = $this->readLayersOrder($qgsXml);
         $this->cfg->setLayersOrder($this->layersOrder);
         $this->attributeLayers = $this->readAttributeLayers($qgsXml, $this->cfg);
@@ -1315,9 +1309,6 @@ class Project
         }
     }
 
-    /**
-     * @return object
-     */
     protected function readEditionLayers(QgisProject $xml)
     {
         $editionLayers = $this->cfg->getEditionLayers();
@@ -1333,12 +1324,7 @@ class Project
                 $this->appContext->logMessage('Spatialite is not available', 'error');
                 $xml->readEditionLayers($editionLayers);
             }
-        } else {
-            $editionLayers = new \stdClass();
         }
-        $this->cfg->setEditionLayers($editionLayers);
-
-        return $editionLayers;
     }
 
     /**
@@ -1457,33 +1443,11 @@ class Project
         }
 
         // Remove editionLayers from config if no right to access this tool
-        if (property_exists($configJson, 'editionLayers')) {
-            if ($this->appContext->aclCheck('lizmap.tools.edition.use', $this->repository->getKey())) {
-                $configJson->editionLayers = clone $this->editionLayers;
-                // Check right to edit this layer (if property "acl" is in config)
-                foreach ($configJson->editionLayers as $key => $eLayer) {
-                    // Check if user groups intersects groups allowed by project editor
-                    // If user is admin, no need to check for given groups
-                    if (property_exists($eLayer, 'acl') and $eLayer->acl) {
-                        // Check if configured groups white list and authenticated user groups list intersects
-                        $editionGroups = $eLayer->acl;
-                        $editionGroups = array_map('trim', explode(',', $editionGroups));
-                        if (is_array($editionGroups) and count($editionGroups) > 0) {
-                            $userGroups = $this->appContext->aclUserGroupsId();
-                            if (array_intersect($editionGroups, $userGroups) or $this->appContext->aclCheck('lizmap.admin.repositories.delete')) {
-                                // User group(s) correspond to the groups given for this edition layer
-                                // or the user is admin
-                                unset($configJson->editionLayers->{$key}->acl);
-                            } else {
-                                // No match found, we deactivate the edition layer
-                                unset($configJson->editionLayers->{$key});
-                            }
-                        }
-                    }
-                }
-            } else {
-                unset($configJson->editionLayers);
-            }
+        if ($this->hasEditionLayersForCurrentUser()) {
+            // give only layer that the user has the right to edit
+            $configJson->editionLayers = $this->editionLayersForCurrentUser;
+        } else {
+            unset($configJson->editionLayers);
         }
 
         // Add export layer right

--- a/lizmap/modules/lizmap/lib/Project/ProjectCache.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectCache.php
@@ -51,7 +51,7 @@ class ProjectCache
      * So you'll be sure that the cache will be updated when Lizmap code source
      * is updated on a server
      */
-    const CACHE_FORMAT_VERSION = 3;
+    const CACHE_FORMAT_VERSION = 4;
 
     /**
      * Initialize the cache of a Qgis project.

--- a/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
@@ -2,6 +2,10 @@
 
 namespace Lizmap\Project;
 
+/**
+ * It allows to access to configuration properties stored into the cfg file
+ * of a project, and to access to some "calculated" properties.
+ */
 class ProjectConfig
 {
     /**
@@ -85,16 +89,11 @@ class ProjectConfig
         'datavizLayers',
     );
 
-    public function __construct($cfgFile, $data = null)
+    /**
+     * @param object $data properties of the QGIS project, coming from the cfg file
+     */
+    public function __construct($data)
     {
-        if ($data === null) {
-            $fileContent = file_get_contents($cfgFile);
-            $data = json_decode($fileContent);
-            if ($data === null) {
-                throw new UnknownLizmapProjectException('The file '.$cfgFile.' cannot be decoded.');
-            }
-        }
-
         foreach (self::$cachedProperties as $prop) {
             if (isset($data->{$prop})) {
                 $this->{$prop} = $data->{$prop};

--- a/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
@@ -207,14 +207,6 @@ class ProjectConfig
     }
 
     /**
-     * @param object $locateByLayer
-     */
-    public function setLocateByLayer($locateByLayer)
-    {
-        $this->locateByLayer = $locateByLayer;
-    }
-
-    /**
      * Call every findLayerBy function to get a layer.
      *
      * @param string $name The name, shortname, typename, id or title of the layer to get

--- a/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
@@ -188,14 +188,12 @@ class ProjectConfig
         }
     }
 
+    /**
+     * @return object
+     */
     public function getAttributeLayers()
     {
         return $this->attributeLayers;
-    }
-
-    public function setAttributeLayers($attributeLayers)
-    {
-        $this->attributeLayers = $attributeLayers;
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
@@ -375,14 +375,6 @@ class ProjectConfig
         return $this->editionLayers;
     }
 
-    /**
-     * @param object $editionLayers
-     */
-    public function setEditionLayers($editionLayers)
-    {
-        $this->editionLayers = $editionLayers;
-    }
-
     public function getEditionLayerByName($name)
     {
         $editionLayers = $this->editionLayers;

--- a/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
@@ -9,16 +9,6 @@ namespace Lizmap\Project;
 class ProjectConfig
 {
     /**
-     * @var int[] keys are layer name
-     */
-    protected $layersOrder = array();
-
-    /**
-     * @var mixed
-     */
-    protected $printCapabilities;
-
-    /**
      * @var object
      */
     protected $locateByLayer;
@@ -74,8 +64,6 @@ class ProjectConfig
     protected $options;
 
     protected static $cachedProperties = array(
-        'layersOrder',
-        'printCapabilities',
         'locateByLayer',
         'formFilterLayers',
         'editionLayers',
@@ -98,9 +86,7 @@ class ProjectConfig
             if (isset($data->{$prop})) {
                 $this->{$prop} = $data->{$prop};
             } else {
-                if ($prop != 'layersOrder') {
-                    $this->{$prop} = new \stdClass();
-                }
+                $this->{$prop} = new \stdClass();
             }
         }
     }
@@ -137,22 +123,6 @@ class ProjectConfig
         }
 
         return (object) $data;
-    }
-
-    /**
-     * @return int[] keys are layer name
-     */
-    public function getLayersOrder()
-    {
-        return $this->layersOrder;
-    }
-
-    /**
-     * @param int[] $layersOrder
-     */
-    public function setLayersOrder($layersOrder)
-    {
-        $this->layersOrder = $layersOrder;
     }
 
     /**
@@ -454,19 +424,6 @@ class ProjectConfig
         }
 
         return null;
-    }
-
-    /**
-     * @return object
-     */
-    public function getPrintCapabilities()
-    {
-        return $this->printCapabilities;
-    }
-
-    public function setPrintCapabilities($printCapabilities)
-    {
-        $this->printCapabilities = $printCapabilities;
     }
 
     public function getFormFilterLayers()

--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -947,7 +947,7 @@ class QgisProject
     }
 
     /**
-     * @param $editionLayers
+     * @param object  $editionLayers
      * @param Project $proj
      */
     public function readEditionForms($editionLayers, $proj)
@@ -963,6 +963,9 @@ class QgisProject
         }
     }
 
+    /**
+     * @param object $attributeLayers
+     */
     public function readAttributeLayers($attributeLayers)
     {
         // Get field order & visibility

--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -245,6 +245,14 @@ class QgisProject
         return $this->themes;
     }
 
+    /**
+     * @return bool
+     */
+    public function isUsingLayerIDs()
+    {
+        return $this->useLayerIDs;
+    }
+
     public function setPropertiesAfterRead(ProjectConfig $cfg)
     {
         $this->setShortNames($cfg);

--- a/tests/units/classes/Project/ProjectConfigTest.php
+++ b/tests/units/classes/Project/ProjectConfigTest.php
@@ -23,7 +23,6 @@ class projectConfigTest extends TestCase
         $expected->tooltipLayers = new stdClass();
         $expected->loginFilteredLayers = new stdClass();
         return array(
-            array(null, $expected),
             array($json, $expected),
         );
     }
@@ -36,9 +35,7 @@ class projectConfigTest extends TestCase
      */
     public function testConstruct($data, $expectedData)
     {
-        $file = __DIR__.'/Ressources/events.qgs.cfg';
-
-        $testCfg = new Project\ProjectConfig($file, $data);
+        $testCfg = new Project\ProjectConfig($data);
         $this->assertEquals($expectedData, $testCfg->getConfigContent());
     }
 
@@ -48,7 +45,7 @@ class projectConfigTest extends TestCase
         $data = json_decode(file_get_contents($file));
         $cachedProperties = array('layersOrder', 'locateByLayer', 'formFilterLayers', 'editionLayers',
             'attributeLayers', 'options', 'layers', );
-        $testCfg = new Project\ProjectConfig($file, $data);
+        $testCfg = new Project\ProjectConfig($data);
         foreach ($cachedProperties as $prop) {
             if (property_exists($data, $prop)) {
                 $meth = 'get'.ucfirst($prop);
@@ -84,7 +81,7 @@ class projectConfigTest extends TestCase
      */
     public function testFindLayer($layers, $key, $layerName)
     {
-        $testCfg = new Project\ProjectConfig(null, $layers);
+        $testCfg = new Project\ProjectConfig($layers);
         if ($layerName) {
             $this->assertSame($testCfg->getLayer($layerName), $testCfg->findLayerByAnyName($key));
         } else {
@@ -113,7 +110,7 @@ class projectConfigTest extends TestCase
      */
     public function testGetEditionLayerByName($eLayers, $name)
     {
-        $testCfg = new Project\ProjectConfig(null, $eLayers);
+        $testCfg = new Project\ProjectConfig($eLayers);
         if ($name) {
             $this->assertSame($eLayers->editionLayers->{$name}, $testCfg->getEditionLayerByName($name));
         } else {
@@ -145,7 +142,7 @@ class projectConfigTest extends TestCase
      */
     public function testGetEditionLayerByLayerId($eLayers, $id, $eLayerName)
     {
-        $testCfg = new Project\ProjectConfig(null, $eLayers);
+        $testCfg = new Project\ProjectConfig($eLayers);
         if ($eLayerName) {
             $this->assertSame($eLayers->editionLayers->$eLayerName, $testCfg->getEditionLayerByLayerId($id));
         } else {
@@ -189,7 +186,8 @@ class projectConfigTest extends TestCase
     public function testGetOption($option, $expectedValue)
     {
         $file = __DIR__.'/Ressources/montpellier.qgs.cfg';
-        $testCfg = new Project\ProjectConfig($file);
+        $data = json_decode(file_get_contents($file));
+        $testCfg = new Project\ProjectConfig($data);
         $this->assertEquals($expectedValue, $testCfg->getOption($option));
     }
 
@@ -198,7 +196,8 @@ class projectConfigTest extends TestCase
     public function testGetBooleanOption()
     {
         $file = __DIR__.'/Ressources/events.qgs.cfg';
-        $testCfg = new Project\ProjectConfig($file);
+        $data = json_decode(file_get_contents($file));
+        $testCfg = new Project\ProjectConfig($data);
         $this->assertTrue($testCfg->getBooleanOption('atlasHighlightGeometry'));
         $this->assertNull($testCfg->getBooleanOption('atlasEnabled'));
     }

--- a/tests/units/classes/Project/ProjectConfigTest.php
+++ b/tests/units/classes/Project/ProjectConfigTest.php
@@ -14,9 +14,6 @@ class projectConfigTest extends TestCase
         $json = json_decode(file_get_contents($file));
 
         $expected = clone $json;
-        $expected->layersOrder = array ();
-        $expected->printCapabilities = new stdClass();
-
         $expected->editionLayers = new stdClass();
         $expected->timemanagerLayers = new stdClass();
         $expected->atlas = new stdClass();

--- a/tests/units/classes/Project/ProjectTest.php
+++ b/tests/units/classes/Project/ProjectTest.php
@@ -20,7 +20,7 @@ class ProjectTest extends TestCase
         $rep = new Project\Repository('key', array(), null, null, null);
         $proj = new ProjectForTests();
         $cfg = json_decode(file_get_contents(__DIR__.'/Ressources/readProject.qgs.cfg'));
-        $config = new Project\ProjectConfig('', $cfg);
+        $config = new Project\ProjectConfig($cfg);
         $proj->setCfg($config);
         $proj->setQgis($qgis_default);
         $proj->setRepo($rep);
@@ -132,7 +132,7 @@ class ProjectTest extends TestCase
      */
     public function testHasAttributeLayer($only, $attributeLayers, $expectedReturn)
     {
-        $config = new Project\ProjectConfig(null, (object)array('attributeLayers' => $attributeLayers));
+        $config = new Project\ProjectConfig((object)array('attributeLayers' => $attributeLayers));
         $proj = new ProjectForTests();
         $proj->setCfg($config);
         $this->assertEquals($expectedReturn, $proj->hasAttributeLayers($only));
@@ -205,7 +205,7 @@ class ProjectTest extends TestCase
         foreach ($editionLayers as $key => $obj) {
             $eLayers->{$key} = clone $obj;
         }
-        $config = new Project\ProjectConfig(null, (object) array('editionLayers' => $eLayers));
+        $config = new Project\ProjectConfig((object) array('editionLayers' => $eLayers));
         $rep = new Project\Repository(null, array(), null, null, null);
         $context = new ContextForTests();
         $context->setResult($acl);
@@ -252,7 +252,7 @@ class ProjectTest extends TestCase
      */
     public function testGetLoginFilteredConfig($lfLayers, $layers, $ln, $expectedLn)
     {
-        $config = new Project\ProjectConfig(null, (object) array(
+        $config = new Project\ProjectConfig((object) array(
             'loginFilteredLayers' => $lfLayers,
             'layers' => $layers));
         $proj = new ProjectForTests();
@@ -294,7 +294,7 @@ class ProjectTest extends TestCase
                                           array('layername' => 'edition_line',
                                                 'filter' => $expectedFilters)),
         );
-        $config = new Project\ProjectConfig($file);
+        $config = new Project\ProjectConfig($json);
         $context = new ContextForTests();
         $context->setResult($aclData);
         $proj = new ProjectForTests($context);
@@ -348,7 +348,7 @@ class ProjectTest extends TestCase
      */
     public function testGoogle($options, $needGoogle, $gKey)
     {
-        $config = new Project\ProjectConfig(null, (object) array('options' => $options));
+        $config = new Project\ProjectConfig((object) array('options' => $options));
         $proj = new ProjectForTests();
         $proj->setCfg($config);
         $this->assertEquals($needGoogle, $proj->needsGoogle());
@@ -405,7 +405,7 @@ class ProjectTest extends TestCase
         $rep = new Project\Repository('key', array(), null, null, null);
         $context = new ContextForTests();
         $context->setResult($aclData);
-        $config = new Project\ProjectConfig(null, (object)array('options' => $options));
+        $config = new Project\ProjectConfig((object)array('options' => $options));
         $proj = new ProjectForTests($context);
         $proj->setRepo($rep);
         $proj->setCfg($config);

--- a/tests/units/classes/Project/QgisProjectTest.php
+++ b/tests/units/classes/Project/QgisProjectTest.php
@@ -219,7 +219,7 @@ class QgisProjectTest extends TestCase
         $json = json_decode(file_get_contents($file));
         $expectedLayer = clone $json->layers;
         $expectedLayer->montpellier_events->opacity = (float) 0.85;
-        $cfg = new Project\ProjectConfig(null, (object) array('layers' => $json->layers));
+        $cfg = new Project\ProjectConfig((object) array('layers' => $json->layers));
         $testProj = new qgisProjectForTests();
         $testProj->setXml(simplexml_load_file(__DIR__.'/Ressources/opacity.qgs'));
         $testProj->setLayerOpacityForTest($cfg);
@@ -369,7 +369,7 @@ class QgisProjectTest extends TestCase
         );
         $testProj = new qgisProjectForTests();
         $testProj->setXml(simplexml_load_file($file));
-        $cfg = new Project\ProjectConfig(null, (object) array('layers' => (object) $layers));
+        $cfg = new Project\ProjectConfig((object) array('layers' => (object) $layers));
         $testProj->setShortNamesForTest($cfg);
         $layer = $cfg->getLayers();
         if ($sname) {

--- a/tests/units/testslib/QgisProjectForTests.php
+++ b/tests/units/testslib/QgisProjectForTests.php
@@ -71,7 +71,7 @@ class QgisProjectForTests extends QgisProject
 
     public function readEditionLayersForTest($eLayer)
     {
-        return $this->readEditionLayers($eLayer);
+        $this->readEditionLayers($eLayer);
     }
 
     public function readAttributeLayersForTest($aLayer)

--- a/tests/units/testslib/QgisProjectForTests.php
+++ b/tests/units/testslib/QgisProjectForTests.php
@@ -76,7 +76,7 @@ class QgisProjectForTests extends QgisProject
 
     public function readAttributeLayersForTest($aLayer)
     {
-        return $this->readAttributeLayers($aLayer);
+        $this->readAttributeLayers($aLayer);
     }
 
     public function getEditTypeForTest($layerXml)


### PR DESCRIPTION
After the refactoring, some properties of QgisProject or ProjectConfig were still duplicated into the Project class. The goal of this patch is to remove them, allowing to save bytes and to have a consistent code.

Improved also the ProjectConfig class, to accept only data in its constructor, instead of having a filename and optional data. It eases tests and this is the responsability to Project to load data from the cfg file if there is no cache.

* Funded by 3liz
