### PR TITLE
Fix: Filter by user edition in popup

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -668,7 +668,8 @@ class WMSRequest extends OGCRequest
             if (array_key_exists('status', $editableFeatures) && $editableFeatures['status'] === 'restricted') {
                 $editionRestricted = 'edition-restricted="true"';
                 foreach ($editableFeatures['features'] as $editableFeature) {
-                    if ($editableFeature->properties->id == $id) {
+                    $pKeyValue = explode('.', $editableFeature->id)[1];
+                    if ($pKeyValue == $id) {
                         $editionRestricted = 'edition-restricted="false"';
 
                         break;


### PR DESCRIPTION
Use primary key value instead of id column which could not exist

Funded by 3Liz
