### PR TITLE
Fix: a missing project broke the configuration page

### DIFF
--- a/lizmap/modules/action/classes/actionConfig.class.php
+++ b/lizmap/modules/action/classes/actionConfig.class.php
@@ -29,7 +29,7 @@ class actionConfig
 
                 return;
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             $this->errors = array(
                 'title' => 'Invalid Query Parameter',
                 'detail' => 'The lizmap project '.strtoupper($project).' does not exist !',

--- a/lizmap/modules/action/controllers/service.classic.php
+++ b/lizmap/modules/action/controllers/service.classic.php
@@ -41,7 +41,7 @@ class serviceCtrl extends jController
 
                 return $this->error($errors);
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             $errors = array(
                 'title' => 'Wrong repository and project !',
                 'detail' => 'The lizmap project '.strtoupper($project).' does not exist !',

--- a/lizmap/modules/admin/classes/listProjectDatasource.class.php
+++ b/lizmap/modules/admin/classes/listProjectDatasource.class.php
@@ -47,7 +47,7 @@ class listProjectDatasource extends jFormsDynamicDatasource
                 if ($p) {
                     return (string) $p->getTitle();
                 }
-            } catch (UnknownLizmapProjectException $e) {
+            } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
                 jLog::logEx($e, 'error');
 
                 return '';

--- a/lizmap/modules/admin/controllers/maps.classic.php
+++ b/lizmap/modules/admin/controllers/maps.classic.php
@@ -630,7 +630,7 @@ class mapsCtrl extends jController
             jMessage::add(jLocale::get('admin~admin.cache.layer.removed', array($layer)));
 
             return $rep;
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             jLog::logEx($e, 'error');
             jMessage::add('The lizmap project '.strtoupper($project).' does not exist !', 'error');
 

--- a/lizmap/modules/dataviz/classes/datavizConfig.class.php
+++ b/lizmap/modules/dataviz/classes/datavizConfig.class.php
@@ -27,7 +27,7 @@ class datavizConfig
 
                 return;
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             $this->errors = array(
                 'title' => 'Invalid Query Parameter',
                 'detail' => 'The lizmap project '.strtoupper($project).' does not exist !',

--- a/lizmap/modules/dataviz/classes/datavizPlot.class.php
+++ b/lizmap/modules/dataviz/classes/datavizPlot.class.php
@@ -217,7 +217,7 @@ class datavizPlot
 
                 return false;
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             jMessage::add('The lizmap project '.strtoupper($project).' does not exist !', 'ProjectNotDefined');
 
             return false;

--- a/lizmap/modules/filter/classes/filterConfig.class.php
+++ b/lizmap/modules/filter/classes/filterConfig.class.php
@@ -30,7 +30,7 @@ class filterConfig
 
                 return false;
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             $this->errors = array(
                 'title' => 'Invalid Query Parameter',
                 'detail' => 'The lizmap project '.strtoupper($project).' does not exist !',

--- a/lizmap/modules/lizmap/classes/lizmap.class.php
+++ b/lizmap/modules/lizmap/classes/lizmap.class.php
@@ -358,6 +358,8 @@ class lizmap
      *
      * @param string $key the project name
      *
+     * @throws \Lizmap\Project\UnknownLizmapProjectException
+     *
      * @return null|Lizmap\Project\Project null if it does not exist
      * @FIXME all calls to getProject construct $key. Why not to
      * deliver directly $rep and $project? It could avoid

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -149,7 +149,7 @@ class editionCtrl extends jController
 
                 return false;
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             $this->setErrorMessage('The lizmap project '.strtoupper($project).' does not exist !', 'ProjectNotDefined');
 
             return false;
@@ -1062,7 +1062,7 @@ class editionCtrl extends jController
 
                 return $rep;
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             $rep->data['message'] = 'The lizmap project '.strtoupper($project).' does not exist !';
 
             return $rep;
@@ -1136,7 +1136,7 @@ class editionCtrl extends jController
 
                 return $this->serviceAnswer();
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             jMessage::add('The lizmap project '.strtoupper($project).' does not exist !', 'ProjectNotDefined');
 
             return $this->serviceAnswer();
@@ -1334,7 +1334,7 @@ class editionCtrl extends jController
 
                 return $this->serviceAnswer();
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             jMessage::add('The lizmap project '.strtoupper($project).' does not exist !', 'ProjectNotDefined');
 
             return $this->serviceAnswer();

--- a/lizmap/modules/lizmap/controllers/search.classic.php
+++ b/lizmap/modules/lizmap/controllers/search.classic.php
@@ -40,7 +40,7 @@ class searchCtrl extends jController
 
                 return $rep;
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             jLog::logEx($e, 'error');
             jMessage::add('The lizmap project '.strtoupper($project).' does not exist !', 'ProjectNotDefined');
 

--- a/lizmap/modules/lizmap/controllers/searchFts.classic.php
+++ b/lizmap/modules/lizmap/controllers/searchFts.classic.php
@@ -64,7 +64,7 @@ class searchFtsCtrl extends jController
 
                 return $rep;
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             jLog::logEx($e, 'error');
             jLog::log('The lizmap project '.strtoupper($project).' does not exist !', 'errors');
 

--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -301,7 +301,7 @@ class serviceCtrl extends jController
 
                 return false;
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             jLog::logEx($e, 'error');
             jMessage::add('The lizmap project '.strtoupper($project).' does not exist !', 'ProjectNotDefined');
 

--- a/lizmap/modules/lizmap/controllers/wmts.cmdline.php
+++ b/lizmap/modules/lizmap/controllers/wmts.cmdline.php
@@ -131,12 +131,12 @@ class wmtsCtrl extends jControllerCmdLine
             $project = lizmap::getProject($this->param('repository').'~'.$this->param('project'));
             // Project not found
             if (!$project) {
-                $rep->addContent("The project has not be found!\n");
+                $rep->addContent("Unknown repository!\n");
                 $rep->setExitCode(1);
 
                 return $rep;
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             $rep->addContent("The project has not be found!\n");
             $rep->setExitCode(1);
 
@@ -225,12 +225,12 @@ class wmtsCtrl extends jControllerCmdLine
             $project = lizmap::getProject($this->param('repository').'~'.$this->param('project'));
             // Project not found
             if (!$project) {
-                $rep->addContent("The project has not be found!\n");
+                $rep->addContent("Unknown repository!\n");
                 $rep->setExitCode(1);
 
                 return $rep;
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             $rep->addContent("The project has not be found!\n");
             $rep->setExitCode(1);
 
@@ -491,12 +491,12 @@ class wmtsCtrl extends jControllerCmdLine
             $project = lizmap::getProject($this->param('repository').'~'.$this->param('project'));
             // Project not found
             if (!$project) {
-                $rep->addContent("The project has not be found!\n");
+                $rep->addContent("Unknown repository!\n");
                 $rep->setExitCode(1);
 
                 return $rep;
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             $rep->addContent("The project has not be found!\n");
             $rep->setExitCode(1);
 

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -139,11 +139,7 @@ class Project
                 throw $e;
             }
 
-            try {
-                $this->qgis = new QgisProject($file, $services, $this->appContext);
-            } catch (UnknownLizmapProjectException $e) {
-                throw $e;
-            }
+            $this->qgis = new QgisProject($file, $services, $this->appContext);
             $this->readProject();
 
             // set project data in cache
@@ -186,17 +182,8 @@ class Project
                 $this->cacheHandler->storeProjectData($data);
             }
 
-            try {
-                $this->cfg = new ProjectConfig($data['cfg']);
-            } catch (UnknownLizmapProjectException $e) {
-                throw $e;
-            }
-
-            try {
-                $this->qgis = new QgisProject($file, $services, $appContext, $data['qgis']);
-            } catch (UnknownLizmapProjectException $e) {
-                throw $e;
-            }
+            $this->cfg = new ProjectConfig($data['cfg']);
+            $this->qgis = new QgisProject($file, $services, $appContext, $data['qgis']);
         }
 
         $this->path = $file;

--- a/lizmap/modules/view/controllers/default.classic.php
+++ b/lizmap/modules/view/controllers/default.classic.php
@@ -59,7 +59,7 @@ class defaultCtrl extends jController
                         jMessage::add(jLocale::get('view~default.project.needs.update'), 'error');
                     }
                     jMessage::add('The \'only maps\' option is not well configured!', 'error');
-                } catch (UnknownLizmapProjectException $e) {
+                } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
                     jMessage::add('The \'only maps\' option is not well configured!', 'error');
                     jLog::logEx($e, 'error');
                 }

