### PR TITLE
Project thumbnails as grid

### DIFF
--- a/lizmap/modules/view/templates/view.tpl
+++ b/lizmap/modules/view/templates/view.tpl
@@ -7,11 +7,11 @@
 {foreach $mapitems as $mi}
 {if $mi->type == 'rep'}
 <h2 class="liz-repository-title">{$mi->title}</h2>
-<ul class="thumbnails liz-repository-project-list">
+<ul class="liz-repository-project-list">
   {foreach $mi->childItems as $p}
   {assign $idm = $idm + 1}
-  <a name="link-projet-{$idm}"></a>
-  <li class="span3 liz-repository-project-item">
+  <li class="liz-repository-project-item">
+    <a name="link-projet-{$idm}"></a>
     <div class="thumbnail">
       <div class="liz-project">
         <img width="250" height="250" src="{$p->img}" alt="project image" class="liz-project-img">
@@ -27,7 +27,7 @@
         </p>
       </div>
       <h5 class="liz-project-title">{$p->title}</h5>
-      <p style="text-align:center;">
+      <p>
         <a class="btn liz-project-view" href="{$p->url}{if $hide_header}&h=0{/if}">{@default.project.open.map@}</a>
         <a class="btn liz-project-show-desc" href="#link-projet-{$idm}" onclick="$('#liz-project-modal-{$idm}').modal('show'); return false;">{@default.project.open.map.metadata@}</a>
       </p>

--- a/lizmap/www/assets/css/view.css
+++ b/lizmap/www/assets/css/view.css
@@ -1,12 +1,10 @@
-.thumbnail {
-  background-color: white;
-}
 .thumbnail h5 {
   text-align: center;
 }
 .liz-project {
   position:relative;
   text-align:center;
+  cursor: pointer;
 }
 .liz-project-img {
   width : 250px;
@@ -32,6 +30,32 @@
   padding:5px;
   margin:0px;
   overflow-wrap: break-word;
+}
+
+.liz-project-title{
+  overflow-wrap: anywhere;
+}
+
+.liz-project-title ~ p {
+  text-align: center;
+  margin: 0;
+}
+
+.liz-repository-project-list{
+  display: grid;
+  list-style: none;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+}
+
+.liz-repository-project-item{
+  display: inline-block;
+}
+
+.liz-repository-project-item .thumbnail{
+  background-color: white;
+  height: 100%;
+  box-sizing: border-box;
 }
 
 #headermenu .input-prepend {
@@ -92,6 +116,12 @@
 .project-keyword .highlight{
   font-weight: bold;
   font-size: 1.1em;
+}
+
+@media (max-width: 767px) {
+  .liz-repository-project-list{
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-height: 500px) {

--- a/lizmap/www/assets/js/view.js
+++ b/lizmap/www/assets/js/view.js
@@ -1,19 +1,3 @@
-(function ($) {
-    $.fn.uniformHeight = function () {
-        var maxHeight = 0,
-            wrapper,
-            wrapperHeight;
-        return this.each(function () {
-            // Applying a wrapper to the contents of the current element to get reliable height
-            wrapper = $(this).wrapInner('<div class="wrapper" />').children('.wrapper');
-            wrapperHeight = wrapper.outerHeight();
-            maxHeight = Math.max(maxHeight, wrapperHeight);
-            // Remove the wrapper
-            wrapper.children().unwrap();
-        }).height(maxHeight);
-    }
-})(jQuery);
-
 var addDescriptionSlider = function(){
     $('.liz-project-img').parent().mouseenter(function(){
       var self = $(this);
@@ -26,15 +10,6 @@ var addDescriptionSlider = function(){
       var self = $(this);
       window.location = self.parent().find('a.liz-project-view').attr('href');
       return false;
-    });
-}
-
-var resizeThumbnails = function(){
-    $(".thumbnail h5").height('auto');
-    $('.thumbnails').height('auto');
-    $('.thumbnails').each(function () {
-        $(this).find('.thumbnail h5').height(Math.max.apply(null, $(this).find('.thumbnail h5').map(function() { return $(this).height(); })));
-        $(this).find('.thumbnail').uniformHeight();
     });
 }
 
@@ -314,8 +289,5 @@ var searchProjects = function(){
 
 window.addEventListener('load', function () {
     addDescriptionSlider();
-    resizeThumbnails();
     searchProjects();
 });
-
-window.addEventListener('resize', resizeThumbnails);

--- a/lizmap/www/assets/js/view.js
+++ b/lizmap/www/assets/js/view.js
@@ -2,7 +2,6 @@ var addDescriptionSlider = function(){
     $('.liz-project-img').parent().mouseenter(function(){
       var self = $(this);
       self.find('.liz-project-desc').slideDown();
-      self.css('cursor','pointer');
     }).mouseleave(function(){
       var self = $(this);
       self.find('.liz-project-desc').hide();


### PR DESCRIPTION
CSS Grid avoid JS to have thumbnails with same height on every line and is easier to overload with custom CSS.
It also allows the use of img lazy loading which is buggy in Firefox with old code based on JS.

* Funded by 3Liz