### PR TITLE
Fix the assets revision mecanism

### DIFF
--- a/lizmap/plugins/configcompiler/lizmapconfig/lizmapconfig.configcompiler.php
+++ b/lizmap/plugins/configcompiler/lizmapconfig/lizmapconfig.configcompiler.php
@@ -27,15 +27,15 @@ class lizmapconfigConfigCompilerPlugin implements \jelix\core\ConfigCompilerPlug
 
     public function atStart($config)
     {
-        if (isset($config->lizmap['assetsRevision'])) {
-            $revision = $config->lizmap['assetsRevision'];
+        if (isset($config->urlengine['assetsRevision'])) {
+            $revision = $config->urlengine['assetsRevision'];
             if ($revision == 'autoconfig') {
                 $revision = date('ymdHis');
             }
         } else {
             $revision = date('ymdHis');
-            jApp::config()->urlengine['assetsRevision'] = $revision;
         }
+        $config->urlengine['assetsRevision'] = $revision;
 
         if ($revision != '') {
             $config->urlengine['assetsRevQueryUrl'] = '_r='.$revision;

--- a/lizmap/var/config/mainconfig.ini.php
+++ b/lizmap/var/config/mainconfig.ini.php
@@ -81,6 +81,14 @@ notfoundAct="jelix~error:notfound"
 ; syntax of the list is the same as explained in the simple_urlengine_entrypoints
 simple_urlengine_https=
 
+
+; this is the revision number to add to url of assets. If empty, no revision will be added.
+; If "autoconfig", the revision number will be generated automatically each time
+; the configuration will be compiled. Else a value can be given directly into the
+; configuration, but it is the responsibility to the developer or the administrator
+; to indicate a new one each time the application is deployed for example.
+assetsRevision = autoconfig
+
 [simple_urlengine_entrypoints]
 ; parameters for the simple url engine. This is the list of entry points
 ; with list of actions attached to each entry points
@@ -323,12 +331,3 @@ daoPropertiesForMapping="login,email,firstname,lastname,phonenumber"
 cadastre=31
 adresse=32
 openads=33
-
-
-[lizmap]
-; this the revision number to add to url of assets. If empty, no revision will be added.
-; If "autoconfig", the revision number will be generated automatically each time
-; the configuration will be compiled. Else a value can be given directly into the
-; configuration, but it is the responsibility to the developer or the administrator
-; to indicate a new one each time the application is deployed for example.
-assetsRevision = autoconfig


### PR DESCRIPTION
The assetsRevision parameter was stored into the lizmap section, but was readed from the urlengine section. It is not consistent.

* Funded by 3liz
