### PR TITLE
[Bugfix] For Value Relation, Empty value is added for required fields

### DIFF
--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -1242,9 +1242,13 @@ class QgisForm implements QgisFormControlsInterface
             $formControl->ctrl->setAttribute('class', 'combobox');
         }
 
-        // Add empty value if the add null value is checked
-        // Jelix does not do it, but we think it is better this way to avoid unwanted set values
-        $dataSource = new QgisFormValueRelationDynamicDatasource($formControl->ref, $formControl->valueRelationData['allowNull']);
+        // Add empty value if the add null value is checked or form is required
+        // Jelix does not do it for required, but we think it is better this way to avoid unwanted set values
+        $emptyValue = (
+            ($formControl->ctrl->required && !$formControl->valueRelationData['allowMulti'])
+            || $formControl->valueRelationData['allowNull']
+        );
+        $dataSource = new QgisFormValueRelationDynamicDatasource($formControl->ref, $emptyValue);
 
         // criteriaFrom based on current_value in filterExpression
         if (array_key_exists('filterExpression', $formControl->valueRelationData)

--- a/lizmap/modules/lizmap/lib/Form/QgisFormValueRelationDynamicDatasource.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisFormValueRelationDynamicDatasource.php
@@ -40,6 +40,7 @@ class QgisFormValueRelationDynamicDatasource extends \jFormsDynamicDatasource
                 // build feature's form
                 $geom = null;
                 $values = array();
+                // check criteria controls
                 $criteriaControls = $this->getCriteriaControls();
                 if ($criteriaControls !== null && is_array($criteriaControls)) {
                     foreach ($criteriaControls as $ref) {
@@ -105,12 +106,12 @@ class QgisFormValueRelationDynamicDatasource extends \jFormsDynamicDatasource
                         }
                     }
                 }
+            }
 
-                // Add default empty value for required fields
-                // Jelix does not do it, but we think it is better this way to avoid unwanted set values
-                if ($this->emptyValue) {
-                    $result[''] = '';
-                }
+            // Add default empty value for required fields
+            // Jelix does not do it, but we think it is better this way to avoid unwanted set values
+            if ($this->emptyValue) {
+                $result[''] = '';
             }
 
             // orderByValue

--- a/lizmap/www/assets/jelix/js/jforms_jquery.js
+++ b/lizmap/www/assets/jelix/js/jforms_jquery.js
@@ -418,6 +418,8 @@ jFormsJQForm.prototype={
                     if(emptyitem)
                         select.append(emptyitem);
                     jQuery.each(data, function(i, item){
+                        if (emptyitem && item.value == '')
+                            return; // do not add empty item if it already exists.
                         if(typeof item.items == 'object'){
                             select.append('<optgroup label="'+item.label+'"/>');
                             var optgroup = select.children('optgroup[label="'+item.label+'"]').eq(0);

--- a/tests/end2end/cypress/integration/form_advanced-ghaction.js
+++ b/tests/end2end/cypress/integration/form_advanced-ghaction.js
@@ -56,8 +56,9 @@ describe('Advanced form', function () {
 
     it('should change selected quartier and sousquartier based on drawn point', function () {
 
-        cy.get('#jforms_view_edition_quartier option').should('have.length', 1)
-        cy.get('#jforms_view_edition_quartier option').should('have.text', 'HOPITAUX-FACULTES')
+        cy.get('#jforms_view_edition_quartier option').should('have.length', 2)
+        cy.get('#jforms_view_edition_quartier option').first().should('have.text', '')
+        cy.get('#jforms_view_edition_quartier option').last().should('have.text', 'HOPITAUX-FACULTES')
 
         // Cancel and open form
         cy.on('window:confirm', () => true);
@@ -67,9 +68,11 @@ describe('Advanced form', function () {
 
         // Assert quartier value is good for another drawn point
         cy.get('#map').click(600, 350)
-        cy.get('#jforms_view_edition_quartier option').should('have.text', 'MONTPELLIER CENTRE')
+        cy.get('#jforms_view_edition_quartier option').should('have.length', 2)
+        cy.get('#jforms_view_edition_quartier option').last().should('have.text', 'MONTPELLIER CENTRE')
+        cy.get('#jforms_view_edition_quartier').select('MC')
 
-        // Assert 11 options are proposed for sousquartier 
+        // Assert 11 options are proposed for sousquartier
         cy.get('#jforms_view_edition_sousquartier option').should('have.length', 11)
 
         // nboisteault : I tried to drag and drop the point but did not achieve to have this behavior

--- a/tests/qgis-projects/tests/form_advanced.qgs
+++ b/tests/qgis-projects/tests/form_advanced.qgs
@@ -416,7 +416,7 @@
         <constraint constraints="3" exp_strength="0" field="id" notnull_strength="1" unique_strength="1"></constraint>
         <constraint constraints="0" exp_strength="0" field="has_photo" notnull_strength="0" unique_strength="0"></constraint>
         <constraint constraints="4" exp_strength="1" field="website" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="1" exp_strength="0" field="quartier" notnull_strength="1" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="quartier" notnull_strength="0" unique_strength="0"></constraint>
         <constraint constraints="0" exp_strength="0" field="sousquartier" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>


### PR DESCRIPTION
Lizmap added an empty value to the value relation list if the field is required. This has been removed form QgisFormValueRelationDynamicDatasource.

* Funded by 3liz
