### PR TITLE
Fix postgresql connection share between modules

### DIFF
--- a/lizmap/modules/lizmap/lib/App/AppContextInterface.php
+++ b/lizmap/modules/lizmap/lib/App/AppContextInterface.php
@@ -168,7 +168,7 @@ interface AppContextInterface
     public function logException($exception, $cat = 'default');
 
     /**
-     * Create a profile to be used with getDbConnection.
+     * Create a profile to be used with jDb or jCache.
      *
      * @param string $category The profile category to create
      * @param string $name     The profile name

--- a/lizmap/modules/lizmap/lib/Request/Proxy.php
+++ b/lizmap/modules/lizmap/lib/Request/Proxy.php
@@ -530,6 +530,19 @@ class Proxy
         $appContext->createVirtualProfile('jcache', $cacheName, $cacheParams);
     }
 
+    /**
+     * Create a profile to cache things related to a project.
+     *
+     * The profile will store content into files, redis or sqlite,
+     * depending on the lizmap configuration
+     *
+     * @param string $repository
+     * @param string $project
+     * @param string $layers
+     * @param string $crs
+     *
+     * @return string the profile name of the cache
+     */
     public static function createVirtualProfile($repository, $project, $layers, $crs)
     {
 

--- a/lizmap/var/config/mainconfig.ini.php
+++ b/lizmap/var/config/mainconfig.ini.php
@@ -316,3 +316,10 @@ useJAuthDbAdminRights=on
 [saml:sp]
 ; list of dao properties that can be used for mapping
 daoPropertiesForMapping="login,email,firstname,lastname,phonenumber"
+
+[pgsqlSchemaTimeout]
+; list of timeout for each schema to be sure we have a different connection
+; for each lizmap modules, to not share the same search_path. See QgisVectorLayer.
+cadastre=31
+adresse=32
+openads=33


### PR DESCRIPTION
The search_path is not used for the connection, so layers
and modules can share the same connection although they want to use
a different search_path. A solution is to set a different timeout for
each different search_path.

* Funded by 3liz
