### PR TITLE
Tests - Remove manual tests covered by cypress

### DIFF
--- a/tests/qgis-projects/tests/popup.md
+++ b/tests/qgis-projects/tests/popup.md
@@ -1,8 +1,0 @@
-# Test Popup
-
-**Project : popup**
-
-## Procedure
-
-- [ ] When clicking on triangle feature a popup with two tabs must appear
-- [ ] When clicking `tab2`, `tab2_value` must appear


### PR DESCRIPTION
Tests - Remove manual tests covered by cypress

It looks covered by https://github.com/3liz/lizmap-web-client/blob/master/tests/end2end/cypress/integration/popup-ghaction.js ?

* Funded by 3Liz
