### PR TITLE
Administration - New page showing a list of projects and their properties

### DIFF
--- a/lizmap/modules/admin/classes/config.listener.php
+++ b/lizmap/modules/admin/classes/config.listener.php
@@ -28,6 +28,15 @@ class configListener extends jEventListener
                 );
             }
 
+            // Project list menu
+            $bloc->childItems[] = new masterAdminMenuItem(
+                'lizmap_project_list',
+                jLocale::get('admin~admin.menu.lizmap.project.list.label'),
+                jUrl::get('admin~qgis_projects:index'),
+                112,
+                'lizmap'
+            );
+
             // Child for the configuration of lizmap landing page content
             $bloc->childItems[] = new masterAdminMenuItem(
                 'lizmap_landing_page_content',

--- a/lizmap/modules/admin/controllers/qgis_projects.classic.php
+++ b/lizmap/modules/admin/controllers/qgis_projects.classic.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * Lizmap administration : Server information page.
+ * Lizmap administration : List of QGIS projects.
  *
  * @author    3liz
- * @copyright 2016 3liz
+ * @copyright 2022 3liz
  *
  * @see      http://3liz.com
  *
  * @license Mozilla Public License : http://www.mozilla.org/MPL/
  */
-class server_informationCtrl extends jController
+class qgis_projectsCtrl extends jController
 {
     // Configure access via jacl2 rights management
     public $pluginParams = array(
@@ -18,23 +18,26 @@ class server_informationCtrl extends jController
 
     /**
      * Get the information from QGIS Server and display them.
+     *
+     * @return jResponseHtml
      */
     public function index()
     {
+        /** @var jResponseHtml */
         $rep = $this->getResponse('html');
+        $rep->title = 'Admin - Lizmap projects';
 
-        // Get the metadata
-        $server = new \Lizmap\Server\Server();
-        $data = $server->getMetadata();
+        // Get the project list from the zone
+        $project_list = jZone::get('project_list', array('repository' => ''));
 
         // Set the HTML content
         $tpl = new jTpl();
         $assign = array(
-            'data' => $data,
+            'project_list' => $project_list,
         );
         $tpl->assign($assign);
-        $rep->body->assign('MAIN', $tpl->fetch('server_information'));
-        $rep->body->assign('selectedMenuItem', 'lizmap_server_information');
+        $rep->body->assign('MAIN', $tpl->fetch('project_list'));
+        $rep->body->assign('selectedMenuItem', 'lizmap_project_list');
 
         return $rep;
     }

--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -4,6 +4,7 @@ header.admin=Administration
 menu.configuration.main.label=Lizmap configuration
 menu.server.information.label=Server information
 menu.lizmap.repositories.label=Maps management
+menu.lizmap.project.list.label=QGIS projects
 menu.lizmap.landingPageContent.label=Landing page content
 menu.lizmap.logs.label=Lizmap Logs
 menu.lizmap.logs.view.label=View logs
@@ -256,3 +257,24 @@ minimum 3.7.0 by reading the documentation about the environment \
 variable https://docs.lizmap.com/current/en/install/pre_requirements.html#lizmap-server-plugin
 server.information.qgis.error.fetching.information.detail.NO_ACCESS=You don't have access to information about QGIS Server
 server.information.qgis.error.fetching.information.detail.HTTP_ERROR=QGIS Server returns an HTTP error about the Lizmap plugin:
+
+
+project.list.column.repository.label=Repository
+project.list.column.project.label=Project
+project.list.column.project.file.time.label=Last modified
+project.list.column.crs.label=Projection
+project.list.column.crs.user.warning.label=Please avoid user-defined projections for projects and layers.
+project.list.column.layers.count.label=Layers
+project.list.column.layers.count.warning.label=This project has many layers. Performance could be degraded.
+project.list.column.layers.count.error.label=This project has a hug number of layers. Performance could be degraded.
+project.list.column.qgis.desktop.version.label=QGIS Desktop
+project.list.column.qgis.desktop.version.above.server=The QGIS project has been saved with a version above the one installed in your server
+project.list.column.qgis.desktop.version.too.old=The QGIS project has been saved with an old version of QGIS
+project.list.column.lizmap.plugin.version.label=Lizmap plugin
+project.list.column.authorized.groups.label=Groups
+project.list.column.hidden.project.label=Hidden
+project.list.column.hidden.project.yes.label=Yes
+project.list.column.hidden.project.no.label=No
+project.list.column.invalid.layers.count.label=Invalid layers
+project.list.column.layout.count.label=Layouts
+project.list.column.used.memory.label=Memory

--- a/lizmap/modules/admin/templates/project_list.tpl
+++ b/lizmap/modules/admin/templates/project_list.tpl
@@ -1,0 +1,8 @@
+{ifacl2 'lizmap.admin.access'}
+
+<h2>{@admin.menu.lizmap.project.list.label@}</h2>
+<div id="lizmap_project_list">
+    {$project_list}
+</div>
+
+{/ifacl2}

--- a/lizmap/modules/admin/templates/project_list_zone.tpl
+++ b/lizmap/modules/admin/templates/project_list_zone.tpl
@@ -1,0 +1,104 @@
+{meta_html css '/assets/css/dataTables.bootstrap.min.css'}
+{meta_html js '/assets/js/jquery.dataTables.min.js'}
+{meta_html js '/assets/js/admin/activate_datatable.js'}
+
+<table class="lizmap_project_list table table-condensed table-striped table-bordered" style="width:95%">
+    <thead>
+        <tr>
+            <th>{@admin.project.list.column.repository.label@}</th>
+            <th>{@admin.project.list.column.project.label@}</th>
+            <th>{@admin.project.list.column.project.file.time.label@}</th>
+            <th>{@admin.project.list.column.crs.label@}</th>
+            <th>{@admin.project.list.column.layers.count.label@}</th>
+            <th>{@admin.project.list.column.qgis.desktop.version.label@}</th>
+            <th>{@admin.project.list.column.lizmap.plugin.version.label@}</th>
+            <th>{@admin.project.list.column.authorized.groups.label@}</th>
+            <th>{@admin.project.list.column.hidden.project.label@}</th>
+
+            <!-- <th>{@admin.project.list.column.invalid.layers.count.label@}</th>
+            <th>{@admin.project.list.column.layout.count.label@}</th>
+            <th>{@admin.project.list.column.used.memory.label@}</th> -->
+        </tr>
+    </thead>
+
+    <tbody>
+
+    <!-- colors for warnings and errors -->
+    {assign $colors = array('warning'=>'lightyellow', 'error'=>'lightcoral')}
+
+    {foreach $map_items as $mi}
+    {if $mi->type == 'rep'}
+        {foreach $mi->childItems as $p}
+        <tr>
+            <td title="{$mi->title}">{$mi->id}</td>
+            <!-- project- KEEP the line break after the title to improve the tooltip readability-->
+            <td title="{$p['title']}
+{$p['abstract']|strip_tags|truncate:150}">
+                <a target="_blank" href="{$p['url']}">{$p['id']}</a>
+            </td>
+
+            <!-- File time -->
+            <td title="">{$p['file_time']|jdatetime:'timestamp':'Y-m-d H:i:s'}</td>
+
+            <!-- Projection -->
+            {assign $style = ''}
+            {assign $title = ''}
+            {if substr($p['projection'], 0, 4) == 'USER'}
+                {assign $style = 'background-color: '.$colors['warning'].';'}
+                {assign $title = @admin.project.list.column.crs.user.warning.label@}
+            {/if}
+            <td title="{$title}" style="{$style}">{$p['projection']}</td>
+
+            <!-- Layer count -->
+            {assign $style = ''}
+            {assign $title = ''}
+            {if $p['layer_count'] > 100}
+                {assign $style = 'background-color: '.$colors['warning'].';'}
+                {assign $title = @admin.project.list.column.layers.count.warning.label@}
+            {/if}
+            {if $p['layer_count'] > 200}
+                {assign $style = 'background-color: '.$colors['error'].';'}
+                {assign $title = @admin.project.list.column.layers.count.error.label@}
+            {/if}
+            <td title="{$title}" style="{$style}">
+                {$p['layer_count']}
+            </td>
+
+            <!-- QGIS project version -->
+            {assign $style = ''}
+            {assign $title = ''}
+            {if $server_versions['qgis_server_version_int'] && $server_versions['qgis_server_version_int'] - $p['qgis_version_int'] > 6 }
+                {assign $style = 'background-color: '.$colors['warning'].';'}
+                {assign $title = @admin.project.list.column.qgis.desktop.version.too.old@.' ('.@admin.form.admin_services.qgisServerVersion.label@.': '.$server_versions['qgis_server_version'].')'}
+            {/if}
+            {if $server_versions['qgis_server_version_int'] && $p['qgis_version_int'] > $server_versions['qgis_server_version_int']}
+                {assign $style = 'background-color: '.$colors['error'].';'}
+                {assign $title = @admin.project.list.column.qgis.desktop.version.above.server@ .' ('.$server_versions['qgis_server_version'].')'}
+            {/if}
+            <td title="{$title}" style="{$style}">{$p['qgis_version']}</td>
+
+            <!-- Version of Lizmap plugin for QGIS Desktop -->
+            <td title="">{$p['lizmap_plugin_version']}</td>
+
+            <!-- Authorized groups -->
+            <td title="">{$p['acl_groups']}</td>
+
+            <!-- Project hidden -->
+            <td title="">
+                {if $p['hidden_project']}
+                    {@admin.project.list.column.hidden.project.yes.label@}
+                {else}
+                    {@admin.project.list.column.hidden.project.no.label@}
+                {/if}
+            </td>
+
+            <!-- future interesting fields which requires using the py-qgis-server API -->
+            <!-- <td title=""></td>
+            <td title=""></td>
+            <td title=""></td> -->
+        </tr>
+        {/foreach}
+    {/if}
+    {/foreach}
+    </tbody>
+</table>

--- a/lizmap/modules/admin/zones/project_list.zone.php
+++ b/lizmap/modules/admin/zones/project_list.zone.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Construct a list of Lizmap projects.
+ *
+ * @author    3liz
+ * @copyright 2022 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license    Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+class project_listZone extends jZone
+{
+    protected $_tplname = 'project_list_zone';
+
+    protected function _prepareTpl()
+    {
+        $maps = array();
+        // Get repository data
+        $repository = $this->param('repository');
+
+        $repositories = array();
+        if ($repository != null) {
+            $repositories[] = $repository;
+        } else {
+            $repositories = lizmap::getRepositoryList();
+        }
+
+        foreach ($repositories as $r) {
+            $lrep = lizmap::getRepository($r);
+            $mrep = new lizmapMainViewItem($r, $lrep->getLabel());
+            $metadata = $lrep->getProjectsMetadata();
+            foreach ($metadata as $meta) {
+                // Get QGIS project version
+                $qgis_version_int = $meta->getQgisProjectVersion();
+                $qgis_version = substr($qgis_version_int, 0, 1);
+                $qgis_version .= '.'.ltrim(substr($qgis_version_int, 1, 2), '');
+                $qgis_version .= '.'.ltrim(substr($qgis_version_int, 3, 2), '');
+
+                // Build the project properties table
+                $project_item = array(
+                    'id' => $meta->getId(),
+                    'title' => $meta->getTitle(),
+                    'abstract' => $meta->getAbstract(),
+                    'projection' => $meta->getProj(),
+                    'url' => jUrl::get(
+                        'view~map:index',
+                        array('repository' => $meta->getRepository(), 'project' => $meta->getId())
+                    ),
+                    'image' => jUrl::get(
+                        'view~media:illustration',
+                        array('repository' => $meta->getRepository(), 'project' => $meta->getId())
+                    ),
+                    'qgis_version' => $qgis_version,
+                    // keep only major and minor versions. Ex: 322 for 3.22.04
+                    'qgis_version_int' => (int) substr($qgis_version_int, 0, 3),
+                    'lizmap_plugin_version' => $meta->getLizmapPluginVersion(),
+                    'file_time' => $meta->getFileTime(),
+                    'layer_count' => $meta->getLayerCount(),
+                    'acl_groups' => $meta->getAclGroups(),
+                    'hidden_project' => $meta->getHidden(),
+                );
+                $mrep->childItems[] = $project_item;
+            }
+            $maps[$r] = $mrep;
+        }
+        $this->_tpl->assign('map_items', $maps);
+
+        // Get the server metadata
+        $server = new \Lizmap\Server\Server();
+        $data = $server->getMetadata();
+        $server_versions = array(
+            'qgis_server_version' => null,
+            'qgis_server_version_int' => null,
+            'lizmap_plugin_server_version' => null,
+            'lizmap_plugin_server_version_int' => null,
+        );
+        if (!array_key_exists('error', $data['qgis_server_info'])) {
+            // QGIS server
+            $qgis_server_version = $data['qgis_server_info']['metadata']['version'];
+            $server_versions['qgis_server_version'] = $qgis_server_version;
+            $explode = explode('.', $qgis_server_version);
+            // Keep only major and minor version
+            $server_versions['qgis_server_version_int'] = (int) $explode[0].str_pad($explode[1], 2, '0', STR_PAD_LEFT);
+
+            // Lizmap server plugin
+            $lizmap_version = $data['info']['version'];
+            $server_versions['lizmap_plugin_server_version'] = $lizmap_version;
+        }
+        $this->_tpl->assign('server_versions', $server_versions);
+
+        // Add JS code for datatable
+        $bp = jApp::urlBasePath();
+    }
+}

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -317,6 +317,22 @@ class Project
         return $this->qgis->getQgisProjectVersion();
     }
 
+    /**
+     * Get the version of the Lizmap plugin
+     * used by the project editor on QGIS Desktop.
+     *
+     * @return null|string Version of the lizmap plugin
+     */
+    public function getLizmapPluginVersion()
+    {
+        $pluginMetadata = $this->cfg->getPluginMetadata();
+        if (!is_null($pluginMetadata)) {
+            return $pluginMetadata->lizmap_plugin_version;
+        }
+
+        return null;
+    }
+
     public function getRelations()
     {
         return $this->qgis->getRelations();
@@ -570,6 +586,16 @@ class Project
     public function getLayers()
     {
         return $this->cfg->getLayers();
+    }
+
+    /**
+     * Get the number of layers.
+     *
+     * @return int
+     */
+    public function getLayerCount()
+    {
+        return count((array) $this->cfg->getLayers());
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
@@ -64,6 +64,11 @@ class ProjectConfig
     protected $datavizLayers;
 
     /**
+     * @var object
+     */
+    protected $metadata;
+
+    /**
      * @var mixed
      */
     protected $options;
@@ -81,6 +86,7 @@ class ProjectConfig
         'loginFilteredLayers',
         'filter_by_polygon',
         'datavizLayers',
+        'metadata',
     );
 
     /**
@@ -481,5 +487,22 @@ class ProjectConfig
     public function getDatavizLayers()
     {
         return $this->datavizLayers;
+    }
+
+    /**
+     * Get the metadata written by Lizmap plugin
+     * about the desktop version used.
+     * qgis_desktop_version, lizmap_plugin_version,
+     * lizmap_web_client_target_version, project_valid.
+     *
+     * @return null|object
+     */
+    public function getPluginMetadata()
+    {
+        if (property_exists($this->metadata, 'lizmap_plugin_version')) {
+            return $this->metadata;
+        }
+
+        return null;
     }
 }

--- a/lizmap/modules/lizmap/lib/Project/ProjectMetadata.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectMetadata.php
@@ -40,7 +40,15 @@ class ProjectMetadata
             'wmtsGetCapabilitiesUrl' => $project->getWMTSGetCapabilitiesUrl(),
             'map' => $project->getRelativeQgisPath(),
             'acl' => $project->checkAcl(),
+            'qgisProjectVersion' => $project->getQgisProjectVersion(),
+            'lizmapPluginVersion' => $project->getLizmapPluginVersion(),
+            'layerCount' => $project->getLayerCount(),
+            'fileTime' => $project->getFileTime(),
+            'aclGroups' => '',
         );
+        if (is_array($project->getOption('acl'))) {
+            $metadata['aclGroups'] = implode(', ', $project->getOption('acl'));
+        }
 
         $metadata['hidden'] = $project->getBooleanOption('hideProject');
 
@@ -167,6 +175,56 @@ class ProjectMetadata
     public function getWMTSGetCapabilitiesUrl()
     {
         return $this->data['wmtsGetCapabilitiesUrl'];
+    }
+
+    /**
+     * The QGIS desktop project version.
+     *
+     * @return string
+     */
+    public function getQgisProjectVersion()
+    {
+        return $this->data['qgisProjectVersion'];
+    }
+
+    /**
+     * The version of the Desktop lizmap plugin.
+     *
+     * @return string
+     */
+    public function getLizmapPluginVersion()
+    {
+        return $this->data['lizmapPluginVersion'];
+    }
+
+    /**
+     * The project file time.
+     *
+     * @return string
+     */
+    public function getFileTime()
+    {
+        return $this->data['fileTime'];
+    }
+
+    /**
+     * The number of layers in the QGIS project.
+     *
+     * @return string
+     */
+    public function getLayerCount()
+    {
+        return $this->data['layerCount'];
+    }
+
+    /**
+     * The acl option which corresponds to authorized groups.
+     *
+     * @return string
+     */
+    public function getAclGroups()
+    {
+        return $this->data['aclGroups'];
     }
 
     /**

--- a/lizmap/modules/view/zones/ajax_view.zone.php
+++ b/lizmap/modules/view/zones/ajax_view.zone.php
@@ -33,38 +33,41 @@ class ajax_viewZone extends jZone
         }
 
         foreach ($repositories as $r) {
-            if (jAcl2::check('lizmap.repositories.view', $r)) {
-                $lrep = lizmap::getRepository($r);
-                $mrep = new lizmapMainViewItem($r, $lrep->getLabel());
-                $metadata = $lrep->getProjectsMetadata();
-                foreach ($metadata as $meta) {
-                    // Avoid project with no access rights
-                    if (!$meta->getAcl()) {
-                        continue;
-                    }
-
-                    // Hide project with option "hideProject"
-                    if ($meta->getHidden()) {
-                        continue;
-                    }
-
-                    // Add item
-                    $mrep->childItems[] = new lizmapMainViewItem(
-                        $meta->getId(),
-                        $meta->getTitle(),
-                        $meta->getAbstract(),
-                        $meta->getKeywordList(),
-                        $meta->getProj(),
-                        $meta->getBbox(),
-                        jUrl::getFull('view~map:index', array('repository' => $meta->getRepository(), 'project' => $meta->getId())),
-                        jUrl::getFull('view~media:illustration', array('repository' => $meta->getRepository(), 'project' => $meta->getId())),
-                        0,
-                        $r,
-                        'map'
-                    );
-                }
-                $maps[$r] = $mrep;
+            // Check if the repository can be viewed
+            if (!jAcl2::check('lizmap.repositories.view', $r)) {
+                continue;
             }
+
+            $lrep = lizmap::getRepository($r);
+            $mrep = new lizmapMainViewItem($r, $lrep->getLabel());
+            $metadata = $lrep->getProjectsMetadata();
+            foreach ($metadata as $meta) {
+                // Avoid project with no access rights
+                if (!$meta->getAcl()) {
+                    continue;
+                }
+
+                // Hide project with option "hideProject"
+                if ($meta->getHidden()) {
+                    continue;
+                }
+
+                // Add item
+                $mrep->childItems[] = new lizmapMainViewItem(
+                    $meta->getId(),
+                    $meta->getTitle(),
+                    $meta->getAbstract(),
+                    $meta->getKeywordList(),
+                    $meta->getProj(),
+                    $meta->getBbox(),
+                    jUrl::getFull('view~map:index', array('repository' => $meta->getRepository(), 'project' => $meta->getId())),
+                    jUrl::getFull('view~media:illustration', array('repository' => $meta->getRepository(), 'project' => $meta->getId())),
+                    0,
+                    $r,
+                    'map'
+                );
+            }
+            $maps[$r] = $mrep;
         }
 
         $req = jApp::coord()->request;

--- a/lizmap/modules/view/zones/main_view.zone.php
+++ b/lizmap/modules/view/zones/main_view.zone.php
@@ -42,63 +42,66 @@ class main_viewZone extends jZone
         // Get excluded project
         $excludedProject = $this->param('excludedProject');
         foreach ($repositories as $r) {
-            if (jAcl2::check('lizmap.repositories.view', $r)) {
-                $lrep = lizmap::getRepository($r);
-                $mrep = new lizmapMainViewItem($r, $lrep->getLabel());
+            // Check if the repository can be viewed
+            if (!jAcl2::check('lizmap.repositories.view', $r)) {
+                continue;
+            }
 
-                // WMS GetCapabilities Url
-                $wmsGetCapabilitiesUrl = jAcl2::check(
-                    'lizmap.tools.displayGetCapabilitiesLinks',
-                    $lrep->getKey()
-                );
-                $wmtsGetCapabilitiesUrl = $wmsGetCapabilitiesUrl;
+            $lrep = lizmap::getRepository($r);
+            $mrep = new lizmapMainViewItem($r, $lrep->getLabel());
 
-                $metadata = $lrep->getProjectsMetadata();
-                foreach ($metadata as $meta) {
-                    // Avoid project with no access rights
-                    if (!$meta->getAcl()) {
-                        continue;
-                    }
+            // WMS GetCapabilities Url
+            $wmsGetCapabilitiesUrl = jAcl2::check(
+                'lizmap.tools.displayGetCapabilitiesLinks',
+                $lrep->getKey()
+            );
+            $wmtsGetCapabilitiesUrl = $wmsGetCapabilitiesUrl;
 
-                    // Hide project with option "hideProject"
-                    if ($meta->getHidden()) {
-                        continue;
-                    }
-
-                    // Get project information
-                    if ($wmsGetCapabilitiesUrl) {
-                        $wmsGetCapabilitiesUrl = $meta->getWMSGetCapabilitiesUrl();
-                        $wmtsGetCapabilitiesUrl = $meta->getWMTSGetCapabilitiesUrl();
-                    }
-                    if ($lrep->getKey().'~'.$meta->getId() != $excludedProject) {
-                        $mrep->childItems[] = new lizmapMainViewItem(
-                            $meta->getId(),
-                            $meta->getTitle(),
-                            $meta->getAbstract(),
-                            $meta->getKeywordList(),
-                            $meta->getProj(),
-                            $meta->getBbox(),
-                            jUrl::get('view~map:index', array('repository' => $meta->getRepository(), 'project' => $meta->getId())),
-                            jUrl::get('view~media:illustration', array('repository' => $meta->getRepository(), 'project' => $meta->getId())),
-                            0,
-                            $r,
-                            'map',
-                            $wmsGetCapabilitiesUrl,
-                            $wmtsGetCapabilitiesUrl
-                        );
-                        /*} else {
-                          $this->_tpl->assign('auth_url_return', jUrl::get('view~map:index',
-                            array(
-                              "repository"=>$lrep->getKey(),
-                              "project"=>$meta->getId(),
-                            )
-                          ) );*/
-                    }
+            $metadata = $lrep->getProjectsMetadata();
+            foreach ($metadata as $meta) {
+                // Avoid project with no access rights
+                if (!$meta->getAcl()) {
+                    continue;
                 }
-                if (count($mrep->childItems) != 0) {
-                    usort($mrep->childItems, 'lizmapMainViewItem::mainViewItemSort');
-                    $maps[$r] = $mrep;
+
+                // Hide project with option "hideProject"
+                if ($meta->getHidden()) {
+                    continue;
                 }
+
+                // Get project information
+                if ($wmsGetCapabilitiesUrl) {
+                    $wmsGetCapabilitiesUrl = $meta->getWMSGetCapabilitiesUrl();
+                    $wmtsGetCapabilitiesUrl = $meta->getWMTSGetCapabilitiesUrl();
+                }
+                if ($lrep->getKey().'~'.$meta->getId() != $excludedProject) {
+                    $mrep->childItems[] = new lizmapMainViewItem(
+                        $meta->getId(),
+                        $meta->getTitle(),
+                        $meta->getAbstract(),
+                        $meta->getKeywordList(),
+                        $meta->getProj(),
+                        $meta->getBbox(),
+                        jUrl::get('view~map:index', array('repository' => $meta->getRepository(), 'project' => $meta->getId())),
+                        jUrl::get('view~media:illustration', array('repository' => $meta->getRepository(), 'project' => $meta->getId())),
+                        0,
+                        $r,
+                        'map',
+                        $wmsGetCapabilitiesUrl,
+                        $wmtsGetCapabilitiesUrl
+                    );
+                    /*} else {
+                        $this->_tpl->assign('auth_url_return', jUrl::get('view~map:index',
+                        array(
+                            "repository"=>$lrep->getKey(),
+                            "project"=>$meta->getId(),
+                        )
+                        ) );*/
+                }
+            }
+            if (count($mrep->childItems) != 0) {
+                usort($mrep->childItems, 'lizmapMainViewItem::mainViewItemSort');
+                $maps[$r] = $mrep;
             }
         }
 

