### PR TITLE
[Bugfix] WFS GetCapabilities - Default version 1.0.0

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/WFSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WFSRequest.php
@@ -122,7 +122,7 @@ class WFSRequest extends OGCRequest
         $version = $this->param('version');
         // force version if not defined
         if (!$version) {
-            $this->params['version'] = '1.3.0';
+            $this->params['version'] = '1.0.0';
         }
 
         $result = parent::process_getcapabilities();

--- a/tests/end2end/cypress/integration/requests-service-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-service-ghaction.js
@@ -30,6 +30,7 @@ describe('Request service', function () {
                 expect(resp.status).to.eq(200)
                 expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
                 expect(resp.body).to.contain('WMS_Capabilities')
+                expect(resp.body).to.contain('version="1.3.0"')
             })
     })
 
@@ -38,6 +39,7 @@ describe('Request service', function () {
             .then((resp) => {
                 expect(resp.status).to.eq(200)
                 expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+                expect(resp.body).to.contain('version="1.0.0"')
             })
     })
 
@@ -47,6 +49,18 @@ describe('Request service', function () {
                 expect(resp.status).to.eq(200)
                 expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
                 expect(resp.body).to.contain('WFS_Capabilities')
+                expect(resp.body).to.contain('version="1.0.0"')
+            })
+        })
+
+    it('WFS GetCapabilities 1.1.0', function () {
+
+        cy.request('/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WFS&VERSION=1.1.0&REQUEST=GetCapabilities')
+            .then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+                expect(resp.body).to.contain('WFS_Capabilities')
+                expect(resp.body).to.contain('version="1.1.0"')
             })
     })
 
@@ -171,6 +185,7 @@ describe('Request service', function () {
             expect(resp.status).to.eq(200)
             expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
             expect(resp.body).to.contain('WFS_Capabilities')
+            expect(resp.body).to.contain('version="1.0.0"')
         })
     })
 })


### PR DESCRIPTION
The default version for WFS in Lizmap Web Client is 1.0.0.

* Funded by 3liz
