### PR TITLE
[Bugfix] GetFeatureInfo click pixel tolerance

### DIFF
--- a/lizmap/www/assets/js/map.js
+++ b/lizmap/www/assets/js/map.js
@@ -3208,6 +3208,11 @@ var lizMap = function() {
             queryVisible: true,
             infoFormat: 'text/html',
             vendorParams: getFeatureInfoTolerances(),
+            handlerOptions: {
+              click: {
+                pixelTolerance: 10
+              }
+            },
             eventListeners: {
                 getfeatureinfo: function(event) {
                     var eventLonLatInfo = map.getLonLatFromPixel(event.xy);


### PR DESCRIPTION
On touch screen, the getFeatureInfo request is not send to the server because the pixel tolerance for click is too small.

Funded by 3Liz
