### PR TITLE
Remove app context from OGCRequest constructor

### DIFF
--- a/lizmap/modules/dataviz/classes/datavizPlot.class.php
+++ b/lizmap/modules/dataviz/classes/datavizPlot.class.php
@@ -459,7 +459,7 @@ class datavizPlot
                 $wfsparams['EXP_FILTER'] = $exp_filter;
             }
 
-            $wfsrequest = new \Lizmap\Request\WFSRequest($this->lproj, $wfsparams, lizmap::getServices(), lizmap::getAppContext());
+            $wfsrequest = new \Lizmap\Request\WFSRequest($this->lproj, $wfsparams, lizmap::getServices());
             // FIXME no support of the case where $wfsresponse is the content of serviceException?
             $wfsresponse = $wfsrequest->process();
             $features = null;

--- a/lizmap/modules/lizmap/classes/lizmapTiler.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapTiler.class.php
@@ -74,8 +74,7 @@ class lizmapTiler
                     'service' => 'WMS',
                     'request' => 'GetCapabilities',
                 ),
-                lizmap::getServices(),
-                lizmap::getAppContext()
+                lizmap::getServices()
             );
             $wmsResult = $wmsRequest->process();
             // Http code error

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -1058,7 +1058,7 @@ class qgisVectorLayer extends qgisMapLayer
         );
 
         // Perform the request to get the editable features
-        $wfsRequest = new \Lizmap\Request\WFSRequest($project, $params, lizmap::getServices(), lizmap::getAppContext());
+        $wfsRequest = new \Lizmap\Request\WFSRequest($project, $params, lizmap::getServices());
         $result = $wfsRequest->process();
 
         // Check code
@@ -1285,7 +1285,7 @@ class qgisVectorLayer extends qgisMapLayer
         }
 
         // Check if the current user is connected
-        $appContext = \lizmap::getAppContext();
+        $appContext = $this->project->getAppContext();
         $is_connected = $appContext->UserIsConnected();
         $user_key = 'anonymous';
         if ($is_connected) {

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -283,8 +283,7 @@ class editionCtrl extends jController
             $wfs_request = new \Lizmap\Request\WFSRequest(
                 $this->project,
                 $wfs_params,
-                lizmap::getServices(),
-                lizmap::getAppContext()
+                lizmap::getServices()
             );
             // FIXME no support of the case where $wfs_response is the content of serviceException?
             $wfs_response = $wfs_request->process();

--- a/lizmap/modules/lizmap/controllers/wmts.cmdline.php
+++ b/lizmap/modules/lizmap/controllers/wmts.cmdline.php
@@ -429,8 +429,7 @@ class wmtsCtrl extends jControllerCmdLine
                                     'TileRow' => $row,
                                     'TileCol' => $col,
                                 ),
-                                lizmap::getServices(),
-                                lizmap::getAppContext()
+                                lizmap::getServices()
                             );
                             if ($forced) {
                                 $request->setForceRequest(true);

--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -1449,7 +1449,7 @@ class QgisForm implements QgisFormControlsInterface
             unset($params['PROPERTYNAME']);
         }
 
-        $wfsRequest = new \Lizmap\Request\WFSRequest($project, $params, \lizmap::getServices(), \lizmap::getAppContext());
+        $wfsRequest = new \Lizmap\Request\WFSRequest($project, $params, \lizmap::getServices());
         $this->PerformWfsRequest($wfsRequest, $formControl, $referencedField, $previewField);
     }
 

--- a/lizmap/modules/lizmap/lib/Form/QgisFormValueRelationDynamicDatasource.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisFormValueRelationDynamicDatasource.php
@@ -86,7 +86,7 @@ class QgisFormValueRelationDynamicDatasource extends \jFormsDynamicDatasource
                 );
 
                 // Perform request
-                $wfsRequest = new \Lizmap\Request\WFSRequest($lproj, $params, \lizmap::getServices(), \lizmap::getAppContext());
+                $wfsRequest = new \Lizmap\Request\WFSRequest($lproj, $params, \lizmap::getServices());
                 $wfsResult = $wfsRequest->process();
 
                 $data = $wfsResult->data;
