### PR TITLE
QGIS - Display the server commit ID if available

### DIFF
--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -241,6 +241,7 @@ server.information.qgis.label=QGIS Server
 server.information.qgis.metadata=Version
 server.information.qgis.version=Number
 server.information.qgis.name=Name
+server.information.qgis.commit_id=Commit ID
 
 server.information.qgis.plugins=Plugins
 server.information.qgis.plugins.version=Version number

--- a/lizmap/modules/admin/templates/server_information.tpl
+++ b/lizmap/modules/admin/templates/server_information.tpl
@@ -57,6 +57,12 @@
             <th>{@admin.server.information.qgis.name@}</th>
             <td>{$data['qgis_server_info']['metadata']['name']}</td>
         </tr>
+        {if $data['qgis_server_info']['metadata']['commit_id']}
+        <tr>
+            <th>{@admin.server.information.qgis.commit_id@}</th>
+            <td><a href="https://github.com/qgis/QGIS/commit/{$data['qgis_server_info']['metadata']['commit_id']}" target="_blank">{$data['qgis_server_info']['metadata']['commit_id']}</a></td>
+        </tr>
+        {/if}
     </table>
     {hook 'QgisServerVersion', $data['qgis_server_info']['metadata']}
 


### PR DESCRIPTION
if we run a compiled QGIS, it's nice to know which commit we are running from the LWC interface.
