### PR TITLE
[BUGFIX] Atlas print link error when no feature id found

### DIFF
--- a/lizmap/www/assets/js/popupQgisAtlas.js
+++ b/lizmap/www/assets/js/popupQgisAtlas.js
@@ -16,6 +16,10 @@ lizMap.events.on({
                 // Atlas print link already exist
                 return true;
             }
+            if($(this).find('input.lizmap-popup-layer-feature-id').length == 0) {
+                // The feature id is not found
+                return true;
+            }
 
             var getLayerId = $(this).find('input.lizmap-popup-layer-feature-id:first').val().split('.');
             var layerId = getLayerId[0];

--- a/lizmap/www/assets/js/popupQgisAtlas.js
+++ b/lizmap/www/assets/js/popupQgisAtlas.js
@@ -12,72 +12,75 @@ lizMap.events.on({
             return;
 
         $('div.lizmapPopupDiv').each(function(){
-            if($(this).find('a.lizmap-atlasprint-link').length == 0){
-                var getLayerId = $(this).find('input.lizmap-popup-layer-feature-id:first').val().split('.');
-                var layerId = getLayerId[0];
-                var fid = getLayerId[1];
-                var layerName=getLayerId[0].split(/[0-9]/)[0];
+            if($(this).find('a.lizmap-atlasprint-link').length != 0) {
+                // Atlas print link already exist
+                return true;
+            }
 
-                for(var i in lizMap.config.printTemplates){
-                    var t = lizMap.config.printTemplates[i];
-                    if('atlas' in t){
-                        if(layerId == t.atlas.coverageLayer){
-                            // Build URL
-                            var url = OpenLayers.Util.urlAppend(
-                                lizUrls.wms,
-                                OpenLayers.Util.getParameterString(lizUrls.params)
-                            );
-                            url += '&SERVICE=WMS';
-                            url += '&VERSION=1.3.0&REQUEST=GetPrintAtlas';
-                            url += '&FORMAT=pdf';
-                            url += '&EXCEPTIONS=application/vnd.ogc.se_inimage&TRANSPARENT=true';
-                            url += '&DPI=100';
-                            url += '&TEMPLATE='+t.title;
-                            url += '&LAYER='+layerName;
-                            url += '&EXP_FILTER=$id IN ('+fid+')';
+            var getLayerId = $(this).find('input.lizmap-popup-layer-feature-id:first').val().split('.');
+            var layerId = getLayerId[0];
+            var fid = getLayerId[1];
+            var layerName=getLayerId[0].split(/[0-9]/)[0];
 
-                            // Add button and div to set custom labels
-                            let customLabels = '';
+            for(var i in lizMap.config.printTemplates){
+                var t = lizMap.config.printTemplates[i];
+                if('atlas' in t){
+                    if(layerId == t.atlas.coverageLayer){
+                        // Build URL
+                        var url = OpenLayers.Util.urlAppend(
+                            lizUrls.wms,
+                            OpenLayers.Util.getParameterString(lizUrls.params)
+                        );
+                        url += '&SERVICE=WMS';
+                        url += '&VERSION=1.3.0&REQUEST=GetPrintAtlas';
+                        url += '&FORMAT=pdf';
+                        url += '&EXCEPTIONS=application/vnd.ogc.se_inimage&TRANSPARENT=true';
+                        url += '&DPI=100';
+                        url += '&TEMPLATE='+t.title;
+                        url += '&LAYER='+layerName;
+                        url += '&EXP_FILTER=$id IN ('+fid+')';
 
-                            const protectedLabelsId = ["lizmap_user", "lizmap_user_groups"];
-                            for(const label of t.labels){
-                                if (protectedLabelsId.includes(label.id)){
-                                    // These values mustn't be shown in the UI and will be overridden by LWC PHP and AtlasPrint anyway
-                                    continue;
-                                }
-                                if (label.htmlState){
-                                    customLabels += `<textarea class="atlasprint-custom-labels" cols="15" data-print-id="${label.id}" name="${label.id}" placeholder="${label.text}">${label.text}</textarea>`;
-                                }else{
-                                    customLabels += `<input type="text" class="atlasprint-custom-labels" size="15" data-print-id="${label.id}" name="${label.id}" placeholder="${label.text}" value="${label.text}">`;
-                                }
+                        // Add button and div to set custom labels
+                        let customLabels = '';
+
+                        const protectedLabelsId = ["lizmap_user", "lizmap_user_groups"];
+                        for(const label of t.labels){
+                            if (protectedLabelsId.includes(label.id)){
+                                // These values mustn't be shown in the UI and will be overridden by LWC PHP and AtlasPrint anyway
+                                continue;
                             }
-
-                            // Create custom labels tool if any custom labels have been defined
-                            const customLabelsTool = (customLabels === '') ? '' : `<div class="toggle-custom-labels-view"><button><i class="icon-cog" title="${lizDict['print.customLabels.tooltip']}"></i></button><div>${customLabels}</div></div>`;
-
-                            $(this).append('<a class="lizmap-atlasprint-link" data-href="' + url + '" href="' + url + '" target="_blank" title="' + lizDict['attributeLayers.toolbar.btn.data.export.title'] + ' ' + t.title + '"><span class="icon"></span>' + t.title + '</a>' + customLabelsTool + '<br>');
-
-                            // Activate toggle on custom labels button
-                            $('.toggle-custom-labels-view > button').click(function () {
-                                $(this).next().toggle();
-                            });
-
-                            // Activate URL rewrite when user modify custom labels value
-                            $('.atlasprint-custom-labels').on('input', function(){
-                                const atlasPrintLink = $(this).parents('.toggle-custom-labels-view').prev();
-
-                                let customLabelsParams = '';
-
-                                $('.atlasprint-custom-labels').each(function(){
-                                    customLabelsParams += '&' + $(this).data('print-id') + '=' + encodeURIComponent($(this).val());
-                                });
-
-                                atlasPrintLink.attr('href', atlasPrintLink.data('href') + customLabelsParams);
-                            });
-
-                            // Add tooltips
-                            $(this).find('a.lizmap-atlasprint-link, .toggle-custom-labels-view button i').tooltip();
+                            if (label.htmlState){
+                                customLabels += `<textarea class="atlasprint-custom-labels" cols="15" data-print-id="${label.id}" name="${label.id}" placeholder="${label.text}">${label.text}</textarea>`;
+                            }else{
+                                customLabels += `<input type="text" class="atlasprint-custom-labels" size="15" data-print-id="${label.id}" name="${label.id}" placeholder="${label.text}" value="${label.text}">`;
+                            }
                         }
+
+                        // Create custom labels tool if any custom labels have been defined
+                        const customLabelsTool = (customLabels === '') ? '' : `<div class="toggle-custom-labels-view"><button><i class="icon-cog" title="${lizDict['print.customLabels.tooltip']}"></i></button><div>${customLabels}</div></div>`;
+
+                        $(this).append('<a class="lizmap-atlasprint-link" data-href="' + url + '" href="' + url + '" target="_blank" title="' + lizDict['attributeLayers.toolbar.btn.data.export.title'] + ' ' + t.title + '"><span class="icon"></span>' + t.title + '</a>' + customLabelsTool + '<br>');
+
+                        // Activate toggle on custom labels button
+                        $('.toggle-custom-labels-view > button').click(function () {
+                            $(this).next().toggle();
+                        });
+
+                        // Activate URL rewrite when user modify custom labels value
+                        $('.atlasprint-custom-labels').on('input', function(){
+                            const atlasPrintLink = $(this).parents('.toggle-custom-labels-view').prev();
+
+                            let customLabelsParams = '';
+
+                            $('.atlasprint-custom-labels').each(function(){
+                                customLabelsParams += '&' + $(this).data('print-id') + '=' + encodeURIComponent($(this).val());
+                            });
+
+                            atlasPrintLink.attr('href', atlasPrintLink.data('href') + customLabelsParams);
+                        });
+
+                        // Add tooltips
+                        $(this).find('a.lizmap-atlasprint-link, .toggle-custom-labels-view button i').tooltip();
                     }
                 }
             }


### PR DESCRIPTION
fixes #2995

When querying (GetFeatureInfo) from a different WMS server (in my case GeoFoncier), I've got a javascript error :
```
Uncaught TypeError: $(...).find(...).val() is undefined for the file PopupQgisAtlas. Line 16
```

Funded by 3Liz
