### PR TITLE
remove nore more used PHPDoc @param

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapLog.listener.php
+++ b/lizmap/modules/lizmap/classes/lizmapLog.listener.php
@@ -14,9 +14,7 @@ class lizmapLogListener extends jEventListener
     /**
      * When a user logs in.
      *
-     * @param string $login The login
-     * @param object $user  jAuth user
-     * @param mixed  $event
+     * @param mixed $event
      */
     public function onAuthCanLogin($event)
     {
@@ -34,11 +32,7 @@ class lizmapLogListener extends jEventListener
     /**
      * Event emitted by lizmap controllers.
      *
-     * @param string $key        Key of the log item
-     * @param string $content    Content to log (optional)
-     * @param string $repository Lizmap repository key (optional)
-     * @param string $project    Lizmap project key (optional)
-     * @param mixed  $event
+     * @param mixed $event
      */
     public function onLizLogItem($event)
     {
@@ -107,10 +101,8 @@ class lizmapLogListener extends jEventListener
     /**
      * Send an email to the administrator.
      *
-     * @param string $subject Email subject
-     * @param string $body    Email body
-     * @param mixed  $key
-     * @param mixed  $data
+     * @param mixed $key
+     * @param mixed $data
      */
     private function sendEmail($key, $data)
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -211,46 +211,6 @@ parameters:
 			path: lizmap/modules/lizmap/classes/lizmapLog.listener.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$body$#"
-			count: 1
-			path: lizmap/modules/lizmap/classes/lizmapLog.listener.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$content$#"
-			count: 1
-			path: lizmap/modules/lizmap/classes/lizmapLog.listener.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$key$#"
-			count: 1
-			path: lizmap/modules/lizmap/classes/lizmapLog.listener.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$login$#"
-			count: 1
-			path: lizmap/modules/lizmap/classes/lizmapLog.listener.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$project$#"
-			count: 1
-			path: lizmap/modules/lizmap/classes/lizmapLog.listener.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$repository$#"
-			count: 1
-			path: lizmap/modules/lizmap/classes/lizmapLog.listener.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$subject$#"
-			count: 1
-			path: lizmap/modules/lizmap/classes/lizmapLog.listener.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$user$#"
-			count: 1
-			path: lizmap/modules/lizmap/classes/lizmapLog.listener.php
-
-		-
 			message: "#^Property Lizmap\\\\Request\\\\OGCRequest\\:\\:\\$project \\(Lizmap\\\\Project\\\\Project\\) does not accept lizmapProject\\.$#"
 			count: 1
 			path: lizmap/modules/lizmap/classes/lizmapOGCRequest.class.php


### PR DESCRIPTION
easy fix removinng PHPDoc `@param`  that  don't match function signature.
didn't explore file history to see when it has changed