### PR TITLE
Fix: Extract Version from OGC XML Request

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/Proxy.php
+++ b/lizmap/modules/lizmap/lib/Request/Proxy.php
@@ -86,6 +86,7 @@ class Proxy
     {
         $service = null;
         $request = null;
+        $version = null;
 
         // Check request XML
         if ($requestXml && substr(trim($requestXml), 0, 1) == '<') {
@@ -108,6 +109,9 @@ class Proxy
                     // OGC service has to be upper case for QGIS Server
                     $service = strtoupper($xml['service']);
                 }
+                if (property_exists($xml->attributes(), 'version')) {
+                    $version = $xml['version'];
+                }
             }
         }
 
@@ -126,6 +130,10 @@ class Proxy
         $params['service'] = $service;
         if ($request !== null) {
             $params['request'] = $request;
+        }
+        // force version from XML in parameters
+        if ($version !== null) {
+            $params['version'] = $version;
         }
         if (in_array($service, array('WMS', 'WMTS', 'WFS'))) {
             $service = '\Lizmap\Request\\'.$service.'Request';


### PR DESCRIPTION
For OGC WXS, the version parameter is mandatory except for GetCapabilities request.
For OGC WXS, the request can be done with an XML Request. The root document contains a service attribute and can contain a version attribute.
The version has to be extracted from XML request to be checked before request processing.

* Linked to https://github.com/3liz/lizmap-web-client/pull/2769
* Funded by 3Liz
