### PR TITLE
Update IGN URL search Adress

### DIFF
--- a/lizmap/www/assets/js/search.js
+++ b/lizmap/www/assets/js/search.js
@@ -183,11 +183,7 @@ var lizSearch = function() {
                 }
                 break;
             case 'ign':
-                service = 'https://wxs.ign.fr/choisirgeoportail/geoportail/ols?';
-
-                if('ignKey' in lizMap.config.options){
-                    service = 'https://wxs.ign.fr/'+lizMap.config.options.ignKey+'/geoportail/ols?';
-                }
+                service = 'https://wxs.ign.fr/essentiels/geoportail/ols?';
             break;
             case 'google':
                 if ( google && 'maps' in google && 'Geocoder' in google.maps ){


### PR DESCRIPTION
The IGN services URL have been updated. The old ones expire the first february 2022.

* Funded by CD64 Pyrénnées-Atlantiques
