### PR TITLE
[BUGIX] Selection & Export - Use the selectiontoken & POST to QGIS Server

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -41,6 +41,9 @@
   the editable features for all the editable layers of the displayed popup items, and not only the first.
   - Lizmap user and groups was not forwarded to the QGIS Server backend. It's now possible to use 
   `@lizmap_user` and `@lizmap_user_groups` in a QGIS Expression in an editing form. 
+- Selection: improve the export tool to allow bigger selections 
+  - use the selection token instead of a list of feature identifiers
+  - internally use POST instead of GET requests to query data from QGIS Server
 - Before the button export to ODS was always visible. The button is now show only if available
 
 ### New JS events

--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -316,6 +316,8 @@ class serviceCtrl extends jController
         }
 
         // Get the selection token
+        // For WMS, create the content for the SELECTION parameter
+        // For WFS, create it for the FEATUREID parameter
         if (isset($params['request'])) {
             $request = strtolower($params['request']);
             if (isset($params['selectiontoken'])
@@ -324,6 +326,7 @@ class serviceCtrl extends jController
                 $tokens = $params['selectiontoken'];
                 $tokens = explode(';', $tokens);
                 $selections = array();
+                $feature_ids = array();
                 foreach ($tokens as $token) {
                     $data = jCache::get($token);
                     if ($data) {
@@ -333,11 +336,21 @@ class serviceCtrl extends jController
                             && count($data->ids) > 0
                         ) {
                             $selections[] = $data->typename.':'.implode(',', $data->ids);
+                            $data_ids = array();
+                            foreach ($data->ids as $id) {
+                                $data_ids[] = $data->typename.'.'.$id;
+                            }
+                            $feature_ids[] = implode(',', $data_ids);
                         }
                     }
                 }
-                if (count($selections) > 0) {
+                // Add SELECTION for WMS
+                if ($request != 'getfeature' && count($selections) > 0) {
                     $this->params['SELECTION'] = implode(';', $selections);
+                }
+                // Add FEATUREID for WFS GetFeature
+                if ($request == 'getfeature' && count($feature_ids) > 0) {
+                    $this->params['FEATUREID'] = implode(',', $feature_ids);
                 }
             }
         }

--- a/lizmap/modules/lizmap/lib/Request/Proxy.php
+++ b/lizmap/modules/lizmap/lib/Request/Proxy.php
@@ -274,6 +274,23 @@ class Proxy
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+
+        // For POST, remove parameters from the URL
+        // and add them to the body of the request
+        // Also change the content type
+        if ($options['method'] === 'post') {
+            if (empty($options['body'])) {
+                $explode_url = explode('?', $url);
+                if (count($explode_url) == 2) {
+                    // Override previous url by removing the parameters after ?
+                    $url = $explode_url[0];
+
+                    // Set the body to use POST instead of GET
+                    $options['body'] = $explode_url[1];
+                    $options['headers']['Content-type'] = 'application/x-www-form-urlencoded';
+                }
+            }
+        }
         curl_setopt($ch, CURLOPT_HTTPHEADER, self::encodeHttpHeaders($options['headers']));
         curl_setopt($ch, CURLOPT_URL, $url);
 
@@ -300,7 +317,9 @@ class Proxy
         }
         if ($options['method'] === 'post') {
             curl_setopt($ch, CURLOPT_POST, 1);
-            curl_setopt($ch, CURLOPT_POSTFIELDS, $options['body']);
+            if (!empty($options['body'])) {
+                curl_setopt($ch, CURLOPT_POSTFIELDS, $options['body']);
+            }
         }
         $data = curl_exec($ch);
         $info = curl_getinfo($ch);

--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -447,7 +447,7 @@ class WMSRequest extends OGCRequest
     {
 
         // Get remote data
-        $response = $this->request();
+        $response = $this->request(true);
 
         return (object) array(
             'code' => $response->code,
@@ -1086,9 +1086,11 @@ class WMSRequest extends OGCRequest
             list($params, $originalParams, $xFactor, $yFactor) = $this->getMetaTileData($params, $metatileSize);
         }
 
-        // Get data from the map server
+        // Get data from the map server: use POST to avoid too long URLS
+        $options = array('method' => 'post');
         list($data, $mime, $code) = Proxy::getRemoteData(
-            Proxy::constructUrl($params, $this->services)
+            Proxy::constructUrl($params, $this->services),
+            $options
         );
 
         \lizmap::logMetric('LIZMAP_PROXY_REQUEST_QGIS_MAP', 'WMS', array(

--- a/lizmap/www/assets/js/map.js
+++ b/lizmap/www/assets/js/map.js
@@ -4797,10 +4797,16 @@ var lizMap = function() {
       if( !selectionLayer )
         selectionLayer = aName;
 
-      var featureid = getVectorLayerSelectionFeatureIdsString( selectionLayer );
-
       // Get WFS url and options
-      var getFeatureUrlData = getVectorLayerWfsUrl( aName, null, featureid, null, restrictToMapExtent );
+      var getFeatureUrlData = getVectorLayerWfsUrl( aName, null, null, null, restrictToMapExtent );
+
+      // If there is a selection, use the selectiontoken,
+      // not a list of features ids to avoid too big urls
+      var config_layer = lizMap.config.layers[selectionLayer];
+      if ('request_params' in config_layer && 'selectiontoken' in config_layer['request_params']) {
+        var selection_token = config_layer['request_params']['selectiontoken'];
+        getFeatureUrlData['options']['SELECTIONTOKEN'] = selection_token;
+      }
 
       // Force download
       getFeatureUrlData['options']['dl'] = 1;


### PR DESCRIPTION
- Selection: improve the export tool to allow bigger selections
  - use the selection token instead of a list of feature identifiers
  - internally use POST instead of GET requests to query data from QGIS Server


* Funded by 3liz & Faunalia
