### PR TITLE
[Tests] e2e: check config.options.hideProject: "True"

### DIFF
--- a/tests/end2end/cypress/integration/projects_homepage-ghaction.js
+++ b/tests/end2end/cypress/integration/projects_homepage-ghaction.js
@@ -214,4 +214,26 @@ describe('Projects homepage', function () {
         cy.get('.liz-repository-project-item:visible .liz-project-title').contains('project_acl').should('not.exist');
         cy.logout();
     })
+
+    it('Check hide_project visibility, it has to never been displayed because config.options.hideProject:"True"', function () {
+        cy.logout();
+        cy.visit('/index.php/view/');
+        cy.get('.liz-repository-project-item:visible .liz-project-title').contains('hide_project').should('not.exist');
+
+        cy.loginAsUserA();
+        cy.visit('/index.php/view/');
+        cy.get('.liz-repository-project-item:visible .liz-project-title').contains('hide_project').should('not.exist');
+
+        cy.loginAsAdmin();
+        cy.visit('/index.php/view/');
+        cy.get('.liz-repository-project-item:visible .liz-project-title').contains('hide_project').should('not.exist');
+        cy.logout();
+
+        // try to go to the hide_project map view
+        cy.visit('/index.php/view/map/?repository=testsrepository&project=hide_project')
+        // redirection to home page
+        cy.url().should('eq', Cypress.config().baseUrl + '/index.php/view/')
+        // with alert error div
+        cy.get('#content div.alert.alert-block.alert-error').should('length', 1)
+    })
 })

