### PR TITLE
Add a revision parameter on assets url for cache

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmap.class.php
+++ b/lizmap/modules/lizmap/classes/lizmap.class.php
@@ -38,17 +38,17 @@ class lizmap
     /**
      * @var lizmapServices The lizmapServices instance for the singleton
      */
-    protected static $lizmapServicesInstance = null;
+    protected static $lizmapServicesInstance;
 
     /**
      * @var lizmapLogConfig The lizmapLogConfig instance for the singleton
      */
-    protected static $lizmapLogConfigInstance = null;
+    protected static $lizmapLogConfigInstance;
 
     /**
      * @var lizmapJelixContext The jelixContext instance for the singleton
      */
-    protected static $appContext = null;
+    protected static $appContext;
 
     /**
      * this is a static class, so private constructor.

--- a/lizmap/modules/lizmap/lib/Request/Proxy.php
+++ b/lizmap/modules/lizmap/lib/Request/Proxy.php
@@ -23,9 +23,9 @@ class Proxy
      */
     protected static $_profiles = array();
 
-    protected static $services = null;
+    protected static $services;
 
-    protected static $appContext = null;
+    protected static $appContext;
 
     /**
      * Sets the services property that contains lizmap Services.

--- a/lizmap/plugins/configcompiler/lizmapconfig/lizmapconfig.configcompiler.php
+++ b/lizmap/plugins/configcompiler/lizmapconfig/lizmapconfig.configcompiler.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Plugin for the jelix configuration compiler.
+ *
+ * @author    3liz
+ * @copyright 2022 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+/**
+ * This object is called each time Jelix should generate the configuration cache into the
+ * temp/ directory.
+ *
+ * Each time Lizmap is upgraded, files of temp directory should be deleted, so this is
+ * the opportunity to generate a new assets revision number, so browsers will receive
+ * new urls for CSS and JS files. (see lizmap/responses/AbstractLizmapHtmlResponse.php)
+ */
+class lizmapconfigConfigCompilerPlugin implements \jelix\core\ConfigCompilerPluginInterface
+{
+    public function getPriority()
+    {
+        return 20;
+    }
+
+    public function atStart($config)
+    {
+        if (isset($config->lizmap['assetsRevision'])) {
+            $revision = $config->lizmap['assetsRevision'];
+            if ($revision == 'autoconfig') {
+                $revision = date('ymdHis');
+            }
+        } else {
+            $revision = date('ymdHis');
+            jApp::config()->urlengine['assetsRevision'] = $revision;
+        }
+
+        if ($revision != '') {
+            $config->urlengine['assetsRevQueryUrl'] = '_r='.$revision;
+        } else {
+            $config->urlengine['assetsRevQueryUrl'] = '';
+        }
+    }
+
+    public function onModule($config, $moduleName, $modulePath, $xml)
+    {
+    }
+
+    public function atEnd($config)
+    {
+    }
+}

