### PR TITLE
[Tests] e2e cypress: Switch to `mapClick` helper

### DIFF
--- a/tests/end2end/cypress/integration/feature_toolbar-ghaction.js
+++ b/tests/end2end/cypress/integration/feature_toolbar-ghaction.js
@@ -32,7 +32,7 @@ describe('Feature Toolbar', function () {
         const pixelmatch = require('pixelmatch');
 
         // Click feature with id=1 on the map
-        cy.get('#map').click(625, 362)
+        cy.mapClick(655, 437)
         cy.wait('@getFeatureInfo')
 
         cy.intercept('*REQUEST=GetMap*',
@@ -86,7 +86,7 @@ describe('Feature Toolbar', function () {
         })
 
         // Click feature with id=1 on the map
-        cy.get('#map').click(625, 362)
+        cy.mapClick(655, 437)
         cy.wait('@getFeatureInfo')
 
         cy.get('#popupcontent lizmap-feature-toolbar[value="parent_layer_d3dc849b_9622_4ad0_8401_ef7d75950111.1"] .feature-filter').click()
@@ -123,7 +123,7 @@ describe('Feature Toolbar', function () {
         })
 
         // Click feature with id=1 on the map
-        cy.get('#map').click(625, 362)
+        cy.mapClick(655, 437)
         cy.wait('@getFeatureInfo')
 
         // Open parent_layer in attribute table
@@ -165,7 +165,7 @@ describe('Feature Toolbar', function () {
     it('should display working custom action', function () {
 
         // Click feature with id=1 on the map
-        cy.get('#map').click(625, 362)
+        cy.mapClick(655, 437)
         cy.wait('@getFeatureInfo')
 
         cy.get('.popupButtonBar .popup-action').click()
@@ -185,7 +185,7 @@ describe('Feature Toolbar', function () {
 
     it('should start child edition linked to a parent feature', function () {
         // Click feature with id=2 on the map
-        cy.get('#map').click(1025, 362)
+        cy.mapClick(1055, 437)
         cy.wait('@getFeatureInfo')
 
         // Start parent edition

--- a/tests/end2end/cypress/integration/filter_layer_data_by_polygon_for_groups-ghaction.js
+++ b/tests/end2end/cypress/integration/filter_layer_data_by_polygon_for_groups-ghaction.js
@@ -93,7 +93,7 @@ describe('Filter layer data by polygon for groups', function () {
         })
 
         // 2/ popup
-        cy.get('#map').click(600, 340)
+        cy.mapClick(630, 415)
 
         cy.get('.lizmapPopupTitle').should('have.text','townhalls_pg')
 
@@ -181,13 +181,13 @@ describe('Filter layer data by polygon for groups', function () {
         })
 
         // 2/ popup
-        cy.get('#map').click(600, 340)
+        cy.mapClick(630, 415)
 
         cy.get('.lizmapPopupTitle').should('have.text', 'townhalls_pg')
 
         cy.get('.lizmapPopupDiv .feature-edit').should('be.disabled')
 
-        cy.get('#map').click(525, 270)//558,345
+        cy.mapClick(555, 345) //588,420
         cy.get('.lizmapPopupDiv .feature-edit').should('not.be.disabled')
 
         // 3/ attribute table
@@ -231,7 +231,7 @@ describe('Filter layer data by polygon for groups', function () {
         cy.wait(200)
 
         // Click to create feature outside allowed area
-        cy.get('#map').click(645, 390)
+        cy.mapClick(675, 465)
 
         cy.get('#jforms_view_edition__submit_submit').click()
 

--- a/tests/end2end/cypress/integration/form_advanced-ghaction.js
+++ b/tests/end2end/cypress/integration/form_advanced-ghaction.js
@@ -8,7 +8,7 @@ describe('Advanced form', function () {
 
         cy.wait(1500)
         // Click on map as form needs a geometry
-        cy.get('#map').click(600, 250)
+        cy.mapClick(630, 325)
 
         cy.wait(1500)
     })
@@ -67,7 +67,7 @@ describe('Advanced form', function () {
         cy.wait(800)
 
         // Assert quartier value is good for another drawn point
-        cy.get('#map').click(600, 350)
+        cy.mapClick(630, 425)
         cy.get('#jforms_view_edition_quartier option').should('have.length', 2)
         cy.get('#jforms_view_edition_quartier option').last().should('have.text', 'MONTPELLIER CENTRE')
         cy.get('#jforms_view_edition_quartier').select('MC')

--- a/tests/end2end/cypress/integration/form_edition-ghaction.js
+++ b/tests/end2end/cypress/integration/form_edition-ghaction.js
@@ -47,14 +47,14 @@ describe('Form edition', function () {
 
         // Assert success message is displayed
         cy.get('#message .jelix-msg-item-success').should('be.visible')
-        
+
         // Allow geom creation when not existing
         cy.get('button[value="end2end_form_edition_geom"].btn-open-attribute-layer').click({ force: true })
         cy.get('button.feature-edit:first').click({ force: true })
         cy.get('.edition-tabs a[href="#tabdigitization"]').should('be.visible')
 
         // Draw point
-        cy.get('#map').click(600, 250)
+        cy.mapClick(630, 325)
 
         // Save feature with new geom point
         cy.get('#jforms_view_edition__submit_submit').click()

--- a/tests/end2end/cypress/integration/form_edition_reverse_geom-ghaction.js
+++ b/tests/end2end/cypress/integration/form_edition_reverse_geom-ghaction.js
@@ -7,12 +7,12 @@ describe('Form edition reverse geom', function () {
 
     it('must reverse geom', function () {
         //Launch edition via the feature popup
-        cy.get('#map').click(678, 430)
+        cy.mapClick(708, 505)
         cy.get('#popupcontent .feature-edit').click()
 
         // Go to digitization tab
         cy.get('#edition a[href="#tabdigitization"]').click()
-        
+
         // Click reverse geom button
         cy.get('#tabdigitization lizmap-reverse-geom').click()
 

--- a/tests/end2end/cypress/integration/form_edition_value_relation_field-ghaction.js
+++ b/tests/end2end/cypress/integration/form_edition_value_relation_field-ghaction.js
@@ -86,7 +86,7 @@ describe('Form edition all field type', function() {
 
         // Click on map as form needs a geometry
         cy.log('Create a geometry over Zone A1')
-        cy.get('#map').click(500, 300)
+        cy.mapClick(530, 375)
         // Wait getListData query ends + slight delay for UI to be ready
         cy.wait('@getListData')
 
@@ -103,7 +103,7 @@ describe('Form edition all field type', function() {
 
         // Click on map as form needs a geometry
         cy.log('Create a geometry over Zone A2')
-        cy.get('#map').click(700, 300)
+        cy.mapClick(730, 375)
         // Wait getListData query ends + slight delay for UI to be ready
         cy.wait('@getListData')
 
@@ -119,7 +119,7 @@ describe('Form edition all field type', function() {
 
         // Click on map as form needs a geometry
         cy.log('Create a geometry over Zone B1')
-        cy.get('#map').click(500, 500)
+        cy.mapClick(530, 575)
         // Wait getListData query ends + slight delay for UI to be ready
         cy.wait('@getListData')
 
@@ -135,7 +135,7 @@ describe('Form edition all field type', function() {
 
         // Click on map as form needs a geometry
         cy.log('Create a geometry over Zone B2')
-        cy.get('#map').click(700, 500)
+        cy.mapClick(730, 575)
         // Wait getListData query ends + slight delay for UI to be ready
         cy.wait('@getListData')
 
@@ -151,7 +151,7 @@ describe('Form edition all field type', function() {
 
         // Click on map as form needs a geometry
         cy.log('Create a geometry outside zones')
-        cy.get('#map').click(700, 700)
+        cy.mapClick(730, 775)
         // Wait getListData query ends + slight delay for UI to be ready
         cy.wait('@getListData')
 
@@ -168,7 +168,7 @@ describe('Form edition all field type', function() {
 
         // Click on map as form needs a geometry
         cy.log('Create a geometry over Zone A1')
-        cy.get('#map').click(500, 300)
+        cy.mapClick(530, 375)
         // Wait getListData query ends + slight delay for UI to be ready
         cy.wait('@getListData')
 
@@ -188,7 +188,7 @@ describe('Form edition all field type', function() {
             .parent().should('have.class', 'active')
         cy.get('#edition-geomtool-restart-drawing').click(true)
 
-        cy.get('#map').click(700, 300)
+        cy.mapClick(730, 375)
         // Wait getListData query ends + slight delay for UI to be ready
         cy.wait('@getListData')
 

--- a/tests/end2end/cypress/integration/form_edition_without_creation-ghaction.js
+++ b/tests/end2end/cypress/integration/form_edition_without_creation-ghaction.js
@@ -10,7 +10,7 @@ describe('Form edition without creation', function () {
         cy.get('#edition-creation').should('not.be.visible')
 
         // Click on a feature then launch its edition form
-        cy.get('#map').click(600, 250)
+        cy.mapClick(630, 325)
         cy.get('.feature-edit').click()
 
         // Only edition form should be visible...

--- a/tests/end2end/cypress/integration/popup-ghaction.js
+++ b/tests/end2end/cypress/integration/popup-ghaction.js
@@ -3,7 +3,7 @@ describe('Popup', function() {
         // Runs before each tests in this block
         cy.visit('/index.php/view/map/?repository=testsrepository&project=popup')
         // Click on triangle
-        cy.get('#map').click(480,340)
+        cy.mapClick(510,415)
     })
 
     it('click on the shape to show the popup', function(){


### PR DESCRIPTION
Replace `cy.get('#map').click` to `cy.mapClick`

Funded by 3liz
