### PR TITLE
Fix the image dialog size on tiny screens

### DIFF
--- a/lib/jelix-www/js/jforms/imageSelector.js
+++ b/lib/jelix-www/js/jforms/imageSelector.js
@@ -275,10 +275,10 @@ function jFormsImageDialog(eltSelector, options) {
     };
 
     if (this.dialog.dataset.dialogWidth) {
-        defaults.width = parseInt(this.dialog.dataset.dialogWidth, 10);
+        defaults.width = this.dialog.dataset.dialogWidth;
     }
     if (this.dialog.dataset.dialogHeight) {
-        defaults.height = parseInt(this.dialog.dataset.dialogHeight, 10);
+        defaults.height = this.dialog.dataset.dialogHeight;
     }
     if (this.dialog.dataset.dialogTitle) {
         defaults.title = this.dialog.dataset.dialogTitle;
@@ -292,13 +292,27 @@ function jFormsImageDialog(eltSelector, options) {
 
     var actual = Object.assign({}, defaults, options);
 
+    this.dialogMarginWidth = 80;
+    this.dialogMarginHeight = 200;
     this.dialogTitle = actual.title;
     this.dialogOkLabel = actual.okLabel || "Ok";
     this.dialogCancelLabel = actual.cancelLabel || "Cancel";
 
     this.dialogWidth = actual.width;
-    this.dialogHeight = actual.height;
+    if (this.dialogWidth === 'auto') {
+        this.dialogWidth = Math.min(1024, document.documentElement.clientWidth-this.dialogMarginWidth-20);
+    }
+    else {
+        this.dialogWidth = parseInt(this.dialogWidth, 10);
+    }
 
+    this.dialogHeight = actual.height;
+    if (this.dialogHeight === 'auto') {
+        this.dialogHeight = Math.min(1024, document.documentElement.clientHeight-this.dialogMarginHeight-20);
+    }
+    else {
+        this.dialogHeight = parseInt(this.dialogHeight, 10);
+    }
     this.sourceImg = null;
     this.sourceFile = null;
 }
@@ -480,8 +494,8 @@ jFormsImageDialog.prototype = {
         return new Promise(function(resolve, reject) {
             $(me.dialog).dialog({
                 autoOpen: true,
-                width: me.dialogWidth+55,
-                height: me.dialogHeight+180,
+                width: me.dialogWidth+me.dialogMarginWidth,
+                height: me.dialogHeight+me.dialogMarginHeight,
                 modal: true,
                 title: me.dialogTitle,
                 buttons: [

--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -279,8 +279,8 @@ class QgisForm implements QgisFormControlsInterface
                 'imgMaxWidth' => 260,
                 'imgMaxHeight' => 320,
                 // size of the dialog box where we can modify the image
-                'dialogWidth' => 640,
-                'dialogHeight' => 480,
+                'dialogWidth' => 'auto',
+                'dialogHeight' => 'auto',
                 // maximum size of the uploaded image. If its size is larger this maximum
                 // size, the image will be resized.
                 'newImgMaxWidth' => $maxWidthHeight,

--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -2348,6 +2348,9 @@ lizmap-mouse-position > div.coords-unit > select{
   }
 }
 
+.ui-dialog {
+  z-index: 1500 !important;
+}
 
 /*dialog wait*/
 .liz-dialog-wait {

--- a/lizmap/www/assets/jelix/js/jforms/imageSelector.js
+++ b/lizmap/www/assets/jelix/js/jforms/imageSelector.js
@@ -275,10 +275,10 @@ function jFormsImageDialog(eltSelector, options) {
     };
 
     if (this.dialog.dataset.dialogWidth) {
-        defaults.width = parseInt(this.dialog.dataset.dialogWidth, 10);
+        defaults.width = this.dialog.dataset.dialogWidth;
     }
     if (this.dialog.dataset.dialogHeight) {
-        defaults.height = parseInt(this.dialog.dataset.dialogHeight, 10);
+        defaults.height = this.dialog.dataset.dialogHeight;
     }
     if (this.dialog.dataset.dialogTitle) {
         defaults.title = this.dialog.dataset.dialogTitle;
@@ -292,13 +292,27 @@ function jFormsImageDialog(eltSelector, options) {
 
     var actual = Object.assign({}, defaults, options);
 
+    this.dialogMarginWidth = 80;
+    this.dialogMarginHeight = 200;
     this.dialogTitle = actual.title;
     this.dialogOkLabel = actual.okLabel || "Ok";
     this.dialogCancelLabel = actual.cancelLabel || "Cancel";
 
     this.dialogWidth = actual.width;
-    this.dialogHeight = actual.height;
+    if (this.dialogWidth === 'auto') {
+        this.dialogWidth = Math.min(1024, document.documentElement.clientWidth-this.dialogMarginWidth-20);
+    }
+    else {
+        this.dialogWidth = parseInt(this.dialogWidth, 10);
+    }
 
+    this.dialogHeight = actual.height;
+    if (this.dialogHeight === 'auto') {
+        this.dialogHeight = Math.min(1024, document.documentElement.clientHeight-this.dialogMarginHeight-20);
+    }
+    else {
+        this.dialogHeight = parseInt(this.dialogHeight, 10);
+    }
     this.sourceImg = null;
     this.sourceFile = null;
 }
@@ -480,8 +494,8 @@ jFormsImageDialog.prototype = {
         return new Promise(function(resolve, reject) {
             $(me.dialog).dialog({
                 autoOpen: true,
-                width: me.dialogWidth+55,
-                height: me.dialogHeight+180,
+                width: me.dialogWidth+me.dialogMarginWidth,
+                height: me.dialogHeight+me.dialogMarginHeight,
                 modal: true,
                 title: me.dialogTitle,
                 buttons: [


### PR DESCRIPTION
Support of the value `auto` for width or height of the dialog. The dialog then have the window size (with a maximum width/height value : 1024).


* Ticket : fix #2766
* Funded by 3liz
