### PR TITLE
Update map.css

### DIFF
--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -480,7 +480,7 @@ SubDock
   background-color:#4A4A4A;
   background-color:rgba(0,0,0,0.7);
   padding:5px;
-  border-left: 1px solid #F0F0F0;
+  border-left: 0px solid #F0F0F0;
 
   flex-grow: 1;
   align-self: flex-end;


### PR DESCRIPTION
to eliminate the white illusory space between the left-dock and bottom-dock

before
![imagem](https://user-images.githubusercontent.com/10053874/139343392-5f93635e-b72e-4a96-a5b7-8bce7b5c8bc0.png)

after
![imagem](https://user-images.githubusercontent.com/10053874/139343527-1fa83e49-8239-4384-bd48-3be0246a6f34.png)
