### PR TITLE
QGIS Vector Layer - New options timeout & setSearchPathFromLayer to set the PostgreSQL connection profile

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -190,11 +190,15 @@ class qgisVectorLayer extends qgisMapLayer
      * getDatasourceConnection() is not useful, as we could need the profile
      * to give to jDao or other components that need a profile, not a connection
      *
+     * @param int  $timeout                default timeout for the connection
+     * @param bool $setSearchPathFromLayer If true, the layer schema is used to set the search_path.
+     *                                     Default to True to keep the same behavior as did the previous version of this method.
+     *
      * @throws jException
      *
      * @return null|string null if there is an issue or no connection parameters
      */
-    public function getDatasourceProfile()
+    public function getDatasourceProfile($timeout = 30, $setSearchPathFromLayer = true)
     {
         if ($this->dbProfile !== null) {
             return $this->dbProfile;
@@ -216,6 +220,7 @@ class qgisVectorLayer extends qgisMapLayer
                 $jdbParams = array(
                     'driver' => 'pgsql',
                     'service' => $dtParams->service,
+                    'timeout' => $timeout,
                 );
                 // Database may be used since dbname
                 // is not mandatory in service file
@@ -230,9 +235,10 @@ class qgisVectorLayer extends qgisMapLayer
                     'database' => $dtParams->dbname,
                     'user' => $dtParams->user,
                     'password' => $dtParams->password,
+                    'timeout' => $timeout,
                 );
             }
-            if (!empty($dtParams->schema)) {
+            if (!empty($dtParams->schema) && $setSearchPathFromLayer) {
                 $jdbParams['search_path'] = '"'.$dtParams->schema.'",public';
             }
         } elseif ($this->provider == 'ogr'


### PR DESCRIPTION
This allows Lizmap Web Client modules to set their connection timeout
and avoid them to share the same PHP PostgreSQL connection.
At present, the connection sharing system is only determined
by the `host, user, service, port, dbname`
not by the `search_path`.

See: https://www.php.net/manual/fr/function.pg-connect.php

In some cases, when a `search_path` is needed, we need to avoid
the modules to reuse the same connection to the database.

* Funded by 3liz
