### PR TITLE
[Bugfix] Dataviz: provide a minimu config with locale for WPS

### DIFF
--- a/lizmap/modules/dataviz/classes/datavizConfig.class.php
+++ b/lizmap/modules/dataviz/classes/datavizConfig.class.php
@@ -57,6 +57,15 @@ class datavizConfig
             return;
         }
 
+        if (empty($datavizConfig['layers'])) {
+            $this->errors = array(
+                'title' => 'Dataviz Configuration: empty layers',
+                'detail' => 'No layers dataviz configuration has been found for this project',
+            );
+
+            return;
+        }
+
         $this->status = true;
         $this->config = $datavizConfig;
     }

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -1288,19 +1288,23 @@ class Project
     }
 
     /**
-     * @return array|bool
+     * @return array the dataviz layers config extended with locale
      */
     public function getDatavizLayersConfig()
     {
-        $datavizLayers = $this->cfg->getDatavizLayers();
-        if (!$datavizLayers) {
-            return false;
-        }
+        // initialize config
         $config = array(
             'layers' => array(),
             'dataviz' => array(),
             'locale' => $this->appContext->appConfig()->locale,
         );
+
+        $datavizLayers = $this->cfg->getDatavizLayers();
+        if (!$datavizLayers) {
+            // provide the empty config with locale
+            return $config;
+        }
+
         foreach ($datavizLayers as $order => $lc) {
             if (!property_exists($lc, 'layerId')) {
                 continue;
@@ -1388,8 +1392,10 @@ class Project
             }
             $config['layers'][$order] = $plotConf;
         }
+
         if (empty($config['layers'])) {
-            return false;
+            // provide the empty config with locale
+            return $config;
         }
 
         $config['dataviz'] = array(

--- a/tests/end2end/cypress/integration/requests-getprojectconfig-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-getprojectconfig-ghaction.js
@@ -1,0 +1,47 @@
+describe('Request Lizmap GetProjectConfig', function () {
+    it('As anonymous', function () {
+        cy.logout();
+
+        cy.request({
+            url: '/index.php/lizmap/service/getProjectConfig?repository=testsrepository&project=selection',
+            failOnStatusCode: false,
+        }).then((resp) => {
+            expect(resp.status).to.eq(200)
+            expect(resp.headers['content-type']).to.eq('application/json')
+
+            expect(resp.body).to.have.property('options')
+            expect(resp.body).to.have.property('layers')
+
+            expect(resp.body).to.have.property('datavizLayers')
+            expect(resp.body.datavizLayers).to.have.property('locale')
+            expect(resp.body.datavizLayers.locale).to.be.not.empty
+            expect(resp.body.datavizLayers).to.have.property('layers')
+            expect(resp.body.datavizLayers.layers).to.be.empty
+            expect(resp.body.datavizLayers).to.have.property('dataviz')
+            expect(resp.body.datavizLayers.dataviz).to.be.empty
+        })
+    })
+
+    it('As anonymous with dataviz', function () {
+        cy.logout();
+
+        cy.request({
+            url: '/index.php/lizmap/service/getProjectConfig?repository=testsrepository&project=dataviz_filtered_in_popup',
+            failOnStatusCode: false,
+        }).then((resp) => {
+            expect(resp.status).to.eq(200)
+            expect(resp.headers['content-type']).to.eq('application/json')
+
+            expect(resp.body).to.have.property('options')
+            expect(resp.body).to.have.property('layers')
+
+            expect(resp.body).to.have.property('datavizLayers')
+            expect(resp.body.datavizLayers).to.have.property('locale')
+            expect(resp.body.datavizLayers.locale).to.be.not.empty
+            expect(resp.body.datavizLayers).to.have.property('layers')
+            expect(resp.body.datavizLayers.layers).to.be.not.empty
+            expect(resp.body.datavizLayers).to.have.property('dataviz')
+            expect(resp.body.datavizLayers.dataviz).to.be.not.empty
+        })
+    })
+})


### PR DESCRIPTION
The WPS module reuses the lizmap buildPlot method which need the locale from config.

Fixes https://github.com/3liz/lizmap-wps-web-client-module/issues/26