### PR TITLE
Fix: integer key column sorted as text in attribute table

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -1,9 +1,10 @@
 # Changelog Lizmap 3.4
 
-## Unreleased
+## 3.4.6 - Unreleased
 
-- Fix: issue during the installation of the ldapdao module. Upgrade it to 2.2.1 
+- Fix: issue during the installation of the ldapdao module. Upgrade it to 2.2.1
 - Fix: export button allowed in filter data with form when format is ODS
+- Fix: integer key column sorted as text in attribute table tool
 
 ## 3.4.5 - 2021-09-14
 

--- a/lizmap/www/assets/js/attributeTable.js
+++ b/lizmap/www/assets/js/attributeTable.js
@@ -1323,15 +1323,20 @@ var lizAttributeTable = function() {
             }
 
             function valueMapInAttributeTable( aName, data, type, full, meta ){
-            // Translate field ( language translation OR code->label translation )
+                // Translate field ( language translation OR code->label translation )
                 var colMeta = meta.settings.aoColumns[meta.col];
                 var colName = colMeta.mData
                 var translation_dict = null;
                 var tdata = data;
-                if(data || data === 0)
+                if (data || data === 0) {
                     tdata = lizMap.translateWfsFieldValues(aName, colName, data.toString(), translation_dict);
-                if( tdata === null )
+                }
+                // lizMap.translateWfsFieldValues() change `data` type integer to string
+                // so we return original `data` if its value has not changed or is null
+                // it avoids wrong sorting in attribute table column
+                if (tdata == data || tdata === null) {
                     tdata = data;
+                }
 
                 return tdata;
             }


### PR DESCRIPTION
lizMap.translateWfsFieldValues() change `data` type integer to string
so we return original `data` if its value has not changed or is null
it avoids wrong sorting in attribute table column
* Ticket : #2231
* Funded by 3Liz