### PR TITLE
[Bugfix] ValueMap widget parsing config

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -11,6 +11,7 @@
 
 - Fix a regression during the loading of embedded projects
 - Fix a regression during the init of relation references into forms
+- Fix a regression in the ValueMap widget config parsing
 - Fix the backup script about third-party modules such as MapBuilder and AltiProfil
 - Update Lizmap locales about missing languages in the package like Romanian and others
 
@@ -57,9 +58,9 @@
   - In case of more than one editable layers, when there is a filter by login (or by polygon) activated,
   some of the popup items could miss the pencil button to open the editing form. Corrected by requesting
   the editable features for all the editable layers of the displayed popup items, and not only the first.
-  - Lizmap user and groups was not forwarded to the QGIS Server backend. It's now possible to use 
-  `@lizmap_user` and `@lizmap_user_groups` in a QGIS Expression in an editing form. 
-- Selection: improve the export tool to allow bigger selections 
+  - Lizmap user and groups was not forwarded to the QGIS Server backend. It's now possible to use
+  `@lizmap_user` and `@lizmap_user_groups` in a QGIS Expression in an editing form.
+- Selection: improve the export tool to allow bigger selections
   - use the selection token instead of a list of feature identifiers
   - internally use POST instead of GET requests to query data from QGIS Server
 - Before the button export to ODS was always visible. The button is now show only if available

--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -1847,23 +1847,29 @@ class QgisProject
             $optionName = (string) $option->attributes()->name;
             $optionType = (string) $option->attributes()->type;
 
+            // Define values extraction type
+            $valuesExtraction = self::MAP_VALUES_AS_VALUES;
+            if ($optionName === 'map') {
+                // If the option is named 'map' the value attributes are keys
+                $valuesExtraction = self::MAP_VALUES_AS_KEYS;
+            } elseif ($optionType === 'StringList') {
+                // If the type is 'StringList' only values are extracted
+                $valuesExtraction = self::MAP_ONLY_VALUES;
+            }
+
             if ($optionType === 'List') {
                 $values = array();
                 foreach ($option->Option as $l) {
                     if ((string) $l->attributes()->type === 'Map') {
-                        $values = array_merge($values, $this->getValuesFromOptions($l, self::MAP_VALUES_AS_KEYS));
+                        $values = array_merge($values, $this->getValuesFromOptions($l, $valuesExtraction));
                     } else {
                         $values[] = (string) $l->attributes()->value;
                     }
                 }
                 $fieldEditOptions[$optionName] = $values;
-            // Option with list of values as Map
-            } elseif ($optionType === 'Map') {
-                $fieldEditOptions[$optionName] = $this->getValuesFromOptions($option);
-
-            // Option with string list of values
-            } elseif ($optionType === 'StringList') {
-                $fieldEditOptions[$optionName] = $this->getValuesFromOptions($option, self::MAP_ONLY_VALUES);
+            // Option with list of values as Map or string list of values
+            } elseif ($optionType === 'Map' || $optionType === 'StringList') {
+                $fieldEditOptions[$optionName] = $this->getValuesFromOptions($option, $valuesExtraction);
             // Simple option
             } else {
                 $fieldEditOptions[$optionName] = (string) $option->attributes()->value;

--- a/tests/units/classes/Project/QgisProjectTest.php
+++ b/tests/units/classes/Project/QgisProjectTest.php
@@ -970,6 +970,45 @@ class QgisProjectTest extends TestCase
         );
         $this->assertEquals($expectedOptions, $options->map);
 
+        $xmlStr = '
+        <maplayer>
+          <fieldConfiguration>
+            <field name="code_for_drill_down_exp">
+              <editWidget type="ValueMap">
+                <config>
+                  <Option type="Map">
+                    <Option type="Map" name="map">
+                      <Option value="A" type="QString" name="Zone A"/>
+                      <Option value="B" type="QString" name="Zone B"/>
+                      <Option value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" type="QString" name="No Zone"/>
+                    </Option>
+                  </Option>
+                </config>
+              </editWidget>
+            </field>
+          </fieldConfiguration>
+        </maplayer>
+        ';
+        $xml = simplexml_load_string($xmlStr);
+
+        $props = $testProj->getFieldConfigurationForTest($xml);
+        $this->assertTrue(is_array($props));
+        $this->assertCount(1, $props);
+        $this->assertTrue(array_key_exists('code_for_drill_down_exp', $props));
+        $prop = $props['code_for_drill_down_exp'];
+
+        $this->assertEquals($prop->getFieldEditType(), 'ValueMap');
+
+        $options = (object) $prop->getEditAttributes();
+        $this->assertTrue(property_exists($options, 'map'));
+        $this->assertCount(3, $options->map);
+        $expectedOptions = array(
+            'A' => 'Zone A',
+            'B' => 'Zone B',
+            '{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}' => 'No Zone',
+        );
+        $this->assertEquals($expectedOptions, $options->map);
+
         // no edit widget type
         $xmlStr = '
         <maplayer>
@@ -1430,7 +1469,7 @@ class QgisProjectTest extends TestCase
                 </config>
               </editWidget>
             </field>
-            
+
             <field configurationFlags="None" name="textorimage_file">
               <editWidget type="ExternalResource">
                 <config>


### PR DESCRIPTION
The refactoring in lizmap project classes introduced a regression in the way to parse the ValueMap widget config.

* Funded by: Valabre