### PR TITLE
Server info - always fetch metadata from qgis server even if we are not an admin

### DIFF
--- a/lizmap/modules/lizmap/lib/Server/Server.php
+++ b/lizmap/modules/lizmap/lib/Server/Server.php
@@ -153,12 +153,6 @@ class Server
         // Get Lizmap services
         $services = \lizmap::getServices();
 
-        // Only show QGIS related data for admins
-        $isAdmin = \jAcl2::check('lizmap.admin.access');
-        if (!$isAdmin) {
-            return array('error' => 'NO_ACCESS');
-        }
-
         // Get the data from the QGIS Server Lizmap plugin
         if (empty($services->lizmapPluginAPIURL)) {
             // When the Lizmap API URL is not set, we use the WMS server URL only

--- a/lizmap/modules/view/controllers/app.classic.php
+++ b/lizmap/modules/view/controllers/app.classic.php
@@ -29,6 +29,12 @@ class appCtrl extends jController
         // Get server metadata from LWC and QGIS Server Lizmap plugin
         $server = new \Lizmap\Server\Server();
         $data = $server->getMetadata();
+
+        // Only show QGIS related data for admins
+        $isAdmin = \jAcl2::check('lizmap.admin.access');
+        if (!$isAdmin) {
+            $data['qgis_server_info'] = array('error' => 'NO_ACCESS');
+        }
         $rep->data = $data;
 
         return $rep;


### PR DESCRIPTION
Master is broken with cypress

Related to comment https://github.com/3liz/lizmap-web-client/pull/3162#issuecomment-1210993700