### PR TITLE
Filter by attribute: the attribute can be upper case

### DIFF
--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -1112,7 +1112,7 @@ class Project
             }
 
             // attribute to filter
-            $attribute = strtolower($loginFilteredConfig->filterAttribute);
+            $attribute = $loginFilteredConfig->filterAttribute;
 
             // default no user connected
             $filter = "\"{$attribute}\" = 'all'";

--- a/tests/units/classes/Project/ProjectTest.php
+++ b/tests/units/classes/Project/ProjectTest.php
@@ -270,8 +270,8 @@ class ProjectTest extends TestCase
         $aclData2 = array(
             'userIsConnected' => false,
         );
-        $filter1 = '"group" IN ( \'admin\' , \'groups\' , \'lizmap\' , \'all\' )';
-        $filter2 = '"group" = \'all\'';
+        $filter1 = '"Group" IN ( \'admin\' , \'groups\' , \'lizmap\' , \'all\' )';
+        $filter2 = '"Group" = \'all\'';
 
         return array(
             array($aclData1, $filter1),


### PR DESCRIPTION
Remove the `strtolower` on `filterAttribute` because the field name can be upper case and it has to stay like it is defined in the database.

* Funded by Terre de Provence Agglomération
