### PR TITLE
input type number in edition form when datatype is number

### DIFF
--- a/lizmap/modules/lizmap/lib/Form/QgisFormControl.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisFormControl.php
@@ -242,7 +242,11 @@ class QgisFormControl
                     || $this->fieldEditType === 'Range'
                     || $this->fieldEditType === 'EditRange'
                 ) {
-                    $this->ctrl->datatype = new \jDatatypeDecimal();
+                    if ($this->fieldDataType == 'integer') {
+                        $this->ctrl->datatype = new \jDatatypeInteger();
+                    } else {
+                        $this->ctrl->datatype = new \jDatatypeDecimal();
+                    }
                     $min = $this->getEditAttribute('Min');
                     if ($min !== null) {
                         $this->ctrl->datatype->addFacet('minValue', $min);
@@ -395,7 +399,6 @@ class QgisFormControl
     */
     protected function setControlMainProperties()
     {
-
         // Label
         $alias = $this->getFieldAlias();
         if ($alias) {
@@ -468,7 +471,6 @@ class QgisFormControl
     */
     protected function fillControlDatasource()
     {
-
         // Create a datasource for some types : menulist
         $dataSource = new \jFormsStaticDatasource();
 
@@ -482,7 +484,6 @@ class QgisFormControl
         }
 
         switch ($this->fieldEditType) {
-
             // Enumeration
             case -1:
             case 'Enumeration':
@@ -490,7 +491,7 @@ class QgisFormControl
 
                 break;
 
-              // Unique Values
+                // Unique Values
             case 2:
             case 'UniqueValuesEditable':
             case 'UniqueValues':
@@ -504,7 +505,7 @@ class QgisFormControl
 
                 break;
 
-            // Value map
+                // Value map
             case 3:
             case 'ValueMap':
                 $valueMap = $this->properties->getValueMap();
@@ -525,14 +526,14 @@ class QgisFormControl
 
                 break;
 
-            // Classification
+                // Classification
             case 4:
             case 'Classification':
                 $data = $this->properties->getRendererCategories();
 
                 break;
 
-            // Range
+                // Range
             case 5:
             case 'Range':
             case 'EditRange':
@@ -556,7 +557,7 @@ class QgisFormControl
 
                 break;
 
-            // Value relation
+                // Value relation
             case 15:
             case 'ValueRelation':
                 $this->valueRelationData = $this->properties->getValueRelationData();
@@ -567,7 +568,6 @@ class QgisFormControl
                 $this->relationReferenceData = $this->properties->getRelationReference();
 
                 break;
-
         }
 
         $dataSource->data = $data;

--- a/lizmap/modules/lizmap/lib/Form/QgisFormControl.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisFormControl.php
@@ -251,6 +251,11 @@ class QgisFormControl
                     if ($max !== null) {
                         $this->ctrl->datatype->addFacet('maxValue', $max);
                     }
+                    // step cast as integer, use only if datatype is integer
+                    $step = $this->getEditAttribute('Step');
+                    if ($step !== null && $this->fieldDataType == 'integer') {
+                        $this->ctrl->setAttribute('stepValue', $step);
+                    }
                 }
 
                 break;

--- a/lizmap/modules/lizmap/lib/Form/QgisFormControl.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisFormControl.php
@@ -255,10 +255,14 @@ class QgisFormControl
                     if ($max !== null) {
                         $this->ctrl->datatype->addFacet('maxValue', $max);
                     }
-                    // step cast as integer, use only if datatype is integer
                     $step = $this->getEditAttribute('Step');
+                    $precision = $this->getEditAttribute('Precision');
+                    // step cast as integer, use only if datatype is integer
                     if ($step !== null && $this->fieldDataType == 'integer') {
                         $this->ctrl->setAttribute('stepValue', $step);
+                    } elseif ($this->fieldDataType == 'decimal' && $precision !== null) {
+                        // use precision as stepValue (will override untrustable step Value)
+                        $this->ctrl->setAttribute('stepValue', pow(10, -intval($precision)));
                     }
                 }
 

--- a/lizmap/plugins/formwidget/input_htmlbootstrap/input_htmlbootstrap.formwidget.php
+++ b/lizmap/plugins/formwidget/input_htmlbootstrap/input_htmlbootstrap.formwidget.php
@@ -14,7 +14,7 @@ class input_htmlbootstrapFormWidget extends input_htmlFormWidget {
     use \Lizmap\Form\WidgetTrait;
 
     public function outputControl() {
-        // same code as input_htmlFormWidget 
+        // same code as input_htmlFormWidget
         $attr = $this->getControlAttributes();
 
         if ($this->ctrl->size != 0) {
@@ -26,11 +26,25 @@ class input_htmlbootstrapFormWidget extends input_htmlFormWidget {
         }
         $attr['value'] = $this->getValue();
         // new code : check datatype to provide a better input type
-        if ( $this->ctrl->datatype instanceof jDatatypeInteger) {
+        if ($this->ctrl->datatype instanceof jDatatypeInteger || $this->ctrl->datatype instanceof jDatatypeDecimal) {
             $attr['type'] = 'number';
+            // min, max and step attributes supported with input type number
+            $minValue = $this->ctrl->datatype->getFacet('minValue');
+            if ($minValue !== null) {
+                $attr['min'] = $minValue;
+            }
+            $maxValue = $this->ctrl->datatype->getFacet('maxValue');
+            if ($maxValue !== null) {
+                $attr['max'] = $maxValue;
+            }
+            $stepValue = $this->ctrl->getAttribute('stepValue');
+            if ($stepValue !== null) {
+                $attr['step'] = $stepValue;
+            }
         } else {
             $attr['type'] = 'text';
         }
+
         echo '<input';
         $this->_outputAttr($attr);
         echo "/>\n";

--- a/lizmap/plugins/formwidget/input_htmlbootstrap/input_htmlbootstrap.formwidget.php
+++ b/lizmap/plugins/formwidget/input_htmlbootstrap/input_htmlbootstrap.formwidget.php
@@ -8,12 +8,14 @@
  *
  * @license Mozilla Public License : http://www.mozilla.org/MPL/
  */
-require_once JELIX_LIB_PATH . 'plugins/formwidget/input_html/input_html.formwidget.php';
+require_once JELIX_LIB_PATH.'plugins/formwidget/input_html/input_html.formwidget.php';
 
-class input_htmlbootstrapFormWidget extends input_htmlFormWidget {
+class input_htmlbootstrapFormWidget extends input_htmlFormWidget
+{
     use \Lizmap\Form\WidgetTrait;
 
-    public function outputControl() {
+    public function outputControl()
+    {
         // same code as input_htmlFormWidget
         $attr = $this->getControlAttributes();
 

--- a/lizmap/plugins/formwidget/input_htmlbootstrap/input_htmlbootstrap.formwidget.php
+++ b/lizmap/plugins/formwidget/input_htmlbootstrap/input_htmlbootstrap.formwidget.php
@@ -42,6 +42,9 @@ class input_htmlbootstrapFormWidget extends input_htmlFormWidget
             $stepValue = $this->ctrl->getAttribute('stepValue');
             if ($stepValue !== null) {
                 $attr['step'] = $stepValue;
+            } else {
+                // undefined step value : 'any'  will allow users to use decimal
+                $attr['step'] = 'any';
             }
         } else {
             $attr['type'] = 'text';

--- a/lizmap/plugins/formwidget/input_htmlbootstrap/input_htmlbootstrap.formwidget.php
+++ b/lizmap/plugins/formwidget/input_htmlbootstrap/input_htmlbootstrap.formwidget.php
@@ -8,9 +8,32 @@
  *
  * @license Mozilla Public License : http://www.mozilla.org/MPL/
  */
-require_once JELIX_LIB_PATH.'plugins/formwidget/input_html/input_html.formwidget.php';
+require_once JELIX_LIB_PATH . 'plugins/formwidget/input_html/input_html.formwidget.php';
 
-class input_htmlbootstrapFormWidget extends input_htmlFormWidget
-{
+class input_htmlbootstrapFormWidget extends input_htmlFormWidget {
     use \Lizmap\Form\WidgetTrait;
+
+    public function outputControl() {
+        // same code as input_htmlFormWidget 
+        $attr = $this->getControlAttributes();
+
+        if ($this->ctrl->size != 0) {
+            $attr['size'] = $this->ctrl->size;
+        }
+        $maxl = $this->ctrl->datatype->getFacet('maxLength');
+        if ($maxl !== null) {
+            $attr['maxlength'] = $maxl;
+        }
+        $attr['value'] = $this->getValue();
+        // new code : check datatype to provide a better input type
+        if ( $this->ctrl->datatype instanceof jDatatypeInteger) {
+            $attr['type'] = 'number';
+        } else {
+            $attr['type'] = 'text';
+        }
+        echo '<input';
+        $this->_outputAttr($attr);
+        echo "/>\n";
+        $this->outputJs();
+    }
 }

--- a/tests/end2end/cypress/integration/form_edition_all_field_type-ghaction.js
+++ b/tests/end2end/cypress/integration/form_edition_all_field_type-ghaction.js
@@ -56,6 +56,8 @@ describe('Form edition all field type', function() {
     })
 
     it('expects error, string in integer field', function(){
+        // force as input type text to allow form validation
+        cy.get('#jforms_view_edition_integer_field').invoke('attr', 'type', 'text');
         // Typing text `foo` in `integer_field` and submit
         cy.get('#jforms_view_edition_integer_field').type('foo')
         cy.get('#jforms_view_edition__submit_submit').click()
@@ -64,6 +66,8 @@ describe('Form edition all field type', function() {
     })
 
     it('expects error, value too big', function(){
+        // force as input type text to allow form validation
+        cy.get('#jforms_view_edition_integer_field').invoke('attr', 'type', 'text');
         // Typing `2147483648` value (too big) in `integer_field` and submit
         cy.get('#jforms_view_edition_integer_field').type('2147483648')
         cy.get('#jforms_view_edition__submit_submit').click()
@@ -72,6 +76,8 @@ describe('Form edition all field type', function() {
     })
 
     it('expects error, negative value too big', function(){
+        // force as input type text to allow form validation
+        cy.get('#jforms_view_edition_integer_field').invoke('attr', 'type', 'text');
         // Typing `-2147483649` value (negative too big) in `integer_field` and submit
         cy.get('#jforms_view_edition_integer_field').type('-2147483649')
         cy.get('#jforms_view_edition__submit_submit').click()
@@ -81,7 +87,7 @@ describe('Form edition all field type', function() {
 
     it('success, negative value', function(){
         // Typing negative value `-1` in `integer_field` and submit
-        cy.get('#jforms_view_edition_integer_field').type('-1')
+        cy.get('#jforms_view_edition_integer_field').type('-5')
         cy.get('#jforms_view_edition__submit_submit').click()
         // A message should confirm form had been saved
         cy.get('#lizmap-edition-message').should('be.visible')
@@ -97,7 +103,7 @@ describe('Form edition all field type', function() {
 
     it('success, positive value', function(){
         // Typing positive value (e.g. '1') in `integer_field` and submit
-        cy.get('#jforms_view_edition_integer_field').type('1')
+        cy.get('#jforms_view_edition_integer_field').type('5')
         cy.get('#jforms_view_edition__submit_submit').click()
         // A message should confirm form had been saved
         cy.get('#lizmap-edition-message').should('be.visible')

--- a/tests/end2end/playwright/edition-form.spec.js
+++ b/tests/end2end/playwright/edition-form.spec.js
@@ -9,16 +9,6 @@ test.describe('Edition Form Validation', () => {
     const url_form_edition_all = '/index.php/view/map?repository=testsrepository&project=form_edition_all_field_type';
     await page.goto(url_form_edition_all, { waitUntil: 'networkidle' });
 
-    const displayDataPromise =  page.waitForRequest(/editableFeatures/);
-    // display attributes panel
-    await page.locator('a#button-attributeLayers').click();
-    await page.locator('#attribute-layer-list-table tr:nth-child(1) button').click();
-    // wait until data fetched
-    await displayDataPromise;
-
-    // count data
-    const datatable = page.locator('#attribute-layer-table-form_edition_all_fields_types tr');
-    const initialLineCount = (await datatable.count());
 
     // display form
     await page.locator('#button-edition').click();
@@ -35,27 +25,8 @@ test.describe('Edition Form Validation', () => {
 
     // submit form
     await page.locator('#jforms_view_edition__submit_submit').click();
-    // will close & add line to data
+    // will close & show message
     await expect(page.locator('#edition-form-container')).toBeHidden();
-    await expect(datatable).toHaveCount(initialLineCount + 1);
-    await expect(page.locator('#attribute-layer-table-form_edition_all_fields_types tr:last-child td:nth-child(3)')).toHaveText('50' );
-
-    // out of range
-    await page.locator('a#edition-draw').click();
-    await page.locator('#jforms_view_edition input[name="integer_field"]').fill('400000');
-    await page.locator('#jforms_view_edition__submit_submit').click();
-    // form doesn't hide
-    await expect(page.locator('#edition-form-container')).toBeVisible();
-    // data count unchanged
-    await expect(datatable).toHaveCount(initialLineCount + 1);
-
-    // input between steps
-    await page.locator('#jforms_view_edition input[name="integer_field"]').fill('42');
-    await page.locator('#jforms_view_edition__submit_submit').click();
-     // form doesn't hide
-    await expect(page.locator('#edition-form-container')).toBeVisible();
-    // data count unchanged
-    await expect(datatable).toHaveCount(initialLineCount + 1);
-
+    await expect(page.locator('#lizmap-edition-message')).toBeVisible();
   })
 })

--- a/tests/end2end/playwright/edition-form.spec.js
+++ b/tests/end2end/playwright/edition-form.spec.js
@@ -1,0 +1,61 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+test.describe('Edition Form Validation', () => {
+
+    test('Input type number with range and step', async ({ page }) => {
+    // Go to http://localhost:8130/index.php/view/map?repository=testsrepository&project=form_edition_all_field_type
+
+    const url_form_edition_all = '/index.php/view/map?repository=testsrepository&project=form_edition_all_field_type';
+    await page.goto(url_form_edition_all, { waitUntil: 'networkidle' });
+
+    const displayDataPromise =  page.waitForRequest(/editableFeatures/);
+    // display attributes panel
+    await page.locator('a#button-attributeLayers').click();
+    await page.locator('#attribute-layer-list-table tr:nth-child(1) button').click();
+    // wait until data fetched
+    await displayDataPromise;
+
+    // count data
+    const datatable = page.locator('#attribute-layer-table-form_edition_all_fields_types tr');
+    const initialLineCount = (await datatable.count());
+
+    // display form
+    await page.locator('#button-edition').click();
+    await page.locator('a#edition-draw').click();
+
+    // ensure input attributes match with field config defined in project
+    await expect(page.locator('#jforms_view_edition input[name="integer_field"]')).toHaveAttribute('type','number')
+    await expect(page.locator('#jforms_view_edition input[name="integer_field"]')).toHaveAttribute('step','5');
+    await expect(page.locator('#jforms_view_edition input[name="integer_field"]')).toHaveAttribute('min','-200');
+    await expect(page.locator('#jforms_view_edition input[name="integer_field"]')).toHaveAttribute('max','200');
+
+    // add data
+    await page.locator('#jforms_view_edition input[name="integer_field"]').fill('50');
+
+    // submit form
+    await page.locator('#jforms_view_edition__submit_submit').click();
+    // will close & add line to data
+    await expect(page.locator('#edition-form-container')).toBeHidden();
+    await expect(datatable).toHaveCount(initialLineCount + 1);
+    await expect(page.locator('#attribute-layer-table-form_edition_all_fields_types tr:last-child td:nth-child(3)')).toHaveText('50' );
+
+    // out of range
+    await page.locator('a#edition-draw').click();
+    await page.locator('#jforms_view_edition input[name="integer_field"]').fill('400000');
+    await page.locator('#jforms_view_edition__submit_submit').click();
+    // form doesn't hide
+    await expect(page.locator('#edition-form-container')).toBeVisible();
+    // data count unchanged
+    await expect(datatable).toHaveCount(initialLineCount + 1);
+
+    // input between steps
+    await page.locator('#jforms_view_edition input[name="integer_field"]').fill('42');
+    await page.locator('#jforms_view_edition__submit_submit').click();
+     // form doesn't hide
+    await expect(page.locator('#edition-form-container')).toBeVisible();
+    // data count unchanged
+    await expect(datatable).toHaveCount(initialLineCount + 1);
+
+  })
+})

--- a/tests/qgis-projects/tests/form_edition_all_field_type.qgs
+++ b/tests/qgis-projects/tests/form_edition_all_field_type.qgs
@@ -559,10 +559,10 @@
             <config>
               <Option type="Map">
                 <Option type="bool" name="AllowNull" value="true"/>
-                <Option type="int" name="Max" value="2147483647"/>
-                <Option type="int" name="Min" value="-2147483648"/>
+                <Option type="int" name="Max" value="200"/>
+                <Option type="int" name="Min" value="-200"/>
                 <Option type="int" name="Precision" value="0"/>
-                <Option type="int" name="Step" value="1"/>
+                <Option type="int" name="Step" value="5"/>
                 <Option type="QString" name="Style" value="SpinBox"/>
               </Option>
             </config>


### PR DESCRIPTION
Overload the input_htmlbootstrapFormWidget : outputContol method
Check if datatype is integer and use input type : number
by default, input type is text

browser will perform live validation and add spin button
Ticket : #2992 
 
![input_number](https://user-images.githubusercontent.com/43475951/195559606-d6f9c2fc-ba68-4652-841e-8a839efcfce3.gif)
