### PR TITLE
Use Makefile to run test stack

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -39,7 +39,7 @@ env:
 	EOF
 
 
-build: 
+build-plugins: 
 	if [ ! -d qgis-server-plugins/lizmap ]; then
 		./add_server_plugins.sh
 	fi

--- a/tests/run-docker
+++ b/tests/run-docker
@@ -4,20 +4,21 @@ set -e
 
 CMD=$1;
 if [ -z "$CMD" ]; then
-    CMD="up"
+    CMD="up -d"
 else
     shift
 fi
+
+# Re-create environment
+make env
 
 if [ "$CMD" == "reset" ]; then
     # Purge docker conainers/volumes
     make reset
     exit 0
 elif [ "$CMD" == "build" ]; then
-    make build
+    make build-plugins
 fi
 
-make up "$@"
-
-echo "Use 'docker-compose logs <service>' to display logs"
+docker-compose $CMD "$@"  
 


### PR DESCRIPTION
Use makefile for running tests stack:

- Better  separation of commands (separate env from docker commands)
- Easier use of direct docker-compose command (use project name as environment variable in env file)
- Better clean up (use `docker-compose down` for real clean up)
- Keep `run-tests` for compatibility
