### PR TITLE
Email configuration: add more explainations to fill correctly data

### DIFF
--- a/lizmap/modules/admin/controllers/config.classic.php
+++ b/lizmap/modules/admin/controllers/config.classic.php
@@ -137,6 +137,7 @@ class configCtrl extends jController
 
         /** @var null|jFormsBase $form */
         if ($form) {
+            $hasSenderEmail = ($form->getData('adminSenderEmail') != '');
             if (lizmap::getServices()->isLdapEnabled()) {
                 $ctrl = $form->getControl('allowUserAccountRequests');
                 $ctrl->help = jLocale::get('admin~admin.configuration.services.allowUserAccountRequests.help.deactivated');
@@ -146,14 +147,16 @@ class configCtrl extends jController
             ) {
                 $form->getControl('adminSenderEmail')->required = true;
             }
-            if (lizmap::getServices()->hideSensitiveProperties() && $form->getData('adminSenderEmail') === '') {
+            if (lizmap::getServices()->hideSensitiveProperties() && !$hasSenderEmail) {
                 $form->getControl('allowUserAccountRequests')->setReadOnly();
                 $form->getControl('allowUserAccountRequests')->help = jLocale::get('admin~admin.config.services.allowUserAccountRequest.noemail');
             }
             // Display form
             $tpl = new jTpl();
             $tpl->assign('form', $form);
+            $tpl->assign('hasSenderEmail', $hasSenderEmail);
             $tpl->assign('showSystem', !lizmap::getServices()->hideSensitiveProperties());
+            $tpl->assign('smtpEnabled', lizmap::getServices()->isSmtpEnabled());
             $rep->body->assign('MAIN', $tpl->fetch('admin~config_services'));
             $rep->body->assign('selectedMenuItem', 'lizmap_configuration');
 

--- a/lizmap/modules/admin/forms/config_services.form.xml
+++ b/lizmap/modules/admin/forms/config_services.form.xml
@@ -149,6 +149,17 @@
 
 
     <!-- emails -->
+    <input ref="adminSenderEmail" type="email">
+        <label locale="admin~admin.form.admin_services.adminSenderEmail.label"/>
+        <help locale="admin~admin.form.admin_services.adminSenderEmail.help"/>
+        <alert type="required" locale="admin~admin.form.admin_services.adminSenderEmail.error.required"/>
+    </input>
+
+    <input ref="adminSenderName" maxlength="250">
+        <label locale="admin~admin.form.admin_services.adminSenderName.label"/>
+        <help locale="admin~admin.form.admin_services.adminSenderName.help"/>
+    </input>
+
 
     <menulist ref="allowUserAccountRequests">
       <label locale="admin~admin.form.admin_services.allowUserAccountRequests.label"/>
@@ -159,17 +170,6 @@
     <input ref="adminContactEmail" type="email">
         <label locale="admin~admin.form.admin_services.adminContactEmail.label"/>
         <help locale="admin~admin.form.admin_services.adminContactEmail.help"/>
-    </input>
-
-    <input ref="adminSenderEmail" type="email">
-        <label locale="admin~admin.form.admin_services.adminSenderEmail.label"/>
-        <help locale="admin~admin.form.admin_services.adminSenderEmail.help"/>
-        <alert type="required" locale="admin~admin.form.admin_services.adminSenderEmail.error.required"/>
-    </input>
-
-    <input ref="adminSenderName" maxlength="250">
-        <label locale="admin~admin.form.admin_services.adminSenderName.label"/>
-        <help locale="admin~admin.form.admin_services.adminSenderName.help"/>
     </input>
 
     <!-- uploaded images properties -->

--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -120,9 +120,9 @@ form.admin_services.adminSenderEmail.help=E-mail address used to send e-mails. I
 form.admin_services.adminSenderEmail.error.required=A sender e-mail address is required to send notification or requests for account creation
 form.admin_services.adminSenderName.label=Sender name of e-mails
 form.admin_services.adminSenderName.help=Name of the sender used to send e-mails.
-form.admin_services.emails.help=To send email, Lizmap needs a sender address. If empty, no emails will be sent by Lizmap, and therefore, some features like password recovery or email notifications won't work.
-form.admin_services.emails.server.help=Be sure the web server is able to send email, or setup SMTP parameters into the configuration files of Lizmap.
-form.admin_services.emails.no.server=No sender address is configured into Lizmap. Some features like password recovery or email notifications can't work. Contact the application administrator if you want enable all email features.
+form.admin_services.emails.help=To send emails, Lizmap needs a sender address. If empty, no emails will be sent by Lizmap, and therefore, some features like password recovery or email notifications won't work.
+form.admin_services.emails.server.help=Be sure the web server is able to send emails, or setup SMTP parameters into the configuration files of Lizmap.
+form.admin_services.emails.no.server=No sender address is configured in Lizmap. Some features like password recovery or email notifications cannot work. Contact the application administrator if you want to enable all email features.
 
 form.admin_services.googleAnalyticsID.label=Google Analytics ID
 form.admin_services.googleAnalyticsID.help=The Google Analytics ID is of the form 'UA-XXXX-Y'. It's also called the "tracking ID".

--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -120,6 +120,9 @@ form.admin_services.adminSenderEmail.help=E-mail address used to send e-mails. I
 form.admin_services.adminSenderEmail.error.required=A sender e-mail address is required to send notification or requests for account creation
 form.admin_services.adminSenderName.label=Sender name of e-mails
 form.admin_services.adminSenderName.help=Name of the sender used to send e-mails.
+form.admin_services.emails.help=To send email, Lizmap needs a sender address. If empty, no emails will be sent by Lizmap, and therefore, some features like password recovery or email notifications won't work.
+form.admin_services.emails.server.help=Be sure the web server is able to send email, or setup SMTP parameters into the configuration files of Lizmap.
+form.admin_services.emails.no.server=No sender address is configured into Lizmap. Some features like password recovery or email notifications can't work. Contact the application administrator if you want enable all email features.
 
 form.admin_services.googleAnalyticsID.label=Google Analytics ID
 form.admin_services.googleAnalyticsID.help=The Google Analytics ID is of the form 'UA-XXXX-Y'. It's also called the "tracking ID".

--- a/lizmap/modules/admin/templates/config.tpl
+++ b/lizmap/modules/admin/templates/config.tpl
@@ -27,7 +27,7 @@
         <div>
             <h2>{@admin~admin.configuration.services.section.emails.label@}</h2>
             <table class="table services-table">
-                {formcontrols array('allowUserAccountRequests', 'adminContactEmail', 'adminSenderEmail', 'adminSenderName')}
+                {formcontrols array( 'adminSenderEmail', 'adminSenderName', 'allowUserAccountRequests', 'adminContactEmail')}
                     <tr>
                         <th>{ctrl_label}</th><td>{ctrl_value}</td>
                     </tr>

--- a/lizmap/modules/admin/templates/config_services.tpl
+++ b/lizmap/modules/admin/templates/config_services.tpl
@@ -16,8 +16,18 @@
 
     <div>
         <h2>{@admin~admin.configuration.services.section.emails.label@}</h2>
+        {if $showSystem}
+            <p>{@admin~admin.form.admin_services.emails.help@}</p>
+            {if !$smtpEnabled}
+                <p>{@admin~admin.form.admin_services.emails.server.help@}</p>
+            {/if}
+        {else}
+            {if !$hasSenderEmail}
+                <p>{@admin~admin.form.admin_services.emails.no.server@}</p>
+            {/if}
+        {/if}
         <table class="table services-table">
-            {formcontrols array('allowUserAccountRequests', 'adminContactEmail', 'adminSenderEmail', 'adminSenderName')}
+            {formcontrols array( 'adminSenderEmail', 'adminSenderName', 'allowUserAccountRequests', 'adminContactEmail')}
                 <tr>
                     <th>{ctrl_label}</th><td>{ctrl_control}</td>
                 </tr>

--- a/lizmap/modules/lizmap/classes/lizmapServices.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapServices.class.php
@@ -302,6 +302,15 @@ class lizmapServices
         return $this->isUsingLdap;
     }
 
+    public function isSmtpEnabled()
+    {
+        $config = \jApp::config()->mailer;
+
+        return $config['mailerType'] == 'smtp'
+            && $config['smtpHost'] != ''
+            && $config['smtpPort'] != '';
+    }
+
     /**
      * @return bool|int
      */


### PR DESCRIPTION
In order to help to fill fields related to email, this patch adds some explainations for the user.. The explainations are differents, depending if we show sensitive informations or not, or if there is a SMTP configuration or not.

Funded by 3Liz
