### PR TITLE
Lizmap service etag

### DIFF
--- a/CHANGELOG-3.6.md
+++ b/CHANGELOG-3.6.md
@@ -61,6 +61,7 @@
   * Convert QGIS XML `Option` value based on type attribute
   * Add a revision parameter on assets url for cache
   * Add ETag HTTP header to GetCapabilities, GetProjectConfig, GetProj4 and WMTS GetTile responses
+  * New class `\Lizmap\Request\OGCResponse`
 * Update Jelix to 1.6.37
 * Update PHP CS Fixer to 3.8.0
 

--- a/CHANGELOG-3.6.md
+++ b/CHANGELOG-3.6.md
@@ -60,6 +60,7 @@
   * New method in `AppContext` to get user public groups id
   * Convert QGIS XML `Option` value based on type attribute
   * Add a revision parameter on assets url for cache
+  * Add ETag HTTP header to GetCapabilities, GetProjectConfig, GetProj4 and WMTS GetTile responses
 * Update Jelix to 1.6.37
 * Update PHP CS Fixer to 3.8.0
 

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -1110,8 +1110,8 @@ class qgisVectorLayer extends qgisMapLayer
 
         // Get data
         $wfsData = $result->data;
-        if (property_exists($result, 'file') and $result->file and is_file($wfsData)) {
-            $wfsData = jFile::read($wfsData);
+        if (substr($wfsData, 0, 7) == 'file://' && is_file(substr($wfsData, 7))) {
+            $wfsData = \jFile::read(substr($wfsData, 7));
         }
 
         // Check data: if there is no data returned by WFS, the user has not access to it

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -290,8 +290,8 @@ class editionCtrl extends jController
             $wfs_response = $wfs_request->process();
             if (property_exists($wfs_response, 'data')) {
                 $data = $wfs_response->data;
-                if (property_exists($wfs_response, 'file') && $wfs_response->file && is_file($data)) {
-                    $data = jFile::read($data);
+                if (substr($data, 0, 7) == 'file://' && is_file(substr($data, 7))) {
+                    $data = jFile::read(substr($data, 7));
                 }
                 $this->featureData = json_decode($data);
                 if (empty($this->featureData)) {

--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -811,8 +811,8 @@ class serviceCtrl extends jController
             return $rep;
         }
 
-        if (property_exists($result, 'file') and $result->file and is_file($result->data)) {
-            $rep->fileName = $result->data;
+        if (substr($result->data, 0, 7) == 'file://' && is_file(substr($result->data, 7))) {
+            $rep->fileName = substr($result->data, 7);
             $rep->deleteFileAfterSending = true;
         } else {
             $rep->content = $result->data; // causes memory_limit for big content

--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -1471,8 +1471,8 @@ class QgisForm implements QgisFormControlsInterface
         $result = $wfsRequest->process();
 
         $wfsData = $result->data;
-        if (property_exists($result, 'file') and $result->file and is_file($wfsData)) {
-            $wfsData = \jFile::read($wfsData);
+        if (substr($wfsData, 0, 7) == 'file://' && is_file(substr($wfsData, 7))) {
+            $wfsData = \jFile::read(substr($wfsData, 7));
         }
         $mime = $result->mime;
 

--- a/lizmap/modules/lizmap/lib/Form/QgisFormValueRelationDynamicDatasource.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisFormValueRelationDynamicDatasource.php
@@ -106,8 +106,8 @@ class QgisFormValueRelationDynamicDatasource extends \jFormsDynamicDatasource
                 $wfsResult = $wfsRequest->process();
 
                 $data = $wfsResult->data;
-                if (property_exists($wfsResult, 'file') and $wfsResult->file and is_file($data)) {
-                    $data = \jFile::read($data);
+                if (substr($data, 0, 7) == 'file://' && is_file(substr($data, 7))) {
+                    $data = \jFile::read(substr($data, 7));
                 }
                 $mime = $wfsResult->mime;
 
@@ -184,8 +184,8 @@ class QgisFormValueRelationDynamicDatasource extends \jFormsDynamicDatasource
         $wfsResult = $wfsRequest->process();
 
         $data = $wfsResult->data;
-        if (property_exists($wfsResult, 'file') and $wfsResult->file and is_file($data)) {
-            $data = \jFile::read($data);
+        if (substr($data, 0, 7) == 'file://' && is_file(substr($data, 7))) {
+            $data = \jFile::read(substr($data, 7));
         }
         $mime = $wfsResult->mime;
 

--- a/lizmap/modules/lizmap/lib/Request/OGCRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/OGCRequest.php
@@ -190,8 +190,8 @@ abstract class OGCRequest
      *
      * @param bool $post Force to use POST request
      *
-     * @return object The request result with HTTP code, response mime-type and response data
-     *                (properties $code, $mime, $data)
+     * @return OGCResponse The request result with HTTP code, response mime-type and response data
+     *                     (properties $code, $mime, $data)
      */
     protected function request($post = false)
     {
@@ -213,11 +213,7 @@ abstract class OGCRequest
 
         list($data, $mime, $code) = \Lizmap\Request\Proxy::getRemoteData($querystring, $options);
 
-        return (object) array(
-            'code' => $code,
-            'mime' => $mime,
-            'data' => $data,
-        );
+        return new OGCResponse($code, $mime, $data);
     }
 
     /**
@@ -225,8 +221,8 @@ abstract class OGCRequest
      *
      * @param int $code The HTTP code to return
      *
-     * @return object The request result with HTTP code, response mime-type, response data
-     *                (properties $code, $mime, $data, $cached)
+     * @return OGCResponse The request result with HTTP code, response mime-type, response data
+     *                     (properties $code, $mime, $data, $cached)
      */
     protected function serviceException($code = 400)
     {
@@ -247,19 +243,14 @@ abstract class OGCRequest
         }
         \jMessage::clearAll();
 
-        return (object) array(
-            'code' => $code,
-            'mime' => $mime,
-            'data' => $data,
-            'cached' => false,
-        );
+        return new OGCResponse($code, $mime, $data);
     }
 
     /**
      * Perform an OGC GetCapabilities Request.
      *
-     * @return object The request result with HTTP code, response mime-type, response data
-     *                (properties $code, $mime, $data, $cached)
+     * @return OGCResponse The request result with HTTP code, response mime-type, response data
+     *                     (properties $code, $mime, $data, $cached)
      */
     protected function process_getcapabilities()
     {
@@ -284,12 +275,7 @@ abstract class OGCRequest
         }
         // return cached data
         if ($cached !== false) {
-            return (object) array(
-                'code' => $cached['code'],
-                'mime' => $cached['mime'],
-                'data' => $cached['data'],
-                'cached' => true,
-            );
+            return new OGCResponse($cached['code'], $cached['mime'], $cached['data'], true);
         }
 
         // Get remote data
@@ -310,12 +296,7 @@ abstract class OGCRequest
             $cached = $this->project->getCacheHandler()->setProjectRelatedDataCache($key, $cachedContent, 3600);
         }
 
-        return (object) array(
-            'code' => $response->code,
-            'mime' => $response->mime,
-            'data' => $response->data,
-            'cached' => $cached,
-        );
+        return new OGCResponse($response->code, $response->mime, $response->data, $cached);
     }
 
     /*

--- a/lizmap/modules/lizmap/lib/Request/OGCResponse.php
+++ b/lizmap/modules/lizmap/lib/Request/OGCResponse.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Manage OGC response.
+ *
+ * @author    3liz
+ * @copyright 2015-2022 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+namespace Lizmap\Request;
+
+class OGCResponse
+{
+    /**
+     * @var int the HTTP status code of the response
+     */
+    public $code;
+
+    /**
+     * @var string the MIME type of the response
+     */
+    public $mime;
+
+    /**
+     * @var string the response body as a string
+     */
+    public $data;
+
+    /**
+     * @var bool the response has been cached
+     */
+    public $cached = false;
+
+    /**
+     * @var array
+     */
+    public $headers = array();
+
+    /**
+     * constructor.
+     *
+     * @param int    $code    the HTTP status code of the response
+     * @param string $mime    the MIME type of the response
+     * @param string $data    the response body as a string
+     * @param bool   $cached  the response has been cached, default value false
+     * @param array  $headers default value an empty array
+     */
+    public function __construct($code, $mime, $data, $cached = false, $headers = array())
+    {
+        $this->code = $code;
+        $this->mime = $mime;
+        $this->data = $data;
+        $this->cached = $cached;
+        $this->headers = $headers;
+    }
+}

--- a/lizmap/modules/lizmap/lib/Request/WFSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WFSRequest.php
@@ -150,6 +150,8 @@ class WFSRequest extends OGCRequest
     }
 
     /**
+     * @return OGCResponse
+     *
      * @see https://en.wikipedia.org/wiki/Web_Feature_Service#Static_Interfaces.
      */
     protected function process_getcapabilities()
@@ -196,15 +198,12 @@ class WFSRequest extends OGCRequest
         }
         $data = str_replace('&amp;&amp;', '&amp;', $data);
 
-        return (object) array(
-            'code' => 200,
-            'mime' => $result->mime,
-            'data' => $data,
-            'cached' => false,
-        );
+        return new OGCResponse($result->code, $result->mime, $data, $result->cached);
     }
 
     /**
+     * @return OGCResponse
+     *
      * @see https://en.wikipedia.org/wiki/Web_Feature_Service#Static_Interfaces.
      */
     protected function process_describefeaturetype()
@@ -260,15 +259,12 @@ class WFSRequest extends OGCRequest
             $mime = 'application/json; charset=utf-8';
         }
 
