### PR TITLE
GetprojectConfig as application/json instead of plain/text

### DIFF
--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -651,7 +651,7 @@ class serviceCtrl extends jController
      * @urlparam string $repository Lizmap Repository
      * @urlparam string $project Name of the project
      *
-     * @return jResponseText JSON configuration file for the specified project
+     * @return jResponseJson JSON configuration file for the specified project
      */
     public function getProjectConfig()
     {
@@ -661,8 +661,8 @@ class serviceCtrl extends jController
             return $this->serviceException();
         }
 
-        $rep = $this->getResponse('text');
-        $rep->content = $this->project->getUpdatedConfig();
+        $rep = $this->getResponse('json');
+        $rep->data = $this->project->getUpdatedConfig();
 
         return $rep;
     }

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -1478,7 +1478,7 @@ class Project
     }
 
     /**
-     * @return false|string the JSON object corresponding to the configuration
+     * @return object the JSON object corresponding to the configuration
      */
     public function getUpdatedConfig()
     {
@@ -1729,7 +1729,7 @@ class Project
             unset($configJson->layers->{$key});
         }
 
-        return json_encode($configJson);
+        return $configJson;
     }
 
     /**


### PR DESCRIPTION
The GetProjectConfig was send as plain/text instead of application/json.

This commit fixes it.

* Funded by 3Liz
