### PR TITLE
[Bugfix] attribute table - doesn't export when a selection is active

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/WFSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WFSRequest.php
@@ -473,6 +473,7 @@ class WFSRequest extends OGCRequest
         }
 
         // Building the expression filter
+        $expFilter = '';
         if ($provider == 'postgres') {
             // for postgres layer we can build the expression filter for
             // simple and multi fields key
@@ -480,7 +481,7 @@ class WFSRequest extends OGCRequest
             $keys = preg_split('/\\s*,\\s*/', $dtparams->key);
             if (count($keys) == 1 && !$hasDoubleAtSign) {
                 // for simple field key
-                return '"'.$keys[0].'" IN ('.implode(', ', $pks).')';
+                $expFilter = '"'.$keys[0].'" IN ('.implode(', ', $pks).')';
             }
             if (count($keys) > 1 && $hasDoubleAtSign) {
                 // for multi fields key
@@ -498,11 +499,15 @@ class WFSRequest extends OGCRequest
                     $filters[] = $filter;
                 }
 
-                return implode(' OR ', $filters);
+                $expFilter = implode(' OR ', $filters);
             }
         } else {
             // for other layers with simple field key
-            return '$id IN ('.implode(', ', $pks).')';
+            $expFilter = '$id IN ('.implode(', ', $pks).')';
+        }
+
+        if ($expFilter && $this->validateExpressionFilter($expFilter)) {
+            return $expFilter;
         }
 
         return '';
