### PR TITLE
Form filter - Allow to use a second field for the numeric type

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -1,11 +1,16 @@
 # Changelog Lizmap 3.7
 
 ## Unreleased
-
 ### Added
 
 * Better management of QGIS projects about versions (desktop, plugin versions etc)
+* **Form filter**: Allow to use a second field for the numeric type like it is already possible for dates.
+  Useful when the layer features contain two fields describing a minimum and maximum value of the same property.
 
 ### Backend
 
 * Some old code about QGIS Server 2
+
+### Funders
+
+* **[Terre de Provence Agglomération](https://www.terredeprovence-agglo.com)**


### PR DESCRIPTION
It was already possible for dates in the previous versions.
Now a second field can also be used for the numeric form widget.
It is useful when the layer features contain two fields describing
a minimum and maximum value of the same property (ex: age, width, depth, etc.)

Funded by Terre de Provence Agglomération https://www.terredeprovence-agglo.com/

Linked to https://github.com/3liz/lizmap-plugin/pull/442