### PR TITLE
fix(request): OGC GetCapabilities with tests

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/OGCRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/OGCRequest.php
@@ -259,6 +259,10 @@ abstract class OGCRequest
         // the cache should be unique between each user/service because the
         // request content depends on rights of the user
         $key = session_id().'-'.$this->param('service');
+        $version = $this->param('version');
+        if ($version) {
+            $key .= '-'.$version;
+        }
         if ($appContext->UserIsConnected()) {
             $juser = $appContext->getUserSession();
             $key .= '-'.$juser->login;

--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -156,7 +156,7 @@ class WMSRequest extends OGCRequest
             $schemaLocation .= ' http://www.opengis.net/sld';
             $schemaLocation .= ' http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd';
             $schemaLocation .= ' http://www.qgis.org/wms';
-            $schemaLocation .= ' '.$sUrl.'SERVICE=WMS&amp;REQUEST=GetSchemaExtension';
+            $schemaLocation .= ' '.$sUrl.'SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetSchemaExtension';
             $data = preg_replace('@xsi:schemaLocation=".*?"@si', 'xsi:schemaLocation="'.$schemaLocation.'"', $data);
             if (!preg_match('@xmlns:qgs@i', $data)) {
                 $data = preg_replace('@xmlns="http://www.opengis.net/wms"@', 'xmlns="http://www.opengis.net/wms" xmlns:qgs="http://www.qgis.org/wms"', $data);

--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -140,7 +140,7 @@ class WMSRequest extends OGCRequest
             array('repository' => $this->repository->getKey(), 'project' => $this->project->getKey())
         );
         $sUrl = str_replace('&', '&amp;', $sUrl).'&amp;';
-        preg_match('/<get>.*\n*.+xlink\:href="([^"]+)"/i', $data, $matches);
+        preg_match('/onlineresource.+xlink\:href="([^"]+)"/i', $data, $matches);
         if (count($matches) < 2) {
             preg_match('/get onlineresource="([^"]+)"/i', $data, $matches);
         }

--- a/tests/end2end/cypress/integration/requests-getcapabilities-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-getcapabilities-ghaction.js
@@ -316,6 +316,26 @@ describe('Request GetCapabilities', function () {
                 expect(xmlBody.documentElement.tagName).to.eq('WFS_Capabilities')
                 expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.0.0')
 
+                // Requests links
+                for (const capabilityElem of getChildrenByTagName(xmlBody.documentElement, 'Capability')) {
+                    for (const requestElem of getChildrenByTagName(capabilityElem, 'Request')) {
+                        for (const getElem of requestElem.getElementsByTagName('Get')) {
+                            expect(getElem.getAttribute('onlineResource'))
+                                .to.eq(
+                                    baseUrl+'/index.php/lizmap/service?repository=testsrepository&project=selection&',
+                                    'OnlineResource error for '+getElem.parentElement.parentElement.parentElement.tagName
+                                )
+                        }
+                        for (const postElem of requestElem.getElementsByTagName('Post')) {
+                            expect(postElem.getAttribute('onlineResource'))
+                                .to.eq(
+                                    baseUrl+'/index.php/lizmap/service?repository=testsrepository&project=selection&',
+                                    'OnlineResource error for '+postElem.parentElement.parentElement.parentElement.tagName
+                                )
+                        }
+                    }
+                }
+
                 const etag = resp.headers['etag']
                 cy.request({
                     url: '/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetCapabilities',
@@ -353,6 +373,26 @@ describe('Request GetCapabilities', function () {
                 const xmlBody = parser.parseFromString(resp.body, 'text/xml')
                 expect(xmlBody.documentElement.tagName).to.eq('WFS_Capabilities')
                 expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.1.0')
+
+                // Operations links
+                for (const operationsMetadataElem of getChildrenByTagName(xmlBody.documentElement, 'ows:OperationsMetadata')) {
+                    for (const operationElem of getChildrenByTagName(operationsMetadataElem, 'ows:Operation')) {
+                        for (const getElem of operationElem.getElementsByTagName('ows:Get')) {
+                            expect(getElem.getAttribute('xlink:href'))
+                                .to.eq(
+                                    baseUrl+'/index.php/lizmap/service?repository=testsrepository&project=selection&',
+                                    'OnlineResource error for '+operationElem.getAttribute('name')
+                                )
+                        }
+                        for (const postElem of operationElem.getElementsByTagName('ows:Post')) {
+                            expect(postElem.getAttribute('xlink:href'))
+                                .to.eq(
+                                    baseUrl+'/index.php/lizmap/service?repository=testsrepository&project=selection&',
+                                    'OnlineResource error for '+operationElem.getAttribute('name')
+                                )
+                        }
+                    }
+                }
 
                 const etag = resp.headers['etag']
                 cy.request({
@@ -392,6 +432,26 @@ describe('Request GetCapabilities', function () {
                 const xmlBody = parser.parseFromString(resp.body, 'text/xml')
                 expect(xmlBody.documentElement.tagName).to.eq('WFS_Capabilities')
                 expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.0.0')
+
+                // Requests links
+                for (const capabilityElem of getChildrenByTagName(xmlBody.documentElement, 'Capability')) {
+                    for (const requestElem of getChildrenByTagName(capabilityElem, 'Request')) {
+                        for (const getElem of requestElem.getElementsByTagName('Get')) {
+                            expect(getElem.getAttribute('onlineResource'))
+                                .to.eq(
+                                    baseUrl+'/index.php/lizmap/service?repository=testsrepository&project=selection&',
+                                    'OnlineResource error for '+getElem.parentElement.parentElement.parentElement.tagName
+                                )
+                        }
+                        for (const postElem of requestElem.getElementsByTagName('Post')) {
+                            expect(postElem.getAttribute('onlineResource'))
+                                .to.eq(
+                                    baseUrl+'/index.php/lizmap/service?repository=testsrepository&project=selection&',
+                                    'OnlineResource error for '+postElem.parentElement.parentElement.parentElement.tagName
+                                )
+                        }
+                    }
+                }
 
                 const etag = resp.headers['etag']
                 cy.request({

--- a/tests/end2end/cypress/integration/requests-getcapabilities-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-getcapabilities-ghaction.js
@@ -228,6 +228,19 @@ describe('Request GetCapabilities', function () {
                 expect(xmlBody.documentElement.tagName).to.eq('Capabilities')
                 expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.0.0')
 
+                let serviceType = null
+                let serviceTypeVersion = null
+                for (const serviceIdentificationElem of getChildrenByTagName(xmlBody.documentElement, 'ows:ServiceIdentification')) {
+                    for (const serviceTypeElem of getChildrenByTagName(serviceIdentificationElem, 'ows:ServiceType')) {
+                        serviceType = serviceTypeElem.childNodes[0].nodeValue
+                    }
+                    for (const serviceTypeVersionElem of getChildrenByTagName(serviceIdentificationElem, 'ows:ServiceTypeVersion')) {
+                        serviceTypeVersion = serviceTypeVersionElem.childNodes[0].nodeValue
+                    }
+                }
+                expect(serviceType).to.eq('OGC WMTS')
+                expect(serviceTypeVersion).to.eq('1.0.0')
+
                 // Operations get link
                 for (const operationsMetadataElem of getChildrenByTagName(xmlBody.documentElement, 'ows:OperationsMetadata')) {
                     for (const operationElem of getChildrenByTagName(operationsMetadataElem, 'ows:Operation')) {
@@ -283,6 +296,19 @@ describe('Request GetCapabilities', function () {
                 const xmlBody = parser.parseFromString(resp.body, 'text/xml')
                 expect(xmlBody.documentElement.tagName).to.eq('Capabilities')
                 expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.0.0')
+
+                let serviceType = null
+                let serviceTypeVersion = null
+                for (const serviceIdentificationElem of getChildrenByTagName(xmlBody.documentElement, 'ows:ServiceIdentification')) {
+                    for (const serviceTypeElem of getChildrenByTagName(serviceIdentificationElem, 'ows:ServiceType')) {
+                        serviceType = serviceTypeElem.childNodes[0].nodeValue
+                    }
+                    for (const serviceTypeVersionElem of getChildrenByTagName(serviceIdentificationElem, 'ows:ServiceTypeVersion')) {
+                        serviceTypeVersion = serviceTypeVersionElem.childNodes[0].nodeValue
+                    }
+                }
+                expect(serviceType).to.eq('OGC WMTS')
+                expect(serviceTypeVersion).to.eq('1.0.0')
 
                 // Operations get link
                 for (const operationsMetadataElem of getChildrenByTagName(xmlBody.documentElement, 'ows:OperationsMetadata')) {

--- a/tests/end2end/cypress/integration/requests-getcapabilities-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-getcapabilities-ghaction.js
@@ -316,6 +316,14 @@ describe('Request GetCapabilities', function () {
                 expect(xmlBody.documentElement.tagName).to.eq('WFS_Capabilities')
                 expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.0.0')
 
+                let serviceName = null
+                for (const serviceElem of getChildrenByTagName(xmlBody.documentElement, 'Service')) {
+                    for (const nameElem of getChildrenByTagName(serviceElem, 'Name')) {
+                        serviceName = nameElem.childNodes[0].nodeValue
+                    }
+                }
+                expect(serviceName).to.eq('WFS')
+
                 // Requests links
                 for (const capabilityElem of getChildrenByTagName(xmlBody.documentElement, 'Capability')) {
                     for (const requestElem of getChildrenByTagName(capabilityElem, 'Request')) {
@@ -373,6 +381,19 @@ describe('Request GetCapabilities', function () {
                 const xmlBody = parser.parseFromString(resp.body, 'text/xml')
                 expect(xmlBody.documentElement.tagName).to.eq('WFS_Capabilities')
                 expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.1.0')
+
+                let serviceType = null
+                let serviceTypeVersion = null
+                for (const serviceIdentificationElem of getChildrenByTagName(xmlBody.documentElement, 'ows:ServiceIdentification')) {
+                    for (const serviceTypeElem of getChildrenByTagName(serviceIdentificationElem, 'ows:ServiceType')) {
+                        serviceType = serviceTypeElem.childNodes[0].nodeValue
+                    }
+                    for (const serviceTypeVersionElem of getChildrenByTagName(serviceIdentificationElem, 'ows:ServiceTypeVersion')) {
+                        serviceTypeVersion = serviceTypeVersionElem.childNodes[0].nodeValue
+                    }
+                }
+                expect(serviceType).to.eq('WFS')
+                expect(serviceTypeVersion).to.eq('1.1.0')
 
                 // Operations links
                 for (const operationsMetadataElem of getChildrenByTagName(xmlBody.documentElement, 'ows:OperationsMetadata')) {
@@ -432,6 +453,14 @@ describe('Request GetCapabilities', function () {
                 const xmlBody = parser.parseFromString(resp.body, 'text/xml')
                 expect(xmlBody.documentElement.tagName).to.eq('WFS_Capabilities')
                 expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.0.0')
+
+                let serviceName = null
+                for (const serviceElem of getChildrenByTagName(xmlBody.documentElement, 'Service')) {
+                    for (const nameElem of getChildrenByTagName(serviceElem, 'Name')) {
+                        serviceName = nameElem.childNodes[0].nodeValue
+                    }
+                }
+                expect(serviceName).to.eq('WFS')
 
                 // Requests links
                 for (const capabilityElem of getChildrenByTagName(xmlBody.documentElement, 'Capability')) {
@@ -498,8 +527,18 @@ describe('Request GetCapabilities', function () {
         }).then((resp) => {
                 expect(resp.status).to.eq(200)
                 expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
-                expect(resp.body).to.contain('WFS_Capabilities')
-                expect(resp.body).to.contain('version="1.0.0"')
+
+                const xmlBody = parser.parseFromString(resp.body, 'text/xml')
+                expect(xmlBody.documentElement.tagName).to.eq('WFS_Capabilities')
+                expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.0.0')
+
+                let serviceName = null
+                for (const serviceElem of getChildrenByTagName(xmlBody.documentElement, 'Service')) {
+                    for (const nameElem of getChildrenByTagName(serviceElem, 'Name')) {
+                        serviceName = nameElem.childNodes[0].nodeValue
+                    }
+                }
+                expect(serviceName).to.eq('WFS')
             })
     })
 
@@ -523,8 +562,23 @@ describe('Request GetCapabilities', function () {
         }).then((resp) => {
                 expect(resp.status).to.eq(200)
                 expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
-                expect(resp.body).to.contain('WFS_Capabilities')
-                expect(resp.body).to.contain('version="1.1.0"')
+
+                const xmlBody = parser.parseFromString(resp.body, 'text/xml')
+                expect(xmlBody.documentElement.tagName).to.eq('WFS_Capabilities')
+                expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.1.0')
+
+                let serviceType = null
+                let serviceTypeVersion = null
+                for (const serviceIdentificationElem of getChildrenByTagName(xmlBody.documentElement, 'ows:ServiceIdentification')) {
+                    for (const serviceTypeElem of getChildrenByTagName(serviceIdentificationElem, 'ows:ServiceType')) {
+                        serviceType = serviceTypeElem.childNodes[0].nodeValue
+                    }
+                    for (const serviceTypeVersionElem of getChildrenByTagName(serviceIdentificationElem, 'ows:ServiceTypeVersion')) {
+                        serviceTypeVersion = serviceTypeVersionElem.childNodes[0].nodeValue
+                    }
+                }
+                expect(serviceType).to.eq('WFS')
+                expect(serviceTypeVersion).to.eq('1.1.0')
             })
     })
 })

--- a/tests/end2end/cypress/integration/requests-getcapabilities-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-getcapabilities-ghaction.js
@@ -204,6 +204,19 @@ describe('Request GetCapabilities', function () {
                 expect(xmlBody.documentElement.tagName).to.eq('Capabilities')
                 expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.0.0')
 
+                // Operations get link
+                for (const operationsMetadataElem of getChildrenByTagName(xmlBody.documentElement, 'ows:OperationsMetadata')) {
+                    for (const operationElem of getChildrenByTagName(operationsMetadataElem, 'ows:Operation')) {
+                        for (const getElem of operationElem.getElementsByTagName('ows:Get')) {
+                            expect(getElem.getAttribute('xlink:href'))
+                                .to.eq(
+                                    baseUrl+'/index.php/lizmap/service?repository=testsrepository&project=cache&',
+                                    'OnlineResource error for '+operationElem.getAttribute('name')
+                                )
+                        }
+                    }
+                }
+
                 let layers = []
                 let tileMatrixSets = []
                 for (const contentsElem of getChildrenByTagName(xmlBody.documentElement, 'Contents')) {
@@ -246,6 +259,19 @@ describe('Request GetCapabilities', function () {
                 const xmlBody = parser.parseFromString(resp.body, 'text/xml')
                 expect(xmlBody.documentElement.tagName).to.eq('Capabilities')
                 expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.0.0')
+
+                // Operations get link
+                for (const operationsMetadataElem of getChildrenByTagName(xmlBody.documentElement, 'ows:OperationsMetadata')) {
+                    for (const operationElem of getChildrenByTagName(operationsMetadataElem, 'ows:Operation')) {
+                        for (const getElem of operationElem.getElementsByTagName('ows:Get')) {
+                            expect(getElem.getAttribute('xlink:href'))
+                                .to.eq(
+                                    baseUrl+'/index.php/lizmap/service?repository=testsrepository&project=cache&',
+                                    'OnlineResource error for '+operationElem.getAttribute('name')
+                                )
+                        }
+                    }
+                }
 
                 let layers = []
                 let tileMatrixSets = []

--- a/tests/end2end/cypress/integration/requests-getcapabilities-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-getcapabilities-ghaction.js
@@ -1,4 +1,5 @@
 const parser = new DOMParser();
+const baseUrl = Cypress.config('baseUrl')
 
 function* getChildrenByTagName(elem, tagName) {
     for (let i = 0; i < elem.children.length; i++) {
@@ -22,6 +23,29 @@ describe('Request GetCapabilities', function () {
                 const xmlBody = parser.parseFromString(resp.body, 'text/xml')
                 expect(xmlBody.documentElement.tagName).to.eq('WMS_Capabilities')
                 expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.3.0')
+
+                // OnlineResource for Service
+                for (const serviceElem of getChildrenByTagName(xmlBody.documentElement, 'Service')) {
+                    for (const onlineResourceElem of serviceElem.getElementsByTagName('OnlineResource')) {
+                        expect(onlineResourceElem.getAttribute('xlink:href'))
+                            .to.eq(
+                                baseUrl+'/index.php/lizmap/service?repository=testsrepository&project=selection&',
+                                'OnlineResource error for Service'
+                            )
+                    }
+                }
+                // OnlineResource for Request
+                for (const capabilityElem of getChildrenByTagName(xmlBody.documentElement, 'Capability')) {
+                    for (const requestElem of getChildrenByTagName(capabilityElem, 'Request')) {
+                        for (const onlineResourceElem of requestElem.getElementsByTagName('OnlineResource')) {
+                            expect(onlineResourceElem.getAttribute('xlink:href'))
+                                .to.eq(
+                                    baseUrl+'/index.php/lizmap/service?repository=testsrepository&project=selection&',
+                                    'OnlineResource error for request: '+onlineResourceElem.parentElement.parentElement.parentElement.parentElement.tagName
+                                )
+                        }
+                    }
+                }
 
                 const etag = resp.headers['etag']
                 cy.request({
@@ -60,6 +84,29 @@ describe('Request GetCapabilities', function () {
                 expect(xmlBody.documentElement.tagName).to.eq('WMT_MS_Capabilities')
                 expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.1.1')
 
+                // OnlineResource for Service
+                for (const serviceElem of getChildrenByTagName(xmlBody.documentElement, 'Service')) {
+                    for (const onlineResourceElem of serviceElem.getElementsByTagName('OnlineResource')) {
+                        expect(onlineResourceElem.getAttribute('xlink:href'))
+                            .to.eq(
+                                baseUrl+'/index.php/lizmap/service?repository=testsrepository&project=selection&',
+                                'OnlineResource error for Service'
+                            )
+                    }
+                }
+                // OnlineResource for Request
+                for (const capabilityElem of getChildrenByTagName(xmlBody.documentElement, 'Capability')) {
+                    for (const requestElem of getChildrenByTagName(capabilityElem, 'Request')) {
+                        for (const onlineResourceElem of requestElem.getElementsByTagName('OnlineResource')) {
+                            expect(onlineResourceElem.getAttribute('xlink:href'))
+                                .to.eq(
+                                    baseUrl+'/index.php/lizmap/service?repository=testsrepository&project=selection&',
+                                    'OnlineResource error for request: '+onlineResourceElem.parentElement.parentElement.parentElement.parentElement.tagName
+                                )
+                        }
+                    }
+                }
+
                 const etag = resp.headers['etag']
                 cy.request({
                     url: '/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities',
@@ -96,6 +143,29 @@ describe('Request GetCapabilities', function () {
                 const xmlBody = parser.parseFromString(resp.body, 'text/xml')
                 expect(xmlBody.documentElement.tagName).to.eq('WMS_Capabilities')
                 expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.3.0')
+
+                // OnlineResource for Service
+                for (const serviceElem of getChildrenByTagName(xmlBody.documentElement, 'Service')) {
+                    for (const onlineResourceElem of serviceElem.getElementsByTagName('OnlineResource')) {
+                        expect(onlineResourceElem.getAttribute('xlink:href'))
+                            .to.eq(
+                                baseUrl+'/index.php/lizmap/service?repository=testsrepository&project=selection&',
+                                'OnlineResource error for Service'
+                            )
+                    }
+                }
+                // OnlineResource for Request
+                for (const capabilityElem of getChildrenByTagName(xmlBody.documentElement, 'Capability')) {
+                    for (const requestElem of getChildrenByTagName(capabilityElem, 'Request')) {
+                        for (const onlineResourceElem of requestElem.getElementsByTagName('OnlineResource')) {
+                            expect(onlineResourceElem.getAttribute('xlink:href'))
+                                .to.eq(
+                                    baseUrl+'/index.php/lizmap/service?repository=testsrepository&project=selection&',
+                                    'OnlineResource error for request: '+onlineResourceElem.parentElement.parentElement.parentElement.parentElement.tagName
+                                )
+                        }
+                    }
+                }
 
                 const etag = resp.headers['etag']
                 cy.request({

--- a/tests/end2end/cypress/integration/requests-getcapabilities-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-getcapabilities-ghaction.js
@@ -24,6 +24,14 @@ describe('Request GetCapabilities', function () {
                 expect(xmlBody.documentElement.tagName).to.eq('WMS_Capabilities')
                 expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.3.0')
 
+                let serviceName = null
+                for (const serviceElem of getChildrenByTagName(xmlBody.documentElement, 'Service')) {
+                    for (const nameElem of getChildrenByTagName(serviceElem, 'Name')) {
+                        serviceName = nameElem.childNodes[0].nodeValue
+                    }
+                }
+                expect(serviceName).to.eq('WMS')
+
                 // OnlineResource for Service
                 for (const serviceElem of getChildrenByTagName(xmlBody.documentElement, 'Service')) {
                     for (const onlineResourceElem of serviceElem.getElementsByTagName('OnlineResource')) {
@@ -84,6 +92,14 @@ describe('Request GetCapabilities', function () {
                 expect(xmlBody.documentElement.tagName).to.eq('WMT_MS_Capabilities')
                 expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.1.1')
 
+                let serviceName = null
+                for (const serviceElem of getChildrenByTagName(xmlBody.documentElement, 'Service')) {
+                    for (const nameElem of getChildrenByTagName(serviceElem, 'Name')) {
+                        serviceName = nameElem.childNodes[0].nodeValue
+                    }
+                }
+                expect(serviceName).to.eq('WMS')
+
                 // OnlineResource for Service
                 for (const serviceElem of getChildrenByTagName(xmlBody.documentElement, 'Service')) {
                     for (const onlineResourceElem of serviceElem.getElementsByTagName('OnlineResource')) {
@@ -143,6 +159,14 @@ describe('Request GetCapabilities', function () {
                 const xmlBody = parser.parseFromString(resp.body, 'text/xml')
                 expect(xmlBody.documentElement.tagName).to.eq('WMS_Capabilities')
                 expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.3.0')
+
+                let serviceName = null
+                for (const serviceElem of getChildrenByTagName(xmlBody.documentElement, 'Service')) {
+                    for (const nameElem of getChildrenByTagName(serviceElem, 'Name')) {
+                        serviceName = nameElem.childNodes[0].nodeValue
+                    }
+                }
+                expect(serviceName).to.eq('WMS')
 
                 // OnlineResource for Service
                 for (const serviceElem of getChildrenByTagName(xmlBody.documentElement, 'Service')) {

--- a/tests/end2end/cypress/integration/requests-getcapabilities-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-getcapabilities-ghaction.js
@@ -1,0 +1,374 @@
+const parser = new DOMParser();
+
+function* getChildrenByTagName(elem, tagName) {
+    for (let i = 0; i < elem.children.length; i++) {
+        const elemChild = elem.children[i]
+        if (elemChild.tagName == tagName) {
+            yield elemChild
+        }
+    }
+}
+
+describe('Request GetCapabilities', function () {
+
+    it('WMS 1.3.0 GetCapabilities', function () {
+        cy.request('/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities')
+            .then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+                expect(resp.headers['cache-control']).to.eq('no-cache')
+                expect(resp.headers['etag']).to.not.eq(undefined)
+
+                const xmlBody = parser.parseFromString(resp.body, 'text/xml')
+                expect(xmlBody.documentElement.tagName).to.eq('WMS_Capabilities')
+                expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.3.0')
+
+                const etag = resp.headers['etag']
+                cy.request({
+                    url: '/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities',
+                    headers: {
+                        'If-None-Match': etag,
+                    },
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    expect(resp.status).to.eq(304)
+                    expect(resp.body).to.have.length(0)
+                })
+            })
+
+        // Project with config.options.hideProject: "True"
+        cy.request('/index.php/lizmap/service/?repository=testsrepository&project=hide_project&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities')
+            .then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+
+                const xmlBody = parser.parseFromString(resp.body, 'text/xml')
+                expect(xmlBody.documentElement.tagName).to.eq('WMS_Capabilities')
+                expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.3.0')
+            })
+    })
+
+    it('WMS 1.1.1 GetCapabilities', function () {
+        cy.request('/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities')
+            .then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+                expect(resp.headers['cache-control']).to.eq('no-cache')
+                expect(resp.headers['etag']).to.not.eq(undefined)
+
+                const xmlBody = parser.parseFromString(resp.body, 'text/xml')
+                expect(xmlBody.documentElement.tagName).to.eq('WMT_MS_Capabilities')
+                expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.1.1')
+
+                const etag = resp.headers['etag']
+                cy.request({
+                    url: '/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities',
+                    headers: {
+                        'If-None-Match': etag,
+                    },
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    expect(resp.status).to.eq(304)
+                    expect(resp.body).to.have.length(0)
+                })
+            })
+
+        // Project with config.options.hideProject: "True"
+        cy.request('/index.php/lizmap/service/?repository=testsrepository&project=hide_project&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities')
+            .then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+
+                const xmlBody = parser.parseFromString(resp.body, 'text/xml')
+                expect(xmlBody.documentElement.tagName).to.eq('WMT_MS_Capabilities')
+                expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.1.1')
+            })
+    })
+
+    it('WMS Default GetCapabilities (version 1.3.0)', function () {
+        cy.request('/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WMS&REQUEST=GetCapabilities')
+            .then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+                expect(resp.headers['cache-control']).to.eq('no-cache')
+                expect(resp.headers['etag']).to.not.eq(undefined)
+
+                const xmlBody = parser.parseFromString(resp.body, 'text/xml')
+                expect(xmlBody.documentElement.tagName).to.eq('WMS_Capabilities')
+                expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.3.0')
+
+                const etag = resp.headers['etag']
+                cy.request({
+                    url: '/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WMS&REQUEST=GetCapabilities',
+                    headers: {
+                        'If-None-Match': etag,
+                    },
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    expect(resp.status).to.eq(304)
+                    expect(resp.body).to.have.length(0)
+                })
+            })
+
+        // Project with config.options.hideProject: "True"
+        cy.request('/index.php/lizmap/service/?repository=testsrepository&project=hide_project&SERVICE=WMS&REQUEST=GetCapabilities')
+            .then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+
+                const xmlBody = parser.parseFromString(resp.body, 'text/xml')
+                expect(xmlBody.documentElement.tagName).to.eq('WMS_Capabilities')
+                expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.3.0')
+            })
+    })
+
+    it('WMTS 1.0.0 GetCapabilities', function () {
+        cy.request('/index.php/lizmap/service/?repository=testsrepository&project=cache&SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetCapabilities')
+            .then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+                expect(resp.headers['cache-control']).to.eq('no-cache')
+                expect(resp.headers['etag']).to.not.eq(undefined)
+
+                const xmlBody = parser.parseFromString(resp.body, 'text/xml')
+                expect(xmlBody.documentElement.tagName).to.eq('Capabilities')
+                expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.0.0')
+
+                let layers = []
+                let tileMatrixSets = []
+                for (const contentsElem of getChildrenByTagName(xmlBody.documentElement, 'Contents')) {
+                    for (const layerElem of getChildrenByTagName(contentsElem, 'Layer')) {
+                        for (const identifierElem of getChildrenByTagName(layerElem, 'ows:Identifier')) {
+                            layers.push(identifierElem.childNodes[0].nodeValue)
+                        }
+                    }
+                    for (const tileMatrixSetElem of getChildrenByTagName(contentsElem, 'TileMatrixSet')) {
+                        for (const identifierElem of getChildrenByTagName(tileMatrixSetElem, 'ows:Identifier')) {
+                            tileMatrixSets.push(identifierElem.childNodes[0].nodeValue)
+                        }
+                    }
+                }
+                expect(layers).to.contain('Quartiers')
+                expect(tileMatrixSets).to.contain('EPSG:3857')
+
+                const etag = resp.headers['etag']
+                cy.request({
+                    url: '/index.php/lizmap/service/?repository=testsrepository&project=cache&SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetCapabilities',
+                    headers: {
+                        'If-None-Match': etag,
+                    },
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    expect(resp.status).to.eq(304)
+                    expect(resp.body).to.have.length(0)
+                })
+            })
+    })
+
+    it('WMTS Default GetCapabilities', function () {
+        cy.request('/index.php/lizmap/service/?repository=testsrepository&project=cache&SERVICE=WMTS&REQUEST=GetCapabilities')
+            .then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+                expect(resp.headers['cache-control']).to.eq('no-cache')
+                expect(resp.headers['etag']).to.not.eq(undefined)
+
+                const xmlBody = parser.parseFromString(resp.body, 'text/xml')
+                expect(xmlBody.documentElement.tagName).to.eq('Capabilities')
+                expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.0.0')
+
+                let layers = []
+                let tileMatrixSets = []
+                for (const contentsElem of getChildrenByTagName(xmlBody.documentElement, 'Contents')) {
+                    for (const layerElem of getChildrenByTagName(contentsElem, 'Layer')) {
+                        for (const identifierElem of getChildrenByTagName(layerElem, 'ows:Identifier')) {
+                            layers.push(identifierElem.childNodes[0].nodeValue)
+                        }
+                    }
+                    for (const tileMatrixSetElem of getChildrenByTagName(contentsElem, 'TileMatrixSet')) {
+                        for (const identifierElem of getChildrenByTagName(tileMatrixSetElem, 'ows:Identifier')) {
+                            tileMatrixSets.push(identifierElem.childNodes[0].nodeValue)
+                        }
+                    }
+                }
+                expect(layers).to.contain('Quartiers')
+                expect(tileMatrixSets).to.contain('EPSG:3857')
+
+                const etag = resp.headers['etag']
+                cy.request({
+                    url: '/index.php/lizmap/service/?repository=testsrepository&project=cache&SERVICE=WMTS&REQUEST=GetCapabilities',
+                    headers: {
+                        'If-None-Match': etag,
+                    },
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    expect(resp.status).to.eq(304)
+                    expect(resp.body).to.have.length(0)
+                })
+            })
+    })
+
+    it('WFS 1.0.0 GetCapabilities', function () {
+        cy.request('/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetCapabilities')
+            .then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+                expect(resp.headers['cache-control']).to.eq('no-cache')
+                expect(resp.headers['etag']).to.not.eq(undefined)
+
+                const xmlBody = parser.parseFromString(resp.body, 'text/xml')
+                expect(xmlBody.documentElement.tagName).to.eq('WFS_Capabilities')
+                expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.0.0')
+
+                const etag = resp.headers['etag']
+                cy.request({
+                    url: '/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetCapabilities',
+                    headers: {
+                        'If-None-Match': etag,
+                    },
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    expect(resp.status).to.eq(304)
+                    expect(resp.body).to.have.length(0)
+                })
+            })
+
+        // Project with config.options.hideProject: "True"
+        cy.request('/index.php/lizmap/service/?repository=testsrepository&project=hide_project&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetCapabilities')
+            .then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+
+                const xmlBody = parser.parseFromString(resp.body, 'text/xml')
+                expect(xmlBody.documentElement.tagName).to.eq('WFS_Capabilities')
+                expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.0.0')
+            })
+    })
+
+    it('WFS 1.1.0 GetCapabilities', function () {
+
+        cy.request('/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WFS&VERSION=1.1.0&REQUEST=GetCapabilities')
+            .then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+                expect(resp.headers['cache-control']).to.eq('no-cache')
+                expect(resp.headers['etag']).to.not.eq(undefined)
+
+                const xmlBody = parser.parseFromString(resp.body, 'text/xml')
+                expect(xmlBody.documentElement.tagName).to.eq('WFS_Capabilities')
+                expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.1.0')
+
+                const etag = resp.headers['etag']
+                cy.request({
+                    url: '/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WFS&VERSION=1.1.0&REQUEST=GetCapabilities',
+                    headers: {
+                        'If-None-Match': etag,
+                    },
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    expect(resp.status).to.eq(304)
+                    expect(resp.body).to.have.length(0)
+                })
+            })
+
+        // Project with config.options.hideProject: "True"
+        cy.request('/index.php/lizmap/service/?repository=testsrepository&project=hide_project&SERVICE=WFS&VERSION=1.1.0&REQUEST=GetCapabilities')
+            .then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+
+                const xmlBody = parser.parseFromString(resp.body, 'text/xml')
+                expect(xmlBody.documentElement.tagName).to.eq('WFS_Capabilities')
+                expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.1.0')
+            })
+    })
+
+
+    it('WFS Default GetCapabilities (version 1.0.0)', function () {
+
+        cy.request('/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WFS&REQUEST=GetCapabilities')
+            .then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+                expect(resp.headers['cache-control']).to.eq('no-cache')
+                expect(resp.headers['etag']).to.not.eq(undefined)
+
+                const xmlBody = parser.parseFromString(resp.body, 'text/xml')
+                expect(xmlBody.documentElement.tagName).to.eq('WFS_Capabilities')
+                expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.0.0')
+
+                const etag = resp.headers['etag']
+                cy.request({
+                    url: '/index.php/lizmap/service/?repository=testsrepository&project=selection&SERVICE=WFS&REQUEST=GetCapabilities',
+                    headers: {
+                        'If-None-Match': etag,
+                    },
+                    failOnStatusCode: false,
+                }).then((resp) => {
+                    expect(resp.status).to.eq(304)
+                    expect(resp.body).to.have.length(0)
+                })
+            })
+
+        // Project with config.options.hideProject: "True"
+        cy.request('/index.php/lizmap/service/?repository=testsrepository&project=hide_project&SERVICE=WFS&REQUEST=GetCapabilities')
+            .then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+
+                const xmlBody = parser.parseFromString(resp.body, 'text/xml')
+                expect(xmlBody.documentElement.tagName).to.eq('WFS_Capabilities')
+                expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.0.0')
+            })
+    })
+
+    it('WFS 1.0.0 GetCapabilities XML', function () {
+        let body = '<?xml version="1.0" encoding="UTF-8"?>'
+        body += '<wfs:GetCapabilities'
+        body += '    service="WFS"'
+        body += '    version="1.0.0"'
+        body += '    xmlns:wfs="http://www.opengis.net/wfs"'
+        body += '    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+        body += '    xsi:schemaLocation="http://www.opengis.net/wfs/1.0.0 http://schemas.opengis.net/wfs/1.0.0/wfs.xsd">'
+        body += '</wfs:GetCapabilities>'
+        body += ''
+        cy.request({
+            method: 'POST',
+            url: '/index.php/lizmap/service/?repository=testsrepository&project=selection',
+            headers: {
+                'Content-Type':'text/xml; charset=utf-8'
+            },
+            body: body,
+        }).then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+                expect(resp.body).to.contain('WFS_Capabilities')
+                expect(resp.body).to.contain('version="1.0.0"')
+            })
+    })
+
+    it('WFS 1.1.0 GetCapabilities XML', function () {
+        let body = '<?xml version="1.0" encoding="UTF-8"?>'
+        body += '<wfs:GetCapabilities'
+        body += '    service="WFS"'
+        body += '    version="1.1.0"'
+        body += '    xmlns:wfs="http://www.opengis.net/wfs"'
+        body += '    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+        body += '    xsi:schemaLocation="http://www.opengis.net/wfs/1.1.0 http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">'
+        body += '</wfs:GetCapabilities>'
+        body += ''
+        cy.request({
+            method: 'POST',
+            url: '/index.php/lizmap/service/?repository=testsrepository&project=selection',
+            headers: {
+                'Content-Type':'text/xml; charset=utf-8'
+            },
+            body: body,
+        }).then((resp) => {
+                expect(resp.status).to.eq(200)
+                expect(resp.headers['content-type']).to.eq('text/xml; charset=utf-8')
+                expect(resp.body).to.contain('WFS_Capabilities')
+                expect(resp.body).to.contain('version="1.1.0"')
+            })
+    })
+})

--- a/tests/end2end/cypress/integration/requests-getcapabilities-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-getcapabilities-ghaction.js
@@ -23,6 +23,8 @@ describe('Request GetCapabilities', function () {
                 const xmlBody = parser.parseFromString(resp.body, 'text/xml')
                 expect(xmlBody.documentElement.tagName).to.eq('WMS_Capabilities')
                 expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.3.0')
+                expect(xmlBody.documentElement.getAttribute('xsi:schemaLocation'))
+                    .to.contain(baseUrl+'/index.php/lizmap/service?repository=testsrepository&project=selection&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetSchemaExtension')
 
                 let serviceName = null
                 for (const serviceElem of getChildrenByTagName(xmlBody.documentElement, 'Service')) {
@@ -159,6 +161,8 @@ describe('Request GetCapabilities', function () {
                 const xmlBody = parser.parseFromString(resp.body, 'text/xml')
                 expect(xmlBody.documentElement.tagName).to.eq('WMS_Capabilities')
                 expect(xmlBody.documentElement.getAttribute('version')).to.contain('1.3.0')
+                expect(xmlBody.documentElement.getAttribute('xsi:schemaLocation'))
+                    .to.contain(baseUrl+'/index.php/lizmap/service?repository=testsrepository&project=selection&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetSchemaExtension')
 
                 let serviceName = null
                 for (const serviceElem of getChildrenByTagName(xmlBody.documentElement, 'Service')) {

--- a/tests/end2end/cypress/integration/requests-service-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-service-ghaction.js
@@ -192,6 +192,7 @@ describe('Request service', function () {
 
                 expect(resp.body).to.contain('WMS_Capabilities')
                 expect(resp.body).to.contain('version="1.3.0"')
+                expect(resp.body).to.contain('index.php/lizmap/service?repository=testsrepository')
 
                 const etag = resp.headers['etag']
                 cy.request({


### PR DESCRIPTION
* Use version for OGC GetCapabilities cache key
* OnelineResource links in WMS GetCapabilities
* Version required for GetSchemaExtension

Fixes #3128
Funded by 3Liz
