### PR TITLE
Change URL ign basemap

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update URL for IGN basemap
+
 ## 3.4.7 - 2021-11-16
 
 ### Fixed

--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -27,6 +27,7 @@
 - Form filter: prepare the possibility to select more than one items in the comboboxes.
 - CSS: make background header easier to override with custom CSS
 - Action popup module has been improved with new options: confirm property, display a message if configured, raise a JS event with the returned result.
+- Update URL for IGN basemap
 
 ### Fixed
 

--- a/lizmap/www/assets/js/map.js
+++ b/lizmap/www/assets/js/map.js
@@ -640,17 +640,13 @@ var lizMap = function() {
         && config.options.bingHybrid == 'True'
         && ('bingKey' in config.options)) ||
        (('ignTerrain' in config.options)
-        && config.options.ignTerrain == 'True'
-        && ('ignKey' in config.options)) ||
+        && config.options.ignTerrain == 'True') ||
        (('ignStreets' in config.options)
-        && config.options.ignStreets == 'True'
-        && ('ignKey' in config.options)) ||
+        && config.options.ignStreets == 'True') ||
        (('ignSatellite' in config.options)
-        && config.options.ignSatellite == 'True'
-        && ('ignKey' in config.options)) ||
+        && config.options.ignSatellite == 'True') ||
        (('ignCadastral' in config.options)
-        && config.options.ignCadastral == 'True'
-        && ('ignKey' in config.options))
+        && config.options.ignCadastral == 'True')
        ) {
          Proj4js.defs['EPSG:3857'] = Proj4js.defs['EPSG:900913'];
 
@@ -695,19 +691,19 @@ var lizMap = function() {
              (('bingStreets' in config.options) && config.options.bingStreets == 'True' && ('bingKey' in config.options)) ||
              (('bingSatellite' in config.options) && config.options.bingSatellite == 'True' && ('bingKey' in config.options)) ||
              (('bingHybrid' in config.options) && config.options.bingHybrid == 'True' && ('bingKey' in config.options)) ||
-             (('ignTerrain' in config.options) && config.options.ignTerrain == 'True' && ('ignKey' in config.options)) ||
-             (('ignStreets' in config.options) && config.options.ignStreets == 'True') && ('ignKey' in config.options)) {
+             (('ignTerrain' in config.options) && config.options.ignTerrain == 'True') ||
+             (('ignStreets' in config.options) && config.options.ignStreets == 'True')) {
            config.options.zoomLevelNumber = 23;
          }
          if ((('googleStreets' in config.options) && config.options.googleStreets == 'True') ||
              (('googleHybrid' in config.options) && config.options.googleHybrid == 'True') ||
-             (('ignCadastral' in config.options) && config.options.ignCadastral == 'True' && ('ignKey' in config.options))) {
+             (('ignCadastral' in config.options) && config.options.ignCadastral == 'True')) {
            config.options.zoomLevelNumber = 20;
          }
          if ( 'googleSatellite' in config.options && config.options.googleSatellite == 'True'){
            config.options.zoomLevelNumber = 21;
          }
-         if ( 'ignSatellite' in config.options && config.options.ignSatellite == 'True' && 'ignKey' in config.options ) {
+         if ( 'ignSatellite' in config.options && config.options.ignSatellite == 'True' ) {
            config.options.zoomLevelNumber = 22;
          }
          config.options.maxScale = 591659030.3224756;
@@ -6402,17 +6398,13 @@ lizMap.events.on({
      && evt.config.options.bingHybrid == 'True'
      && ('bingKey' in evt.config.options)) ||
     (('ignTerrain' in evt.config.options)
-     && evt.config.options.ignTerrain == 'True'
-     && ('ignKey' in evt.config.options)) ||
+     && evt.config.options.ignTerrain == 'True') ||
     (('ignStreets' in evt.config.options)
-     && evt.config.options.ignStreets == 'True'
-     && ('ignKey' in evt.config.options)) ||
+     && evt.config.options.ignStreets == 'True') ||
     (('ignSatellite' in evt.config.options)
-     && evt.config.options.ignSatellite == 'True'
-     && ('ignKey' in evt.config.options)) ||
+     && evt.config.options.ignSatellite == 'True') ||
     (('ignCadastral' in evt.config.options)
-     && evt.config.options.ignCadastral == 'True'
-     && ('ignKey' in evt.config.options))
+     && evt.config.options.ignCadastral == 'True')
     ) {
       //adding baselayers
       var maxExtent = null;
@@ -6739,11 +6731,11 @@ lizMap.events.on({
           evt.map.allOverlays = false;
        }
 
+       var ignAttribution = '<a href="http://www.ign.fr" target="_blank"><img width="25" src="https://wxs.ign.fr/static/logos/IGN/IGN.gif" title="Institut national de l\'information géographique et forestière" alt="IGN"></a>';
+       
        // IGN base layers
         if ('ignKey' in evt.config.options){
           var ignKey = evt.config.options.ignKey;
-          var isFreeIgnKey = ignKey === "choisirgeoportail" || ignKey === "pratique";
-          var ignAttribution = '<a href="http://www.ign.fr" target="_blank"><img width="25" src="https://wxs.ign.fr/static/logos/IGN/IGN.gif" title="Institut national de l\'information géographique et forestière" alt="IGN"></a>';
 
           if (('ignTerrain' in evt.config.options) && evt.config.options.ignTerrain == 'True') {
             var options = {
@@ -6761,7 +6753,7 @@ lizMap.events.on({
               options.numZoomLevels = options.numZoomLevels - lOptions.zoomOffset;
             var ignmap = new OpenLayers.Layer.WMTS({
               name: "ignmap",
-              url: "https://wxs.ign.fr/" + ignKey + "/wmts",
+              url: "https://wxs.ign.fr/" + ignKey + "/geoportail/wmts",
               layer: "GEOGRAPHICALGRIDSYSTEMS.MAPS",
               matrixSet: "PM",
               style: "normal",
@@ -6781,116 +6773,116 @@ lizMap.events.on({
             evt.baselayers.push(ignmap);
             evt.map.allOverlays = false;
           }
-          if (('ignStreets' in evt.config.options) && evt.config.options.ignStreets == 'True') {
-            var options = {
-              zoomOffset: 0,
-              maxResolution: 156543.03390625,
-              numZoomLevels: 18
-            };
-            if (lOptions.zoomOffset != 0) {
-              options.zoomOffset = lOptions.zoomOffset;
-              options.maxResolution = lOptions.maxResolution;
-            }
-            if (lOptions.zoomOffset + lOptions.numZoomLevels <= options.numZoomLevels)
-              options.numZoomLevels = lOptions.numZoomLevels;
-            else
-              options.numZoomLevels = options.numZoomLevels - lOptions.zoomOffset;
-            var ignplan = new OpenLayers.Layer.WMTS({
-              name: "ignplan",
-              url: "https://wxs.ign.fr/" + ignKey + "/wmts",
-              layer: "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2",
-              matrixSet: "PM",
-              style: "normal",
-              format: "image/png",
-              projection: new OpenLayers.Projection("EPSG:3857"),
-              attribution: ignAttribution
-              , numZoomLevels: options.numZoomLevels, maxResolution: options.maxResolution, minZoomLevel: options.zoomOffset
-              , zoomOffset: options.zoomOffset
-
-            });
-            ignplan.maxExtent = maxExtent;
-            var ignplanCfg = {
-              "name": "ignplan"
-              , "title": "IGN Plan"
-              , "type": "baselayer"
-            };
-            evt.config.layers['ignplan'] = ignplanCfg;
-            evt.baselayers.push(ignplan);
-            evt.map.allOverlays = false;
+        }
+        if (('ignStreets' in evt.config.options) && evt.config.options.ignStreets == 'True') {
+          var options = {
+            zoomOffset: 0,
+            maxResolution: 156543.03390625,
+            numZoomLevels: 18
+          };
+          if (lOptions.zoomOffset != 0) {
+            options.zoomOffset = lOptions.zoomOffset;
+            options.maxResolution = lOptions.maxResolution;
           }
-          if (('ignSatellite' in evt.config.options) && evt.config.options.ignSatellite == 'True') {
-            var options = {
-              zoomOffset: 0,
-              maxResolution: 156543.03390625,
-              numZoomLevels: 22
-            };
-            if (lOptions.zoomOffset != 0) {
-              options.zoomOffset = lOptions.zoomOffset;
-              options.maxResolution = lOptions.maxResolution;
-            }
-            if (lOptions.zoomOffset + lOptions.numZoomLevels <= options.numZoomLevels)
-              options.numZoomLevels = lOptions.numZoomLevels;
-            else
-              options.numZoomLevels = options.numZoomLevels - lOptions.zoomOffset;
-            var ignphoto = new OpenLayers.Layer.WMTS({
-              name: "ignphoto",
-              url: "https://wxs.ign.fr/" + ignKey + "/wmts",
-              layer: "ORTHOIMAGERY.ORTHOPHOTOS",
-              matrixSet: "PM",
-              style: "normal",
-              projection: new OpenLayers.Projection("EPSG:3857"),
-              attribution: ignAttribution
-              , numZoomLevels: options.numZoomLevels, maxResolution: options.maxResolution, minZoomLevel: options.zoomOffset
-              , zoomOffset: options.zoomOffset
+          if (lOptions.zoomOffset + lOptions.numZoomLevels <= options.numZoomLevels)
+            options.numZoomLevels = lOptions.numZoomLevels;
+          else
+            options.numZoomLevels = options.numZoomLevels - lOptions.zoomOffset;
+          var ignplan = new OpenLayers.Layer.WMTS({
+            name: "ignplan",
+            url: "https://wxs.ign.fr/cartes/geoportail/wmts",
+            layer: "GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2",
+            matrixSet: "PM",
+            style: "normal",
+            format: "image/png",
+            projection: new OpenLayers.Projection("EPSG:3857"),
+            attribution: ignAttribution
+            , numZoomLevels: options.numZoomLevels, maxResolution: options.maxResolution, minZoomLevel: options.zoomOffset
+            , zoomOffset: options.zoomOffset
 
-            });
-            ignphoto.maxExtent = maxExtent;
-            var ignphotoCfg = {
-              "name": "ignphoto"
-              , "title": "IGN Photos"
-              , "type": "baselayer"
-            };
-            evt.config.layers['ignphoto'] = ignphotoCfg;
-            evt.baselayers.push(ignphoto);
-            evt.map.allOverlays = false;
+          });
+          ignplan.maxExtent = maxExtent;
+          var ignplanCfg = {
+            "name": "ignplan"
+            , "title": "IGN Plan"
+            , "type": "baselayer"
+          };
+          evt.config.layers['ignplan'] = ignplanCfg;
+          evt.baselayers.push(ignplan);
+          evt.map.allOverlays = false;
+        }
+        if (('ignSatellite' in evt.config.options) && evt.config.options.ignSatellite == 'True') {
+          var options = {
+            zoomOffset: 0,
+            maxResolution: 156543.03390625,
+            numZoomLevels: 22
+          };
+          if (lOptions.zoomOffset != 0) {
+            options.zoomOffset = lOptions.zoomOffset;
+            options.maxResolution = lOptions.maxResolution;
           }
-          if (('ignCadastral' in evt.config.options) && evt.config.options.ignCadastral == 'True') {
-            var options = {
-              zoomOffset: 0,
-              maxResolution: 156543.03390625,
-              numZoomLevels: 20
-            };
-            if (lOptions.zoomOffset != 0) {
-              options.zoomOffset = lOptions.zoomOffset;
-              options.maxResolution = lOptions.maxResolution;
-            }
-            if (lOptions.zoomOffset + lOptions.numZoomLevels <= options.numZoomLevels)
-              options.numZoomLevels = lOptions.numZoomLevels;
-            else
-              options.numZoomLevels = options.numZoomLevels - lOptions.zoomOffset;
-            var igncadastral = new OpenLayers.Layer.WMTS({
-              name: "igncadastral",
-              url: "https://wxs.ign.fr/" + ignKey + "/wmts",
-              layer: isFreeIgnKey ? "CADASTRALPARCELS.PARCELLAIRE_EXPRESS" : "CADASTRALPARCELS.PARCELS",
-              matrixSet: "PM",
-              style: isFreeIgnKey ? "PCI vecteur" : "normal",
-              format: "image/png",
-              projection: new OpenLayers.Projection("EPSG:3857"),
-              attribution: ignAttribution
-              , numZoomLevels: options.numZoomLevels, maxResolution: options.maxResolution, minZoomLevel: options.zoomOffset
-              , zoomOffset: options.zoomOffset
+          if (lOptions.zoomOffset + lOptions.numZoomLevels <= options.numZoomLevels)
+            options.numZoomLevels = lOptions.numZoomLevels;
+          else
+            options.numZoomLevels = options.numZoomLevels - lOptions.zoomOffset;
+          var ignphoto = new OpenLayers.Layer.WMTS({
+            name: "ignphoto",
+            url: "https://wxs.ign.fr/ortho/geoportail/wmts",
+            layer: "ORTHOIMAGERY.ORTHOPHOTOS",
+            matrixSet: "PM",
+            style: "normal",
+            projection: new OpenLayers.Projection("EPSG:3857"),
+            attribution: ignAttribution
+            , numZoomLevels: options.numZoomLevels, maxResolution: options.maxResolution, minZoomLevel: options.zoomOffset
+            , zoomOffset: options.zoomOffset
 
-            });
-            igncadastral.maxExtent = maxExtent;
-            var igncadastralCfg = {
-              "name": "igncadastral"
-              , "title": "IGN Cadastre"
-              , "type": "baselayer"
-            };
-            evt.config.layers['igncadastral'] = igncadastralCfg;
-            evt.baselayers.push(igncadastral);
-            evt.map.allOverlays = false;
+          });
+          ignphoto.maxExtent = maxExtent;
+          var ignphotoCfg = {
+            "name": "ignphoto"
+            , "title": "IGN Photos"
+            , "type": "baselayer"
+          };
+          evt.config.layers['ignphoto'] = ignphotoCfg;
+          evt.baselayers.push(ignphoto);
+          evt.map.allOverlays = false;
+        }
+        if (('ignCadastral' in evt.config.options) && evt.config.options.ignCadastral == 'True') {
+          var options = {
+            zoomOffset: 0,
+            maxResolution: 156543.03390625,
+            numZoomLevels: 20
+          };
+          if (lOptions.zoomOffset != 0) {
+            options.zoomOffset = lOptions.zoomOffset;
+            options.maxResolution = lOptions.maxResolution;
           }
+          if (lOptions.zoomOffset + lOptions.numZoomLevels <= options.numZoomLevels)
+            options.numZoomLevels = lOptions.numZoomLevels;
+          else
+            options.numZoomLevels = options.numZoomLevels - lOptions.zoomOffset;
+          var igncadastral = new OpenLayers.Layer.WMTS({
+            name: "igncadastral",
+            url: "https://wxs.ign.fr/parcellaire/geoportail/wmts",
+            layer: "CADASTRALPARCELS.PARCELLAIRE_EXPRESS",
+            matrixSet: "PM",
+            style: "normal",
+            format: "image/png",
+            projection: new OpenLayers.Projection("EPSG:3857"),
+            attribution: ignAttribution
+            , numZoomLevels: options.numZoomLevels, maxResolution: options.maxResolution, minZoomLevel: options.zoomOffset
+            , zoomOffset: options.zoomOffset
+
+          });
+          igncadastral.maxExtent = maxExtent;
+          var igncadastralCfg = {
+            "name": "igncadastral"
+            , "title": "IGN Cadastre"
+            , "type": "baselayer"
+          };
+          evt.config.layers['igncadastral'] = igncadastralCfg;
+          evt.baselayers.push(igncadastral);
+          evt.map.allOverlays = false;
         }
       } catch(e) {
        }

--- a/tests/qgis-projects/tests/base_layers.qgs
+++ b/tests/qgis-projects/tests/base_layers.qgs
@@ -1,0 +1,521 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.16.14-Hannover" saveDateTime="2021-12-03T15:11:35" projectname="" saveUser="user" saveUserFull="User">
+  <homePath path=""/>
+  <title></title>
+  <autotransaction active="0"/>
+  <evaluateDefaultValues active="0"/>
+  <trust active="0"/>
+  <projectCrs>
+    <spatialrefsys>
+      <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["unknown"],AREA["World - 85°S to 85°N"],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+      <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+      <srsid>3857</srsid>
+      <srid>3857</srid>
+      <authid>EPSG:3857</authid>
+      <description>WGS 84 / Pseudo-Mercator</description>
+      <projectionacronym>merc</projectionacronym>
+      <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+      <geographicflag>false</geographicflag>
+    </spatialrefsys>
+  </projectCrs>
+  <layer-tree-group>
+    <customproperties/>
+    <layer-tree-layer providerKey="postgres" checked="Qt::Checked" source="service='lizmapdb' sslmode=disable key='quartier' estimatedmetadata=true srid=4326 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;quartiers&quot; (geom)" legend_exp="" name="quartiers" id="quartiers_c253f702_37b3_42f8_8e81_8458a742ec97" expanded="1" legend_split_behavior="0" patch_size="-1,-1">
+      <customproperties/>
+    </layer-tree-layer>
+    <custom-order enabled="0">
+      <item>quartiers_c253f702_37b3_42f8_8e81_8458a742ec97</item>
+    </custom-order>
+  </layer-tree-group>
+  <snapping-settings enabled="0" intersection-snapping="0" type="1" maxScale="0" mode="2" unit="1" minScale="0" tolerance="12" self-snapping="0" scaleDependencyMode="0">
+    <individual-layer-settings>
+      <layer-setting enabled="0" type="1" maxScale="0" id="quartiers_c253f702_37b3_42f8_8e81_8458a742ec97" units="1" minScale="0" tolerance="12"/>
+    </individual-layer-settings>
+  </snapping-settings>
+  <relations/>
+  <mapcanvas annotationsVisible="1" name="theMapCanvas">
+    <units>meters</units>
+    <extent>
+      <xmin>411663.70288056740537286</xmin>
+      <ymin>5391504.37829577922821045</ymin>
+      <xmax>452642.10332443891093135</xmax>
+      <ymax>5418025.57999029755592346</ymax>
+    </extent>
+    <rotation>0</rotation>
+    <destinationsrs>
+      <spatialrefsys>
+        <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["unknown"],AREA["World - 85°S to 85°N"],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+        <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+        <srsid>3857</srsid>
+        <srid>3857</srid>
+        <authid>EPSG:3857</authid>
+        <description>WGS 84 / Pseudo-Mercator</description>
+        <projectionacronym>merc</projectionacronym>
+        <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+        <geographicflag>false</geographicflag>
+      </spatialrefsys>
+    </destinationsrs>
+    <rendermaptile>0</rendermaptile>
+    <expressionContextScope/>
+  </mapcanvas>
+  <projectModels/>
+  <legend updateDrawingOrder="true">
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" showFeatureCount="0" name="quartiers" open="true">
+      <filegroup open="true" hidden="false">
+        <legendlayerfile layerid="quartiers_c253f702_37b3_42f8_8e81_8458a742ec97" isInOverview="0" visible="1"/>
+      </filegroup>
+    </legendlayer>
+  </legend>
+  <mapViewDocks/>
+  <mapViewDocks3D/>
+  <main-annotation-layer refreshOnNotifyMessage="" autoRefreshEnabled="0" type="annotation" refreshOnNotifyEnabled="0" autoRefreshTime="0">
+    <id>Annotations_23a1f26c_1934_499d_96e5_57b4a0f9a7b8</id>
+    <datasource></datasource>
+    <keywordList>
+      <value></value>
+    </keywordList>
+    <layername>Annotations</layername>
+    <srs>
+      <spatialrefsys>
+        <wkt></wkt>
+        <proj4></proj4>
+        <srsid>0</srsid>
+        <srid>0</srid>
+        <authid></authid>
+        <description></description>
+        <projectionacronym></projectionacronym>
+        <ellipsoidacronym></ellipsoidacronym>
+        <geographicflag>false</geographicflag>
+      </spatialrefsys>
+    </srs>
+    <resourceMetadata>
+      <identifier></identifier>
+      <parentidentifier></parentidentifier>
+      <language></language>
+      <type></type>
+      <title></title>
+      <abstract></abstract>
+      <links/>
+      <fees></fees>
+      <encoding></encoding>
+      <crs>
+        <spatialrefsys>
+          <wkt></wkt>
+          <proj4></proj4>
+          <srsid>0</srsid>
+          <srid>0</srid>
+          <authid></authid>
+          <description></description>
+          <projectionacronym></projectionacronym>
+          <ellipsoidacronym></ellipsoidacronym>
+          <geographicflag>false</geographicflag>
+        </spatialrefsys>
+      </crs>
+      <extent/>
+    </resourceMetadata>
+    <items/>
+    <layerOpacity>1</layerOpacity>
+  </main-annotation-layer>
+  <projectlayers>
+    <maplayer maxScale="0" readOnly="0" simplifyDrawingHints="1" minScale="100000000" type="vector" simplifyLocal="0" simplifyAlgorithm="0" styleCategories="AllStyleCategories" refreshOnNotifyMessage="" hasScaleBasedVisibilityFlag="0" geometry="Polygon" simplifyDrawingTol="1" labelsEnabled="0" wkbType="MultiPolygon" autoRefreshEnabled="0" simplifyMaxScale="1" refreshOnNotifyEnabled="0" autoRefreshTime="0">
+      <extent>
+        <xmin>3.80707036695971013</xmin>
+        <ymin>43.56670409545019851</ymin>
+        <xmax>3.94133068060566982</xmax>
+        <ymax>43.65337122449290064</ymax>
+      </extent>
+      <id>quartiers_c253f702_37b3_42f8_8e81_8458a742ec97</id>
+      <datasource>service='lizmapdb' sslmode=disable key='quartier' estimatedmetadata=true srid=4326 type=MultiPolygon checkPrimaryKeyUnicity='1' table="tests_projects"."quartiers" (geom)</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>quartiers</layername>
+      <srs>
+        <spatialrefsys>
+          <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+          <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+          <srsid>3452</srsid>
+          <srid>4326</srid>
+          <authid>EPSG:4326</authid>
+          <description>WGS 84</description>
+          <projectionacronym>longlat</projectionacronym>
+          <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+          <geographicflag>true</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type>dataset</type>
+        <title></title>
+        <abstract></abstract>
+        <links/>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys>
+            <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+            <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+            <srsid>3452</srsid>
+            <srid>4326</srid>
+            <authid>EPSG:4326</authid>
+            <description>WGS 84</description>
+            <projectionacronym>longlat</projectionacronym>
+            <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+            <geographicflag>true</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent/>
+      </resourceMetadata>
+      <provider encoding="">postgres</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <expressionfields/>
+      <map-layer-style-manager current="default">
+        <map-layer-style name="default"/>
+      </map-layer-style-manager>
+      <auxiliaryLayer/>
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+      </flags>
+      <temporal enabled="0" accumulate="0" durationUnit="min" startExpression="" fixedDuration="0" startField="" endField="" durationField="" endExpression="" mode="0">
+        <fixedRange>
+          <start></start>
+          <end></end>
+        </fixedRange>
+      </temporal>
+      <renderer-v2 enableorderby="0" type="singleSymbol" forceraster="0" symbollevels="0">
+        <symbols>
+          <symbol alpha="1" type="fill" name="0" force_rhr="0" clip_to_extent="1">
+            <layer enabled="1" pass="0" locked="0" class="SimpleFill">
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="color" v="196,60,57,255"/>
+              <prop k="joinstyle" v="bevel"/>
+              <prop k="offset" v="0,0"/>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="outline_color" v="35,35,35,255"/>
+              <prop k="outline_style" v="solid"/>
+              <prop k="outline_width" v="0.26"/>
+              <prop k="outline_width_unit" v="MM"/>
+              <prop k="style" v="solid"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </symbols>
+        <rotation/>
+        <sizescale/>
+      </renderer-v2>
+      <customproperties/>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerOpacity>1</layerOpacity>
+      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+        <activeChecks type="StringList">
+          <Option value="" type="QString"/>
+        </activeChecks>
+        <checkConfiguration/>
+      </geometryOptions>
+      <legend type="default-vector"/>
+      <referencedLayers/>
+      <fieldConfiguration>
+        <field configurationFlags="None" name="quartier">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field configurationFlags="None" name="quartmno">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field configurationFlags="None" name="libquart">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field configurationFlags="None" name="photo">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field configurationFlags="None" name="url">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias field="quartier" name="" index="0"/>
+        <alias field="quartmno" name="" index="1"/>
+        <alias field="libquart" name="" index="2"/>
+        <alias field="photo" name="" index="3"/>
+        <alias field="url" name="" index="4"/>
+      </aliases>
+      <defaults>
+        <default expression="" field="quartier" applyOnUpdate="0"/>
+        <default expression="" field="quartmno" applyOnUpdate="0"/>
+        <default expression="" field="libquart" applyOnUpdate="0"/>
+        <default expression="" field="photo" applyOnUpdate="0"/>
+        <default expression="" field="url" applyOnUpdate="0"/>
+      </defaults>
+      <constraints>
+        <constraint notnull_strength="1" field="quartier" unique_strength="1" exp_strength="0" constraints="3"/>
+        <constraint notnull_strength="0" field="quartmno" unique_strength="0" exp_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" field="libquart" unique_strength="0" exp_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" field="photo" unique_strength="0" exp_strength="0" constraints="0"/>
+        <constraint notnull_strength="0" field="url" unique_strength="0" exp_strength="0" constraints="0"/>
+      </constraints>
+      <constraintExpressions>
+        <constraint field="quartier" desc="" exp=""/>
+        <constraint field="quartmno" desc="" exp=""/>
+        <constraint field="libquart" desc="" exp=""/>
+        <constraint field="photo" desc="" exp=""/>
+        <constraint field="url" desc="" exp=""/>
+      </constraintExpressions>
+      <expressionfields/>
+      <attributeactions>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+      </attributeactions>
+      <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+        <columns/>
+      </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <storedexpressions/>
+      <editform tolerant="1"></editform>
+      <editforminit/>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath></editforminitfilepath>
+      <editforminitcode><![CDATA[]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>generatedlayout</editorlayout>
+      <editable/>
+      <labelOnTop/>
+      <dataDefinedFieldProperties/>
+      <widgets/>
+      <previewExpression></previewExpression>
+      <mapTip></mapTip>
+    </maplayer>
+  </projectlayers>
+  <layerorder>
+    <layer id="quartiers_c253f702_37b3_42f8_8e81_8458a742ec97"/>
+  </layerorder>
+  <properties>
+    <DefaultStyles>
+      <ColorRamp type="QString"></ColorRamp>
+      <Fill type="QString"></Fill>
+      <Line type="QString"></Line>
+      <Marker type="QString"></Marker>
+      <Opacity type="double">1</Opacity>
+      <RandomColors type="bool">true</RandomColors>
+    </DefaultStyles>
+    <Digitizing>
+      <AvoidIntersectionsMode type="int">0</AvoidIntersectionsMode>
+    </Digitizing>
+    <Gui>
+      <CanvasColorBluePart type="int">255</CanvasColorBluePart>
+      <CanvasColorGreenPart type="int">255</CanvasColorGreenPart>
+      <CanvasColorRedPart type="int">255</CanvasColorRedPart>
+      <SelectionColorAlphaPart type="int">255</SelectionColorAlphaPart>
+      <SelectionColorBluePart type="int">0</SelectionColorBluePart>
+      <SelectionColorGreenPart type="int">255</SelectionColorGreenPart>
+      <SelectionColorRedPart type="int">255</SelectionColorRedPart>
+    </Gui>
+    <Legend>
+      <filterByMap type="bool">false</filterByMap>
+    </Legend>
+    <Macros>
+      <pythonCode type="QString"></pythonCode>
+    </Macros>
+    <Measure>
+      <Ellipsoid type="QString">WGS84</Ellipsoid>
+    </Measure>
+    <Measurement>
+      <AreaUnits type="QString">m2</AreaUnits>
+      <DistanceUnits type="QString">meters</DistanceUnits>
+    </Measurement>
+    <PAL>
+      <CandidatesLinePerCM type="double">5</CandidatesLinePerCM>
+      <CandidatesPolygonPerCM type="double">2.5</CandidatesPolygonPerCM>
+      <DrawRectOnly type="bool">false</DrawRectOnly>
+      <DrawUnplaced type="bool">false</DrawUnplaced>
+      <PlacementEngineVersion type="int">1</PlacementEngineVersion>
+      <SearchMethod type="int">0</SearchMethod>
+      <ShowingAllLabels type="bool">false</ShowingAllLabels>
+      <ShowingCandidates type="bool">false</ShowingCandidates>
+      <ShowingPartialsLabels type="bool">true</ShowingPartialsLabels>
+      <TextFormat type="int">0</TextFormat>
+      <UnplacedColor type="QString">255,0,0,255</UnplacedColor>
+    </PAL>
+    <Paths>
+      <Absolute type="bool">false</Absolute>
+    </Paths>
+    <PositionPrecision>
+      <Automatic type="bool">true</Automatic>
+      <DecimalPlaces type="int">2</DecimalPlaces>
+      <DegreeFormat type="QString">MU</DegreeFormat>
+    </PositionPrecision>
+    <SpatialRefSys>
+      <ProjectionsEnabled type="int">1</ProjectionsEnabled>
+    </SpatialRefSys>
+    <Variables>
+      <variableNames type="QStringList">
+        <value>lizmap_user</value>
+        <value>lizmap_user_groups</value>
+      </variableNames>
+      <variableValues type="QStringList">
+        <value></value>
+        <value></value>
+      </variableValues>
+    </Variables>
+    <WCSLayers type="QStringList"/>
+    <WCSUrl type="QString"></WCSUrl>
+    <WFSLayers type="QStringList"/>
+    <WFSTLayers>
+      <Delete type="QStringList"/>
+      <Insert type="QStringList"/>
+      <Update type="QStringList"/>
+    </WFSTLayers>
+    <WFSUrl type="QString"></WFSUrl>
+    <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
+    <WMSAddWktGeometry type="bool">false</WMSAddWktGeometry>
+    <WMSContactMail type="QString"></WMSContactMail>
+    <WMSContactOrganization type="QString"></WMSContactOrganization>
+    <WMSContactPerson type="QString"></WMSContactPerson>
+    <WMSContactPhone type="QString"></WMSContactPhone>
+    <WMSContactPosition type="QString"></WMSContactPosition>
+    <WMSCrsList type="QStringList">
+      <value>EPSG:3857</value>
+    </WMSCrsList>
+    <WMSDefaultMapUnitsPerMm type="double">1</WMSDefaultMapUnitsPerMm>
+    <WMSExtent type="QStringList">
+      <value>423427.48992039589211345</value>
+      <value>5396856.63471086136996746</value>
+      <value>439120.56915665057022125</value>
+      <value>5413731.37831568531692028</value>
+    </WMSExtent>
+    <WMSFees type="QString">conditions unknown</WMSFees>
+    <WMSImageQuality type="int">90</WMSImageQuality>
+    <WMSKeywordList type="QStringList">
+      <value></value>
+    </WMSKeywordList>
+    <WMSMaxAtlasFeatures type="int">1</WMSMaxAtlasFeatures>
+    <WMSOnlineResource type="QString"></WMSOnlineResource>
+    <WMSPrecision type="QString">8</WMSPrecision>
+    <WMSRootName type="QString"></WMSRootName>
+    <WMSSegmentizeFeatureInfoGeometry type="bool">false</WMSSegmentizeFeatureInfoGeometry>
+    <WMSServiceAbstract type="QString"></WMSServiceAbstract>
+    <WMSServiceCapabilities type="bool">true</WMSServiceCapabilities>
+    <WMSServiceTitle type="QString">base_layers</WMSServiceTitle>
+    <WMSTileBuffer type="int">0</WMSTileBuffer>
+    <WMSUrl type="QString"></WMSUrl>
+    <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
+    <WMTSGrids>
+      <CRS type="QStringList"/>
+      <Config type="QStringList"/>
+    </WMTSGrids>
+    <WMTSJpegLayers>
+      <Group type="QStringList"/>
+      <Layer type="QStringList"/>
+      <Project type="bool">false</Project>
+    </WMTSJpegLayers>
+    <WMTSLayers>
+      <Group type="QStringList"/>
+      <Layer type="QStringList"/>
+      <Project type="bool">false</Project>
+    </WMTSLayers>
+    <WMTSMinScale type="int">5000</WMTSMinScale>
+    <WMTSPngLayers>
+      <Group type="QStringList"/>
+      <Layer type="QStringList"/>
+      <Project type="bool">false</Project>
+    </WMTSPngLayers>
+    <WMTSUrl type="QString"></WMTSUrl>
+  </properties>
+  <dataDefinedServerProperties>
+    <Option type="Map">
+      <Option value="" type="QString" name="name"/>
+      <Option name="properties"/>
+      <Option value="collection" type="QString" name="type"/>
+    </Option>
+  </dataDefinedServerProperties>
+  <visibility-presets/>
+  <transformContext/>
+  <projectMetadata>
+    <identifier></identifier>
+    <parentidentifier></parentidentifier>
+    <language></language>
+    <type></type>
+    <title></title>
+    <abstract></abstract>
+    <contact>
+      <name></name>
+      <organization></organization>
+      <position></position>
+      <voice></voice>
+      <fax></fax>
+      <email></email>
+      <role></role>
+    </contact>
+    <links/>
+    <author>nboisteault</author>
+    <creation>2021-12-03T11:41:42</creation>
+  </projectMetadata>
+  <Annotations/>
+  <Layouts/>
+  <Bookmarks/>
+  <ProjectViewSettings UseProjectScales="0">
+    <Scales/>
+    <DefaultViewExtent xmin="408877.57982432888820767" ymin="5391504.37829577922821045" ymax="5418025.57999029755592346" xmax="455428.22638067742809653">
+      <spatialrefsys>
+        <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["unknown"],AREA["World - 85°S to 85°N"],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+        <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+        <srsid>3857</srsid>
+        <srid>3857</srid>
+        <authid>EPSG:3857</authid>
+        <description>WGS 84 / Pseudo-Mercator</description>
+        <projectionacronym>merc</projectionacronym>
+        <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+        <geographicflag>false</geographicflag>
+      </spatialrefsys>
+    </DefaultViewExtent>
+  </ProjectViewSettings>
+  <ProjectTimeSettings timeStep="1" frameRate="1" cumulativeTemporalRange="0" timeStepUnit="h"/>
+  <ProjectDisplaySettings>
+    <BearingFormat id="bearing">
+      <Option type="Map">
+        <Option value="" type="QChar" name="decimal_separator"/>
+        <Option value="6" type="int" name="decimals"/>
+        <Option value="0" type="int" name="direction_format"/>
+        <Option value="0" type="int" name="rounding_type"/>
+        <Option value="false" type="bool" name="show_plus"/>
+        <Option value="true" type="bool" name="show_thousand_separator"/>
+        <Option value="false" type="bool" name="show_trailing_zeros"/>
+        <Option value="" type="QChar" name="thousand_separator"/>
+      </Option>
+    </BearingFormat>
+  </ProjectDisplaySettings>
+</qgis>

--- a/tests/qgis-projects/tests/base_layers.qgs.cfg
+++ b/tests/qgis-projects/tests/base_layers.qgs.cfg
@@ -1,0 +1,109 @@
+{
+    "metadata": {
+        "qgis_desktop_version": 31614,
+        "lizmap_plugin_version": "master",
+        "lizmap_web_client_target_version": 30500,
+        "project_valid": true
+    },
+    "options": {
+        "projection": {
+            "proj4": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs",
+            "ref": "EPSG:3857"
+        },
+        "bbox": [
+            "423427.48992039589211345",
+            "5396856.63471086136996746",
+            "439120.56915665057022125",
+            "5413731.37831568531692028"
+        ],
+        "mapScales": [
+            10000,
+            25000,
+            50000,
+            100000,
+            250000,
+            500000
+        ],
+        "minScale": 10000,
+        "maxScale": 500000,
+        "initialExtent": [
+            423427.4899203959,
+            5396856.634710861,
+            439120.56915665057,
+            5413731.378315685
+        ],
+        "osmMapnik": "True",
+        "osmStamenToner": "True",
+        "ignKey": "xncfzodr1xmo4ou5cf89qlyz",
+        "ignStreets": "True",
+        "ignSatellite": "True",
+        "ignTerrain": "True",
+        "ignCadastral": "True",
+        "popupLocation": "dock",
+        "pointTolerance": 25,
+        "lineTolerance": 10,
+        "polygonTolerance": 5,
+        "tmTimeFrameSize": 10,
+        "tmTimeFrameType": "seconds",
+        "tmAnimationFrameLength": 1000,
+        "emptyBaselayer": "True",
+        "startupBaselayer": "empty",
+        "datavizLocation": "dock",
+        "theme": "light"
+    },
+    "layers": {
+        "quartiers": {
+            "id": "quartiers_c253f702_37b3_42f8_8e81_8458a742ec97",
+            "name": "quartiers",
+            "type": "layer",
+            "geometryType": "polygon",
+            "extent": [
+                3.80707036695971,
+                43.5667040954502,
+                3.94133068060567,
+                43.6533712244929
+            ],
+            "crs": "EPSG:4326",
+            "title": "quartiers",
+            "abstract": "",
+            "link": "",
+            "minScale": 1,
+            "maxScale": 1000000000000,
+            "toggled": "False",
+            "popup": "False",
+            "popupFrame": null,
+            "popupSource": "auto",
+            "popupTemplate": "",
+            "popupMaxFeatures": 10,
+            "popupDisplayChildren": "False",
+            "noLegendImage": "False",
+            "groupAsLayer": "False",
+            "baseLayer": "False",
+            "displayInLegend": "True",
+            "group_visibility": [],
+            "singleTile": "True",
+            "imageFormat": "image/png",
+            "cached": "False",
+            "serverFrame": null,
+            "clientCacheExpiration": 300
+        }
+    },
+    "atlas": {
+        "layers": []
+    },
+    "locateByLayer": {},
+    "attributeLayers": {},
+    "tooltipLayers": {},
+    "editionLayers": {},
+    "loginFilteredLayers": {},
+    "timemanagerLayers": {},
+    "datavizLayers": {},
+    "filter_by_polygon": {
+        "config": {
+            "polygon_layer_id": "quartiers_c253f702_37b3_42f8_8e81_8458a742ec97",
+            "group_field": ""
+        },
+        "layers": []
+    },
+    "formFilterLayers": {}
+}


### PR DESCRIPTION
<!-- Add "fix" in front of "#" if it fixes the ticket or do nothing to only mention it.

This PR will be harvested on changelog.lizmap.com if there is a "changelog" label.
Funded by NAME URL
-->
* Ticket : #2496 
* Tous les fonds de carte IGN proposés via le plugin Lizmap sont utilisables sans clé via les nouvelles URL a l’exception de un.
Il y a le nom de couche `GEOGRAPHICALGRIDSYSTEMS.MAPS` correspondant au fond de cartes `ign-scan` (Scan 25) qui n'est disponible qu'avec une clé à présent.
* Ensuite pour le fond `ign-cadastre` on proposait `CADASTRALPARCELS.PARCELLAIRE_EXPRESS` avec la clé gratuite et `CADASTRALPARCELS.PARCELS` avec une clé non gratuite or maintenant les 2 sont gratuits. Lequel propose-t-on ? ou alors on propose-t-on au utilisateur de choisir ? 
