### PR TITLE
fix: The `editionLayers` of `$configJson` in `Project::getUpdatedConfig` can be `unset`

### DIFF
--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -1776,7 +1776,8 @@ class Project
                 unset($configJson->tooltipLayers->{$key});
             }
             // editionLayers
-            if (property_exists($configJson->editionLayers, $key)) {
+            if ($this->hasEditionLayersForCurrentUser()
+                && property_exists($configJson->editionLayers, $key)) {
                 unset($configJson->editionLayers->{$key});
             }
             // datavizLayers


### PR DESCRIPTION

If there is no edition layers for the user, the `editionLayers` of the `$configJson` is `unset`.
So when lizmap removed layers from config to provide only available configuration for user, the code does not check if the `editionLayers` of `$configJson` is still here.

Funded by 3Liz