@@ -168,7 +168,7 @@ class QgisFormValueRelationDynamicDatasource extends \jFormsDynamicDatasource
         );
 
         // Perform request
-        $wfsRequest = new \Lizmap\Request\WFSRequest($lproj, $params, \lizmap::getServices(), \lizmap::getAppContext());
+        $wfsRequest = new \Lizmap\Request\WFSRequest($lproj, $params, \lizmap::getServices());
         $wfsResult = $wfsRequest->process();
 
         $data = $wfsResult->data;

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -297,6 +297,14 @@ class Project
         return $this->qgis->findLayersByKeyword($key, $this);
     }
 
+    /**
+     * @return App\AppContextInterface
+     */
+    public function getAppContext()
+    {
+        return $this->appContext;
+    }
+
     public function getKey()
     {
         return $this->key;

--- a/lizmap/modules/lizmap/lib/Request/OGCRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/OGCRequest.php
@@ -51,6 +51,9 @@ abstract class OGCRequest
      */
     protected $tplExceptions;
 
+    /**
+     * @var App\AppContextInterface
+     */
     protected $appContext;
 
     /**
@@ -61,14 +64,14 @@ abstract class OGCRequest
      * @param \lizmapServices         $services
      * @param string                  $requestXml the params array
      */
-    public function __construct($project, $params, $services, App\AppContextInterface $appContext, $requestXml = null)
+    public function __construct($project, $params, $services, $requestXml = null)
     {
         //print_r( $project != null );
         $this->project = $project;
         $this->repository = $project->getRepository();
 
         $this->services = $services;
-        $this->appContext = $appContext;
+        $this->appContext = $this->project->getAppContext();
 
         $params['map'] = $project->getRelativeQgisPath();
         $this->params = Proxy::normalizeParams($params);

--- a/lizmap/modules/lizmap/lib/Request/WMTSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMTSRequest.php
@@ -189,7 +189,7 @@ class WMTSRequest extends OGCRequest
             $wmsParams['exp_filter'] = $exp_filter;
         }
 
-        $wmsRequest = new WMSRequest($this->project, $wmsParams, $this->services, $this->appContext);
+        $wmsRequest = new WMSRequest($this->project, $wmsParams, $this->services);
         $wmsRequest->setForceRequest($this->forceRequest);
 
         return $wmsRequest->process();

--- a/tests/units/classes/Request/OGCRequestTest.php
+++ b/tests/units/classes/Request/OGCRequestTest.php
@@ -11,7 +11,7 @@ class OGCRequestTest extends TestCase
             'service' => 'WMS',
             'empty' => ''
         );
-        $ogc = new OGCRequestForTests(new ProjectForOGCForTests(), $params, null, new ContextForTests());
+        $ogc = new OGCRequestForTests(new ProjectForOGCForTests(), $params, null);
         foreach ($params as $key => $value) {
             $this->assertEquals($value, $ogc->param($key));
         }
@@ -39,10 +39,13 @@ class OGCRequestTest extends TestCase
         );
         $testContext = new ContextForTests();
         $testContext->setResult($contextResult);
-        $ogc = new OGCRequestForTests(new ProjectForOGCForTests(), $params, null, $testContext);
+
+        $ogc = new OGCRequestForTests(new ProjectForOGCForTests($testContext), $params, null);
         $parameters = $ogc->parameters();
         $this->assertEquals($expectedParameters, $parameters);
-        $proj = new ProjectForOGCForTests();
+
+
+        $proj = new ProjectForOGCForTests($testContext);
         $proj->setRepo(new Lizmap\Project\Repository('test', array(), '', null, $testContext));
         $contextResult = array(
             'userIsConnected' => true,
@@ -58,7 +61,7 @@ class OGCRequestTest extends TestCase
             'Lizmap_User_Groups' => 'admins, users',
             'Lizmap_Override_Filter' => true
         );
-        $ogc = new OGCRequestForTests($proj, $params, null, $testContext);
+        $ogc = new OGCRequestForTests($proj, $params, null);
         $parameters = $ogc->parameters();
         $this->assertEquals($expectedParameters, $parameters);
     }
