### PR TITLE
[Bugfix] View Popup class: manually canonize path to authorize symlink

### DIFF
--- a/lizmap/modules/view/classes/popup.class.php
+++ b/lizmap/modules/view/classes/popup.class.php
@@ -100,7 +100,7 @@ class popup
                 $n_abspath = explode('/', $n_abspath);
                 $n_keys = array_keys($n_abspath, '..');
                 foreach ($n_keys as $keypos => $key) {
-                    array_splice($address, $key - ($keypos * 2 + 1), 2);
+                    array_splice($n_abspath, $key - ($keypos * 2 + 1), 2);
                 }
                 $n_abspath = implode('/', $n_abspath);
                 $n_abspath = str_replace('./', '', $n_abspath);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,10 +5,6 @@ parameters:
   level: 0
   ignoreErrors:
     -
-      # This error is normal, the undefined variable is a reference and it's defined in the function it's passed to.
-      message: '#Undefined variable: \$address#'
-      path: lizmap/modules/view/classes/popup.class.php
-    -
       # This error is normal, the undefined variables are dynamically assigned.
       message: '#Undefined variable: #'
       path: lizmap/modules/lizmap/lib/Request/WMTSRequest.php


### PR DESCRIPTION
The PHPStan error was #Undefined variable: `$address` in path /home/runner/work/lizmap-web-client/lizmap-web-client/lizmap/modules/view/classes/popup.class.php

Issue introduced 5 years ago by 18c0db388134bce68ebe9928cd6d95295e9b67d7 to try to fix #556