### PR TITLE
Add color picker to theme edition in admin

### DIFF
--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -159,6 +159,7 @@ form.admin_section.message.accessControlAllowOrigin.bad.domain=Content is not a 
 menu.lizmap.theme.label=Theme
 configuration.button.modify.theme.label=Modify
 form.admin_theme.h1=Theme
+form.admin_theme.helpcolor=You can select colors with this <a href="https://mdn.github.io/css-examples/tools/color-picker/">colorpicker</a> (e.g. <code>rgb(148 193 31 / 0.5)</code>).
 form.admin_theme.headerLogo.label=Header - logo
 form.admin_theme.headerLogo.help=The image to be used for the header logo (200ko Maximum).
 form.admin_theme.headerLogoWidth.label=Header - logo width

--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -159,7 +159,7 @@ form.admin_section.message.accessControlAllowOrigin.bad.domain=Content is not a 
 menu.lizmap.theme.label=Theme
 configuration.button.modify.theme.label=Modify
 form.admin_theme.h1=Theme
-form.admin_theme.helpcolor=You can select colors with this <a href="https://mdn.github.io/css-examples/tools/color-picker/">colorpicker</a> (e.g. <code>rgb(148 193 31 / 0.5)</code>).
+form.admin_theme.helpcolor=You can select colors with this <a href="https://mdn.github.io/css-examples/tools/color-picker/" target="_blank">colorpicker</a> (e.g. <code>rgb(148 193 31 / 0.5)</code>).
 form.admin_theme.headerLogo.label=Header - logo
 form.admin_theme.headerLogo.help=The image to be used for the header logo (200ko Maximum).
 form.admin_theme.headerLogoWidth.label=Header - logo width

--- a/lizmap/modules/admin/templates/config_theme.tpl
+++ b/lizmap/modules/admin/templates/config_theme.tpl
@@ -1,5 +1,6 @@
 {jmessage_bootstrap}
 <h1>{@admin.form.admin_theme.h1@}</h1>
+<p class="lead">{@admin.form.admin_theme.helpcolor@}</p>
 {formfull $form, 'theme:save', array(), 'htmlbootstrap'}
 <div>
   <a class="btn" href="{jurl 'theme:index'}">{@admin~admin.configuration.button.back.label@}</a>


### PR DESCRIPTION
It would be convenient to have color pickers instead of text input where people don't always know what to put in.
It is just a quick draft to discuss.
By default color pickers have their default value to `#000000` (black) so if someone saves the form without changing any colors this color will apply to all fields. So we need to display default values when opening the form.

We could use CSS custom properties. It would also allow to use them in custom themes defined in `media`.

Funded by 3Liz

![image](https://user-images.githubusercontent.com/2145040/189093072-619348ea-1340-4d45-a63c-9f4debd687ea.png)