@@ -71,7 +74,8 @@ class OGCRequestTest extends TestCase
         );
         $ogc = $this->getMockBuilder(OGCRequestForTests::class)
             ->setMethods(['process_getcapabilities'])
-            ->setConstructorArgs([new ProjectForOGCForTests(), $params, null, new ContextForTests()])->getMock();
+            ->setConstructorArgs([new ProjectForOGCForTests(), $params, null])
+            ->getMock();
         $ogc->expects($this->once())->method('process_getcapabilities');
         $ogc->process();
         $params = array(
@@ -80,7 +84,8 @@ class OGCRequestTest extends TestCase
         );
         $ogc = $this->getMockBuilder(OGCRequestForTests::class)
             ->setMethods(['serviceException'])
-            ->setConstructorArgs([new ProjectForOGCForTests(), $params, null, new ContextForTests()])->getMock();
+            ->setConstructorArgs([new ProjectForOGCForTests(), $params, null])
+            ->getMock();
         $ogc->expects($this->once())->method('serviceException')->with(501);
         $testMock = $ogc->process();
     }

--- a/tests/units/classes/Request/WFSRequestTest.php
+++ b/tests/units/classes/Request/WFSRequestTest.php
@@ -7,7 +7,7 @@ class WFSRequestTest extends TestCase
 {
     public function testParameters()
     {
-        $wfs = new WFSRequest(new ProjectForOGCForTests(), array('request' => 'notGetFeature'), null, new ContextForTests());
+        $wfs = new WFSRequest(new ProjectForOGCForTests(), array('request' => 'notGetFeature'), null);
         $expectedParameters = array(
             'request' => 'notGetFeature',
             'map' => null,
@@ -18,7 +18,7 @@ class WFSRequestTest extends TestCase
         $this->assertEquals($expectedParameters, $parameters);
         $proj = new ProjectForOGCForTests();
         $proj->setRepo(new Lizmap\Project\Repository('test', array(), '', null, new ContextForTests()));
-        $wfs = new WFSRequest($proj, array('request' => 'notGetFeature'), null, new ContextForTests());
+        $wfs = new WFSRequest($proj, array('request' => 'notGetFeature'), null);
         $parameters = $wfs->parameters();
         $this->assertEquals($expectedParameters, $parameters);
     }
@@ -76,10 +76,10 @@ class WFSRequestTest extends TestCase
     {
         $testContext = new ContextForTests();
         $testContext->setResult(array('lizmap.tools.loginFilteredLayers.override' => false));
-        $proj = new ProjectForOGCForTests();
+        $proj = new ProjectForOGCForTests($testContext);
         $proj->loginFilters = $loginFilters;
         $proj->setRepo(new Lizmap\Project\Repository('test', array(), '', null, $testContext));
-        $wfs = new WFSRequest($proj, $params, null, $testContext);
+        $wfs = new WFSRequest($proj, $params, null);
         $parameters = $wfs->parameters();
         $this->assertEquals($expectedParameters, $parameters);
     }

--- a/tests/units/classes/Request/WMTSRequestTest.php
+++ b/tests/units/classes/Request/WMTSRequestTest.php
@@ -11,7 +11,10 @@ class WMTSRequestTest extends TestCase
         $repo = new \Lizmap\Project\Repository('test', array(), '', null, $appContext);
         $project->setRepo($repo);
         $project->setKey('test');
-        $wmtsMock = $this->getMockBuilder(WMTSRequestForTests::class)->setMethods(['serviceException'])->setConstructorArgs(array($project, array(), null, $appContext))->getMock();
+        $wmtsMock = $this->getMockBuilder(WMTSRequestForTests::class)
+                         ->setMethods(['serviceException'])
+                         ->setConstructorArgs(array($project, array(), null))
+                         ->getMock();
         LizmapTilerForTests::$tileCapFail = true;
         $wmtsMock->expects($this->exactly(2))->method('serviceException');
         $wmtsMock->getcapabilitiesForTests();


### PR DESCRIPTION
Requests objects should rely on the same app context of the project object.
It is not consistent to have different appContext objects (and it could
brake some unit tests).

* Funded by 3Liz
