### PR TITLE
Media - Fix the mime type for SVG files: should be image/svg+xml

### DIFF
--- a/lizmap/modules/view/controllers/media.classic.php
+++ b/lizmap/modules/view/controllers/media.classic.php
@@ -177,6 +177,7 @@ class mediaCtrl extends jController
         $mime = jFile::getMimeType($abspath);
         if ($mime == 'text/plain' || $mime == ''
             || $mime == 'application/octet-stream'
+            || in_array(strtolower($path_parts['extension']), array('svg', 'svgz'))
             || ($mime == 'text/html'
                 && !in_array($path_parts['extension'], array('html', 'htm')))
         ) {


### PR DESCRIPTION
We need to ensure the SVG files are sent with the correct mime type `image/svg+xml`

* Funded by Valabre
