### PR TITLE
Fix: button to toggle compact/explode table view in popups

### DIFF
--- a/CHANGELOG-3.6.md
+++ b/CHANGELOG-3.6.md
@@ -18,6 +18,7 @@
 
 * Better management of paths for Lizmap repositories
 * Fixed PHP syntax error in the dataviz module, contribution from @RobiFag
+* Fix button to toggle compact/explode table view in popups. Also each button only toggle its own children popup group
 * Fix some requests to QGIS Server
 
 ### Tests

--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -3272,7 +3272,12 @@ window.lizMap = function() {
                   clname = cleanName(configLayer.name);
                   configLayer.cleanname = clname;
                 }
-                var childPopup = $('<div class="lizmapPopupChildren ' + clname + '" data-layername="' + clname + '" data-title="' + configLayer.title + '">' + popupChildData + '</div>');
+
+                const resizeTablesButtons = 
+                  '<button class="compact-tables btn btn-small" data-original-title="' + lizDict['popup.table.compact'] + '"><i class="icon-resize-small"></i></button>'+
+                  '<button class="explode-tables btn btn-small hide" data-original-title="' + lizDict['popup.table.explode'] + '"><i class="icon-resize-full"></i></button>';
+
+                var childPopup = $('<div class="lizmapPopupChildren ' + clname + '" data-layername="' + clname + '" data-title="' + configLayer.title + '">' + resizeTablesButtons + popupChildData + '</div>');
 
                 //Manage if the user choose to create a table for children
                 if (['qgis', 'form'].indexOf(configLayer.popupSource) !== -1 &&
@@ -3329,6 +3334,28 @@ window.lizMap = function() {
                 );
               }
             }
+
+            // Handle compact-tables/explode-tables behaviour
+            $('.lizmapPopupChildren .popupAllFeaturesCompact table').DataTable({
+              language: { url: lizUrls["dataTableLanguage"] }
+            });
+
+            $('.lizmapPopupChildren .compact-tables, .lizmapPopupChildren .explode-tables').tooltip();
+
+            $('.lizmapPopupChildren .compact-tables').click(function() {
+              $(this)
+                .addClass('hide')
+                .siblings('.explode-tables').removeClass('hide')
+                .siblings('.popupAllFeaturesCompact, .lizmapPopupSingleFeature').toggle();
+            });
+
+            $('.lizmapPopupChildren .explode-tables').click(function () {
+              $(this)
+                .addClass('hide')
+                .siblings('.compact-tables').removeClass('hide')
+                .siblings('.popupAllFeaturesCompact, .lizmapPopupSingleFeature').toggle();
+            });
+
             // Trigger event for all popup children
             lizMap.events.triggerEvent(
               "lizmappopupallchildrendisplayed",


### PR DESCRIPTION
Also each button only toggle its own children popup group

This feature has been lost by mistake in https://github.com/3liz/lizmap-web-client/commit/b2e248be79154446a7d0742760ba6ecad5118cf7

Fix #2759
Fix #2435

Funded by 3Liz
