### PR TITLE
Use Makefile to run test stack

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,56 @@
+#
+# Makefile for running tests
+#
+
+SHELL:=bash
+.ONESHELL:
+.PHONY: env
+
+export LZMBRANCH:=$(shell git rev-parse --abbrev-ref HEAD)
+
+PREFIX:=lizmap-$(LZMBRANCH)-tests
+
+LIZMAP_USER_ID ?= $(shell id -u)
+LIZMAP_GROUP_ID ?= $(shell id -g)
+LZMPOSTGISVERSION ?= 11-2.5
+LZMQGSRVVERSION ?= 3.16
+LZMPGPORT ?= 8132
+LZMQGSRVPORT ?= 8131
+LZMWEBPORT ?= 8130
+LIZMAP_ADMIN_LOGIN ?= admin
+LIZMAP_ADMIN_EMAIL ?= admin@localhost.local
+LIZMAP_ADMIN_DEFAULT_PASSWORD_SOURCE ?= /srv/etc/admin.conf
+
+env:
+	@echo "Creating environment file for docker-compose"
+	@cat <<-EOF > .env
+	LIZMAP_USER_ID=$(LIZMAP_USER_ID)
+	LIZMAP_GROUP_ID=$(LIZMAP_GROUP_ID)
+	LZMPOSTGISVERSION=$(LZMPOSTGISVERSION)
+	LZMQGSRVVERSION=$(LZMQGSRVVERSION)
+	LZMBRANCH=$(LZMBRANCH)
+	LZMPGPORT=$(LZMPGPORT)
+	LZMQGSRVPORT=$(LZMQGSRVPORT)
+	LZMWEBPORT=$(LZMWEBPORT)
+	LIZMAP_ADMIN_LOGIN=$(LIZMAP_ADMIN_LOGIN)
+	LIZMAP_ADMIN_EMAIL=$(LIZMAP_ADMIN_EMAIL)
+	LIZMAP_ADMIN_DEFAULT_PASSWORD_SOURCE=$(LIZMAP_ADMIN_DEFAULT_PASSWORD_SOURCE)
+	COMPOSE_PROJECT_NAME=$(PREFIX)
+	EOF
+
+
+build: 
+	if [ ! -d qgis-server-plugins/lizmap ]; then
+		./add_server_plugins.sh
+	fi
+
+up: env
+	docker-compose up  -V --force-recreate -d
+
+stop:
+	docker-compose stop 
+
+reset:
+	docker-compose down -v --remove-orphans
+	./lizmap-ctl clean
+

--- a/tests/run-docker
+++ b/tests/run-docker
@@ -2,8 +2,6 @@
 
 set -e
 
-export LZMBRANCH=${LZMBRANCH:-$(git rev-parse --abbrev-ref HEAD)}
-
 CMD=$1;
 if [ -z "$CMD" ]; then
     CMD="up"
@@ -12,34 +10,14 @@ else
 fi
 
 if [ "$CMD" == "reset" ]; then
-    # Stop/Remove containers
-    docker-compose -p lizmap-${LZMBRANCH}-tests rm -sf || true
-    # Clean postgres volume
-    docker volume rm "lizmap${LZMBRANCH}_pg_data" || true
-    # Clean up lizmap config
-    ./lizmap-ctl clean
+    # Purge docker conainers/volumes
+    make reset
     exit 0
 elif [ "$CMD" == "build" ]; then
-    if [ ! -d qgis-server-plugins/lizmap ]; then
-        ./add_server_plugins.sh
-    fi
+    make build
 fi
 
-# Create a .env file so that we may use subsequent docker-compose 
-# commands directly
-cat > .env << End-of-env
-LIZMAP_USER_ID=${LIZMAP_USER_ID:-$(id -u)}
-LIZMAP_GROUP_ID=${LIZMAP_GROUP_ID:-$(id -g)}
-LZMPOSTGISVERSION=${LZMPOSTGISVERSION:-11-2.5}
-LZMQGSRVVERSION=${LZMQGSRVVERSION:-3.16}
-LZMBRANCH=${LZMBRANCH}
-LZMPGPORT=${LZMPGPORT:-8132}
-LZMQGSRVPORT=${LZMQGSRVPORT:-8131}
-LZMWEBPORT=${LZMWEBPORT:-8130}
-LIZMAP_ADMIN_LOGIN=${LIZMAP_ADMIN_LOGIN:-admin}
-LIZMAP_ADMIN_EMAIL=${LIZMAP_ADMIN_EMAIL:-admin@localhost.local}
-LIZMAP_ADMIN_DEFAULT_PASSWORD_SOURCE=${LIZMAP_ADMIN_DEFAULT_PASSWORD_SOURCE:-/srv/etc/admin.conf}
-End-of-env
+make up "$@"
 
-docker-compose -p lizmap-${LZMBRANCH}-tests $CMD "$@"
+echo "Use 'docker-compose logs <service>' to display logs"
 


### PR DESCRIPTION
Use makefile for running tests stack:

- Better  separation of commands (separate env from docker commands)
- Easier use of direct docker-compose command (use project name as environment variable in env file)
- Better clean up (use `docker-compose down` for real clean up)
- Keep `run-tests` for compatibility