### PR TITLE
Tests: PHPSTan - pathinfo always returns filename

### DIFF
--- a/lizmap/modules/view/controllers/media.classic.php
+++ b/lizmap/modules/view/controllers/media.classic.php
@@ -175,7 +175,8 @@ class mediaCtrl extends jController
 
         // Get the name of the file
         $path_parts = pathinfo($abspath);
-        if (isset($path_parts['filename'])) {
+        // If the basename of the path starts with a dot, the following characters are interpreted as extension, and the filename is empty
+        if ($path_parts['filename'] !== '') {
             $rep->outputFileName = $path_parts['filename'].'.'.$path_parts['extension'];
         } else {
             $rep->outputFileName = $path_parts['basename'];

--- a/lizmap/modules/view/controllers/media.classic.php
+++ b/lizmap/modules/view/controllers/media.classic.php
@@ -84,10 +84,6 @@ class mediaCtrl extends jController
      * Get a media file (image, html, csv, pdf, etc.) store in the repository.
      * Used to display media in the popup, via the information icon, etc.
      *
-     * @param string $repository repository of the project
-     * @param string $project    project key
-     * @param string $path       path to the media relative to the project file
-     *
      * @return jResponseBinary|jResponseJson object The media
      */
     public function getMedia()
@@ -209,9 +205,6 @@ class mediaCtrl extends jController
     /**
      * Get illustration image for a specified project.
      *
-     * @param string $repository repository of the project
-     * @param string $project    project key
-     *
      * @return jResponseBinary|jResponseJson object The image for this project
      */
     public function illustration()
@@ -290,10 +283,6 @@ class mediaCtrl extends jController
     /**
      * Get a CSS file stored in the repository in a "media/themes" folder.
      * Url to images are replaced by getMedia URL.
-     *
-     * @param string $repository repository of the project
-     * @param string $project    project key
-     * @param string $path       path to the CSS file relative to the project file
      *
      * @return jResponseBinary|jResponseText object The transformed CSS file
      */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1042,11 +1042,6 @@ parameters:
 			path: lizmap/modules/view/controllers/lizMap.classic.php
 
 		-
-			message: "#^Offset 'filename' on array\\{dirname\\: string, basename\\: string, filename\\: string, extension\\?\\: string\\} in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 1
-			path: lizmap/modules/view/controllers/media.classic.php
-
-		-
 			message: "#^PHPDoc tag @param references unknown parameter\\: \\$path$#"
 			count: 2
 			path: lizmap/modules/view/controllers/media.classic.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1042,21 +1042,6 @@ parameters:
 			path: lizmap/modules/view/controllers/lizMap.classic.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$path$#"
-			count: 2
-			path: lizmap/modules/view/controllers/media.classic.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$project$#"
-			count: 3
-			path: lizmap/modules/view/controllers/media.classic.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$repository$#"
-			count: 3
-			path: lizmap/modules/view/controllers/media.classic.php
-
-		-
 			message: "#^Cannot access property \\$id on array\\.$#"
 			count: 5
 			path: lizmap/modules/view/zones/ajax_view.zone.php


### PR DESCRIPTION
PHP `pathinfo` returns an associative array containing the following elements is returned: dirname, basename, extension (if any), and filename. https://www.php.net/manual/en/function.pathinfo.php

If the basename of the path starts with a dot, the following characters are interpreted as extension, and the filename is empty

Funded by 3Liz