-        return (object) array(
-            'code' => $code,
-            'mime' => $mime,
-            'data' => $data,
-            'cached' => false,
-        );
+        return new OGCResponse($code, $mime, $data);
     }
 
     /**
+     * @return OGCResponse
+     *
      * @see https://en.wikipedia.org/wiki/Web_Feature_Service#Static_Interfaces.
      */
     protected function process_getfeature()
@@ -349,6 +345,8 @@ class WFSRequest extends OGCRequest
     /**
      * Queries Qgis Server for getFeature.
      *
+     * @return OGCResponse
+     *
      * @see https://en.wikipedia.org/wiki/Web_Feature_Service#Static_Interfaces
      */
     protected function getfeatureQgis()
@@ -395,12 +393,7 @@ class WFSRequest extends OGCRequest
             }
         }
 
-        return (object) array(
-            'code' => $code,
-            'mime' => $mime,
-            'data' => $data,
-            'cached' => false,
-        );
+        return new OGCResponse($code, $mime, $data);
     }
 
     /**
@@ -726,8 +719,11 @@ class WFSRequest extends OGCRequest
     }
 
     /**
-     * https://en.wikipedia.org/wiki/Web_Feature_Service#Static_Interfaces
      * Queries The PostGreSQL Server for getFeature.
+     *
+     * @return OGCResponse
+     *
+     * @see https://en.wikipedia.org/wiki/Web_Feature_Service#Static_Interfaces
      */
     protected function getfeaturePostgres()
     {
@@ -854,13 +850,14 @@ class WFSRequest extends OGCRequest
         fclose($fd);
 
         // Return response
-        return (object) array(
+        /*return (object) array(
             'code' => '200',
             'mime' => 'application/vnd.geo+json; charset=utf-8',
             'file' => true, // we use this to inform controler postgres has been used
             'data' => $path,
             'cached' => false,
-        );
+        );*/
+        return new OGCResponse(200, 'application/vnd.geo+json; charset=utf-8', 'file://'.$path);
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -101,6 +101,8 @@ class WMSRequest extends OGCRequest
     }
 
     /**
+     * @return OGCResponse
+     *
      * @see https://en.wikipedia.org/wiki/Web_Map_Service#Requests.
      */
     protected function process_getcapabilities()
@@ -180,14 +182,12 @@ class WMSRequest extends OGCRequest
             }
         }
 
