### PR TITLE
Minify JS files

### DIFF
--- a/assets/webpack.common.js
+++ b/assets/webpack.common.js
@@ -2,7 +2,19 @@ const path = require('path');
 
 module.exports = {
     entry: {
-        lizmap: './src/index.js'
+        lizmap: './src/index.js',
+        map: '../lizmap/www/assets/js/map.js',
+        attributeTable: '../lizmap/www/assets/js/attributeTable.js',
+        edition: '../lizmap/www/assets/js/edition.js',
+        filter: '../lizmap/www/assets/js/filter.js',
+        atlas: '../lizmap/www/assets/js/atlas.js',
+        'switcher-layers-actions': '../lizmap/www/assets/js/switcher-layers-actions.js',
+        timemanager: '../lizmap/www/assets/js/timemanager.js',
+        search: '../lizmap/www/assets/js/search.js',
+        view: '../lizmap/www/assets/js/view.js',
+        action: '../lizmap/www/assets/js/action.js',
+        'bottom-dock': '../lizmap/www/assets/js/bottom-dock.js',
+        popupQgisAtlas: '../lizmap/www/assets/js/popupQgisAtlas.js',
     },
     output: {
         filename: '../../lizmap/www/assets/js/[name].js',

--- a/lizmap/www/assets/js/edition.js
+++ b/lizmap/www/assets/js/edition.js
@@ -2091,3 +2091,5 @@ lizEditionErrorDecorator.prototype = {
         }
     }
 };
+
+window.lizEditionErrorDecorator = lizEditionErrorDecorator;

--- a/lizmap/www/assets/js/map.js
+++ b/lizmap/www/assets/js/map.js
@@ -9,7 +9,7 @@
 */
 
 
-var lizMap = function() {
+window.lizMap = function() {
   /**
    * PRIVATE Property: config
    * {object} The map config


### PR DESCRIPTION
Use terser in Webpack to minify our JS files.
That saves more than 400Ko!
before terser : 649,6 Ko
after terser : 246,7 Ko

Funded by 3Liz
