### PR TITLE
fix Unknown group id leads to php error while loading project

### DIFF
--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -1617,7 +1617,7 @@ class Project
         // Remove editionLayers from config if no right to access this tool
         if ($this->hasEditionLayersForCurrentUser()) {
             // give only layer that the user has the right to edit
-            $configJson->editionLayers = $this->editionLayersForCurrentUser;
+            $configJson->editionLayers = (object) $this->editionLayersForCurrentUser;
         } else {
             unset($configJson->editionLayers);
         }


### PR DESCRIPTION
<!-- Add "fix" in front of "#" if it fixes the ticket or do nothing to only mention it.

This PR will be harvested on changelog.lizmap.com if there is a "changelog" label.
Funded by NAME URL
-->

quick & dirt fix to prevent php error (force object cast)
must be related to a php8 behavior change in property_exists

fix https://github.com/3liz/lizmap-web-client/issues/3171

not sure of labels ...