-        return (object) array(
-            'code' => 200,
-            'mime' => $result->mime,
-            'data' => $data,
-            'cached' => false,
-        );
+        return new OGCResponse($result->code, $result->mime, $data, $result->cached);
     }
 
+    /**
+     * @return OGCResponse
+     */
     protected function process_getcontext()
     {
         // Get remote data
@@ -202,14 +202,12 @@ class WMSRequest extends OGCRequest
         $data = $response->data;
         $data = preg_replace('/xlink\:href=".*"/', 'xlink:href="'.$sUrl.'&amp;"', $data);
 
-        return (object) array(
-            'code' => $response->code,
-            'mime' => $response->mime,
-            'data' => $data,
-            'cached' => false,
-        );
+        return new OGCResponse($response->code, $response->mime, $data, $response->cached);
     }
 
+    /**
+     * @return OGCResponse
+     */
     protected function process_getschemaextension()
     {
         $data = '<?xml version="1.0" encoding="UTF-8"?>
@@ -220,15 +218,12 @@ class WMSRequest extends OGCRequest
   <element name="GetStyles" type="wms:OperationType" substitutionGroup="wms:_ExtendedOperation" />
 </schema>';
 
-        return (object) array(
-            'code' => 200,
-            'mime' => 'text/xml',
-            'data' => $data,
-            'cached' => false,
-        );
+        return new OGCResponse(200, 'text/xml', $data);
     }
 
     /**
+     * @return OGCResponse
+     *
      * @see https://en.wikipedia.org/wiki/Web_Map_Service#Requests.
      */
     protected function process_getmap()