--- a/lizmap/www/assets/js/admin/activate_datatable.js
+++ b/lizmap/www/assets/js/admin/activate_datatable.js
@@ -1,0 +1,13 @@
+
+$(document).ready(function() {
+
+    // Activate datatable for the project list table
+    if ($('table.lizmap_project_list').length) {
+        $('table.lizmap_project_list').DataTable({
+            "paging":   false,
+            scrollY:        '50vh',
+            scrollCollapse: true,
+            "info":     true
+        });
+    }
+});

--- a/tests/units/classes/Project/ProjectConfigTest.php
+++ b/tests/units/classes/Project/ProjectConfigTest.php
@@ -20,6 +20,7 @@ class projectConfigTest extends TestCase
         $expected->tooltipLayers = new stdClass();
         $expected->loginFilteredLayers = new stdClass();
         $expected->filter_by_polygon = new stdClass();
+        $expected->metadata = new stdClass();
         return array(
             array($json, $expected),
         );
@@ -42,7 +43,7 @@ class projectConfigTest extends TestCase
         $file = __DIR__.'/Ressources/events.qgs.cfg';
         $data = json_decode(file_get_contents($file));
         $cachedProperties = array('layersOrder', 'locateByLayer', 'formFilterLayers', 'editionLayers',
-            'attributeLayers', 'options', 'layers', );
+            'attributeLayers', 'options', 'layers', 'metadata');
         $testCfg = new Project\ProjectConfig($data);
         foreach ($cachedProperties as $prop) {
             if (property_exists($data, $prop)) {


### PR DESCRIPTION
This PR add a new page in the admin panel showing the list of published projects in a dynamic table. 

* **visible properties**: repository, project name, modification date, projection, layer count, qgis desktop version, lizmap plugin version, acl groups
* Some colors have been used depending on the values to help the admin see what must be corrected:
  * QGIS version: 
    * lightyellow if the version is old compared to the QGIS Server (minor version difference > 6)
    * lightcoral if the QGIS desktop version is above the installed QGIS Server version
  * Layer count: 
    * lightyellow if above 100, 
    * lightcoral if above 200
  * Projection: 
    * lightcoral if it is a user defined projection
* **Tooltips** have been added to show more information on hover
  * Repository: shows the label
  * Project: shows the title and abtract
  * QGIS version, layer count and projection if an issue has been detected (see above)
* The admin will be able to sort the projects by clicking on the columns header or filter the list by typing the searched value in the top text input.

Funded by Valabre (Centre de gravité de la formation des métiers de la Sécurité Civile, de la Recherche, des Nouvelles Technologies et de la Prévention dans le domaine des risques naturels)

![2022-04-14_155045_1348x810](https://user-images.githubusercontent.com/3492210/163405930-aca1ce68-53d2-449f-bf3d-6663b9899317.png)
