### PR TITLE
UX - Do not show custom label if some label IDs are protected and managed by LWC

### DIFF
--- a/lizmap/www/assets/js/popupQgisAtlas.js
+++ b/lizmap/www/assets/js/popupQgisAtlas.js
@@ -39,7 +39,12 @@ lizMap.events.on({
                             // Add button and div to set custom labels
                             let customLabels = '';
 
+                            const protectedLabelsId = ["lizmap_user", "lizmap_user_groups"];
                             for(const label of t.labels){
+                                if (protectedLabelsId.includes(label.id)){
+                                    // These values mustn't be shown in the UI and will be overridden by LWC PHP and AtlasPrint anyway
+                                    continue;
+                                }
                                 if (label.htmlState){
                                     customLabels += `<textarea class="atlasprint-custom-labels" cols="15" data-print-id="${label.id}" name="${label.id}" placeholder="${label.text}">${label.text}</textarea>`;
                                 }else{


### PR DESCRIPTION
The goal is not be able to customize a label which will be overriden later by AtlasPrint anyway later :  
![Screenshot from 2022-03-04 13-14-51](https://user-images.githubusercontent.com/1609292/156761728-aed45828-6e5a-4d62-a969-214bd9b55d58.png)