@@ -241,16 +236,13 @@ class WMSRequest extends OGCRequest
 
         $getMap = $this->getMapData($this->project, $this->parameters(), $this->forceRequest);
 
-        return (object) array(
-            'code' => $getMap[2],
-            'mime' => $getMap[1],
-            'data' => $getMap[0],
-            'cached' => $getMap[3],
-        );
+        return new OGCResponse($getMap[2], $getMap[1], $getMap[0], $getMap[3]);
     }
 
     /**
      * Check wether the height and width values are valid.
+     *
+     * @return bool
      */
     protected function checkMaximumWidthHeight()
     {
@@ -276,6 +268,8 @@ class WMSRequest extends OGCRequest
     }
 
     /**
+     * @return OGCResponse
+     *
      * @see https://en.wikipedia.org/wiki/Web_Map_Service#Requests.
      */
     protected function process_getlegendgraphic()
@@ -296,17 +290,12 @@ class WMSRequest extends OGCRequest
         }
 
         // Get remote data
-        $response = $this->request(true);
-
-        return (object) array(
-            'code' => $response->code,
-            'mime' => $response->mime,
-            'data' => $response->data,
-            'cached' => false,
-        );
+        return $this->request(true);
     }
 
     /**
+     * @return OGCResponse
+     *
      * @see https://en.wikipedia.org/wiki/Web_Map_Service#Requests.
      */
     protected function process_getfeatureinfo()
@@ -400,27 +389,21 @@ class WMSRequest extends OGCRequest
             $rep .= $data;
         }
 
-        return (object) array(
-            'code' => $code,
-            'mime' => $mime,
-            'data' => $rep,
-            'cached' => false,
-        );
+        return new OGCResponse($code, $mime, $rep, $response->cached);
     }
 
+    /**
+     * @return OGCResponse
+     */
     protected function process_getprint()
     {
         // Get remote data
-        $response = $this->request(true);
-
-        return (object) array(
-            'code' => $response->code,
-            'mime' => $response->mime,
-            'data' => $response->data,
-            'cached' => false,
-        );
+        return $this->request(true);
     }
 
+    /**
+     * @return OGCResponse
+     */
     protected function process_getprintatlas()
     {
         // Trigger optional actions by other modules
@@ -433,30 +416,30 @@ class WMSRequest extends OGCRequest
         $this->appContext->eventNotify('BeforePdfCreation', $eventParams);
 
         // Get remote data
-        $response = $this->request(true);
-
-        return (object) array(
-            'code' => $response->code,
-            'mime' => $response->mime,
-            'data' => $response->data,
-            'cached' => false,
-        );
+        return $this->request(true);
     }
 
+    /**
+     * @return OGCResponse
+     *
+     * @see https://en.wikipedia.org/wiki/Web_Map_Service#Requests.
+     */
     protected function process_getstyles()
     {
 
         // Get remote data
-        $response = $this->request(true);
-
-        return (object) array(
-            'code' => $response->code,
-            'mime' => $response->mime,
-            'data' => $response->data,
-            'cached' => false,
-        );
+        return $this->request(true);
     }
 
