### PR TITLE
ACL - Check that QGIS server is OK before opening a project

### DIFF
--- a/CHANGELOG-3.6.md
+++ b/CHANGELOG-3.6.md
@@ -8,6 +8,7 @@
   * Lizmap QGIS server plugin is running with a minimum required version
   * QGIS server version is running with at least 3.10
   * These two versions are hardcoded in the source code and updated when a new version of Lizmap is released
+* Display the version of Py-QGIS-Server in the administration panel if it's used
 
 ## 3.6.0-beta.2 - 2022-07-29
 

--- a/CHANGELOG-3.6.md
+++ b/CHANGELOG-3.6.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## Added
+
+* Before opening a QGIS project, Lizmap is now checking that :
+  * Lizmap QGIS server plugin is running with a minimum required version
+  * QGIS server version is running with at least 3.10
+  * These two versions are hardcoded in the source code and updated when a new version of Lizmap is released
 
 ## 3.6.0-beta.2 - 2022-07-29
 

--- a/lizmap/modules/admin/controllers/server_information.classic.php
+++ b/lizmap/modules/admin/controllers/server_information.classic.php
@@ -34,11 +34,37 @@ class server_informationCtrl extends jController
         $lizmapPluginMinimumVersionRequired = jApp::config()->minimumRequiredVersion['lizmapServerPlugin'];
         $linkDocumentation = 'https://docs.lizmap.com/current/en/install/pre_requirements.html#lizmap-server-plugin';
 
