### PR TITLE
[Bugfix] Printing twice the same extent does not provide the same

### DIFF
--- a/lizmap/www/assets/js/map.js
+++ b/lizmap/www/assets/js/map.js
@@ -3819,7 +3819,10 @@ var lizMap = function() {
                 return t.vectorLayer;
           });
       // Print Extent
-      var extent = dragCtrl.layer.features[0].geometry.getBounds();
+      // Clone it to fix transform
+      var extent = new OpenLayers.Bounds(
+          dragCtrl.layer.features[0].geometry.getBounds().toArray()
+      );
 
       // Projection code and reverseAxisOrder
       var projCode = map.projection.getCode();


### PR DESCRIPTION
The extent for printing has to be cloned before transform to do not change the printing geometry.

* Ticket : #2582
* Funded by 3liz