+    /**
+     * @param mixed $tplName
+     * @param mixed $layerName
+     * @param mixed $layerId
+     * @param mixed $layerTitle
+     * @param mixed $params
+     *
+     * @return string
+     */
     protected function getViewTpl($tplName, $layerName, $layerId, $layerTitle, $params = array())
     {
         $tpl = new \jTpl();
@@ -734,7 +717,7 @@ class WMSRequest extends OGCRequest
      * @param string            $layerTitle
      * @param \SimpleXmlElement $layer
      *
-     * @return array Raster feature Info in HTML format
+     * @return string Raster feature Info in HTML format
      */
     protected function gfiRasterXmlToHtml($layerId, $layerName, $layerTitle, $layer)
     {

--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -234,9 +234,7 @@ class WMSRequest extends OGCRequest
             return $this->serviceException();
         }
 
-        $getMap = $this->getMapData($this->project, $this->parameters(), $this->forceRequest);
-
-        return new OGCResponse($getMap[2], $getMap[1], $getMap[0], $getMap[3]);
+        return $this->getMapData($this->project, $this->parameters(), $this->forceRequest);
     }
 
     /**
@@ -1036,7 +1034,7 @@ class WMSRequest extends OGCRequest
      * @param array   $params  array of parameters
      * @param mixed   $forced
      *
-     * @return array $data normalized and filtered array
+     * @return OGCResponse normalized and filtered response
      */
     protected function getMapData($project, $params, $forced = false)
     {
@@ -1060,7 +1058,7 @@ class WMSRequest extends OGCRequest
         list($repository, $project) = $this->getVProfileInfos($configLayer, $repository, $project);
 
         if ($repository === 'error') {
-            return array('error', 'text/plain', '404', false);
+            return new OGCResponse(404, 'text/plain', 'error', false);
         }
 
         // Get tile cache virtual profile (tile storage)
@@ -1077,7 +1075,7 @@ class WMSRequest extends OGCRequest
         // Get cache if exists
         $key = $this->getTileCache($params, $profile, $useCache, $forced);
         if (is_array($key)) {
-            return $key;
+            return new OGCResponse($key[2], $key[1], $key[0], $key[3]);
         }
 
         // ***************************
@@ -1150,6 +1148,6 @@ class WMSRequest extends OGCRequest
             }
         }
 
-        return array($data, $mime, $code, $cached);
+        return new OGCResponse($code, $mime, $data, $cached);
     }
 }

--- a/lizmap/modules/lizmap/lib/Request/WMTSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMTSRequest.php
@@ -21,17 +21,27 @@ class WMTSRequest extends OGCRequest
 
     private $forceRequest = false;
 
+    /**
+     * @return bool
+     */
     public function getForceRequest()
     {
         return $this->forceRequest;
     }
 
+    /**
+     * @param bool $forced
+     *
+     * @return bool
+     */
     public function setForceRequest($forced)
     {
         return $this->forceRequest = $forced;
     }
 
     /**
+     * @return OGCResponse
+     *
      * @see https://en.wikipedia.org/wiki/Web_Map_Tile_Service#Requests.
      */
     protected function process_getcapabilities()
@@ -72,15 +82,12 @@ class WMTSRequest extends OGCRequest
         $tpl->assign('tileMatrixSetList', $tileCapabilities->tileMatrixSetList);
         $tpl->assign('layers', $tileCapabilities->layerTileInfoList);
 
-        return (object) array(
-            'code' => 200,
-            'mime' => 'text/xml; charset=utf-8',
-            'data' => $tpl->fetch('lizmap~wmts_capabilities'),
-            'cached' => false,
-        );
+        return new OGCResponse(200, 'text/xml; charset=utf-8', $tpl->fetch('lizmap~wmts_capabilities'));
     }
 
     /**
+     * @return OGCResponse
+     *
      * @see https://en.wikipedia.org/wiki/Web_Map_Tile_Service#Requests.
      */
     protected function process_gettile()

