### PR TITLE
Server - Set minimum required versions for QGIS server plugins

### DIFF
--- a/lizmap/app/system/mainconfig.ini.php
+++ b/lizmap/app/system/mainconfig.ini.php
@@ -30,7 +30,13 @@ fallbackLocale=en_US
 ; Versions on the server, for the system administrator
 ; The minimum version required about external software to make Lizmap Web Client happy
 qgisServer="3.10"
-lizmapServerPlugin="1.1.1"
+lizmap_server="1.1.1"
+; These plugins are optional for Lizmap Web Client, but if they are found, the minimum version is required
+wfsOutputExtension="1.7.0"
+atlasprint="3.3.1"
+; About cadastre, not all versions are related to the server side, check the changelog for "serveur" keyword for instance
+cadastre="1.14.1"
+; dataPlotLy="3.9.2"
 
 ; Versions written in QGIS projects, for the GIS administrator
 ; QGIS project with a lower version are not displayed in the landing page, but displayed in the administration panel

--- a/lizmap/modules/admin/controllers/config.classic.php
+++ b/lizmap/modules/admin/controllers/config.classic.php
@@ -153,7 +153,7 @@ class configCtrl extends jController
             }
 
             $qgisMinimumVersionRequired = jApp::config()->minimumRequiredVersion['qgisServer'];
-            $lizmapPluginMinimumVersionRequired = jApp::config()->minimumRequiredVersion['lizmapServerPlugin'];
+            $lizmapPluginMinimumVersionRequired = jApp::config()->minimumRequiredVersion['lizmap_server'];
             $form->getControl('lizmapPluginAPIURL')->help = jLocale::get(
                 'admin~admin.form.admin_services.lizmapPluginAPIURL.help',
                 array(

--- a/lizmap/modules/admin/controllers/server_information.classic.php
+++ b/lizmap/modules/admin/controllers/server_information.classic.php
@@ -31,7 +31,7 @@ class server_informationCtrl extends jController
         $data = $server->getMetadata();
 
         $qgisMinimumVersionRequired = jApp::config()->minimumRequiredVersion['qgisServer'];
-        $lizmapPluginMinimumVersionRequired = jApp::config()->minimumRequiredVersion['lizmapServerPlugin'];
+        $lizmapPluginMinimumVersionRequired = jApp::config()->minimumRequiredVersion['lizmap_server'];
         $linkDocumentation = 'https://docs.lizmap.com/current/en/install/pre_requirements.html#lizmap-server-plugin';
 
         $qgisServerNeedsUpdate = $server->versionCompare(
@@ -44,15 +44,10 @@ class server_informationCtrl extends jController
         }
 
         $displayPluginActionColumn = false;
-        $lizmapQgisServerNeedsUpdate = $server->pluginServerNeedsUpdate(
-            $server->getLizmapPluginServerVersion(),
-            $lizmapPluginMinimumVersionRequired
-        );
-        $updateLizmapPlugin = jLocale::get('admin.server.information.plugin.update', array('lizmap_server'));
-        if ($lizmapQgisServerNeedsUpdate) {
-            // lizmap_server is required to use LWC
-            jLog::log($updateLizmapPlugin, 'error');
+        $pluginsNeedsUpdate = $server->updatableQgisServerPlugins();
+        if (count($pluginsNeedsUpdate) >= 1) {
             $displayPluginActionColumn = true;
+            jLog::log('At least one QGIS Server plugin needs to be updated. Check the table in the administration panel', 'error');
         }
 
         // Set the HTML content
@@ -63,8 +58,7 @@ class server_informationCtrl extends jController
             'qgisServerNeedsUpdate' => $qgisServerNeedsUpdate,
             'updateQgisServer' => $updateQgisServer,
             'displayPluginActionColumn' => $displayPluginActionColumn,
-            'lizmapQgisServerNeedsUpdate' => $lizmapQgisServerNeedsUpdate,
-            'lizmapPluginUpdate' => $updateLizmapPlugin,
+            'qgisServerPluginNeedsUpdate' => $pluginsNeedsUpdate,
             'errorQgisPlugin' => jLocale::get(
                 'admin.server.information.qgis.error.fetching.information.detail',
                 array(

--- a/lizmap/modules/admin/templates/server_information.tpl
+++ b/lizmap/modules/admin/templates/server_information.tpl
@@ -86,15 +86,15 @@
                 <th>{@admin.server.information.qgis.plugin.action@}</th>
             {/if}
         <tr/>
-        {foreach $data['qgis_server_info']['plugins'] as $name=>$version}
+        {foreach $data['qgis_server_info']['plugins'] as $folder=>$info}
         <tr>
-            <th style="width:20%;">{$name}</th>
-            <td style="width:20%;">{$version['version']}</td>
+            <th style="width:20%;">{$info['name']}</th>
+            <td style="width:20%;">{$info['version']}</td>
             {if $displayPluginActionColumn }
-                {if $name == 'lizmap_server' && $lizmapQgisServerNeedsUpdate}
-                    <td style="background-color:lightcoral;"><strong>{$lizmapPluginUpdate}</strong></td>
+                {if in_array($info['name'], $qgisServerPluginNeedsUpdate)}
+                    <td style="background-color:lightcoral;"><strong>{jlocale 'admin.server.information.plugin.update', array($info['name'])}</strong></td>
                 {else}
-                <td></td>
+                    <td></td>
                 {/if}
             {/if}
         </tr>

--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -77,10 +77,8 @@ class lizMapCtrl extends jController
             return $rep;
         }
 
-        // lizmap_server plugin version
-        $requiredLizmapVersion = jApp::config()->minimumRequiredVersion['lizmapServerPlugin'];
-        $currentLizmapVersion = $server->getLizmapPluginServerVersion();
-        if ($server->pluginServerNeedsUpdate($currentLizmapVersion, $requiredLizmapVersion)) {
+        // QGIS server plugins
+        if (count($server->updatableQgisServerPlugins()) >= 1) {
             jMessage::add(jLocale::get('view~default.server.information.error'), 'error');
 
             return $rep;


### PR DESCRIPTION
Server - Set minimum required versions for QGIS server plugins

Only "Lizmap server" is required. Other plugins, if they are found, their version will be checked.

Funded by 3Liz