@@ -854,6 +859,25 @@ class WFSRequest extends OGCRequest
     }
 
     /**
+     * Validate an expression filter.
+     *
+     * @param string $filter The expression filter to validate
+     *
+     * @return bool returns if the expression does not contains dangerous chars
+     */
+    protected function validateExpressionFilter($filter)
+    {
+        $block_items = array();
+        if (preg_match('#'.implode('|', $this->blockSqlWords).'#i', $filter, $block_items)) {
+            $this->appContext->logMessage('The EXP_FILTER param contains dangerous chars : '.implode(', ', $block_items));
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Parses and validate a filter for postgresql.
      *
      * @param string $filter The filter to parse
@@ -862,16 +886,13 @@ class WFSRequest extends OGCRequest
      */
     protected function validateFilter($filter)
     {
-        $block_items = array();
-        if (preg_match('#'.implode('|', $this->blockSqlWords).'#i', $filter, $block_items)) {
-            $this->appContext->logMessage('The EXP_FILTER param contains dangerous chars : '.implode(', ', $block_items));
-
+        if (!$this->validateExpressionFilter($filter)) {
             return false;
         }
-        $filter = str_replace('intersects', 'ST_Intersects', $filter);
-        $filter = str_replace('geom_from_gml', 'ST_GeomFromGML', $filter);
+        $vfilter = str_replace('intersects', 'ST_Intersects', $filter);
+        $vfilter = str_replace('geom_from_gml', 'ST_GeomFromGML', $vfilter);
 
-        return str_replace('$geometry', '"'.$this->datasource->geocol.'"', $filter);
+        return str_replace('$geometry', '"'.$this->datasource->geocol.'"', $vfilter);
     }
 
     /**

--- a/tests/end2end/cypress/integration/requests-service-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-service-ghaction.js
@@ -296,6 +296,177 @@ describe('Request service', function () {
         })
     })
 
+    it('WFS GetFeature TYPENAME && BBOX', function () {
+        cy.request({
+            method: 'POST',
+            url: '/index.php/lizmap/service/?repository=testsrepository&project=selection',
+            qs: {
+                'SERVICE': 'WFS',
+                'VERSION': '1.0.0',
+                'REQUEST': 'GetFeature',
+                'TYPENAME': 'selection_polygon',
+                'BBOX': '160786,900949,186133,925344',
+                'OUTPUTFORMAT': 'GeoJSON',
+            },
+        }).then((resp) => {
+            expect(resp.status).to.eq(200)
+            expect(resp.headers['content-type']).to.contain('application/vnd.geo+json')
+            expect(resp.body).to.have.property('type', 'FeatureCollection')
+            expect(resp.body).to.have.property('features')
+            expect(resp.body.features).to.have.length(1)
+            const feature = resp.body.features[0]
+            expect(feature).to.have.property('id')
+            expect(feature.id).to.equal('selection_polygon.1')
+            expect(feature).to.have.property('bbox')
+            expect(feature.bbox).to.have.length(4)
+            assert.isNumber(feature.bbox[0], 'BBox xmin is number')
+            assert.isNumber(feature.bbox[1], 'BBox ymin is number')
+            assert.isNumber(feature.bbox[2], 'BBox xmax is number')
+            assert.isNumber(feature.bbox[3], 'BBox ymax is number')
+            expect(feature).to.have.property('properties')
+            expect(feature.properties).to.have.property('id', 1)
+            expect(feature).to.have.property('geometry')
+            expect(feature.geometry).to.have.property('type', 'Polygon')
+            expect(feature.geometry).to.have.property('coordinates')
+            expect(feature.geometry.coordinates).to.have.length(1)
+            expect(feature.geometry.coordinates[0]).to.have.length(5)
+            expect(feature.geometry.coordinates[0][0]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][1]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][2]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][3]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][4]).to.have.length(2)
+        })
+    })
+
+    it('WFS GetFeature TYPENAME && EXP_FILTER', function () {
+        cy.request({
+            method: 'POST',
+            url: '/index.php/lizmap/service/?repository=testsrepository&project=selection',
+            qs: {
+                'SERVICE': 'WFS',
+                'VERSION': '1.0.0',
+                'REQUEST': 'GetFeature',
+                'TYPENAME': 'selection_polygon',
+                'EXP_FILTER': '$id IN (1)',
+                'OUTPUTFORMAT': 'GeoJSON',
+            },
+        }).then((resp) => {
+            expect(resp.status).to.eq(200)
+            expect(resp.headers['content-type']).to.contain('application/vnd.geo+json')
+            expect(resp.body).to.have.property('type', 'FeatureCollection')
+            expect(resp.body).to.have.property('features')
+            expect(resp.body.features).to.have.length(1)
+            const feature = resp.body.features[0]
+            expect(feature).to.have.property('id')
+            expect(feature.id).to.equal('selection_polygon.1')
+            expect(feature).to.have.property('bbox')
+            expect(feature.bbox).to.have.length(4)
+            assert.isNumber(feature.bbox[0], 'BBox xmin is number')
+            assert.isNumber(feature.bbox[1], 'BBox ymin is number')
+            assert.isNumber(feature.bbox[2], 'BBox xmax is number')
+            assert.isNumber(feature.bbox[3], 'BBox ymax is number')
+            expect(feature).to.have.property('properties')
+            expect(feature.properties).to.have.property('id', 1)
+            expect(feature).to.have.property('geometry')
+            expect(feature.geometry).to.have.property('type', 'Polygon')
+            expect(feature.geometry).to.have.property('coordinates')
+            expect(feature.geometry.coordinates).to.have.length(1)
+            expect(feature.geometry.coordinates[0]).to.have.length(5)
+            expect(feature.geometry.coordinates[0][0]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][1]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][2]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][3]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][4]).to.have.length(2)
+        })
+    })
+
+    it('WFS GetFeature TYPENAME && EXP_FILTER && BBOX', function () {
+        cy.request({
+            method: 'POST',
+            url: '/index.php/lizmap/service/?repository=testsrepository&project=selection',
+            qs: {
+                'SERVICE': 'WFS',
+                'VERSION': '1.0.0',
+                'REQUEST': 'GetFeature',
+                'TYPENAME': 'selection_polygon',
+                'EXP_FILTER': '$id IN (1)',
+                'BBOX': '160786,900949,186133,925344',
+                'OUTPUTFORMAT': 'GeoJSON',
+            },
+        }).then((resp) => {
+            expect(resp.status).to.eq(200)
+            expect(resp.headers['content-type']).to.contain('application/vnd.geo+json')
+            expect(resp.body).to.have.property('type', 'FeatureCollection')
+            expect(resp.body).to.have.property('features')
+            expect(resp.body.features).to.have.length(1)
+            const feature = resp.body.features[0]
+            expect(feature).to.have.property('id')
+            expect(feature.id).to.equal('selection_polygon.1')
+            expect(feature).to.have.property('bbox')
+            expect(feature.bbox).to.have.length(4)
+            assert.isNumber(feature.bbox[0], 'BBox xmin is number')
+            assert.isNumber(feature.bbox[1], 'BBox ymin is number')
+            assert.isNumber(feature.bbox[2], 'BBox xmax is number')
+            assert.isNumber(feature.bbox[3], 'BBox ymax is number')
+            expect(feature).to.have.property('properties')
+            expect(feature.properties).to.have.property('id', 1)
+            expect(feature).to.have.property('geometry')
+            expect(feature.geometry).to.have.property('type', 'Polygon')
+            expect(feature.geometry).to.have.property('coordinates')
+            expect(feature.geometry.coordinates).to.have.length(1)
+            expect(feature.geometry.coordinates[0]).to.have.length(5)
+            expect(feature.geometry.coordinates[0][0]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][1]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][2]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][3]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][4]).to.have.length(2)
+        })
+    })
+
+    it('WFS GetFeature TYPENAME && EXP_FILTER && BBOX && FORCE_QGIS', function () {
+        cy.request({
+            method: 'POST',
+            url: '/index.php/lizmap/service/?repository=testsrepository&project=selection',
+            qs: {
+                'SERVICE': 'WFS',
+                'VERSION': '1.0.0',
+                'REQUEST': 'GetFeature',
+                'TYPENAME': 'selection_polygon',
+                'EXP_FILTER': '$id IN (1)',
+                'BBOX': '160786,900949,186133,925344',
+                'OUTPUTFORMAT': 'GeoJSON',
+                'FORCE_QGIS': '1',
+            },
+        }).then((resp) => {
+            expect(resp.status).to.eq(200)
+            expect(resp.headers['content-type']).to.contain('application/vnd.geo+json')
+            expect(resp.body).to.have.property('type', 'FeatureCollection')
+            expect(resp.body).to.have.property('features')
+            expect(resp.body.features).to.have.length(1)
+            const feature = resp.body.features[0]
+            expect(feature).to.have.property('id')
+            expect(feature.id).to.equal('selection_polygon.1')
+            expect(feature).to.have.property('bbox')
+            expect(feature.bbox).to.have.length(4)
+            assert.isNumber(feature.bbox[0], 'BBox xmin is number')
+            assert.isNumber(feature.bbox[1], 'BBox ymin is number')
+            assert.isNumber(feature.bbox[2], 'BBox xmax is number')
+            assert.isNumber(feature.bbox[3], 'BBox ymax is number')
+            expect(feature).to.have.property('properties')
+            expect(feature.properties).to.have.property('id', 1)
+            expect(feature).to.have.property('geometry')
+            expect(feature.geometry).to.have.property('type', 'Polygon')
+            expect(feature.geometry).to.have.property('coordinates')
+            expect(feature.geometry.coordinates).to.have.length(1)
+            expect(feature.geometry.coordinates[0]).to.have.length(5)
+            expect(feature.geometry.coordinates[0][0]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][1]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][2]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][3]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][4]).to.have.length(2)
+        })
+    })
+
     it('WFS GetFeature FEATUREID', function () {
         cy.request({
             method: 'POST',
@@ -305,6 +476,90 @@ describe('Request service', function () {
                 'VERSION': '1.0.0',
                 'REQUEST': 'GetFeature',
                 'FEATUREID': 'selection_polygon.1',
+                'OUTPUTFORMAT': 'GeoJSON',
+            },
+        }).then((resp) => {
+            expect(resp.status).to.eq(200)
+            expect(resp.headers['content-type']).to.contain('application/vnd.geo+json')
+            expect(resp.body).to.have.property('type', 'FeatureCollection')
+            expect(resp.body).to.have.property('features')
+            expect(resp.body.features).to.have.length(1)
+            const feature = resp.body.features[0]
+            expect(feature).to.have.property('id')
+            expect(feature.id).to.equal('selection_polygon.1')
+            expect(feature).to.have.property('bbox')
+            expect(feature.bbox).to.have.length(4)
+            assert.isNumber(feature.bbox[0], 'BBox xmin is number')
+            assert.isNumber(feature.bbox[1], 'BBox ymin is number')
+            assert.isNumber(feature.bbox[2], 'BBox xmax is number')
+            assert.isNumber(feature.bbox[3], 'BBox ymax is number')
+            expect(feature).to.have.property('properties')
+            expect(feature.properties).to.have.property('id', 1)
+            expect(feature).to.have.property('geometry')
+            expect(feature.geometry).to.have.property('type', 'Polygon')
+            expect(feature.geometry).to.have.property('coordinates')
+            expect(feature.geometry.coordinates).to.have.length(1)
+            expect(feature.geometry.coordinates[0]).to.have.length(5)
+            expect(feature.geometry.coordinates[0][0]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][1]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][2]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][3]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][4]).to.have.length(2)
+        })
+    })
+
+    it('WFS GetFeature FEATUREID && BBOX', function () {
+        cy.request({
+            method: 'POST',
+            url: '/index.php/lizmap/service/?repository=testsrepository&project=selection',
+            qs: {
+                'SERVICE': 'WFS',
+                'VERSION': '1.0.0',
+                'REQUEST': 'GetFeature',
+                'FEATUREID': 'selection_polygon.1',
+                'BBOX': '160786,900949,186133,925344',
+                'OUTPUTFORMAT': 'GeoJSON',
+            },
+        }).then((resp) => {
+            expect(resp.status).to.eq(200)
+            expect(resp.headers['content-type']).to.contain('application/vnd.geo+json')
+            expect(resp.body).to.have.property('type', 'FeatureCollection')
+            expect(resp.body).to.have.property('features')
+            expect(resp.body.features).to.have.length(1)
+            const feature = resp.body.features[0]
+            expect(feature).to.have.property('id')
+            expect(feature.id).to.equal('selection_polygon.1')
+            expect(feature).to.have.property('bbox')
+            expect(feature.bbox).to.have.length(4)
+            assert.isNumber(feature.bbox[0], 'BBox xmin is number')
+            assert.isNumber(feature.bbox[1], 'BBox ymin is number')
+            assert.isNumber(feature.bbox[2], 'BBox xmax is number')
+            assert.isNumber(feature.bbox[3], 'BBox ymax is number')
+            expect(feature).to.have.property('properties')
+            expect(feature.properties).to.have.property('id', 1)
+            expect(feature).to.have.property('geometry')
+            expect(feature.geometry).to.have.property('type', 'Polygon')
+            expect(feature.geometry).to.have.property('coordinates')
+            expect(feature.geometry.coordinates).to.have.length(1)
+            expect(feature.geometry.coordinates[0]).to.have.length(5)
+            expect(feature.geometry.coordinates[0][0]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][1]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][2]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][3]).to.have.length(2)
+            expect(feature.geometry.coordinates[0][4]).to.have.length(2)
+        })
+    })
+
+    it('WFS GetFeature FEATUREID && BBOX && FORCE_QGIS', function () {
+        cy.request({
+            method: 'POST',
+            url: '/index.php/lizmap/service/?repository=testsrepository&project=selection',
+            qs: {
+                'SERVICE': 'WFS',
+                'VERSION': '1.0.0',
+                'REQUEST': 'GetFeature',
+                'FEATUREID': 'selection_polygon.1',
+                'BBOX': '160786,900949,186133,925344',
                 'OUTPUTFORMAT': 'GeoJSON',
             },
         }).then((resp) => {

--- a/tests/units/classes/Request/WFSRequestTest.php
+++ b/tests/units/classes/Request/WFSRequestTest.php
@@ -255,6 +255,45 @@ class WFSRequestTest extends TestCase
         $this->assertEquals($expectedSql, $result);
     }
 
+    public function getValidateExpressionFilterData()
+    {
+        return array(
+            array(';', false),
+            array('select', false),
+            array('delete', false),
+            array('insert', false),
+            array('update', false),
+            array('drop', false),
+            array('alter', false),
+            array('--', false),
+            array('truncate', false),
+            array('vacuum', false),
+            array('create', false),
+            array('selectoioio', false),
+            array('test intersects other test', true),
+            array('test geom_from_gml other test', true),
+            array('test intersects $geometry', true),
+            array('$id IN (1)', true),
+            array('$id IN (1, 2)', true),
+            array('"id" IN (1)', true),
+            array('"id" IN (1, 2)', true),
+            array('"id" IN (\'test\')', true),
+            array('("foo" = \'test\' AND "id" = 55)', true),
+            array('("foo" = \'test\' AND "id" = 55) OR ("foo" = \'bar\' AND "id" = 44)', true),
+            array('("foo" = \'test\' AND "id" = 55) OR ("foo" = \'bar\' AND "id" = 44); -- SELECT * FROM jlx_user', false),
+        );
+    }
+
+    /**
+     * @dataProvider getValidateExpressionFilterData
+     */
+    public function testValidateExpressionFilter($filter, $expectedResult)
+    {
+        $wfs = new WFSRequestForTests();
+        $wfs->appContext = new ContextForTests();
+        $this->assertEquals($expectedResult, $wfs->validateExpressionFilterForTests($filter));
+    }
+
     public function getValidateFilterData()
     {
         return array(

--- a/tests/units/classes/Request/WFSRequestTest.php
+++ b/tests/units/classes/Request/WFSRequestTest.php
@@ -84,6 +84,45 @@ class WFSRequestTest extends TestCase
         $this->assertEquals($expectedParameters, $parameters);
     }
 
+    public function getGetFeatureIdFilterExpData()
+    {
+        return array(
+            array('', '', '', array()), //nothing
+            array('type.1', '', '', array()), // only featureid
+            array('type', 'type', '', array()), // featureid not well formed
+            array('type.', 'type', '', array()), // fetaureid not well formed
+            array('type.1', 'typed', '', array()), // featureid and typename are not for the same layer
+            array('type.test@@55', 'type', '', array()), // featureid with multi fields key not for postgres layer
+            array('type.test@@55', 'type', '', array('provider'=>'postgres')), // featureid with multi fields key for postgres layer with simple field key
+            array('type.1', 'type', '$id IN (1)', array()),
+            array('type.1,type.2', 'type', '$id IN (1, 2)', array()),
+            array('type.1', 'type', '"id" IN (1)', array('provider'=>'postgres')),
+            array('type.1,type.2', 'type', '"id" IN (1, 2)', array('provider'=>'postgres')),
+            array('type.test', 'type', '"id" IN (\'test\')', array('provider'=>'postgres')),
+            array('type.test@@55', 'type', '("foo" = \'test\' AND "id" = 55)', array('provider'=>'postgres', 'dtparams'=>array('key' => 'foo,id'))),
+            array('type.test@@55,type.bar@@44', 'type', '("foo" = \'test\' AND "id" = 55) OR ("foo" = \'bar\' AND "id" = 44)', array('provider'=>'postgres', 'dtparams'=>array('key' => 'foo,id'))),
+        );
+    }
+
+    /**
+     * @dataProvider getGetFeatureIdFilterExpData
+     */
+    public function testGetFeatureIdFilterExp($featureid, $typename, $expectedExpFilter, $layerOptions)
+    {
+        $wfs = new WFSRequestForTests();
+        $qgisLayer = new LayerWFSForTests();
+        if ($layerOptions) {
+            if (array_key_exists('provider', $layerOptions)) {
+                $qgisLayer->provider = $layerOptions['provider'];
+            }
+            if (array_key_exists('dtparams', $layerOptions)) {
+                $qgisLayer->dtparams = $layerOptions['dtparams'];
+            }
+        }
+        $expFilter = $wfs->getFeatureIdFilterExpForTests($featureid, $typename, $qgisLayer);
+        $this->assertEquals($expectedExpFilter, $expFilter);
+    }
+
     public function getBuildQueryBaseData()
     {
         $paramsComplete = array(
@@ -176,6 +215,7 @@ class WFSRequestTest extends TestCase
             array('', '', '', ''),
             array('type', 'type.test@@55', 'key,otherKey', ' AND (key = "test" AND otherKey = 55)'),
             array('type', 'type.test@@55,you shall not pass,type.name@@42', 'key,otherKey', ' AND (key = "test" AND otherKey = 55) OR (key = "name" AND otherKey = 42)'),
+            array('', 'type.test@@55', 'key,otherKey', ' AND (key = "test" AND otherKey = 55)'),
         );
     }
 

--- a/tests/units/testslib/LayerWFSForTests.php
+++ b/tests/units/testslib/LayerWFSForTests.php
@@ -2,8 +2,22 @@
 
 class LayerWFSForTests
 {
+    public $provider = 'ogr';
+
+    public $dtparams = array('key' => 'id');
+
     public function getSrid()
     {
         return 'SRID';
+    }
+
+    public function getProvider()
+    {
+        return $this->provider;
+    }
+
+    public function getDatasourceParameters()
+    {
+        return (object) $this->dtparams;
     }
 }

--- a/tests/units/testslib/WFSRequestForTests.php
+++ b/tests/units/testslib/WFSRequestForTests.php
@@ -46,6 +46,11 @@ class WFSRequestForTests extends WFSRequest {
         return $this->getQueryOrder($cnx, $params, $wfsFields);
     }
 
+    public function validateExpressionFilterForTests($filter)
+    {
+        return $this->validateExpressionFilter($filter);
+    }
+
     public function validateFilterForTests($filter)
     {
         return $this->validateFilter($filter);

--- a/tests/units/testslib/WFSRequestForTests.php
+++ b/tests/units/testslib/WFSRequestForTests.php
@@ -15,6 +15,11 @@ class WFSRequestForTests extends WFSRequest {
     public function __construct()
     {}
 
+    public function getFeatureIdFilterExpForTests($featureid, $typename, $qgisLayer)
+    {
+        return $this->getFeatureIdFilterExp($featureid, $typename, $qgisLayer);
+    }
+
     public function buildQueryBaseForTests($cnx, $params, $wfsFields)
     {
         return $this->buildQueryBase($cnx, $params, $wfsFields);


### PR DESCRIPTION
fixes #2770

In the WFS OGC standard FEATUREID and BBOX parameters cannot be mutually set
but in Lizmap, the user can do a selection, based on featureid, and can request
a download, a WFS GetFeature request, based on this selection with a restriction
to map extent, sofeatureid and bbox parameter can be set mutually and featureid
parameter needs to be transform in an expression filter.

A parameter `FORCE_QGIS` has been introduced for GetFeature to compare lizmap
postgres GetFeature response and QGIS Server GetFeature response.

* Funded by 3Liz
