### PR TITLE
[Bugfix] Force to open GetPrint in blank window

### DIFF
--- a/lizmap/www/assets/js/map.js
+++ b/lizmap/www/assets/js/map.js
@@ -4709,22 +4709,7 @@ var lizMap = function() {
               } else {
                   var URL = window.URL || window.webkitURL;
                   var downloadUrl = URL.createObjectURL(blob);
-
-                  if (filename) {
-                      // use HTML5 a[download] attribute to specify filename
-                      var a = document.createElement("a");
-                      // safari doesn't support this yet
-                      if (typeof a.download === 'undefined') {
-                          window.location = downloadUrl;
-                      } else {
-                          a.href = downloadUrl;
-                          a.download = filename;
-                          document.body.appendChild(a);
-                          a.click();
-                      }
-                  } else {
-                      window.location = downloadUrl;
-                  }
+                  window.open(downloadUrl, '_blank');
 
                   setTimeout(function () { URL.revokeObjectURL(downloadUrl); }, 100); // cleanup
               }

--- a/tests/end2end/cypress/integration/print.js
+++ b/tests/end2end/cypress/integration/print.js
@@ -42,19 +42,145 @@ describe('Print', function () {
 
         cy.get('#print-format').select('png')
         cy.intercept('POST', '*test_print*').as('GetPrint')
+        let getprinturl = null
+        cy.window().then((win) => {
+            cy.stub(win, 'open', (_url, _target) => {
+                expect(_target).to.be.equal('_blank')
+                expect(_url).to.contain('blob:')
+                getprinturl = _url
+                // By default the method is replaced and do nothing
+                // To reactivate window.open uncomment the next line
+                //return win.open.wrappedMethod.call(win, _url, _target)
+            }).as("OpenGetPrint")
+        })
 
         // Default values in title labels
         cy.get('#print-launch').click()
 
-        cy.wait('@GetPrint').then(() => {
-            cy.fixture('images/print/print_default_labels.png', 'base64').then((fixturePNG) => {
-                cy.readFile(path.join(downloadsFolder, "test_print_print_labels.png"), 'base64').then((downloadedPNG) => {
-                    // image encoded as base64
-                    const img1 = PNG.sync.read(Buffer.from(downloadedPNG, 'base64'));
-                    const img2 = PNG.sync.read(Buffer.from(fixturePNG, 'base64'));
-                    const { width, height } = img1;
+        cy.wait('@GetPrint').should(({ request, response }) => {
+            expect(response.headers['content-type']).to.contain('image/png')
+            expect(response.headers['content-disposition']).to.contain('attachment; filename=')
+            const responseBodyAsBase64 = arrayBufferToBase64(response.body)
 
-                    expect(pixelmatch(img1.data, img2.data, null, width, height, { threshold: 0 }), 'expect print default values in the title labels').to.equal(0)
+            cy.fixture('images/print/print_default_labels.png').then((image) => {
+                // image encoded as base64
+                const img1 = PNG.sync.read(Buffer.from(responseBodyAsBase64, 'base64'));
+                const img2 = PNG.sync.read(Buffer.from(image, 'base64'));
+                const { width, height } = img1;
+
+                expect(pixelmatch(img1.data, img2.data, null, width, height, { threshold: 0 }), 'expect print default values in the title labels').to.equal(0)
+            })
+
+            // stub has been called
+            cy.get('@OpenGetPrint').should("be.called")
+            expect(getprinturl).to.be.not.null
+
+            // check URL provided window.open
+            fetch(getprinturl).then(r => {
+                expect([...(r.headers.keys())]).to.include.members(['content-type', 'content-length'])
+                expect(r.headers.get('content-type')).to.contain('image/png')
+                expect(parseInt(r.headers.get('content-length'))).to.be.greaterThan(0)
+                expect(r.url).to.contain('blob:')
+                //r.blob()
+            })
+        })
+
+        // Changed values in title labels
+        cy.get('#print [name="simple_title"]').clear()
+        cy.get('#print [name="simple_title"]').type('A test')
+
+        cy.get('#print [name="html_title"]').clear()
+        cy.get('#print [name="html_title"]').type('A test<br>with an <i>HTML</i> line break')
+
+        cy.get('#print-launch').click()
+        cy.wait('@GetPrint').should(({ request, response }) => {
+            expect(response.headers['content-type']).to.contain('image/png')
+            expect(response.headers['content-disposition']).to.contain('attachment; filename=')
+            const responseBodyAsBase64 = arrayBufferToBase64(response.body)
+
+            cy.fixture('images/print/print_changed_labels.png').then((image) => {
+                // image encoded as base64
+                const img1 = PNG.sync.read(Buffer.from(responseBodyAsBase64, 'base64'));
+                const img2 = PNG.sync.read(Buffer.from(image, 'base64'));
+                const { width, height } = img1;
+
+                expect(pixelmatch(img1.data, img2.data, null, width, height, { threshold: 0 }), 'expect print changed values in the title labels').to.equal(0)
+            })
+        })
+    })
+
+    it('should print JPG', function () {
+        cy.get('#print-format').select('jpg')
+        cy.intercept('POST', '*test_print*').as('GetPrint')
+        let getprinturl = null
+        cy.window().then((win) => {
+            cy.stub(win, 'open', (_url, _target) => {
+                expect(_target).to.be.equal('_blank')
+                expect(_url).to.contain('blob:')
+                getprinturl = _url
+                // By default the method is replaced and do nothing
+                // To reactivate window.open uncomment the next line
+                //return win.open.wrappedMethod.call(win, _url, _target)
+            }).as("OpenGetPrint")
+        })
+
+        // Default values in title labels
+        cy.get('#print-launch').click()
+
+        cy.wait('@GetPrint').should(({ request, response }) => {
+            expect(response.headers['content-type']).to.contain('image/jpeg')
+            expect(response.headers['content-disposition']).to.contain('attachment; filename=')
+
+            // stub has been called
+            cy.get('@OpenGetPrint').should("be.called")
+            expect(getprinturl).to.be.not.null
+
+            // check URL provided window.open
+            fetch(getprinturl).then(r => {
+                expect([...(r.headers.keys())]).to.include.members(['content-type', 'content-length'])
+                expect(r.headers.get('content-type')).to.contain('image/jpeg')
+                expect(parseInt(r.headers.get('content-length'))).to.be.greaterThan(0)
+                expect(r.url).to.contain('blob:')
+                //r.blob()
+            })
+        })
+    })
+
+    it('should print SVG', function () {
+        cy.get('#print-format').select('svg')
+        cy.intercept('POST', '*test_print*').as('GetPrint')
+        let getprinturl = null
+        cy.window().then((win) => {
+            cy.stub(win, 'open', (_url, _target) => {
+                expect(_target).to.be.equal('_blank')
+                expect(_url).to.contain('blob:')
+                getprinturl = _url
+                // By default the method is replaced and do nothing
+                // To reactivate window.open uncomment the next line
+                //return win.open.wrappedMethod.call(win, _url, _target)
+            }).as("OpenGetPrint")
+        })
+
+        // Default values in title labels
+        cy.get('#print-launch').click()
+
+        cy.wait('@GetPrint').should(({ request, response }) => {
+            expect(response.headers['content-type']).to.contain('image/svg+xml')
+            expect(response.headers['content-disposition']).to.contain('attachment; filename=')
+            expect(response.body).to.contain('Change title')
+
+            // stub has been called
+            cy.get('@OpenGetPrint').should("be.called")
+            expect(getprinturl).to.be.not.null
+
+            // check URL provided window.open
+            fetch(getprinturl).then(r => {
+                expect([...(r.headers.keys())]).to.include.members(['content-type', 'content-length'])
+                expect(r.headers.get('content-type')).to.contain('image/svg+xml')
+                expect(parseInt(r.headers.get('content-length'))).to.be.greaterThan(0)
+                expect(r.url).to.contain('blob:')
+                r.text().then(body => {
+                    expect(body).to.contain('Change title')
                 })
             })
         })
@@ -67,17 +193,62 @@ describe('Print', function () {
         cy.get('#print [name="html_title"]').type('A test<br>with an <i>HTML</i> line break')
 
         cy.get('#print-launch').click()
+        cy.wait('@GetPrint').should(({ request, response }) => {
+            expect(response.headers['content-type']).to.contain('image/svg+xml')
+            expect(response.headers['content-disposition']).to.contain('attachment; filename=')
+            expect(response.body).to.contain('A test')
 
-        cy.wait('@GetPrint').then(() => {
-            cy.fixture('images/print/print_changed_labels.png', 'base64').then((fixturePNG) => {
-                cy.readFile(path.join(downloadsFolder, "test_print_print_labels.png"), 'base64').then((downloadedPNG) => {
-                    // image encoded as base64
-                    const img1 = PNG.sync.read(Buffer.from(downloadedPNG, 'base64'));
-                    const img2 = PNG.sync.read(Buffer.from(fixturePNG, 'base64'));
-                    const { width, height } = img1;
+            // stub has been called
+            cy.get('@OpenGetPrint').should("be.called")
+            expect(getprinturl).to.be.not.null
 
-                    expect(pixelmatch(img1.data, img2.data, null, width, height, { threshold: 0 }), 'expect print changed values in the title labels').to.equal(0)
+            // check URL provided window.open
+            fetch(getprinturl).then(r => {
+                expect([...(r.headers.keys())]).to.include.members(['content-type', 'content-length'])
+                expect(r.headers.get('content-type')).to.contain('image/svg+xml')
+                expect(parseInt(r.headers.get('content-length'))).to.be.greaterThan(0)
+                expect(r.url).to.contain('blob:')
+                r.text().then(body => {
+                    expect(body).to.contain('A test')
                 })
+            })
+        })
+    })
+
+
+    it('should print PDF', function () {
+        cy.get('#print-format').select('pdf')
+        cy.intercept('POST', '*test_print*').as('GetPrint')
+        let getprinturl = null
+        cy.window().then((win) => {
+            cy.stub(win, 'open', (_url, _target) => {
+                expect(_target).to.be.equal('_blank')
+                expect(_url).to.contain('blob:')
+                getprinturl = _url
+                // By default the method is replaced and do nothing
+                // To reactivate window.open uncomment the next line
+                //return win.open.wrappedMethod.call(win, _url, _target)
+            }).as("OpenGetPrint")
+        })
+
+        // Default values in title labels
+        cy.get('#print-launch').click()
+
+        cy.wait('@GetPrint').should(({ request, response }) => {
+            expect(response.headers['content-type']).to.contain('application/pdf')
+            expect(response.headers['content-disposition']).to.contain('attachment; filename=')
+
+            // stub has been called
+            cy.get('@OpenGetPrint').should("be.called")
+            expect(getprinturl).to.be.not.null
+
+            // check URL provided window.open
+            fetch(getprinturl).then(r => {
+                expect([...(r.headers.keys())]).to.include.members(['content-type', 'content-length'])
+                expect(r.headers.get('content-type')).to.contain('application/pdf')
+                expect(parseInt(r.headers.get('content-length'))).to.be.greaterThan(0)
+                expect(r.url).to.contain('blob:')
+                //r.blob()
             })
         })
     })
@@ -85,7 +256,7 @@ describe('Print', function () {
     // PDFs can't be intercepted due to a Cypress bug : https://github.com/cypress-io/cypress/issues/15038
     // So we compare downloaded file to fixture
     // TODO : test is flaky, maybe assert pdf is downloaded
-    
+
     // const path = require("path");
     // it('should download PDF with default title labels', function () {
 


### PR DESCRIPTION
Because some browser like Firefox opens PDF content in the internal PDF viewer, lizmap has to force to open GetPrint content in a blank window whixh is a new tab.

* Funded by 3Liz
