### PR TITLE
Convert QGis XML Option value based on type attribute

### DIFF
--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -1787,12 +1787,15 @@ class QgisProject
         $values = array();
 
         foreach ($optionList->Option as $v) {
+            // converting values based on type
+            $value = $this->convertValueOptions((string) $v->attributes()->value, (string) $v->attributes()->type);
+
             if ($valuesExtraction == self::MAP_ONLY_VALUES) {
-                $values[] = (string) $v->attributes()->value;
+                $values[] = $value;
             } elseif ($valuesExtraction == self::MAP_VALUES_AS_VALUES) {
-                $values[(string) $v->attributes()->name] = (string) $v->attributes()->value;
+                $values[(string) $v->attributes()->name] = $value;
             } else { // self::MAP_VALUES_AS_KEYS
-                $values[(string) $v->attributes()->value] = (string) $v->attributes()->name;
+                $values[$value] = (string) $v->attributes()->name;
             }
         }
 
@@ -1867,7 +1870,7 @@ class QgisProject
                         // numerical values, and this is not what we want.
                         $values += $optionValues;
                     } else {
-                        $values[] = (string) $l->attributes()->value;
+                        $values[] = $this->convertValueOptions((string) $l->attributes()->value, (string) $l->attributes()->type);
                     }
                 }
                 $fieldEditOptions[$optionName] = $values;
@@ -1876,7 +1879,7 @@ class QgisProject
                 $fieldEditOptions[$optionName] = $this->getValuesFromOptions($option, $valuesExtraction);
             // Simple option
             } else {
-                $fieldEditOptions[$optionName] = (string) $option->attributes()->value;
+                $fieldEditOptions[$optionName] = $this->convertValueOptions((string) $option->attributes()->value, (string) $option->attributes()->type);
             }
         }
 
@@ -2021,6 +2024,34 @@ class QgisProject
                 }
             }
         }
+    }
+
+    /**
+     * @param string $value the option value attribute content
+     * @param string $type  the option type attribute content
+     *
+     * @return string
+     */
+    protected function convertValueOptions($value, $type)
+    {
+        switch ($type) {
+            case 'double':
+            case 'float':
+                return (float) $value;
+
+            case 'int':
+            case 'LongLong':
+            case 'ULongLong':
+                return (int) $value;
+
+                break;
+
+            case 'bool':
+                return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+
+        }
+
+        return $value;
     }
 
     /**

--- a/tests/units/classes/Project/QgisProjectTest.php
+++ b/tests/units/classes/Project/QgisProjectTest.php
@@ -1097,6 +1097,20 @@ class QgisProjectTest extends TestCase
         $this->assertEquals($expectedOptions, $options);
 
         $xmlStr = '
+          <Option type="Map">
+            <Option value="0" type="int" name="IsMultiline"/>
+            <Option value="0" type="int" name="UseHtml"/>
+          </Option>
+        ';
+        $xml = simplexml_load_string($xmlStr);
+        $options = $testProj->getFieldConfigurationOptionsForTest($xml);
+        $expectedOptions = array(
+            'IsMultiline' => 0,
+            'UseHtml' => 0,
+        );
+        $this->assertEquals($expectedOptions, $options);
+
+        $xmlStr = '
               <Option type="Map">
                 <Option value="false" type="bool" name="IsMultiline"/>
                 <Option value="false" type="bool" name="UseHtml"/>
@@ -1108,8 +1122,8 @@ class QgisProjectTest extends TestCase
         $this->assertTrue(is_array($options));
         $this->assertCount(2, $options);
         $expectedOptions = array(
-            'IsMultiline' => 'false',
-            'UseHtml' => 'false',
+            'IsMultiline' => false,
+            'UseHtml' => false,
         );
         $this->assertEquals($expectedOptions, $options);
 
@@ -1125,6 +1139,29 @@ class QgisProjectTest extends TestCase
         $this->assertCount(1, $options);
         $expectedOptions = array(
             'Zone A' => 'A',
+        );
+        $this->assertEquals($expectedOptions, $options);
+
+        $xmlStr = '
+          <Option type="Map">
+            <Option name="AllowNull" type="bool" value="true"></Option>
+            <Option name="Max" type="int" value="2147483647"></Option>
+            <Option name="Min" type="int" value="-2147483648"></Option>
+            <Option name="Precision" type="int" value="0"></Option>
+            <Option name="Step" type="int" value="1"></Option>
+            <Option name="Style" type="QString" value="SpinBox"></Option>
+          </Option>
+        ';
+        $xml = simplexml_load_string($xmlStr);
+        $options = $testProj->getValuesFromOptionsForTest($xml);
+        $this->assertTrue(is_array($options));
+        $expectedOptions = array(
+            'AllowNull' => true,
+            'Max' => 2147483647,
+            'Min' => -2147483648,
+            'Precision' => 0,
+            'Step' => 1,
+            'Style' => 'SpinBox',
         );
         $this->assertEquals($expectedOptions, $options);
 


### PR DESCRIPTION
The QGis XML Option contains a type attribute that contains the QVariant type name.

* QgsXmlUtils::writeVariant https://github.com/qgis/QGIS/blob/master/src/core/qgsxmlutils.cpp
* QMetaType::Type https://github.com/qt/qtbase/blob/5.6/src/corelib/kernel/qmetatype.cpp

Funded by 3liz
