### PR TITLE
Form filter - Prepare the possibility to select more than one combobox item

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -24,6 +24,7 @@
 - Allow new OpenLayers Map to be used on top of OL2 one
 - Update OpenLayers to 6.6.1
 - Update jQuery-ui to 1.12.1
+- Form filter: prepare the possibility to select more than one items in the comboboxes.
 - Action popup module has been improved with new options: confirm property, display a message if configured, raise a JS event with the returned result.
 
 ### Fixed

--- a/lizmap/www/assets/js/filter.js
+++ b/lizmap/www/assets/js/filter.js
@@ -491,7 +491,11 @@ var lizLayerFilterTool = function () {
                     var clist = [];
                     for (var f_val in filterConfig[field_item.order]['items']) {
                         // Get checked status
-                        var achecked = (selectVal == lizMap.cleanName(f_val));
+                        if (Array.isArray(selectVal)) {
+                            var achecked = selectVal.includes(lizMap.cleanName(f_val));
+                        } else {
+                            var achecked = (selectVal == lizMap.cleanName(f_val));
+                        }
                         if (!achecked) {
                             allchecked = false;
                         } else {
@@ -735,6 +739,7 @@ var lizLayerFilterTool = function () {
             }
 
             function resetFormField(field_item_order) {
+
                 var field_item = filterConfig[field_item_order];
 
                 if (field_item.type == 'date') {
@@ -750,10 +755,18 @@ var lizLayerFilterTool = function () {
                         $('#liz-filter-box-' + lizMap.cleanName(field_item.title) + ' button.liz-filter-field-value.checked').removeClass('checked');
                     }
                     else if (field_item.format == 'select') {
-                        $('#liz-filter-field-' + lizMap.cleanName(field_item.title)).val(
-                            $('#liz-filter-field-' + lizMap.cleanName(field_item.title) + ' option:first').val()
-                        );
-
+                        var selectField = $('#liz-filter-field-' + lizMap.cleanName(field_item.title));
+                        // If the select is multiple && sumoSelect has been used to transform the combobox
+                        if ('sumo' in selectField[0]) {
+                            if (selectField[0].hasAttribute('multiple')) {
+                                selectField[0].sumo.unSelectAll();
+                            } else {
+                                selectField[0].sumo.unSelectItem(selectField.val());
+                            }
+                        } else {
+                            var firstOptionValue = selectField.find('option:first').val();
+                            selectField.val(firstOptionValue);
+                        }
                     }
                 }
                 else if (field_item['type'] == 'text') {


### PR DESCRIPTION
If we want to use tools like [SumoSelect](https://hemantnegi.github.io/jquery.sumoselect/) to better display heavily populated combo-boxes, or allow multiple selection, we need to support multiple `<select>` values.

* Funded by 3liz
