### PR TITLE
Tests - Use qgis-plugin-manager to install all plugins

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -41,16 +41,22 @@ env:
 	EOF
 
 
-build-plugins: 
-	./add_server_plugins.sh
+build-plugins:
+	docker run \
+	    -u $(LIZMAP_USER_ID):$(LIZMAP_GROUP_ID) \
+	    --rm -it \
+	    -e QGSRV_SERVER_PLUGINPATH=/srv/plugins \
+	    -v $(shell pwd)/qgis-server-plugins:/srv/plugins \
+	    -v $(shell pwd)/:/src \
+        --entrypoint /src/add_server_plugins.sh \
+	    3liz/qgis-map-server:${LZMQGSRVVERSION} \
 
 up: env
 	docker compose up  -V --force-recreate -d
 
 stop:
-	docker compose stop 
+	docker compose stop
 
 reset:
 	docker compose down -v --remove-orphans
 	./lizmap-ctl clean
-

--- a/tests/add_server_plugins.sh
+++ b/tests/add_server_plugins.sh
@@ -4,16 +4,21 @@
 echo "QGIS Server Lizmap plugin"
 
 # Latest commit
-wget https://packages.3liz.org/pub/lizmap-server-qgis-plugin/lizmap_server.master.zip -O lizmap_server.master.zip
+echo "Latest commit from https://packages.3liz.org"
+wget https://packages.3liz.org/pub/lizmap-server-qgis-plugin/lizmap_server.master.zip -O /tmp/lizmap_server.master.zip
 
 # Latest release
 # VERSION=1.1.1
-# wget https://github.com/3liz/qgis-lizmap-server-plugin/releases/latest/download/lizmap_server.${VERSION}.zip -O lizmap_server.master.zip
+# echo "Stable release from GitHub"
+# wget https://github.com/3liz/qgis-lizmap-server-plugin/releases/latest/download/lizmap_server.${VERSION}.zip -O /tmp/lizmap_server.master.zip
 
-unzip -o lizmap_server.master.zip -d qgis-server-plugins/
-rm lizmap_server.master.zip
+unzip -o /tmp/lizmap_server.master.zip -d /srv/plugins/
+rm /tmp/lizmap_server.master.zip
 
-# Remove legacy package for a few weeks
-if [ -d qgis-server-plugins/lizmap/ ]; then
-  rm -rf qgis-server-plugins/lizmap
-fi
+echo "QGIS Server WfsOutputExtension and AlasPrint plugins"
+echo "Stable releases from http://plugins.qgis.org"
+qgis-plugin-manager init
+qgis-plugin-manager update
+# qgis-plugin-manager install "Lizmap server"
+qgis-plugin-manager install atlasprint
+qgis-plugin-manager install wfsOutputExtension


### PR DESCRIPTION
Use qgis-plugin-manager to install plugins

Drawback for now, it's only downloading plugin released version, based on a tag.
