### PR TITLE
fix atlas to refresh input list

### DIFF
--- a/lizmap/www/assets/js/atlas.js
+++ b/lizmap/www/assets/js/atlas.js
@@ -147,7 +147,7 @@ var lizAtlas = function () {
                 lizMap.getFeatureData(lizAtlasConfig['featureType'], lizAtlasConfig['featureType'] + ':', null, 'geom', false, null, null,
                     function (aName, aFilter, aFeatures, aAliases) {
                         lizAtlasConfig['features'] = aFeatures;
-                        prepareFeatures();
+                        prepareFeatures(lizAtlasConfig);
 
                         var options = '<option value="-1"> --- </option>';
                         var pkey_field = lizAtlasConfig['primaryKey'];


### PR DESCRIPTION
When i update a layer (Create or delete feature) configured as an atlas layer i have an error and the input list does not refresh
![bug-atlas](https://user-images.githubusercontent.com/16720972/143895533-c32944ce-ce2a-4539-bf4d-57da734947a7.png)
After checking the atlas script i found the problem [L150 in atlas.js](https://github.com/3liz/lizmap-web-client/blob/master/lizmap/www/assets/js/atlas.js#L150).
you just have to put the `lizAtlasConfig` variable as a parameter

