### PR TITLE
[BUGFIX] Fix editing buttons visibility in popup with several filtered layers

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -5,6 +5,10 @@
 - Fix: issue during the installation of the ldapdao module. Upgrade it to 2.2.1
 - Fix: export button allowed in filter data with form when format is ODS
 - Fix: integer key column sorted as text in attribute table tool
+- Fix: Editing
+  - In case of more than one editable layers, when there is a filter by login (or by polygon) activated,
+  some of the popup items could miss the pencil button to open the editing form. Corrected by requesting
+  the editable features for all the editable layers of the displayed popup items, and not only the first.
 
 ## 3.4.5 - 2021-09-14
 

--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -34,6 +34,10 @@
   - If the map has external base layers such as OpenStreetMap, and is then displayed in Pseudo Mercator (EPSG:3857),
   the exported map is now printed in the QGIS project projection (e.g. EPSG:2154) to avoid wrong scale.
   You can now use your ruler in the printed paper and trust your measure.
+- Editing
+  - In case of more than one editable layers, when there is a filter by login (or by polygon) activated,
+  some of the popup items could miss the pencil button to open the editing form. Corrected by requesting
+  the editable features for all the editable layers of the displayed popup items, and not only the first.
 
 ### New JS events
 


### PR DESCRIPTION
In case of more than one editable layers, when there is a filter by login (or by polygon) activated,
some of the popup items could miss the pencil button to open the editing form. Corrected by requesting
the editable features for all the editable layers of the displayed popup items, and not only the first.

* Funded by 3liz