--- a/lizmap/modules/view/controllers/lizAjax.classic.php
+++ b/lizmap/modules/view/controllers/lizAjax.classic.php
@@ -142,7 +142,7 @@ class lizAjaxCtrl extends jController
                     return $this->error404('The parameter project is mandatory!');
                 }
                 $project = $lser->defaultProject;
-            } catch (UnknownLizmapProjectException $e) {
+            } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
                 return $this->error404('The parameter project is mandatory!');
             }
         }
@@ -153,7 +153,7 @@ class lizAjaxCtrl extends jController
             if (!$lproj) {
                 return $this->error404('The lizmap project '.strtoupper($project).' does not exist !');
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             return $this->error404('The lizmap project '.strtoupper($project).' does not exist !');
         }
 

--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -105,7 +105,7 @@ class lizMapCtrl extends jController
                     return $rep;
                 }
                 $project = $lser->defaultProject;
-            } catch (UnknownLizmapProjectException $e) {
+            } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
                 jMessage::add('The parameter project is mandatory!', 'error');
 
                 return $rep;
@@ -120,7 +120,7 @@ class lizMapCtrl extends jController
 
                 return $rep;
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             jMessage::add('The lizmap project '.strtoupper($project).' does not exist !', 'error');
 
             return $rep;

--- a/lizmap/modules/view/controllers/media.classic.php
+++ b/lizmap/modules/view/controllers/media.classic.php
@@ -108,7 +108,7 @@ class mediaCtrl extends jController
             if (!$lproj) {
                 return $this->error404('The lizmap project '.strtoupper($project).' does not exist !');
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             jLog::logEx($e, 'error');
 
             return $this->error404('The lizmap project '.strtoupper($project).' does not exist !');
@@ -234,7 +234,7 @@ class mediaCtrl extends jController
             if (!$lproj) {
                 return $this->error404('The lizmap project '.strtoupper($project).' does not exist !');
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             jLog::logEx($e, 'error');
 
             return $this->error404('The lizmap project '.strtoupper($project).' does not exist !');

--- a/lizmap/modules/view/zones/map_headermenu.zone.php
+++ b/lizmap/modules/view/zones/map_headermenu.zone.php
@@ -51,7 +51,7 @@ class map_headermenuZone extends jZone
             if ($externalSearch !== null) {
                 $assign['externalSearch'] = $externalSearch;
             }
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             jLog::logEx($e, 'error');
         }
 

--- a/lizmap/modules/view/zones/map_menu.zone.php
+++ b/lizmap/modules/view/zones/map_menu.zone.php
@@ -57,7 +57,7 @@ class map_menuZone extends jZone
             $assign['timemanager'] = $lproj->hasTimemanagerLayers();
 
             $assign['attributeLayers'] = $lproj->hasAttributeLayers();
-        } catch (UnknownLizmapProjectException $e) {
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             jLog::logEx($e, 'error');
         }
 

