### PR TITLE
Fix Remove user private group from request to QGIS Server

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisExpressionUtils.class.php
+++ b/lizmap/modules/lizmap/classes/qgisExpressionUtils.class.php
@@ -353,7 +353,7 @@ class qgisExpressionUtils
         if ($appContext->UserIsConnected()) {
             // Provide user and groups to lizmap plugin access control
             $user = $appContext->getUserSession();
-            $userGroups = $appContext->aclUserGroupsId();
+            $userGroups = $appContext->aclUserPublicGroupsId();
             $loginFilteredOverride = $appContext->aclCheck('lizmap.tools.loginFilteredLayers.override', $project->getRepository()->getKey());
 
             $merged_params = array_merge($params, array(

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -1406,7 +1406,7 @@ class qgisVectorLayer extends qgisMapLayer
             'Lizmap_Edition_Context' => $editing_context,
         );
         if ($is_connected) {
-            $userGroups = $appContext->aclUserGroupsId();
+            $userGroups = $appContext->aclUserPublicGroupsId();
             $loginFilteredOverride = $appContext->aclCheck('lizmap.tools.loginFilteredLayers.override', $repository->getKey());
             $user_and_groups['Lizmap_User'] = $user->login;
             $user_and_groups['Lizmap_User_Groups'] = implode(', ', $userGroups);

--- a/lizmap/modules/lizmap/lib/App/AppContextInterface.php
+++ b/lizmap/modules/lizmap/lib/App/AppContextInterface.php
@@ -65,11 +65,12 @@ interface AppContextInterface
     public function aclUserGroupsId();
 
     /**
-     * Returns the groups ids of an user.
+     * Retrieve the list of group the given user is member of
+     * in the acl system.
      *
-     * @param string $login The login of the user
+     * @param string $login The user's login
      *
-     * @return array an array containing the user's groups ids
+     * @return array list of group id
      */
     public function aclGroupsIdByUser($login);
 

--- a/lizmap/modules/lizmap/lib/App/AppContextInterface.php
+++ b/lizmap/modules/lizmap/lib/App/AppContextInterface.php
@@ -75,6 +75,26 @@ interface AppContextInterface
     public function aclGroupsIdByUser($login);
 
     /**
+     * Retrieve the list of public group the given user is member of
+     * in the acl system.
+     *
+     * @param string $login The user's login
+     *
+     * @return array list of public group id
+     */
+    public function aclUserPublicGroupsId($login = null);
+
+    /**
+     * Get the private group for the current user or for the given login
+     * in the acl system.
+     *
+     * @param string $login The user's login
+     *
+     * @return string the id of the private group
+     */
+    public function aclUserPrivateGroup($login = null);
+
+    /**
      * Retrieve the list of groups properties, the current user is member of,
      * in the acl system.
      *

--- a/lizmap/modules/lizmap/lib/App/JelixContext.php
+++ b/lizmap/modules/lizmap/lib/App/JelixContext.php
@@ -78,6 +78,14 @@ class JelixContext implements AppContextInterface
         return \jAcl2DbUserGroup::getGroupList($login);
     }
 
+    /**
+     * Retrieve the list of group the given user is member of
+     * in the acl system.
+     *
+     * @param string $login The user's login
+     *
+     * @return array list of group id
+     */
     public function aclGroupsIdByUser($login)
     {
         return \jAcl2DbUserGroup::getGroupsIdByUser($login);

--- a/lizmap/modules/lizmap/lib/App/JelixContext.php
+++ b/lizmap/modules/lizmap/lib/App/JelixContext.php
@@ -79,6 +79,48 @@ class JelixContext implements AppContextInterface
     }
 
     /**
+     * Retrieve the list of public group the given user is member of
+     * in the acl system.
+     *
+     * @param string $login The user's login
+     *
+     * @return array list of public group id
+     */
+    public function aclUserPublicGroupsId($login = null)
+    {
+        // Get user groups
+        $userGroups = array();
+        if ($login === '' || $login === null) {
+            $userGroups = $this->aclUserGroupsId();
+        } else {
+            $userGroups = $this->aclGroupsIdByUser($login);
+        }
+
+        // Filter user groups to extract private group
+        $userPublicGroups = array();
+        foreach ($userGroups as $uGroup) {
+            if (substr($uGroup, 0, 7) !== '__priv_') {
+                $userPublicGroups[] = $uGroup;
+            }
+        }
+
+        return $userPublicGroups;
+    }
+
+    /**
+     * Get the private group for the current user or for the given login
+     * in the acl system.
+     *
+     * @param string $login The user's login
+     *
+     * @return string the id of the private group
+     */
+    public function aclUserPrivateGroup($login = null)
+    {
+        return \jAcl2DbUserGroup::getPrivateGroup($login);
+    }
+
+    /**
      * Retrieve the list of group the given user is member of
      * in the acl system.
      *

--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -1105,9 +1105,9 @@ class QgisForm implements QgisFormControlsInterface
                     $data[$user->login] = $user->login;
                     $value = $user->login;
                 } else {
-                    $userGroups = $this->appContext->aclUserGroupsId();
+                    $userGroups = $this->appContext->aclUserPublicGroupsId();
                     foreach ($userGroups as $uGroup) {
-                        if ($uGroup != 'users' and substr($uGroup, 0, 7) != '__priv_') {
+                        if ($uGroup != 'users') {
                             $data[$uGroup] = $uGroup;
                         }
                     }
@@ -1540,7 +1540,7 @@ class QgisForm implements QgisFormControlsInterface
                 if ($type == 'login') {
                     $where = ' "'.$attribute."\" IN ( '".$login."' , 'all' )";
                 } else {
-                    $userGroups = $this->appContext->aclUserGroupsId();
+                    $userGroups = $this->appContext->aclUserPublicGroupsId();
                     // Set XML Filter if getFeature request
                     $flatGroups = implode("' , '", $userGroups);
                     $where = ' "'.$attribute."\" IN ( '".$flatGroups."' , 'all' )";

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -1071,7 +1071,7 @@ class Project
                 ) {
                     $filter = "\"{$attribute}\" IN ( '".$login."' , 'all' )";
                 } else {
-                    $userGroups = $this->appContext->aclUserGroupsId();
+                    $userGroups = $this->appContext->aclUserPublicGroupsId();
                     $flatGroups = implode("' , '", $userGroups);
                     $filter = "\"{$attribute}\" IN ( '".$flatGroups."' , 'all' )";
                 }

--- a/lizmap/modules/lizmap/lib/Request/OGCRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/OGCRequest.php
@@ -121,9 +121,9 @@ abstract class OGCRequest
             ));
         }
 
-        // Provide user and groups to lizmap plugin access control
+        // Provide user and groups to lizmap plugin access control without private group
         $user = $appContext->getUserSession();
-        $userGroups = $appContext->aclUserGroupsId();
+        $userGroups = $appContext->aclUserPublicGroupsId();
         $loginFilteredOverride = $appContext->aclCheck('lizmap.tools.loginFilteredLayers.override', $this->repository->getKey());
 
         return array_merge($this->params, array(

--- a/lizmap/modules/lizmap/lib/Request/Proxy.php
+++ b/lizmap/modules/lizmap/lib/Request/Proxy.php
@@ -458,7 +458,7 @@ class Proxy
 
         // Provide user and groups to lizmap plugin access control
         $user = $appContext->getUserSession();
-        $userGroups = $appContext->aclUserGroupsId();
+        $userGroups = $appContext->aclUserPublicGroupsId();
 
         return array(
             'X-Lizmap-User' => $user->login,

--- a/tests/units/testslib/ContextForTests.php
+++ b/tests/units/testslib/ContextForTests.php
@@ -50,7 +50,37 @@ class ContextForTests implements AppContextInterface
     public function aclGroupsIdByUser($login)
     {
     }
-    
+
+    public function aclUserPublicGroupsId($login = null)
+    {
+        $userGroups = $this->aclUserGroupsId();
+        $privateIndex = null;
+        foreach ($userGroups as $idx => $uGroup) {
+            if (substr($uGroup, 0, 7) == '__priv_') {
+                $privateIndex = $idx;
+
+                break;
+            }
+        }
+        if ($privateIndex !== null) {
+            return array_splice($userGroups, $privateIndex, 1);
+        }
+
+        return $userGroups;
+    }
+
+    public function aclUserPrivateGroup($login = null)
+    {
+        $userGroups = $this->aclUserGroupsId();
+        foreach($userGroups as $uGroup) {
+            if (substr($uGroup, 0, 7) == '__priv_') {
+                return $uGroup;
+            }
+        }
+
+        return null;
+    }
+
     public function aclUserGroupsInfo()
     {
     }
@@ -127,7 +157,7 @@ class ContextForTests implements AppContextInterface
         }
         unset($this->cache[$profile]);
     }
-    
+
     public function logMessage($message, $cat = 'default')
     {
     }


### PR DESCRIPTION
Lizmap provides user login and groups to QGIS Server through headers or parameters. The user private group was in the user group list.