### PR TITLE
[Tests] end2end and manually: coverage cypress form value relation tests

### DIFF
--- a/tests/end2end/cypress/integration/form_edition_value_relation_field-ghaction.js
+++ b/tests/end2end/cypress/integration/form_edition_value_relation_field-ghaction.js
@@ -11,22 +11,25 @@ describe('Form edition all field type', function() {
         cy.log('No expression menulist 4 values + 1 empty value')
         cy.get('#jforms_view_edition_code_without_exp option').should('have.length', 5)
         cy.get('#jforms_view_edition_code_without_exp option').first().should('have.text', '')
-            .nextAll().each(($opt, index, $options) => {
-                cy.wrap($opt).should('not.have.text', '')
+            .nextAll().then(options => {
+                const actual = [...options].map(o => o.text)
+                expect(actual).to.deep.equal(['Zone A1', 'Zone A2', 'Zone B1', 'Zone B2'])
             })
 
         cy.log('Simple expression menulist 2 values + 1 empty value')
         cy.get('#jforms_view_edition_code_with_simple_exp option').should('have.length', 3)
         cy.get('#jforms_view_edition_code_with_simple_exp option').first().should('have.text', '')
-            .nextAll().each(($opt, index, $options) => {
-                cy.wrap($opt).should('not.have.text', '')
+            .nextAll().then(options => {
+                const actual = [...options].map(o => o.text)
+                expect(actual).to.deep.equal(['Zone A1', 'Zone B1'])
             })
 
         cy.log('Parent field menulist 3 values + 1 empty value')
         cy.get('#jforms_view_edition_code_for_drill_down_exp option').should('have.length', 4)
         cy.get('#jforms_view_edition_code_for_drill_down_exp option').first().should('have.text', '')
-            .nextAll().each(($opt, index, $options) => {
-                cy.wrap($opt).should('not.have.text', '')
+            .nextAll().then(options => {
+                const actual = [...options].map(o => o.text)
+                expect(actual).to.deep.equal(['Zone A', 'Zone B', 'No Zone'])
             })
 
         cy.log('Child field menulist 0 value + 1 empty value')

--- a/tests/end2end/cypress/integration/form_edition_value_relation_field-ghaction.js
+++ b/tests/end2end/cypress/integration/form_edition_value_relation_field-ghaction.js
@@ -8,39 +8,34 @@ describe('Form edition all field type', function() {
     })
 
     it('Check initial states', function() {
-        context('No expression menulist 4 values + 1 empty value', function () {
-            cy.get('#jforms_view_edition_code_without_exp option').should('have.length', 5)
-            cy.get('#jforms_view_edition_code_without_exp option').first().should('have.text', '')
-                .nextAll().each(($opt, index, $options) => {
-                    cy.wrap($opt).should('not.have.text', '')
-                })
-        })
+        cy.log('No expression menulist 4 values + 1 empty value')
+        cy.get('#jforms_view_edition_code_without_exp option').should('have.length', 5)
+        cy.get('#jforms_view_edition_code_without_exp option').first().should('have.text', '')
+            .nextAll().each(($opt, index, $options) => {
+                cy.wrap($opt).should('not.have.text', '')
+            })
 
-        context('Simple expression menulist 2 values + 1 empty value', function () {
-            cy.get('#jforms_view_edition_code_with_simple_exp option').should('have.length', 3)
-            cy.get('#jforms_view_edition_code_with_simple_exp option').first().should('have.text', '')
-                .nextAll().each(($opt, index, $options) => {
-                    cy.wrap($opt).should('not.have.text', '')
-                })
-        })
+        cy.log('Simple expression menulist 2 values + 1 empty value')
+        cy.get('#jforms_view_edition_code_with_simple_exp option').should('have.length', 3)
+        cy.get('#jforms_view_edition_code_with_simple_exp option').first().should('have.text', '')
+            .nextAll().each(($opt, index, $options) => {
+                cy.wrap($opt).should('not.have.text', '')
+            })
 
-        context('Parent field menulist 3 values + 1 empty value', function () {
-            cy.get('#jforms_view_edition_code_for_drill_down_exp option').should('have.length', 4)
-            cy.get('#jforms_view_edition_code_for_drill_down_exp option').first().should('have.text', '')
-                .nextAll().each(($opt, index, $options) => {
-                    cy.wrap($opt).should('not.have.text', '')
-                })
-        })
+        cy.log('Parent field menulist 3 values + 1 empty value')
+        cy.get('#jforms_view_edition_code_for_drill_down_exp option').should('have.length', 4)
+        cy.get('#jforms_view_edition_code_for_drill_down_exp option').first().should('have.text', '')
+            .nextAll().each(($opt, index, $options) => {
+                cy.wrap($opt).should('not.have.text', '')
+            })
 
-        context('Child field menulist 0 value + 1 empty value', function () {
-            cy.get('#jforms_view_edition_code_with_drill_down_exp option').should('have.length', 1)
-            cy.get('#jforms_view_edition_code_with_drill_down_exp option').first().should('have.text', '')
-        })
+        cy.log('Child field menulist 0 value + 1 empty value')
+        cy.get('#jforms_view_edition_code_with_drill_down_exp option').should('have.length', 1)
+        cy.get('#jforms_view_edition_code_with_drill_down_exp option').first().should('have.text', '')
 
-        context('Geom expression menulist 0 value + 1 empty value', function () {
-            cy.get('#jforms_view_edition_code_with_geom_exp option').should('have.length', 1)
-            cy.get('#jforms_view_edition_code_with_geom_exp option').first().should('have.text', '')
-        })
+        cy.log('Geom expression menulist 0 value + 1 empty value')
+        cy.get('#jforms_view_edition_code_with_geom_exp option').should('have.length', 1)
+        cy.get('#jforms_view_edition_code_with_geom_exp option').first().should('have.text', '')
     })
 
     it('Child field menulist after parent select', function () {

--- a/tests/end2end/cypress/integration/form_edition_value_relation_field-ghaction.js
+++ b/tests/end2end/cypress/integration/form_edition_value_relation_field-ghaction.js
@@ -82,6 +82,7 @@ describe('Form edition all field type', function() {
         cy.intercept('/index.php/jelix/jforms/getListData*').as('getListData')
 
         // Click on map as form needs a geometry
+        cy.log('Create a geometry over Zone A1')
         cy.get('#map').click(500, 300)
         // Wait getListData query ends + slight delay for UI to be ready
         cy.wait('@getListData')
@@ -89,6 +90,70 @@ describe('Form edition all field type', function() {
         cy.get('#jforms_view_edition_code_with_geom_exp option').should('have.length', 2)
         cy.get('#jforms_view_edition_code_with_geom_exp option').first().should('have.text', '')
         cy.get('#jforms_view_edition_code_with_geom_exp option').last().should('have.text', 'Zone A1')
+
+        // Did not achieve to move the geometry so
+        // Cancel and open form
+        cy.on('window:confirm', () => true);
+        cy.get('#jforms_view_edition__submit_cancel').click()
+        cy.get('#edition-draw').click()
+        cy.wait(800)
+
+        // Click on map as form needs a geometry
+        cy.log('Create a geometry over Zone A2')
+        cy.get('#map').click(700, 300)
+        // Wait getListData query ends + slight delay for UI to be ready
+        cy.wait('@getListData')
+
+        cy.get('#jforms_view_edition_code_with_geom_exp option').should('have.length', 2)
+        cy.get('#jforms_view_edition_code_with_geom_exp option').first().should('have.text', '')
+        cy.get('#jforms_view_edition_code_with_geom_exp option').last().should('have.text', 'Zone A2')
+
+        // Cancel and open form
+        cy.on('window:confirm', () => true);
+        cy.get('#jforms_view_edition__submit_cancel').click()
+        cy.get('#edition-draw').click()
+        cy.wait(800)
+
+        // Click on map as form needs a geometry
+        cy.log('Create a geometry over Zone B1')
+        cy.get('#map').click(500, 500)
+        // Wait getListData query ends + slight delay for UI to be ready
+        cy.wait('@getListData')
+
+        cy.get('#jforms_view_edition_code_with_geom_exp option').should('have.length', 2)
+        cy.get('#jforms_view_edition_code_with_geom_exp option').first().should('have.text', '')
+        cy.get('#jforms_view_edition_code_with_geom_exp option').last().should('have.text', 'Zone B1')
+
+        // Cancel and open form
+        cy.on('window:confirm', () => true);
+        cy.get('#jforms_view_edition__submit_cancel').click()
+        cy.get('#edition-draw').click()
+        cy.wait(800)
+
+        // Click on map as form needs a geometry
+        cy.log('Create a geometry over Zone B2')
+        cy.get('#map').click(700, 500)
+        // Wait getListData query ends + slight delay for UI to be ready
+        cy.wait('@getListData')
+
+        cy.get('#jforms_view_edition_code_with_geom_exp option').should('have.length', 2)
+        cy.get('#jforms_view_edition_code_with_geom_exp option').first().should('have.text', '')
+        cy.get('#jforms_view_edition_code_with_geom_exp option').last().should('have.text', 'Zone B2')
+
+        // Cancel and open form
+        cy.on('window:confirm', () => true);
+        cy.get('#jforms_view_edition__submit_cancel').click()
+        cy.get('#edition-draw').click()
+        cy.wait(800)
+
+        // Click on map as form needs a geometry
+        cy.log('Create a geometry outside zones')
+        cy.get('#map').click(700, 700)
+        // Wait getListData query ends + slight delay for UI to be ready
+        cy.wait('@getListData')
+
+        cy.get('#jforms_view_edition_code_with_geom_exp option').should('have.length', 1)
+        cy.get('#jforms_view_edition_code_with_geom_exp option').first().should('have.text', '')
     })
 
 })

--- a/tests/qgis-projects/tests/form_edition_value_relation_field.md
+++ b/tests/qgis-projects/tests/form_edition_value_relation_field.md
@@ -6,42 +6,9 @@ Lizmap plugin installed for QGIS Server is needed
 
 ## Procedure
 
-### Check the default form
-
-* [ ] Click on add a `point` in the *Edition* panel (do not click on the map yet)
-* [ ] Check that the *No expression* available values has **5** options :
-  * [ ] **Zone A1**
-  * [ ] **Zone A2**
-  * [ ] **Zone B1**
-  * [ ] **Zone B2**
-  * [ ] an empty value
-* [ ] Check that the *Simple expression* available values has **3** options :
-  * [ ] **Zone A1**
-  * [ ] **Zone B1**
-  * [ ] an empty value
-* [ ] Check that the *Child field* available values has **1** option :
-  * [ ] an empty value
-* [ ] Check that the *Geom expression* available values has **1** option
-  * [ ] an empty value
-
-### Check the drill-down fields
-
-* [ ] Click on add a `point` in the *Edition* panel (do not  click on the map yet)
-* [ ] Select **Zone A** for *Parent field*
-* [ ] Check that the *Child field* available values has **3** options :
-  * [ ] **Zone A1**
-  * [ ] **Zone A2**
-  * [ ] an empty value
-* [ ] Select **Zone B** for *Parent field*
-* [ ] Check that the *Child field* available values has **3** options :
-  * [ ] **Zone B1**
-  * [ ] **Zone B2**
-  * [ ] an empty value
-* [ ] Select **No Zone** for *Parent field*
-* [ ] Check that the *Child field* available values has **1** option :
-  * [ ] an empty value
-
 ### Check the field available values filtered by geometry
+
+Partially covered by Cypress (the move part is not covered)
 
 * [ ] Click on add a `point` in the *Edition* panel
 * [ ] Click on the map to draw the point within **Zone A1**


### PR DESCRIPTION
* Using cy.log instead of cy.context
* Extend cypress filter by geometry
* Extend cypress initial form state to cover manually tests
* Update manually tests because of cypress overage

* Funded by 3liz