+        $qgisServerNeedsUpdate = $server->versionCompare(
+            $server->getQgisServerVersion(),
+            $qgisMinimumVersionRequired
+        );
+        $updateQgisServer = jLocale::get('admin.server.information.qgis.update', array($qgisMinimumVersionRequired));
+        if ($qgisServerNeedsUpdate) {
+            jLog::log($updateQgisServer, 'error');
+        }
+
+        $displayPluginActionColumn = false;
+        $lizmapQgisServerNeedsUpdate = $server->pluginServerNeedsUpdate(
+            $server->getLizmapPluginServerVersion(),
+            $lizmapPluginMinimumVersionRequired
+        );
+        $updateLizmapPlugin = jLocale::get('admin.server.information.plugin.update', array('lizmap_server'));
+        if ($lizmapQgisServerNeedsUpdate) {
+            // lizmap_server is required to use LWC
+            jLog::log($updateLizmapPlugin, 'error');
+            $displayPluginActionColumn = true;
+        }
+
         // Set the HTML content
         $tpl = new jTpl();
         $assign = array(
             'data' => $data,
             'linkDocumentation' => $linkDocumentation,
+            'qgisServerNeedsUpdate' => $qgisServerNeedsUpdate,
+            'updateQgisServer' => $updateQgisServer,
+            'displayPluginActionColumn' => $displayPluginActionColumn,
+            'lizmapQgisServerNeedsUpdate' => $lizmapQgisServerNeedsUpdate,
+            'lizmapPluginUpdate' => $updateLizmapPlugin,
             'errorQgisPlugin' => jLocale::get(
                 'admin.server.information.qgis.error.fetching.information.detail',
                 array(

--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -246,9 +246,13 @@ server.information.qgis.metadata=Version
 server.information.qgis.version=Number
 server.information.qgis.name=Name
 server.information.qgis.commit_id=Commit ID
+server.information.qgis.action=Action
 
 server.information.qgis.plugins=Plugins
 server.information.qgis.plugins.version=Version number
+server.information.qgis.plugin=Plugin
+server.information.qgis.plugin.version=Version
+server.information.qgis.plugin.action=Action
 
 server.information.qgis.test.ok=QGIS Server is correctly installed and returns the expected response for OGC requests.
 server.information.qgis.test.error=QGIS Server is not correctly installed in your server or the URL for OGC requests given in Lizmap configuration is not correct.
@@ -259,6 +263,8 @@ Please upgrade QGIS Server to minimum %s and install or upgrade the Lizmap serve
 minimum %s by reading the documentation about the environment variable
 server.information.qgis.error.fetching.information.detail.NO_ACCESS=You don't have access to information about QGIS Server
 server.information.qgis.error.fetching.information.detail.HTTP_ERROR=QGIS Server returns an HTTP error about the Lizmap plugin:
+server.information.qgis.update=QGIS Server needs to be updated at least to version %s for this version of Lizmap Web Client.
+server.information.plugin.update=The %s plugin needs to be updated.
 
 
 project.list.column.repository.label=Repository

--- a/lizmap/modules/admin/templates/server_information.tpl
+++ b/lizmap/modules/admin/templates/server_information.tpl
@@ -66,15 +66,35 @@
             <td><a href="https://github.com/qgis/QGIS/commit/{$data['qgis_server_info']['metadata']['commit_id']}" target="_blank">{$data['qgis_server_info']['metadata']['commit_id']}</a></td>
         </tr>
         {/if}
+        {if $qgisServerNeedsUpdate }
+        <tr>
+            <th>{@admin.server.information.qgis.action@}</th>
+            <td style="background-color:lightcoral;"><strong>{$updateQgisServer}</strong></td>
+        </tr>
+        {/if}
     </table>
     {hook 'QgisServerVersion', $data['qgis_server_info']['metadata']}
 
     <h4>{@admin.server.information.qgis.plugins@}</h4>
     <table class="table table-condensed table-striped table-bordered table-server-info">
+        <tr>
+            <th style="width:20%;">{@admin.server.information.qgis.plugin@}</th>
+            <th style="width:20%;">{@admin.server.information.qgis.plugin.version@}</th>
+            {if $displayPluginActionColumn }
+                <th>{@admin.server.information.qgis.plugin.action@}</th>
+            {/if}
+        <tr/>
         {foreach $data['qgis_server_info']['plugins'] as $name=>$version}
         <tr>
-            <th>{$name}</th>
-            <td>{$version['version']}</td>
+            <th style="width:20%;">{$name}</th>
+            <td style="width:20%;">{$version['version']}</td>
+            {if $displayPluginActionColumn }
+                {if $name == 'lizmap_server' && $lizmapQgisServerNeedsUpdate}
+                    <td style="background-color:lightcoral;"><strong>{$lizmapPluginUpdate}</strong></td>
+                {else}
+                <td></td>
+                {/if}
+            {/if}
         </tr>
         {/foreach}
     </table>

--- a/lizmap/modules/admin/templates/server_information.tpl
+++ b/lizmap/modules/admin/templates/server_information.tpl
@@ -60,12 +60,14 @@
             <th>{@admin.server.information.qgis.name@}</th>
             <td>{$data['qgis_server_info']['metadata']['name']}</td>
         </tr>
-        {if $data['qgis_server_info']['metadata']['commit_id']}
         <tr>
             <th>{@admin.server.information.qgis.commit_id@}</th>
             <td><a href="https://github.com/qgis/QGIS/commit/{$data['qgis_server_info']['metadata']['commit_id']}" target="_blank">{$data['qgis_server_info']['metadata']['commit_id']}</a></td>
         </tr>
-        {/if}
+        <tr>
+            <th>Py-QGIS-Server</th>
+            <td>{$data['qgis_server_info']['metadata']['py_qgis_server_version']}</td>
+        </tr>
         {if $qgisServerNeedsUpdate }
         <tr>
             <th>{@admin.server.information.qgis.action@}</th>

--- a/lizmap/modules/lizmap/lib/Server/Server.php
+++ b/lizmap/modules/lizmap/lib/Server/Server.php
@@ -38,6 +38,52 @@ class Server
         return $this->metadata;
     }
 
+    /** Get the current Lizmap server version.
+     *
+     * @return string String containing the current Lizmap QGIS server version
+     */
+    public function getLizmapPluginServerVersion()
+    {
+        return $this->metadata['qgis_server_info']['plugins']['lizmap_server']['version'];
+    }
+
+    /** Get the current QGIS server version.
+     *
+     * @return string String containing the current QGIS server version
+     */
+    public function getQgisServerVersion()
+    {
+        return $this->metadata['qgis_server_info']['metadata']['version'];
+    }
+
+    /** Check if a QGIS server plugin needs to be updated.
+     *
+     * @param string $currentVersion  The current version to check
+     * @param string $requiredVersion The minimum required version
+     *
+     * @return bool boolean If the plugin needs to be updated
+     */
+    public function pluginServerNeedsUpdate($currentVersion, $requiredVersion)
+    {
+        if ($currentVersion == 'master' || $currentVersion == 'dev') {
+            return false;
+        }
+
+        return $this->versionCompare($currentVersion, $requiredVersion);
+    }
+
+    /** Compare two versions and return true if the second parameter is greater or equal to the first parameter.
+     *
+     * @param string $currentVersion  The current version to check
+     * @param string $requiredVersion The minimum required version
+     *
+     * @return bool boolean If the software needs to be updated
+     */
+    public function versionCompare($currentVersion, $requiredVersion)
+    {
+        return version_compare($currentVersion, $requiredVersion) < 0;
+    }
+
     /**
      * Get Lizmap Web Client metadata.
      *

--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -65,6 +65,27 @@ class lizMapCtrl extends jController
         $rep = $this->getResponse('redirect');
         $rep->action = 'view~default:index';
 
+        // Check server status
+        $server = new \Lizmap\Server\Server();
+
+        // Minimum QGIS server version
+        $requiredQgisVersion = jApp::config()->minimumRequiredVersion['qgisServer'];
+        $currentQgisVersion = $server->getQgisServerVersion();
+        if ($server->versionCompare($currentQgisVersion, $requiredQgisVersion)) {
+            jMessage::add(jLocale::get('view~default.server.information.error'), 'error');
+
+            return $rep;
+        }
+
+        // lizmap_server plugin version
+        $requiredLizmapVersion = jApp::config()->minimumRequiredVersion['lizmapServerPlugin'];
+        $currentLizmapVersion = $server->getLizmapPluginServerVersion();
+        if ($server->pluginServerNeedsUpdate($currentLizmapVersion, $requiredLizmapVersion)) {
+            jMessage::add(jLocale::get('view~default.server.information.error'), 'error');
+
+            return $rep;
+        }
+
         if (!$lrep or !jAcl2::check('lizmap.repositories.view', $lrep->getKey())) {
             jMessage::add(jLocale::get('view~default.repository.access.denied'), 'error');
             if (!jAuth::isConnected()) {

--- a/lizmap/modules/view/locales/en_US/default.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/default.UTF-8.properties
@@ -3,6 +3,8 @@ repository.list.title=Projects
 
 home.title=Home
 
+server.information.error=This map cannot be displayed. Please contact the server administrator to check the server information panel.
+
 project.access.denied=Access denied for this project.
 project.title.label=Title
 project.abstract.label=Abstract

--- a/tests/end2end/cypress/integration/requests-metadata-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-metadata-ghaction.js
@@ -28,6 +28,7 @@ describe('Request JSON metadata', function () {
             expect(response.body.qgis_server.test).to.eq("OK")
 
             expect(response.body.qgis_server_info.metadata.py_qgis_server).to.eq(true)
+            expect(response.body.qgis_server_info.metadata.py_qgis_server_version).to.contain('.')
             expect(response.body.qgis_server_info.metadata.version).to.contain('3.')
             expect(response.body.qgis_server_info.plugins.lizmap_server.version).to.contain('alpha')
         });
@@ -45,6 +46,7 @@ describe('Request JSON metadata', function () {
             expect(response.body.qgis_server.test).to.eq("OK")
 
             expect(response.body.qgis_server_info.metadata.py_qgis_server).to.eq(true)
+            expect(response.body.qgis_server_info.metadata.py_qgis_server_version).to.contain('.')
             expect(response.body.qgis_server_info.metadata.version).to.contain('3.')
             expect(response.body.qgis_server_info.plugins.lizmap_server.version).to.contain("alpha")
         });


### PR DESCRIPTION
* Before opening a QGIS project, Lizmap is now checking that :
  * Lizmap QGIS server plugin is running with a minimum required version
  * QGIS server version is running with at least 3.10
  * These two versions are hardcoded in the source code and updated when a new version of Lizmap is released

Fix #2972 and linked to #2058

Funded by 3Liz