--- a/tests/end2end/cypress/integration/requests-getprojectconfig-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-getprojectconfig-ghaction.js
@@ -1,4 +1,75 @@
 describe('Request Lizmap GetProjectConfig', function () {
+    it('Empty config form hide_project', function () {
+        cy.logout();
+
+        cy.request({
+            url: '/index.php/lizmap/service/getProjectConfig?repository=testsrepository&project=hide_project',
+            failOnStatusCode: false,
+        }).then((resp) => {
+            expect(resp.status).to.eq(200)
+            expect(resp.headers['content-type']).to.eq('application/json')
+
+            expect(resp.body).to.have.property('metadata')
+            expect(resp.body.metadata).to.have.property('lizmap_plugin_version')
+            expect(resp.body.metadata).to.have.property('lizmap_plugin_version_str')
+            expect(resp.body.metadata).to.have.property('lizmap_web_client_target_version')
+            expect(resp.body.metadata).to.have.property('project_valid')
+            expect(resp.body.metadata).to.have.property('qgis_desktop_version')
+
+            expect(resp.body).to.have.property('options')
+            expect(resp.body.options).to.have.property('hideProject', 'True')
+            expect(resp.body.options).to.have.property('bbox')
+            expect(resp.body.options).to.have.property('initialExtent')
+            expect(resp.body.options).to.have.property('mapScales')
+            expect(resp.body.options).to.have.property('minScale')
+            expect(resp.body.options).to.have.property('maxScale')
+            expect(resp.body.options).to.have.property('projection')
+            expect(resp.body.options).to.have.property('pointTolerance')
+            expect(resp.body.options).to.have.property('lineTolerance')
+            expect(resp.body.options).to.have.property('polygonTolerance')
+            expect(resp.body.options).to.have.property('popupLocation')
+            expect(resp.body.options).to.have.property('datavizLocation')
+            expect(resp.body.options).to.have.property('wmsMaxHeight')
+            expect(resp.body.options).to.have.property('wmsMaxWidth')
+
+            expect(resp.body).to.have.property('layers')
+            expect(resp.body.layers).to.be.empty
+
+            expect(resp.body).to.have.property('locateByLayer')
+            expect(resp.body.locateByLayer).to.be.empty
+
+            expect(resp.body).to.have.property('attributeLayers')
+            expect(resp.body.attributeLayers).to.be.empty
+
+            expect(resp.body).to.have.property('timemanagerLayers')
+            expect(resp.body.timemanagerLayers).to.be.empty
+
+            expect(resp.body).to.have.property('relations')
+            expect(resp.body.relations).to.have.property('pivot')
+            expect(resp.body.relations.pivot).to.be.empty
+
+            expect(resp.body).to.have.property('printTemplates')
+            expect(resp.body.printTemplates).to.be.empty
+
+            expect(resp.body).to.have.property('tooltipLayers')
+            expect(resp.body.timemanagerLayers).to.be.empty
+
+            expect(resp.body).to.have.property('formFilterLayers')
+            expect(resp.body.formFilterLayers).to.be.empty
+
+            expect(resp.body).to.have.property('datavizLayers')
+            expect(resp.body.datavizLayers).to.have.property('locale')
+            expect(resp.body.datavizLayers.locale).to.be.not.empty
+            expect(resp.body.datavizLayers).to.have.property('layers')
+            expect(resp.body.datavizLayers.layers).to.be.empty
+            expect(resp.body.datavizLayers).to.have.property('dataviz')
+            expect(resp.body.datavizLayers.dataviz).to.be.empty
+
+            expect(resp.body).to.have.property('loginFilteredLayers')
+            expect(resp.body.loginFilteredLayers).to.be.empty
+        })
+    })
+
     it('As anonymous', function () {
         cy.logout();
 

--- a/tests/end2end/cypress/integration/requests-service-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-service-ghaction.js
@@ -155,6 +155,15 @@ describe('Request service', function () {
                 expect(resp.body).to.contain('WMS_Capabilities')
                 expect(resp.body).to.contain('version="1.3.0"')
             })
+
+        // Project with config.options.hideProject: "True"
+        cy.request('/index.php/lizmap/service/?repository=testsrepository&project=hide_project&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities')
+            .then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+                expect(resp.body).to.contain('WMS_Capabilities')
+                expect(resp.body).to.contain('version="1.3.0"')
+            })
     })
 
     it('WMTS GetCapabilities', function () {
@@ -170,6 +179,15 @@ describe('Request service', function () {
 
     it('WFS GetCapabilities', function () {
         cy.request('/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetCapabilities')
+            .then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+                expect(resp.body).to.contain('WFS_Capabilities')
+                expect(resp.body).to.contain('version="1.0.0"')
+            })
+
+        // Project with config.options.hideProject: "True"
+        cy.request('/index.php/lizmap/service/?repository=testsrepository&project=hide_project&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetCapabilities')
             .then((resp) => {
                 expect(resp.status).to.eq(200)
                 expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')

--- a/tests/qgis-projects/tests/hide_project.qgs
+++ b/tests/qgis-projects/tests/hide_project.qgs
@@ -1,0 +1,227 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis saveDateTime="2022-06-09T20:18:40" saveUserFull="" saveUser="" version="3.16.16-Hannover" projectname="">
+  <homePath path=""/>
+  <title></title>
+  <autotransaction active="0"/>
+  <evaluateDefaultValues active="0"/>
+  <trust active="0"/>
+  <projectCrs>
+    <spatialrefsys>
+      <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+      <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+      <srsid>3452</srsid>
+      <srid>4326</srid>
+      <authid>EPSG:4326</authid>
+      <description>WGS 84</description>
+      <projectionacronym>longlat</projectionacronym>
+      <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+      <geographicflag>true</geographicflag>
+    </spatialrefsys>
+  </projectCrs>
+  <layer-tree-group>
+    <customproperties/>
+    <custom-order enabled="0"/>
+  </layer-tree-group>
+  <snapping-settings maxScale="0" enabled="0" mode="2" tolerance="12" intersection-snapping="0" self-snapping="0" type="1" scaleDependencyMode="0" unit="1" minScale="0">
+    <individual-layer-settings/>
+  </snapping-settings>
+  <relations/>
+  <mapcanvas annotationsVisible="1" name="theMapCanvas">
+    <units>degrees</units>
+    <extent>
+      <xmin>-1</xmin>
+      <ymin>-1</ymin>
+      <xmax>1</xmax>
+      <ymax>1</ymax>
+    </extent>
+    <rotation>0</rotation>
+    <destinationsrs>
+      <spatialrefsys>
+        <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+        <srsid>3452</srsid>
+        <srid>4326</srid>
+        <authid>EPSG:4326</authid>
+        <description>WGS 84</description>
+        <projectionacronym>longlat</projectionacronym>
+        <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+        <geographicflag>true</geographicflag>
+      </spatialrefsys>
+    </destinationsrs>
+    <rendermaptile>0</rendermaptile>
+    <expressionContextScope/>
+  </mapcanvas>
+  <projectModels/>
+  <legend updateDrawingOrder="true"/>
+  <mapViewDocks/>
+  <mapViewDocks3D/>
+  <main-annotation-layer autoRefreshTime="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" autoRefreshEnabled="0" type="annotation">
+    <id>Annotations_f7a5e6c0_79b2_4b23_8dc2_d578126babb8</id>
+    <datasource></datasource>
+    <keywordList>
+      <value></value>
+    </keywordList>
+    <layername>Annotations</layername>
+    <srs>
+      <spatialrefsys>
+        <wkt></wkt>
+        <proj4></proj4>
+        <srsid>0</srsid>
+        <srid>0</srid>
+        <authid></authid>
+        <description></description>
+        <projectionacronym></projectionacronym>
+        <ellipsoidacronym></ellipsoidacronym>
+        <geographicflag>false</geographicflag>
+      </spatialrefsys>
+    </srs>
+    <resourceMetadata>
+      <identifier></identifier>
+      <parentidentifier></parentidentifier>
+      <language></language>
+      <type></type>
+      <title></title>
+      <abstract></abstract>
+      <links/>
+      <fees></fees>
+      <encoding></encoding>
+      <crs>
+        <spatialrefsys>
+          <wkt></wkt>
+          <proj4></proj4>
+          <srsid>0</srsid>
+          <srid>0</srid>
+          <authid></authid>
+          <description></description>
+          <projectionacronym></projectionacronym>
+          <ellipsoidacronym></ellipsoidacronym>
+          <geographicflag>false</geographicflag>
+        </spatialrefsys>
+      </crs>
+      <extent/>
+    </resourceMetadata>
+    <items/>
+    <layerOpacity>1</layerOpacity>
+  </main-annotation-layer>
+  <projectlayers/>
+  <layerorder/>
+  <properties>
+    <Digitizing>
+      <AvoidIntersectionsMode type="int">0</AvoidIntersectionsMode>
+    </Digitizing>
+    <Gui>
+      <CanvasColorBluePart type="int">255</CanvasColorBluePart>
+      <CanvasColorGreenPart type="int">255</CanvasColorGreenPart>
+      <CanvasColorRedPart type="int">255</CanvasColorRedPart>
+      <SelectionColorAlphaPart type="int">255</SelectionColorAlphaPart>
+      <SelectionColorBluePart type="int">0</SelectionColorBluePart>
+      <SelectionColorGreenPart type="int">255</SelectionColorGreenPart>
+      <SelectionColorRedPart type="int">255</SelectionColorRedPart>
+    </Gui>
+    <Legend>
+      <filterByMap type="bool">false</filterByMap>
+    </Legend>
+    <Measure>
+      <Ellipsoid type="QString">EPSG:7030</Ellipsoid>
+    </Measure>
+    <Measurement>
+      <AreaUnits type="QString">m2</AreaUnits>
+      <DistanceUnits type="QString">meters</DistanceUnits>
+    </Measurement>
+    <PAL>
+      <CandidatesLinePerCM type="double">5</CandidatesLinePerCM>
+      <CandidatesPolygonPerCM type="double">2.5</CandidatesPolygonPerCM>
+      <DrawRectOnly type="bool">false</DrawRectOnly>
+      <DrawUnplaced type="bool">false</DrawUnplaced>
+      <PlacementEngineVersion type="int">1</PlacementEngineVersion>
+      <SearchMethod type="int">0</SearchMethod>
+      <ShowingAllLabels type="bool">false</ShowingAllLabels>
+      <ShowingCandidates type="bool">false</ShowingCandidates>
+      <ShowingPartialsLabels type="bool">true</ShowingPartialsLabels>
+      <TextFormat type="int">0</TextFormat>
+      <UnplacedColor type="QString">255,0,0,255</UnplacedColor>
+    </PAL>
+    <Paths>
+      <Absolute type="bool">false</Absolute>
+    </Paths>
+    <PositionPrecision>
+      <Automatic type="bool">true</Automatic>
+      <DecimalPlaces type="int">2</DecimalPlaces>
+    </PositionPrecision>
+    <SpatialRefSys>
+      <ProjectionsEnabled type="int">1</ProjectionsEnabled>
+    </SpatialRefSys>
+    <Variables>
+      <variableNames type="QStringList">
+        <value>lizmap_user</value>
+        <value>lizmap_user_groups</value>
+      </variableNames>
+      <variableValues type="QStringList">
+        <value></value>
+        <value></value>
+      </variableValues>
+    </Variables>
+    <WMSExtent type="QStringList">
+      <value>-3.5</value>
+      <value>-1.0</value>
+      <value>3.5</value>
+      <value>1.0</value>
+    </WMSExtent>
+    <WMSServiceCapabilities type="QString">True</WMSServiceCapabilities>
+    <WMSServiceTitle type="QString">no_ui</WMSServiceTitle>
+  </properties>
+  <dataDefinedServerProperties>
+    <Option type="Map">
+      <Option name="name" value="" type="QString"/>
+      <Option name="properties"/>
+      <Option name="type" value="collection" type="QString"/>
+    </Option>
+  </dataDefinedServerProperties>
+  <visibility-presets/>
+  <transformContext/>
+  <projectMetadata>
+    <identifier></identifier>
+    <parentidentifier></parentidentifier>
+    <language></language>
+    <type></type>
+    <title></title>
+    <abstract></abstract>
+    <links/>
+    <author></author>
+    <creation>2022-06-09T20:13:03</creation>
+  </projectMetadata>
+  <Annotations/>
+  <Layouts/>
+  <Bookmarks/>
+  <ProjectViewSettings UseProjectScales="0">
+    <Scales/>
+    <DefaultViewExtent ymin="-1" xmax="1.12971698113207553" xmin="-1.12971698113207553" ymax="1">
+      <spatialrefsys>
+        <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+        <srsid>3452</srsid>
+        <srid>4326</srid>
+        <authid>EPSG:4326</authid>
+        <description>WGS 84</description>
+        <projectionacronym>longlat</projectionacronym>
+        <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+        <geographicflag>true</geographicflag>
+      </spatialrefsys>
+    </DefaultViewExtent>
+  </ProjectViewSettings>
+  <ProjectTimeSettings timeStep="1" frameRate="1" timeStepUnit="h" cumulativeTemporalRange="0"/>
+  <ProjectDisplaySettings>
+    <BearingFormat id="bearing">
+      <Option type="Map">
+        <Option name="decimal_separator" value="" type="QChar"/>
+        <Option name="decimals" value="6" type="int"/>
+        <Option name="direction_format" value="0" type="int"/>
+        <Option name="rounding_type" value="0" type="int"/>
+        <Option name="show_plus" value="false" type="bool"/>
+        <Option name="show_thousand_separator" value="true" type="bool"/>
+        <Option name="show_trailing_zeros" value="false" type="bool"/>
+        <Option name="thousand_separator" value="" type="QChar"/>
+      </Option>
+    </BearingFormat>
+  </ProjectDisplaySettings>
+</qgis>

--- a/tests/qgis-projects/tests/hide_project.qgs.cfg
+++ b/tests/qgis-projects/tests/hide_project.qgs.cfg
@@ -1,0 +1,64 @@
+{
+    "metadata": {
+        "qgis_desktop_version": 31616,
+        "lizmap_plugin_version_str": "3.8.1",
+        "lizmap_plugin_version": 30801,
+        "lizmap_web_client_target_version": 30400,
+        "project_valid": true
+    },
+    "options": {
+        "projection": {
+            "proj4": "+proj=longlat +datum=WGS84 +no_defs",
+            "ref": "EPSG:4326"
+        },
+        "bbox": [
+            "-3.5",
+            "-1.0",
+            "3.5",
+            "1.0"
+        ],
+        "mapScales": [
+            10000,
+            25000,
+            50000,
+            100000,
+            250000,
+            500000
+        ],
+        "minScale": 10000,
+        "maxScale": 500000,
+        "initialExtent": [
+            -3.5,
+            -1.0,
+            3.5,
+            1.0
+        ],
+        "popupLocation": "dock",
+        "pointTolerance": 25,
+        "lineTolerance": 10,
+        "polygonTolerance": 5,
+        "hideProject": "True",
+        "tmTimeFrameSize": 10,
+        "tmTimeFrameType": "seconds",
+        "tmAnimationFrameLength": 1000,
+        "datavizLocation": "dock",
+        "theme": "light",
+        "fixed_scale_overview_map": true
+    },
+    "layers": {},
+    "atlas": {
+        "layers": []
+    },
+    "locateByLayer": {},
+    "attributeLayers": {},
+    "tooltipLayers": {},
+    "editionLayers": {},
+    "loginFilteredLayers": {},
+    "timemanagerLayers": {},
+    "datavizLayers": {},
+    "filter_by_polygon": {
+        "config": {},
+        "layers": []
+    },
+    "formFilterLayers": {}
+}


### PR DESCRIPTION
New tests to check the lizmap config options hide project.
The project is empty: no layers, no other config.

Funded by 3Liz
