### PR TITLE
Fix: Use cache for QGIS Server plugins data

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisServer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisServer.class.php
@@ -30,6 +30,13 @@ class qgisServer
 
     public function getPlugins($project)
     {
+        $key = 'qgis/server/plugins';
+        $key = jCache::normalizeKey($key);
+        $plugins = jCache::get($key);
+        if ($plugins !== false && $plugins !== null) {
+            return $plugins;
+        }
+
         $plugins = array();
 
         // Check Lizmap plugin
@@ -62,6 +69,8 @@ class qgisServer
             $metadata = $json->metadata;
             $plugins[$metadata->name] = array('version' => $metadata->version);
         }
+
+        jCache::set($key, $plugins, 3600);
 
         return $plugins;
     }


### PR DESCRIPTION
The request to QGIS Server to get plugins data is not QGIS Project dependant.
The requests have not to be perform each time lizmap needs to get the plugins list.

* Funded by 3liz
