### PR TITLE
Remove code about spatialite and edition of layer, not supported for a long time in the plugin

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -451,9 +451,4 @@ class lizmapProject
     {
         return $this->proj->checkAclByUser($login);
     }
-
-    public function getSpatialiteExtension()
-    {
-        return $this->proj->getSpatialiteExtension();
-    }
 }

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -227,12 +227,10 @@ class qgisVectorLayer extends qgisMapLayer
 
         $dtParams = $this->getDatasourceParameters();
         if ($this->provider == 'spatialite') {
-            $spatialiteExt = $this->project->getSpatialiteExtension();
             $repository = $this->project->getRepository();
             $jdbParams = array(
                 'driver' => 'sqlite3',
                 'database' => realpath($repository->getPath().$dtParams->dbname),
-                'extensions' => $spatialiteExt,
             );
         } elseif ($this->provider == 'postgres') {
             // no persistent connexions, it may reach max connections to pgsql if
@@ -276,12 +274,10 @@ class qgisVectorLayer extends qgisMapLayer
             }
         } elseif ($this->provider == 'ogr'
             and preg_match('#(gpkg|sqlite)$#', $dtParams->dbname)) {
-            $spatialiteExt = $this->project->getSpatialiteExtension();
             $repository = $this->project->getRepository();
             $jdbParams = array(
                 'driver' => 'sqlite3',
                 'database' => realpath($repository->getPath().$dtParams->dbname),
-                'extensions' => $spatialiteExt,
             );
         } else {
             return null;

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -1558,18 +1558,7 @@ class Project
             return;
         }
 
-        $editionLayers = $this->cfg->getEditionLayers();
-
-        // Check ability to load spatialite extension
-        // And remove ONLY spatialite layers if no extension found
-        $spatialiteExt = '';
-        if (class_exists('SQLite3')) {
-            $spatialiteExt = $this->getSpatialiteExtension();
-        }
-        if (!$spatialiteExt) {
-            $this->appContext->logMessage('Spatialite is not available', 'error');
-            $xml->readEditionLayers($editionLayers);
-        }
+        $xml->readEditionLayers($this->cfg->getEditionLayers());
     }
 
     protected function readAttributeLayers(QgisProject $xml, ProjectConfig $cfg)
@@ -2265,38 +2254,5 @@ class Project
         }
 
         return false;
-    }
-
-    public function getSpatialiteExtension()
-    {
-        if ($this->spatialiteExt !== null && $this->spatialiteExt !== '') {
-            return $this->spatialiteExt;
-        }
-
-        // Try with mod_spatialite
-        try {
-            $db = new \SQLite3(':memory:');
-            $this->spatialiteExt = 'mod_spatialite.so';
-            $spatial = @$db->loadExtension($this->spatialiteExt); // loading SpatiaLite as an extension
-            if ($spatial) {
-                return $this->spatialiteExt;
-            }
-        } catch (\Exception $e) {
-            $spatial = false;
-        }
-
-        try {
-            $db = new \SQLite3(':memory:');
-            $this->spatialiteExt = 'libspatialite.so';
-            $spatial = @$db->loadExtension($this->spatialiteExt); // loading SpatiaLite as an extension
-            if ($spatial) {
-                return $this->spatialiteExt;
-            }
-        } catch (\Exception $e) {
-        }
-
-        $this->spatialiteExt = '';
-
-        return '';
     }
 }


### PR DESCRIPTION
In the Lizmap plugin, Spatialite layers for edition capabilities has been disabled for a long time.

So I think this code can be removed ?
Or am I missing something ?

If correct, this can be backported to LWC 3.5.
