### PR TITLE
UX - Review the error message about the HTTP code from QGIS Server

### DIFF
--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -255,5 +255,4 @@ Please upgrade QGIS Server to minimum 3.10 and install or upgrade the Lizmap plu
 minimum 3.7.0 by reading the documentation about the environment \
 variable https://docs.lizmap.com/current/en/install/pre_requirements.html#lizmap-server-plugin
 server.information.qgis.error.fetching.information.detail.NO_ACCESS=You don't have access to information about QGIS Server
-server.information.qgis.error.fetching.information.detail.BAD_DATA=The Lizmap plugin API returns bad data. Please check your QGIS Server.
 server.information.qgis.error.fetching.information.detail.HTTP_ERROR=QGIS Server returns an HTTP error about the Lizmap plugin:

--- a/lizmap/modules/admin/templates/server_information.tpl
+++ b/lizmap/modules/admin/templates/server_information.tpl
@@ -31,17 +31,17 @@
 
     <p>
         <b>{@admin.server.information.qgis.error.fetching.information@}</b><br/>
-        {if in_array($data['qgis_server_info']['error'], array('NO_ACCESS', 'BAD_DATA'))}
-            {assign $errorcode=$data['qgis_server_info']['error']}
-            <i>{@admin.server.information.qgis.error.fetching.information.detail.$errorcode@}</i>
-        {elseif $data['qgis_server_info']['error'] == 'HTTP_ERROR'}
-            {if $data['qgis_server_info']['error_http_code'] != '404'}
-                <i>{@admin.server.information.qgis.error.fetching.information.detail.HTTP_ERROR@} {$data['qgis_server_info']['error_http_code']}</i><br>
-            {else}
-            <i>{@admin.server.information.qgis.error.fetching.information.detail@}</i>
-            {/if}
+        {if $data['qgis_server_info']['error'] == 'NO_ACCESS'}
+            <i>{@admin.server.information.qgis.error.fetching.information.detail.NO_ACCESS@}</i><br>
         {else}
-            <i>{@admin.server.information.qgis.error.fetching.information.detail@}</i>
+            <i>{@admin.server.information.qgis.error.fetching.information.detail@}</i><br>
+            {if $data['qgis_server_info']['error_http_code'] == '200'}
+                {* QGIS Server might return a 200, it's confusing for users. Ticket #2755 *}
+                {assign $errorcode='Unknown'}
+            {else}
+                {assign $errorcode=$data['qgis_server_info']['error_http_code']}
+            {/if}
+            <i>{@admin.server.information.qgis.error.fetching.information.detail.HTTP_ERROR@} {$errorcode}</i><br>
         {/if}
     </p>
 


### PR DESCRIPTION
<!-- Add "fix" in front of "#" if it fixes the ticket or do nothing to only mention it.

This PR will be harvested on changelog.lizmap.com if there is a "changelog" label.
Funded by NAME URL
-->
* Ticket : fix #2755
* Funded by 3Liz

UX - Review the error message about the HTTP code from QGIS Server

Before, we could have a 200 HTTP from QGIS Server, according to screenshots in #2755 which is misleading for users.