--- a/tests/end2end/cypress/integration/cmdline-wmts-ghaction.js
+++ b/tests/end2end/cypress/integration/cmdline-wmts-ghaction.js
@@ -169,6 +169,7 @@ describe('WMTS command line', function () {
             .should('contain', '0')
     })
 
+
     it('lizmap~wmts:capabilities failed', function () {
         // Not enough parameters
         cy.exec('./../lizmap-ctl script lizmap~wmts:capabilities -v', {failOnNonZeroExit: false})
@@ -180,33 +181,44 @@ describe('WMTS command line', function () {
             .should('not.contain', 'Missing parameter "project"')
             .should('not.contain', 'The QGIS project /srv/lzm/tests/qgis-projects/tests/unknown.qgs does not exist!')
 
+        cy.exec('./../lizmap-ctl docker-exec truncate -s 0 /srv/lzm/lizmap/var/log/errors.log')
+
         cy.exec('./../lizmap-ctl script lizmap~wmts:capabilities -v testsrepository', {failOnNonZeroExit: false})
             .its('code').should('eq', 1)
 
         cy.exec('./../lizmap-ctl docker-exec cat /srv/lzm/lizmap/var/log/errors.log')
             .its('stdout')
-            .should('contain', 'Missing parameter "repository"')
+            .should('not.contain', 'Missing parameter "repository"')
             .should('contain', 'Missing parameter "project"')
             .should('not.contain', 'The QGIS project /srv/lzm/tests/qgis-projects/tests/unknown.qgs does not exist!')
 
+
         // Bad parameters
+        cy.exec('./../lizmap-ctl docker-exec truncate -s 0 /srv/lzm/lizmap/var/log/errors.log')
         cy.exec('./../lizmap-ctl script lizmap~wmts:capabilities -v norepository cache', {failOnNonZeroExit: false})
-            .its('code').should('eq', 1)
+            .then((result) => {
+                expect(result.stdout).to.contain('Unknown repository!')
+                expect(result.code).to.equal(1)
+            })
 
         cy.exec('./../lizmap-ctl docker-exec cat /srv/lzm/lizmap/var/log/errors.log')
             .its('stdout')
-            .should('contain', 'Missing parameter "repository"')
-            .should('contain', 'Missing parameter "project"')
+            .should('not.contain', 'Missing parameter "repository"')
+            .should('not.contain', 'Missing parameter "project"')
             .should('not.contain', 'The QGIS project /srv/lzm/tests/qgis-projects/tests/unknown.qgs does not exist!')
 
+        cy.exec('./../lizmap-ctl docker-exec truncate -s 0 /srv/lzm/lizmap/var/log/errors.log')
         cy.exec('./../lizmap-ctl script lizmap~wmts:capabilities -v testsrepository unknown', {failOnNonZeroExit: false})
-            .its('code').should('eq', 1)
+            .then((result) => {
+                expect(result.stdout).to.contain('The project has not be found!')
+                expect(result.code).to.equal(1)
+            })
 
         cy.exec('./../lizmap-ctl docker-exec cat /srv/lzm/lizmap/var/log/errors.log')
         .its('stdout')
-        .should('contain', 'Missing parameter "repository"')
-        .should('contain', 'Missing parameter "project"')
-        .should('contain', 'The QGIS project /srv/lzm/tests/qgis-projects/tests/unknown.qgs does not exist!')
+        .should('not.contain', 'Missing parameter "repository"')
+        .should('not.contain', 'Missing parameter "project"')
+        .should('not.contain', 'The QGIS project /srv/lzm/tests/qgis-projects/tests/unknown.qgs does not exist!')
 
         // Clear errors
         cy.exec('./../lizmap-ctl docker-exec truncate -s 0 /srv/lzm/lizmap/var/log/errors.log')
@@ -227,12 +239,13 @@ describe('WMTS command line', function () {
             .should('not.contain', 'Missing parameter "TileMatrixMax"')
             .should('not.contain', 'The QGIS project /srv/lzm/tests/qgis-projects/tests/unknown.qgs does not exist!')
 
+        cy.exec('./../lizmap-ctl docker-exec truncate -s 0 /srv/lzm/lizmap/var/log/errors.log')
         cy.exec('./../lizmap-ctl script lizmap~wmts:seeding -v -f -dry-run testsrepository', {failOnNonZeroExit: false})
             .its('code').should('eq', 1)
 
         cy.exec('./../lizmap-ctl docker-exec cat /srv/lzm/lizmap/var/log/errors.log')
             .its('stdout')
-            .should('contain', 'Missing parameter "repository"')
+            .should('not.contain', 'Missing parameter "repository"')
             .should('contain', 'Missing parameter "project"')
             .should('not.contain', 'Missing parameter "layers"')
             .should('not.contain', 'Missing parameter "TileMatrixSet"')
@@ -240,98 +253,125 @@ describe('WMTS command line', function () {
             .should('not.contain', 'Missing parameter "TileMatrixMax"')
             .should('not.contain', 'The QGIS project /srv/lzm/tests/qgis-projects/tests/unknown.qgs does not exist!')
 
+        cy.exec('./../lizmap-ctl docker-exec truncate -s 0 /srv/lzm/lizmap/var/log/errors.log')
         cy.exec('./../lizmap-ctl script lizmap~wmts:seeding -v -f -dry-run testsrepository cache', {failOnNonZeroExit: false})
             .its('code').should('eq', 1)
 
         cy.exec('./../lizmap-ctl docker-exec cat /srv/lzm/lizmap/var/log/errors.log')
             .its('stdout')
-            .should('contain', 'Missing parameter "repository"')
-            .should('contain', 'Missing parameter "project"')
+            .should('not.contain', 'Missing parameter "repository"')
+            .should('not.contain', 'Missing parameter "project"')
             .should('contain', 'Missing parameter "layers"')
             .should('not.contain', 'Missing parameter "TileMatrixSet"')
             .should('not.contain', 'Missing parameter "TileMatrixMin"')
             .should('not.contain', 'Missing parameter "TileMatrixMax"')
             .should('not.contain', 'The QGIS project /srv/lzm/tests/qgis-projects/tests/unknown.qgs does not exist!')
 
+        cy.exec('./../lizmap-ctl docker-exec truncate -s 0 /srv/lzm/lizmap/var/log/errors.log')
         cy.exec('./../lizmap-ctl script lizmap~wmts:seeding -v -f -dry-run testsrepository cache Quartiers', {failOnNonZeroExit: false})
             .its('code').should('eq', 1)
 
         cy.exec('./../lizmap-ctl docker-exec cat /srv/lzm/lizmap/var/log/errors.log')
             .its('stdout')
-            .should('contain', 'Missing parameter "repository"')
-            .should('contain', 'Missing parameter "project"')
-            .should('contain', 'Missing parameter "layers"')
+            .should('not.contain', 'Missing parameter "repository"')
+            .should('not.contain', 'Missing parameter "project"')
+            .should('not.contain', 'Missing parameter "layers"')
             .should('contain', 'Missing parameter "TileMatrixSet"')
             .should('not.contain', 'Missing parameter "TileMatrixMin"')
             .should('not.contain', 'Missing parameter "TileMatrixMax"')
             .should('not.contain', 'The QGIS project /srv/lzm/tests/qgis-projects/tests/unknown.qgs does not exist!')
 
+        cy.exec('./../lizmap-ctl docker-exec truncate -s 0 /srv/lzm/lizmap/var/log/errors.log')
         cy.exec('./../lizmap-ctl script lizmap~wmts:seeding -v -f -dry-run testsrepository cache Quartiers EPSG:3857', {failOnNonZeroExit: false})
             .its('code').should('eq', 1)
 
         cy.exec('./../lizmap-ctl docker-exec cat /srv/lzm/lizmap/var/log/errors.log')
             .its('stdout')
-            .should('contain', 'Missing parameter "repository"')
-            .should('contain', 'Missing parameter "project"')
-            .should('contain', 'Missing parameter "layers"')
-            .should('contain', 'Missing parameter "TileMatrixSet"')
+            .should('not.contain', 'Missing parameter "repository"')
+            .should('not.contain', 'Missing parameter "project"')
+            .should('not.contain', 'Missing parameter "layers"')
+            .should('not.contain', 'Missing parameter "TileMatrixSet"')
             .should('contain', 'Missing parameter "TileMatrixMin"')
             .should('not.contain', 'Missing parameter "TileMatrixMax"')
             .should('not.contain', 'The QGIS project /srv/lzm/tests/qgis-projects/tests/unknown.qgs does not exist!')
 
+        cy.exec('./../lizmap-ctl docker-exec truncate -s 0 /srv/lzm/lizmap/var/log/errors.log')
         cy.exec('./../lizmap-ctl script lizmap~wmts:seeding -v -f -dry-run testsrepository cache Quartiers EPSG:3857 10', {failOnNonZeroExit: false})
             .its('code').should('eq', 1)
 
         cy.exec('./../lizmap-ctl docker-exec cat /srv/lzm/lizmap/var/log/errors.log')
             .its('stdout')
-            .should('contain', 'Missing parameter "repository"')
-            .should('contain', 'Missing parameter "project"')
-            .should('contain', 'Missing parameter "layers"')
-            .should('contain', 'Missing parameter "TileMatrixSet"')
-            .should('contain', 'Missing parameter "TileMatrixMin"')
+            .should('not.contain', 'Missing parameter "repository"')
+            .should('not.contain', 'Missing parameter "project"')
+            .should('not.contain', 'Missing parameter "layers"')
+            .should('not.contain', 'Missing parameter "TileMatrixSet"')
+            .should('not.contain', 'Missing parameter "TileMatrixMin"')
             .should('contain', 'Missing parameter "TileMatrixMax"')
             .should('not.contain', 'The QGIS project /srv/lzm/tests/qgis-projects/tests/unknown.qgs does not exist!')
 
         // Bad parameters
+        cy.exec('./../lizmap-ctl docker-exec truncate -s 0 /srv/lzm/lizmap/var/log/errors.log')
         cy.exec('./../lizmap-ctl script lizmap~wmts:seeding -v -f -dry-run norepository cache Quartiers EPSG:3857 10 10', {failOnNonZeroExit: false})
-            .its('code').should('eq', 1)
+            .then((result) => {
+                expect(result.code).to.equal(1)
+                expect(result.stdout).to.contain('Unknown repository!')
+            })
 
         cy.exec('./../lizmap-ctl docker-exec cat /srv/lzm/lizmap/var/log/errors.log')
             .its('stdout')
-            .should('contain', 'Missing parameter "repository"')
-            .should('contain', 'Missing parameter "project"')
-            .should('contain', 'Missing parameter "layers"')
-            .should('contain', 'Missing parameter "TileMatrixSet"')
-            .should('contain', 'Missing parameter "TileMatrixMin"')
-            .should('contain', 'Missing parameter "TileMatrixMax"')
+            .should('not.contain', 'Missing parameter "repository"')
+            .should('not.contain', 'Missing parameter "project"')
+            .should('not.contain', 'Missing parameter "layers"')
+            .should('not.contain', 'Missing parameter "TileMatrixSet"')
+            .should('not.contain', 'Missing parameter "TileMatrixMin"')
+            .should('not.contain', 'Missing parameter "TileMatrixMax"')
             .should('not.contain', 'The QGIS project /srv/lzm/tests/qgis-projects/tests/unknown.qgs does not exist!')
 
+        cy.exec('./../lizmap-ctl docker-exec truncate -s 0 /srv/lzm/lizmap/var/log/errors.log')
         cy.exec('./../lizmap-ctl script lizmap~wmts:seeding -v -f -dry-run testsrepository unknown Quartiers EPSG:3857 10 10', {failOnNonZeroExit: false})
-            .its('code').should('eq', 1)
+            .then((result) => {
+                expect(result.code).to.equal(1)
+                expect(result.stdout).to.contain('The project has not be found!')
+            })
 
         cy.exec('./../lizmap-ctl docker-exec cat /srv/lzm/lizmap/var/log/errors.log')
             .its('stdout')
-            .should('contain', 'Missing parameter "repository"')
-            .should('contain', 'Missing parameter "project"')
-            .should('contain', 'Missing parameter "layers"')
-            .should('contain', 'Missing parameter "TileMatrixSet"')
-            .should('contain', 'Missing parameter "TileMatrixMin"')
-            .should('contain', 'Missing parameter "TileMatrixMax"')
-            .should('contain', 'The QGIS project /srv/lzm/tests/qgis-projects/tests/unknown.qgs does not exist!')
+            .should('not.contain', 'Missing parameter "repository"')
+            .should('not.contain', 'Missing parameter "project"')
+            .should('not.contain', 'Missing parameter "layers"')
+            .should('not.contain', 'Missing parameter "TileMatrixSet"')
+            .should('not.contain', 'Missing parameter "TileMatrixMin"')
+            .should('not.contain', 'Missing parameter "TileMatrixMax"')
+            .should('not.contain', 'The QGIS project /srv/lzm/tests/qgis-projects/tests/unknown.qgs does not exist!')
 
         // Clear errors
         cy.exec('./../lizmap-ctl docker-exec truncate -s 0 /srv/lzm/lizmap/var/log/errors.log')
 
         cy.exec('./../lizmap-ctl script lizmap~wmts:seeding -v -f -dry-run testsrepository cache unknown EPSG:3857 10 10', {failOnNonZeroExit: false})
-            .its('code').should('eq', 1)
+            .then((result) => {
+                expect(result.code).to.equal(1)
+                expect(result.stdout).to.contain('The layers \'unknown\' have not be found!')
+            })
 
+        cy.exec('./../lizmap-ctl docker-exec truncate -s 0 /srv/lzm/lizmap/var/log/errors.log')
         cy.exec('./../lizmap-ctl script lizmap~wmts:seeding -v -f -dry-run testsrepository cache Quartiers unknown 10 10', {failOnNonZeroExit: false})
-            .its('code').should('eq', 1)
+            .then((result) => {
+                expect(result.code).to.equal(1)
+                expect(result.stdout).to.contain("The TileMatrixSet 'EPSG:3857'!\nThe TileMatrixSet 'unknown' has not be found!")
+            })
 
+        cy.exec('./../lizmap-ctl docker-exec truncate -s 0 /srv/lzm/lizmap/var/log/errors.log')
         cy.exec('./../lizmap-ctl script lizmap~wmts:seeding -v -f -dry-run -bbox xmin,ymin,xmax,ymax testsrepository cache Quartiers EPSG:3857 10 10', {failOnNonZeroExit: false})
-            .its('code').should('eq', 1)
+            .then((result) => {
+                expect(result.code).to.equal(1)
+                expect(result.stdout).to.contain("The TileMatrixSet 'EPSG:3857'!\nThe optional bbox has to contain 4 numbers separated by comma!")
+            })
 
+        cy.exec('./../lizmap-ctl docker-exec truncate -s 0 /srv/lzm/lizmap/var/log/errors.log')
         cy.exec('./../lizmap-ctl script lizmap~wmts:seeding -v -f -dry-run -bbox 417094.94691622,5398163.2080343 testsrepository cache Quartiers EPSG:3857 10 10', {failOnNonZeroExit: false})
-            .its('code').should('eq', 1)
+            .then((result) => {
+                expect(result.code).to.equal(1)
+                expect(result.stdout).to.contain("The TileMatrixSet 'EPSG:3857'!\nThe optional bbox has to contain 4 numbers separated by comma!")
+            })
     })
 })


### PR DESCRIPTION
When we display the configuration page, we retrieve the list of projects to display the label of the default project. But if this default project does not exists any more, the page turned into a 500 error page.

This is because, in a try/catch block, we catch the deprecated exception UnknownLizmapProjectException instead of the \Lizmap\Project\UnknownLizmapProjectException.

Many other try/catch have the same issue.

(UnknownLizmapProjectException is still there to not break external modules, but is not used anymore by our code).

Funded by 3liz
