### PR TITLE
fixed syntax error in in dataviz module

### DIFF
--- a/lizmap/modules/dataviz/controllers/service.classic.php
+++ b/lizmap/modules/dataviz/controllers/service.classic.php
@@ -65,7 +65,7 @@ class serviceCtrl extends jController
             array(
                 'title' => 'Not supported request',
                 'detail' => 'The request "'.$request.'" is not supported!',
-            ),
+            )
         );
     }
 
@@ -109,7 +109,7 @@ class serviceCtrl extends jController
                 array(
                     'title' => 'No corresponding plot',
                     'detail' => 'No plot could be created for this request',
-                ),
+                )
             );
         }
 
@@ -143,7 +143,7 @@ class serviceCtrl extends jController
                 array(
                     'title' => 'No corresponding plot',
                     'detail' => 'No plot could be created for this request',
-                ),
+                )
             );
         }
 


### PR DESCRIPTION
<!-- Add "fix" in front of "#" if it fixes the ticket or do nothing to only mention it.

This PR will be harvested on changelog.lizmap.com if there is a "changelog" label.
Funded by NAME URL
-->

Ticket :  fix #3186 

This PR is related to the open issue https://github.com/3liz/lizmap-web-client/issues/3186 and fix a syntax error in the service.classic.php file of the dataviz module.