--- a/lizmap/responses/AbstractLizmapHtmlResponse.php
+++ b/lizmap/responses/AbstractLizmapHtmlResponse.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Abstract class for our custom HTML response objects.
+ *
+ * @author    3liz
+ * @copyright 2022 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+require_once JELIX_LIB_CORE_PATH.'response/jResponseHtml.class.php';
+
+/**
+ * One of the goal of this class is to redefine methods manipulating
+ * JS and CSS links, to add a revision number to the url of this assets,
+ * in order to force browsers to reload assets when the revision number
+ * has changed.
+ * See plugins/configcompiler/lizmapconfig.configcompiler.php.
+ */
+class AbstractLizmapHtmlResponse extends jResponseHtml
+{
+    /**
+     * Append the revision parameter to the given url string.
+     *
+     * @param string $url
+     *
+     * @return string
+     */
+    public function appendRevisionToUrl($url)
+    {
+        $revisionParam = jApp::config()->urlengine['assetsRevQueryUrl'];
+        if ($revisionParam != '') {
+            $url .= (strpos($url, '?') === false) ? '?' : '&';
+            $url .= $revisionParam;
+        }
+
+        return $url;
+    }
+
+    /**
+     * Add the revision parameter to the given list of query parameters.
+     *
+     * @param array $parameters list of query parameters
+     */
+    public function appendRevisionToQueryParameters(&$parameters)
+    {
+        $revision = jApp::config()->urlengine['assetsRevision'];
+        if ($revision != '') {
+            $parameters['_r'] = $revision;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addJSLink($src, $params = array(), $forIE = false)
+    {
+        if (isset($this->_JSLink[$src])) {
+            // if the resource has already been added without the revision let's remove it
+            unset($this->_JSLink[$src]);
+        }
+        $src = $this->appendRevisionToUrl($src);
+        parent::addJSLink($src, $params, $forIE);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addJSLinkModule($module, $src, $params = array(), $forIE = false)
+    {
+        $jurlParams = array('targetmodule' => $module, 'file' => $src);
+        $this->appendRevisionToQueryParameters($jurlParams);
+        $url = jUrl::get('jelix~www:getfile', $jurlParams);
+        parent::addJSLink($url, $params, $forIE);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addCSSLink($src, $params = array(), $forIE = false)
+    {
+        if (isset($this->_CSSLink[$src])) {
+            // if the resource has already been added without the revision let's remove it
+            unset($this->_CSSLink[$src]);
+        }
+        $src = $this->appendRevisionToUrl($src);
+        parent::addCSSLink($src, $params, $forIE);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addCSSLinkModule($module, $src, $params = array(), $forIE = false)
+    {
+        $jurlParams = array('targetmodule' => $module, 'file' => $src);
+        $this->appendRevisionToQueryParameters($jurlParams);
+        $src = jUrl::get('jelix~www:getfile', $jurlParams);
+        parent::addCSSLink($src, $params, $forIE);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addCSSThemeLinkModule($module, $src, $params = array(), $forIE = false)
+    {
+        $file = 'themes/'.jApp::config()->theme.'/'.$src;
+        $jurlParams = array('targetmodule' => $module, 'file' => $file);
+        $this->appendRevisionToQueryParameters($jurlParams);
+        $url = jUrl::get('jelix~www:getfile', $jurlParams);
+        parent::addCSSLink($url, $params, $forIE);
+    }
+}

--- a/lizmap/responses/adminHtmlResponse.class.php
+++ b/lizmap/responses/adminHtmlResponse.class.php
@@ -3,15 +3,15 @@
  * HTML Jelix response for full screen map.
  *
  * @author    3liz
- * @copyright 2011 3liz
+ * @copyright 2011-2022 3liz
  *
  * @see      http://3liz.com
  *
  * @license Mozilla Public License : http://www.mozilla.org/MPL/
  */
-require_once JELIX_LIB_CORE_PATH.'response/jResponseHtml.class.php';
+require_once __DIR__.'/AbstractLizmapHtmlResponse.php';
 
-class adminHtmlResponse extends jResponseHtml
+class adminHtmlResponse extends AbstractLizmapHtmlResponse
 {
     public $bodyTpl = 'master_admin~main';
 

--- a/lizmap/responses/adminLoginHtmlResponse.class.php
+++ b/lizmap/responses/adminLoginHtmlResponse.class.php
@@ -3,15 +3,15 @@
  * HTML Jelix response for full screen map.
  *
  * @author    3liz
- * @copyright 2011 3liz
+ * @copyright 2011-2022 3liz
  *
  * @see      http://3liz.com
  *
  * @license Mozilla Public License : http://www.mozilla.org/MPL/
  */
-require_once JELIX_LIB_CORE_PATH.'response/jResponseHtml.class.php';
+require_once __DIR__.'/AbstractLizmapHtmlResponse.php';
 
-class adminLoginHtmlResponse extends jResponseHtml
+class adminLoginHtmlResponse extends AbstractLizmapHtmlResponse
 {
     public function __construct()
     {

--- a/lizmap/responses/myHtmlMapResponse.class.php
+++ b/lizmap/responses/myHtmlMapResponse.class.php
@@ -3,15 +3,15 @@
  * HTML Jelix response for full screen map.
  *
  * @author    3liz
- * @copyright 2011 3liz
+ * @copyright 2011-2022 3liz
  *
  * @see      http://3liz.com
  *
  * @license Mozilla Public License : http://www.mozilla.org/MPL/
  */
-require_once JELIX_LIB_CORE_PATH.'response/jResponseHtml.class.php';
+require_once __DIR__.'/AbstractLizmapHtmlResponse.php';
 
-class myHtmlMapResponse extends jResponseHtml
+class myHtmlMapResponse extends AbstractLizmapHtmlResponse
 {
     public $bodyTpl = 'view~map';
 

--- a/lizmap/responses/myHtmlResponse.class.php
+++ b/lizmap/responses/myHtmlResponse.class.php
@@ -3,15 +3,15 @@
  * HTML Jelix response for full screen map.
  *
  * @author    3liz
- * @copyright 2011 3liz
+ * @copyright 2011-2022 3liz
  *
  * @see      http://3liz.com
  *
  * @license Mozilla Public License : http://www.mozilla.org/MPL/
  */
-require_once JELIX_LIB_CORE_PATH.'response/jResponseHtml.class.php';
+require_once __DIR__.'/AbstractLizmapHtmlResponse.php';
 
-class myHtmlResponse extends jResponseHtml
+class myHtmlResponse extends AbstractLizmapHtmlResponse
 {
     public $bodyTpl = 'view~main';
 

--- a/lizmap/responses/simpleHtmlResponse.class.php
+++ b/lizmap/responses/simpleHtmlResponse.class.php
@@ -3,15 +3,15 @@
  * HTML Jelix response for full screen map.
  *
  * @author    3liz
- * @copyright 2011 3liz
+ * @copyright 2011-2022 3liz
  *
  * @see      http://3liz.com
  *
  * @license Mozilla Public License : http://www.mozilla.org/MPL/
  */
-require_once JELIX_LIB_CORE_PATH.'response/jResponseHtml.class.php';
+require_once __DIR__.'/AbstractLizmapHtmlResponse.php';
 
-class simpleHtmlResponse extends jResponseHtml
+class simpleHtmlResponse extends AbstractLizmapHtmlResponse
 {
     public $bodyTpl = 'view~simplepage';
 

--- a/lizmap/var/config/mainconfig.ini.php
+++ b/lizmap/var/config/mainconfig.ini.php
@@ -323,3 +323,12 @@ daoPropertiesForMapping="login,email,firstname,lastname,phonenumber"
 cadastre=31
 adresse=32
 openads=33
+
+
+[lizmap]
+; this the revision number to add to url of assets. If empty, no revision will be added.
+; If "autoconfig", the revision number will be generated automatically each time
+; the configuration will be compiled. Else a value can be given directly into the
+; configuration, but it is the responsibility to the developer or the administrator
+; to indicate a new one each time the application is deployed for example.
+assetsRevision = autoconfig


### PR DESCRIPTION
It allows to invalidate the cache in browser of CSS and JS,
each time the temp directory is clean, so each time Lizmap
is upgraded.

* Funded by 3liz
