### PR TITLE
[Bugfix] Lizmap WKT parser: support Multi 

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapWkt.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapWkt.class.php
@@ -9,7 +9,7 @@
  */
 class lizmapWkt
 {
-    /** @var regExes[] */
+    /** @var array<string, string> */
     protected static $regExes = array(
         'typeStr' => '/^\s*(\w+)\s*(\w+)?\s*\(\s*(.*)\s*\)\s*$/',
         'spaces' => '/\s+/',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -831,16 +831,6 @@ parameters:
 			path: lizmap/modules/lizmap/classes/lizmapTiler.class.php
 
 		-
-			message: "#^Property lizmapWkt\\:\\:\\$regExes has unknown class regExes as its type\\.$#"
-			count: 1
-			path: lizmap/modules/lizmap/classes/lizmapWkt.class.php
-
-		-
-			message: "#^Static property lizmapWkt\\:\\:\\$regExes \\(array\\<regExes\\>\\) does not accept default value of type array\\<string, string\\>\\.$#"
-			count: 1
-			path: lizmap/modules/lizmap/classes/lizmapWkt.class.php
-
-		-
 			message: "#^Method qgisExpressionUtils\\:\\:evaluateExpressions\\(\\) should return array but returns null\\.$#"
 			count: 2
 			path: lizmap/modules/lizmap/classes/qgisExpressionUtils.class.php

--- a/tests/units/classes/lizmapWktTest.php
+++ b/tests/units/classes/lizmapWktTest.php
@@ -12,6 +12,48 @@ class lizmapWktTest extends TestCase {
         $this->assertEquals($geom['type'], 'Point');
         $this->assertArrayHasKey('coordinates', $geom);
         $this->assertCount(2, $geom['coordinates']);
+
+        $wkt = 'POINT(30 10)';
+        $geom = lizmapWkt::parse($wkt);
+
+        $this->assertNotNull($geom);
+        $this->assertArrayHasKey('type', $geom);
+        $this->assertEquals($geom['type'], 'Point');
+        $this->assertArrayHasKey('coordinates', $geom);
+        $this->assertCount(2, $geom['coordinates']);
+    }
+
+    function testMultiPoint() {
+        $wkt = 'MULTIPOINT ((30 10))';
+        $geom = lizmapWkt::parse($wkt);
+
+        $this->assertNotNull($geom);
+        $this->assertArrayHasKey('type', $geom);
+        $this->assertEquals($geom['type'], 'MultiPoint');
+        $this->assertArrayHasKey('coordinates', $geom);
+        $this->assertCount(1, $geom['coordinates']);
+        $this->assertCount(2, $geom['coordinates'][0]);
+
+        $wkt = 'MULTIPOINT ((30 10), (40 40))';
+        $geom = lizmapWkt::parse($wkt);
+
+        $this->assertNotNull($geom);
+        $this->assertArrayHasKey('type', $geom);
+        $this->assertEquals($geom['type'], 'MultiPoint');
+        $this->assertArrayHasKey('coordinates', $geom);
+        $this->assertCount(2, $geom['coordinates']);
+        $this->assertCount(2, $geom['coordinates'][0]);
+        $this->assertCount(2, $geom['coordinates'][1]);
+
+        $wkt = 'MULTIPOINT((30 10))';
+        $geom = lizmapWkt::parse($wkt);
+
+        $this->assertNotNull($geom);
+        $this->assertArrayHasKey('type', $geom);
+        $this->assertEquals($geom['type'], 'MultiPoint');
+        $this->assertArrayHasKey('coordinates', $geom);
+        $this->assertCount(1, $geom['coordinates']);
+        $this->assertCount(2, $geom['coordinates'][0]);
     }
 
     function testLineString() {
@@ -23,6 +65,48 @@ class lizmapWktTest extends TestCase {
         $this->assertEquals($geom['type'], 'LineString');
         $this->assertArrayHasKey('coordinates', $geom);
         $this->assertCount(3, $geom['coordinates']);
+
+        $wkt = 'LINESTRING(30 10, 10 30, 40 40)';
+        $geom = lizmapWkt::parse($wkt);
+
+        $this->assertNotNull($geom);
+        $this->assertArrayHasKey('type', $geom);
+        $this->assertEquals($geom['type'], 'LineString');
+        $this->assertArrayHasKey('coordinates', $geom);
+        $this->assertCount(3, $geom['coordinates']);
+    }
+
+    function testMultiLineString() {
+        $wkt = 'MULTILINESTRING ((30 10, 10 30, 40 40))';
+        $geom = lizmapWkt::parse($wkt);
+
+        $this->assertNotNull($geom);
+        $this->assertArrayHasKey('type', $geom);
+        $this->assertEquals($geom['type'], 'MultiLineString');
+        $this->assertArrayHasKey('coordinates', $geom);
+        $this->assertCount(1, $geom['coordinates']);
+        $this->assertCount(3, $geom['coordinates'][0]);
+
+        $wkt = 'MULTILINESTRING ((30 10, 10 30, 40 40), (20 30, 35 35))';
+        $geom = lizmapWkt::parse($wkt);
+
+        $this->assertNotNull($geom);
+        $this->assertArrayHasKey('type', $geom);
+        $this->assertEquals($geom['type'], 'MultiLineString');
+        $this->assertArrayHasKey('coordinates', $geom);
+        $this->assertCount(2, $geom['coordinates']);
+        $this->assertCount(3, $geom['coordinates'][0]);
+        $this->assertCount(2, $geom['coordinates'][1]);
+
+        $wkt = 'MULTILINESTRING((30 10, 10 30, 40 40))';
+        $geom = lizmapWkt::parse($wkt);
+
+        $this->assertNotNull($geom);
+        $this->assertArrayHasKey('type', $geom);
+        $this->assertEquals($geom['type'], 'MultiLineString');
+        $this->assertArrayHasKey('coordinates', $geom);
+        $this->assertCount(1, $geom['coordinates']);
+        $this->assertCount(3, $geom['coordinates'][0]);
     }
 
     function testPolygon() {
@@ -46,5 +130,51 @@ class lizmapWktTest extends TestCase {
         $this->assertCount(2, $geom['coordinates']);
         $this->assertCount(5, $geom['coordinates'][0]);
         $this->assertCount(4, $geom['coordinates'][1]);
+
+        $wkt = 'POLYGON((30 10, 40 40, 20 40, 10 20, 30 10))';
+        $geom = lizmapWkt::parse($wkt);
+
+        $this->assertNotNull($geom);
+        $this->assertArrayHasKey('type', $geom);
+        $this->assertEquals($geom['type'], 'Polygon');
+        $this->assertArrayHasKey('coordinates', $geom);
+        $this->assertCount(1, $geom['coordinates']);
+        $this->assertCount(5, $geom['coordinates'][0]);
+    }
+
+    function testMultiPolygon() {
+        $wkt = 'MULTIPOLYGON (((30 10, 40 40, 20 40, 10 20, 30 10)))';
+        $geom = lizmapWkt::parse($wkt);
+
+        $this->assertNotNull($geom);
+        $this->assertArrayHasKey('type', $geom);
+        $this->assertEquals($geom['type'], 'MultiPolygon');
+        $this->assertArrayHasKey('coordinates', $geom);
+        $this->assertCount(1, $geom['coordinates']);
+        $this->assertCount(1, $geom['coordinates'][0]);
+        $this->assertCount(5, $geom['coordinates'][0][0]);
+
+        $wkt = 'MULTIPOLYGON ((35 10, 45 45, 15 40, 10 20, 35 10), (20 30, 35 35, 30 20, 20 30))';
+        $geom = lizmapWkt::parse($wkt);
+
+        $this->assertNotNull($geom);
+        $this->assertArrayHasKey('type', $geom);
+        $this->assertEquals($geom['type'], 'MultiPolygon');
+        $this->assertArrayHasKey('coordinates', $geom);
+        $this->assertCount(1, $geom['coordinates']);
+        $this->assertCount(2, $geom['coordinates'][0]);
+        $this->assertCount(5, $geom['coordinates'][0][0]);
+        $this->assertCount(4, $geom['coordinates'][0][1]);
+
+        $wkt = 'MULTIPOLYGON(((30 10, 40 40, 20 40, 10 20, 30 10)))';
+        $geom = lizmapWkt::parse($wkt);
+
+        $this->assertNotNull($geom);
+        $this->assertArrayHasKey('type', $geom);
+        $this->assertEquals($geom['type'], 'MultiPolygon');
+        $this->assertArrayHasKey('coordinates', $geom);
+        $this->assertCount(1, $geom['coordinates']);
+        $this->assertCount(1, $geom['coordinates'][0]);
+        $this->assertCount(5, $geom['coordinates'][0][0]);
     }
 }

--- a/tests/units/classes/qgisExpressionUtilsTest.php
+++ b/tests/units/classes/qgisExpressionUtilsTest.php
@@ -158,6 +158,9 @@ class qgisExpressionUtilsTest extends TestCase {
 
         $exp = 'intersects(@current_geometry, $geometry) AND area(@current_geometry)>1000';
         $this->assertTrue(qgisExpressionUtils::hasCurrentGeometry($exp));
+
+        $exp = 'intersects(buffer(@current_geometry,50), $geometry )';
+        $this->assertTrue(qgisExpressionUtils::hasCurrentGeometry($exp));
     }
 
 }


### PR DESCRIPTION
Multi geometries like multi point, multi linestring and multi polygon were not supported.
So expression based on layer with multi geometries does not work at all.

* Funded by Terre de Provence Agglomération