--- a/tests/end2end/cypress/integration/requests-service-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-service-ghaction.js
@@ -4,6 +4,20 @@ describe('Request service', function () {
             .then((resp) => {
                 expect(resp.status).to.eq(200)
                 expect(resp.headers['content-type']).to.eq('application/json')
+                expect(resp.headers['cache-control']).to.eq('no-cache')
+                expect(resp.headers['etag']).to.not.eq(undefined)
+
+                const etag = resp.headers['etag']
+                cy.request({
+                    url: '/index.php/lizmap/service/getProjectConfig?repository=testsrepository&project=selection',
+                    headers: {
+                        'If-None-Match': etag,
+                    },
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    expect(resp.status).to.eq(304)
+                    expect(resp.body).to.have.length(0)
+                })
             })
     })
 

--- a/tests/end2end/cypress/integration/requests-service-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-service-ghaction.js
@@ -34,7 +34,28 @@ describe('Request service', function () {
         }).then((resp) => {
             expect(resp.status).to.eq(200)
             expect(resp.headers['content-type']).to.contain('text/plain')
+            expect(resp.headers['cache-control']).to.eq('no-cache')
+            expect(resp.headers['etag']).to.not.eq(undefined)
+
             expect(resp.body).to.contain('+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs')
+
+            const etag = resp.headers['etag']
+            cy.request({
+                url: '/index.php/lizmap/service/?repository=testsrepository&project=selection',
+                qs: {
+                    'SERVICE': 'WMS',
+                    'VERSION': '1.3.0',
+                    'REQUEST': 'GetProj4',
+                    'AUTHID': 'EPSG:2154',
+                },
+                headers: {
+                    'If-None-Match': etag,
+                },
+                failOnStatusCode: false,
+            }).then((resp) => {
+                expect(resp.status).to.eq(304)
+                expect(resp.body).to.have.length(0)
+            })
         })
     })
 

