### PR TITLE
[Bugfix][Edition] Boolean nullable displayed as menulist in release_3_4

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisFormControl.class.php
+++ b/lizmap/modules/lizmap/classes/qgisFormControl.class.php
@@ -499,7 +499,7 @@ class qgisFormControl
         }
 
         // Rework for boolean
-        if ($this->fieldDataType == 'boolean'
+        if ($this->fieldDataType == 'boolean' && $prop->notNull
             && in_array($markup, array('menulist', 'checkboxes'))) {
             // Get data list, to use label
             $data = $this->ctrl->datasource->data;


### PR DESCRIPTION
#2862 and cypress tests reveal a regression in the way boolean nullable is displayed.