### PR TITLE
[Bugfix] Edition: update and delete is not authorized for feature id 0

### DIFF
--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -87,7 +87,7 @@ class editionCtrl extends jController
         // Get title layer
         if ($this->layer) {
             $_title = $this->layer->getTitle();
-            if ($_title and $_title != '') {
+            if ($_title && $_title != '') {
                 $title = $_title;
             }
         }
@@ -240,7 +240,7 @@ class editionCtrl extends jController
         // Get features primary key field values corresponding to featureId(s)
         if (!empty($featureId) || $featureId === 0 || $featureId === '0') {
             $typename = $this->layer->getShortName();
-            if (!$typename or $typename == '') {
+            if (!$typename || $typename == '') {
                 $typename = str_replace(' ', '_', $this->layer->getName());
             }
             if (is_array($featureId)) {
@@ -289,7 +289,7 @@ class editionCtrl extends jController
             $wfs_response = $wfs_request->process();
             if (property_exists($wfs_response, 'data')) {
                 $data = $wfs_response->data;
-                if (property_exists($wfs_response, 'file') and $wfs_response->file and is_file($data)) {
+                if (property_exists($wfs_response, 'file') && $wfs_response->file && is_file($data)) {
                     $data = jFile::read($data);
                 }
                 $this->featureData = json_decode($data);
@@ -396,7 +396,7 @@ class editionCtrl extends jController
         // SELECT data from the database and set the form data accordingly
 
         $qgisForm->setFormDataFromDefault();
-        if ($this->featureId) {
+        if ($this->featureId || $this->featureId === 0 || $this->featureId === '0') {
             $qgisForm->setFormDataFromFields($this->featureData->features[0]);
             $form->initModifiedControlsList();
         }
@@ -527,13 +527,15 @@ class editionCtrl extends jController
 
         // Check if data has been fetched via WFS for the feature
         $this->getWfsFeature();
-        if ($this->featureId and !$this->featureData) {
+        if (($this->featureId || $this->featureId === 0 || $this->featureId === '0') && !$this->featureData) {
             jMessage::add(jLocale::get('view~edition.message.error.feature.get'), 'featureNotFoundViaWfs');
 
             return $this->serviceAnswer();
         }
 
-        if (!$this->loginFilteredOverride and $this->featureId and $this->featureData) {
+        if (!$this->loginFilteredOverride
+            && ($this->featureId || $this->featureId === 0 || $this->featureId === '0')
+            && $this->featureData) {
             $is_editable = $this->featureIsEditable();
             if (!$is_editable) {
                 $this->setErrorMessage(jLocale::get('view~edition.message.error.feature.editable'), 'FeatureNotEditable');
@@ -595,7 +597,7 @@ class editionCtrl extends jController
 
         // Get title layer
         $title = $this->layer->getTitle();
-        if (!$title or $title == '') {
+        if (!$title || $title == '') {
             $title = 'No title';
         }
 
@@ -694,7 +696,7 @@ class editionCtrl extends jController
 
         // Check the form data and redirect if needed
         $feature = null;
-        if ($this->featureId) {
+        if ($this->featureId || $this->featureId === 0 || $this->featureId === '0') {
             $feature = $this->featureData->features[0];
         }
         $check = $qgisForm->check($feature);
@@ -728,7 +730,7 @@ class editionCtrl extends jController
         }
 
         // Some errors where encoutered
-        if (!$check or !$pkvals) {
+        if (!$check || !$pkvals) {
             // Redirect to the display action
             $rep->params['status'] = '1';
             $rep->action = 'lizmap~edition:editFeature';
@@ -863,7 +865,7 @@ class editionCtrl extends jController
             return $this->serviceAnswer();
         }
 
-        if (!$this->featureId) {
+        if (!$this->featureId && $this->featureId !== 0 && $this->featureId !== '0') {
             jMessage::add(jLocale::get('view~edition.message.error.parameter.featureId'), 'error');
 
             return $this->serviceAnswer();
@@ -1019,7 +1021,7 @@ class editionCtrl extends jController
         // Save data into database
         // And get returned primary key values
         $feature = null;
-        if ($this->featureId) {
+        if ($this->featureId || $this->featureId === 0 || $this->featureId === '0') {
             $feature = $this->featureData->features[0];
         }
         $pkvals = $qgisForm->saveToDb($feature);
@@ -1027,7 +1029,7 @@ class editionCtrl extends jController
         jForms::destroy('view~edition', '____new__feature___');
 
         // Some errors where encoutered
-        if (!$check or !$pkvals) {
+        if (!$check || !$pkvals) {
             $rep->data['success'] = false;
             $rep->data['message'] = 'Error during the save of the feature';
 
@@ -1172,7 +1174,7 @@ class editionCtrl extends jController
         $features1 = $this->param('features1');
         $features2 = $this->param('features2');
         $pivotId = $this->param('pivot');
-        if (!$features1 or !$features2 or !$pivotId) {
+        if (!$features1 || !$features2 || !$pivotId) {
             jMessage::add(jLocale::get('view~edition.link.error.missing.parameter'), 'error');
 
             return $this->serviceAnswer();
@@ -1181,7 +1183,7 @@ class editionCtrl extends jController
         // Cut layers id and features ids and check if data is correctly sent
         $exp1 = explode(':', $features1);
         $exp2 = explode(':', $features2);
-        if (count($exp1) != 3 or count($exp2) != 3) {
+        if (count($exp1) != 3 || count($exp2) != 3) {
             jMessage::add(jLocale::get('view~edition.link.error.missing.parameter'), 'error');
 
             return $this->serviceAnswer();
@@ -1192,7 +1194,7 @@ class editionCtrl extends jController
         $ids2 = explode(',', $exp2[2]);
 
         // Not enough id given
-        if (count($ids1) == 0 or count($ids2) == 0 or empty($exp1[2]) or empty($exp2[2])) {
+        if (count($ids1) == 0 || count($ids2) == 0 || empty($exp1[2]) || empty($exp2[2])) {
             jMessage::add(jLocale::get('view~edition.link.error.missing.id'), 'error');
 
             return $this->serviceAnswer();
@@ -1201,7 +1203,7 @@ class editionCtrl extends jController
         // Get the layer names
         $layer1 = $lproj->getLayer($exp1[0]);
         $layer2 = $lproj->getLayer($exp2[0]);
-        if (!$layer1 or !$layer2) {
+        if (!$layer1 || !$layer2) {
             jMessage::add(jLocale::get('view~edition.link.error.wrong.layer'), 'error');
 
             return $this->serviceAnswer();
@@ -1211,8 +1213,8 @@ class editionCtrl extends jController
 
         // Verifying the layers are present in the attribute table configuration
         if (!$lproj->hasAttributeLayers()
-            or !$lproj->hasAttributeLayersForLayer($layerName1)
-            or !$lproj->hasAttributeLayersForLayer($layerName2)
+            || !$lproj->hasAttributeLayersForLayer($layerName1)
+            || !$lproj->hasAttributeLayersForLayer($layerName2)
         ) {
             jMessage::add(jLocale::get('view~edition.link.error.not.attribute.layer'), 'error');
 
@@ -1267,7 +1269,7 @@ class editionCtrl extends jController
         $dataFields = $dbFieldsInfo->dataFields;
 
         // Check fields
-        if (!array_key_exists($exp1[1], $dataFields) or !array_key_exists($exp2[1], $dataFields)) {
+        if (!array_key_exists($exp1[1], $dataFields) || !array_key_exists($exp2[1], $dataFields)) {
             jMessage::add(jLocale::get('view~edition.link.error.no.given.fields'), 'error');
 
             return $this->serviceAnswer();
@@ -1334,7 +1336,7 @@ class editionCtrl extends jController
         $project = $this->param('project');
         $repository = $this->param('repository');
 
-        if (!$lid or !$fkey or !$pkey or !$pkeyval or !$project or !$repository) {
+        if (!$lid || !$fkey || !$pkey || !$pkeyval || !$project || !$repository) {
             jMessage::add(jLocale::get('view~edition.link.error.missing.parameter'), 'error');
 
             return $this->serviceAnswer();
@@ -1385,7 +1387,7 @@ class editionCtrl extends jController
         $dataFields = $dbFieldsInfo->dataFields;
 
         // Check fields
-        if (!array_key_exists($fkey, $dataFields) or !array_key_exists($pkey, $dataFields)) {
+        if (!array_key_exists($fkey, $dataFields) || !array_key_exists($pkey, $dataFields)) {
             jMessage::add(jLocale::get('view~edition.link.error.no.given.fields'), 'error');
 
             return $this->serviceAnswer();


### PR DESCRIPTION
The feature id can be equal to 0 and it is valid but the edition controller does not authorize edition in this case.

Also replace `and` by `&&` and `or` by `||`.

* Funded by 3Liz