--- a/tests/end2end/cypress/integration/requests-service-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-service-ghaction.js
@@ -166,8 +166,23 @@ describe('Request service', function () {
             .then((resp) => {
                 expect(resp.status).to.eq(200)
                 expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+                expect(resp.headers['cache-control']).to.eq('no-cache')
+                expect(resp.headers['etag']).to.not.eq(undefined)
+
                 expect(resp.body).to.contain('WMS_Capabilities')
                 expect(resp.body).to.contain('version="1.3.0"')
+
+                const etag = resp.headers['etag']
+                cy.request({
+                    url: '/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities',
+                    headers: {
+                        'If-None-Match': etag,
+                    },
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    expect(resp.status).to.eq(304)
+                    expect(resp.body).to.have.length(0)
+                })
             })
 
         // Project with config.options.hideProject: "True"
@@ -175,6 +190,7 @@ describe('Request service', function () {
             .then((resp) => {
                 expect(resp.status).to.eq(200)
                 expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+
                 expect(resp.body).to.contain('WMS_Capabilities')
                 expect(resp.body).to.contain('version="1.3.0"')
             })
@@ -185,9 +201,24 @@ describe('Request service', function () {
             .then((resp) => {
                 expect(resp.status).to.eq(200)
                 expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+                expect(resp.headers['cache-control']).to.eq('no-cache')
+                expect(resp.headers['etag']).to.not.eq(undefined)
+
                 expect(resp.body).to.contain('version="1.0.0"')
                 expect(resp.body).to.contain('<ows:Identifier>Quartiers</ows:Identifier>')
                 expect(resp.body).to.contain('<TileMatrixSet>EPSG:3857</TileMatrixSet>')
+
+                const etag = resp.headers['etag']
+                cy.request({
+                    url: '/index.php/lizmap/service/?repository=testsrepository&project=cache&SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetCapabilities',
+                    headers: {
+                        'If-None-Match': etag,
+                    },
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    expect(resp.status).to.eq(304)
+                    expect(resp.body).to.have.length(0)
+                })
             })
     })
 
@@ -196,8 +227,23 @@ describe('Request service', function () {
             .then((resp) => {
                 expect(resp.status).to.eq(200)
                 expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+                expect(resp.headers['cache-control']).to.eq('no-cache')
+                expect(resp.headers['etag']).to.not.eq(undefined)
+
                 expect(resp.body).to.contain('WFS_Capabilities')
                 expect(resp.body).to.contain('version="1.0.0"')
+
+                const etag = resp.headers['etag']
+                cy.request({
+                    url: '/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetCapabilities',
+                    headers: {
+                        'If-None-Match': etag,
+                    },
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    expect(resp.status).to.eq(304)
+                    expect(resp.body).to.have.length(0)
+                })
             })
 
         // Project with config.options.hideProject: "True"
@@ -205,6 +251,7 @@ describe('Request service', function () {
             .then((resp) => {
                 expect(resp.status).to.eq(200)
                 expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+
                 expect(resp.body).to.contain('WFS_Capabilities')
                 expect(resp.body).to.contain('version="1.0.0"')
             })
@@ -216,8 +263,23 @@ describe('Request service', function () {
             .then((resp) => {
                 expect(resp.status).to.eq(200)
                 expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+                expect(resp.headers['cache-control']).to.eq('no-cache')
+                expect(resp.headers['etag']).to.not.eq(undefined)
+
                 expect(resp.body).to.contain('WFS_Capabilities')
                 expect(resp.body).to.contain('version="1.1.0"')
+
+                const etag = resp.headers['etag']
+                cy.request({
+                    url: '/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WFS&VERSION=1.1.0&REQUEST=GetCapabilities',
+                    headers: {
+                        'If-None-Match': etag,
+                    },
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    expect(resp.status).to.eq(304)
+                    expect(resp.body).to.have.length(0)
+                })
             })
     })
 

--- a/tests/units/classes/Request/WMSRequestTest.php
+++ b/tests/units/classes/Request/WMSRequestTest.php
@@ -3,6 +3,7 @@
 use Lizmap\Project\Repository;
 use PHPUnit\Framework\TestCase;
 use Lizmap\Request\WMSRequest;
+use Lizmap\Request\OGCResponse;
 
 class WMSRequestTest extends TestCase
 {
@@ -84,16 +85,22 @@ class WMSRequestTest extends TestCase
 
     public function getGetContextData()
     {
-        $responseNoUrl = (object)array(
+        $responseNoUrl = new OGCResponse(
+            200,
+            'text/xml',
+            '<whatever><nourl/></whatever>'
+        );
+
+        $expectedResponseNoUrl = (object)array(
             'code' => 200,
             'mime' => 'text/xml',
             'data' => '<whatever><nourl/></whatever>',
         );
 
-        $responseSimpleUrl = (object)array(
-            'code' => 200,
-            'mime' => 'text/xml',
-            'data' => '<whatever><location xlink:href="test.google.com"/></whatever>',
+        $responseSimpleUrl = new OGCResponse(
+            200,
+            'text/xml',
+            '<whatever><location xlink:href="test.google.com"/></whatever>',
         );
 
         $expectedResponseSimpleUrl = (object)array(
@@ -102,10 +109,10 @@ class WMSRequestTest extends TestCase
             'data' => '<whatever><location xlink:href="http://localhost?repo=test&amp;project=test&amp;&amp;"/></whatever>',
         );
 
-        $responseMultiplesUrl = (object)array(
-            'code' => 200,
-            'mime' => 'text/xml',
-            'data' => '<xml>
+        $responseMultiplesUrl = new OGCResponse(
+            200,
+            'text/xml',
+            '<xml>
             <tagtest xlink:href="http://localhost?test=test&otherTest=test"/>
             <otherTagTest>
             <just to=see if=itsworking xlink:href=""/>
@@ -125,7 +132,7 @@ class WMSRequestTest extends TestCase
         );
 
         return array(
-            array($responseNoUrl, 'http://localhost?repo=test&project=test', $responseNoUrl),
+            array($responseNoUrl, 'http://localhost?repo=test&project=test', $expectedResponseNoUrl),
             array($responseSimpleUrl, 'http://localhost?repo=test&project=test', $expectedResponseSimpleUrl),
             array($responseSimpleUrl, 'http://localhost?repo=test&project=test', $expectedResponseSimpleUrl),
         );


### PR DESCRIPTION
Add the [ETag HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) for some service responses with `Cache-Control: no-cache` header.

The responses for GetProjectConfig, GetCapabilities and GetProj4 have an Etag HTTP header

* Funded by 3liz
