### PR TITLE
[docker] wait after the Postgresql server before installing lizmap

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -22,6 +22,10 @@ The container deploys one Lizmap instance and may run php-fpm on the command lin
 - `LIZMAP_ADMIN_EMAIL`: Email address of the admin user
 - `LIZMAP_ADMIN_DEFAULT_PASSWORD_SOURCE`: The password to set for the admin user. See [Admin Setup Section](#admin-setup)
 - `LIZMAP_CONFIG_INCLUDE`: Base directory where to find configurations snippets directories. Default to `/www/lizmap/var/config`.
+- `LIZMAP_DATABASE_CHECK_RETRIES`: Number of retries to connect to the postgresql database
+   during the startup of the container (default is 10). Used only if Lizmap is configured to
+   use a Postgresql database (see [profiles.ini.php](https://docs.lizmap.com/3.5/en/install/linux.html#postgresql)).
+   The startup script waits 2 secondes before retries.
 
 **Important**: `LIZMAP_HOME` is the prefix of the path towards Lizmap web files (`lizmap/www`). This prefix
 must be identical to the one given in the nginx *root* directive, ex:

--- a/docker/README.md
+++ b/docker/README.md
@@ -22,12 +22,12 @@ The container deploys one Lizmap instance and may run php-fpm on the command lin
 - `LIZMAP_ADMIN_EMAIL`: Email address of the admin user
 - `LIZMAP_ADMIN_DEFAULT_PASSWORD_SOURCE`: The password to set for the admin user. See [Admin Setup Section](#admin-setup)
 - `LIZMAP_CONFIG_INCLUDE`: Base directory where to find configurations snippets directories. Default to `/www/lizmap/var/config`.
-- `LIZMAP_DATABASE_CHECK_RETRIES`: Number of retries to connect to the postgresql database
+- `LIZMAP_DATABASE_CHECK_RETRIES`: Number of retries to connect to the PostgreSQL database
    during the startup of the container (default is 10). Used only if Lizmap is configured to
-   use a Postgresql database (see [profiles.ini.php](https://docs.lizmap.com/3.5/en/install/linux.html#postgresql)).
-   The startup script waits 2 seconds before retries (see `LIZMAP_DATABASE_CHECK_WAIT_BEFORE_RETRY`).
+   use a PostgreSQL database (see [profiles.ini.php](https://docs.lizmap.com/3.5/en/install/linux.html#postgresql)).
+   The startup script waits for 2 seconds before retries (see `LIZMAP_DATABASE_CHECK_WAIT_BEFORE_RETRY`).
 - `LIZMAP_DATABASE_CHECK_WAIT_BEFORE_RETRY`: the amount of time in seconds, between
-   two retries of connecting to Postgresql during the startup. Default is 2 seconds.
+   two retries of connecting to the PostgreSQL database during the startup. Default is 2 seconds.
 
 **Important**: `LIZMAP_HOME` is the prefix of the path towards Lizmap web files (`lizmap/www`). This prefix
 must be identical to the one given in the nginx *root* directive, ex:

--- a/docker/README.md
+++ b/docker/README.md
@@ -25,7 +25,9 @@ The container deploys one Lizmap instance and may run php-fpm on the command lin
 - `LIZMAP_DATABASE_CHECK_RETRIES`: Number of retries to connect to the postgresql database
    during the startup of the container (default is 10). Used only if Lizmap is configured to
    use a Postgresql database (see [profiles.ini.php](https://docs.lizmap.com/3.5/en/install/linux.html#postgresql)).
-   The startup script waits 2 secondes before retries.
+   The startup script waits 2 seconds before retries (see `LIZMAP_DATABASE_CHECK_WAIT_BEFORE_RETRY`).
+- `LIZMAP_DATABASE_CHECK_WAIT_BEFORE_RETRY`: the amount of time in seconds, between
+   two retries of connecting to Postgresql during the startup. Default is 2 seconds.
 
 **Important**: `LIZMAP_HOME` is the prefix of the path towards Lizmap web files (`lizmap/www`). This prefix
 must be identical to the one given in the nginx *root* directive, ex:

--- a/docker/update-config.php
+++ b/docker/update-config.php
@@ -92,7 +92,7 @@ function pgSqlConnect ($profile)
  * @return bool
  * @throws Exception
  */
-function checkAndWaitPostgresql($profilesConfig, $profileName, $nbRetries=10)
+function checkAndWaitPostgresql($profilesConfig, $profileName, $nbRetries=10, $wait=2)
 {
     $origProfileName = $profileName;
     $profileAlias = $profilesConfig->getValue($profileName, 'jdb');
@@ -117,7 +117,7 @@ function checkAndWaitPostgresql($profilesConfig, $profileName, $nbRetries=10)
         // if there is nothing on the host/port, pg_connect fails immediately,
         // it doesn't take account on timeout. So we're waiting a bit before retrying.
         echo "  Cannot connect yet, wait a bit before retrying...\n";
-        sleep(2);
+        sleep($wait);
         echo "  Retry...\n";
     }
     echo "Error: cannot connect to the Postgresql database.\n";
@@ -244,15 +244,20 @@ if ($retries == 0) {
     $retries = 10;
 }
 
+$waits = intval(getenv('LIZMAP_DATABASE_CHECK_WAIT_BEFORE_RETRY'));
+if ($waits == 0) {
+    $waits = 2;
+}
+
 // Try to connect to the postgresql database, and retries if it does not ready yet
 // we should wait after Postgresql to be sure the Lizmap installer could create
 // its table and so on.
 // Try with the default profile
-if (!checkAndWaitPostgresql($profilesConfig, 'default', $retries)) {
+if (!checkAndWaitPostgresql($profilesConfig, 'default', $retries, $waits)) {
     exit (1);
 }
 // try with the lizlog profile, it may be a different database.
-if (!checkAndWaitPostgresql($profilesConfig, 'lizlog', $retries)) {
+if (!checkAndWaitPostgresql($profilesConfig, 'lizlog', $retries, $waits)) {
     exit (1);
 }
 

--- a/docker/update-config.php
+++ b/docker/update-config.php
@@ -1,6 +1,7 @@
 #!/usr/bin/env php
 <?php
 require('/www/lib/jelix/utils/jIniFileModifier.class.php');
+require('/www/lib/jelix/db/jDbParameters.class.php');
 
 function load_include_config($varname, $iniFileModifier)
 {
@@ -14,6 +15,117 @@ function load_include_config($varname, $iniFileModifier)
         }  
     }  
 } 
+
+/**
+ * connect to Postgresql with the given profile
+ * @param array
+ */
+function pgSqlConnect ($profile) 
+{
+    $str = '';
+
+    // Service is PostgreSQL way to store credentials in a file :
+    // http://www.postgresql.org/docs/9.1/static/libpq-pgservice.html
+    // If given, no need to add host, user, database, port and password
+    if(isset($profile['service']) && $profile['service'] != ''){
+        $str = 'service=\''.$profile['service'].'\''.$str;
+
+        // Database name may be given, even if service is used
+        // dbname should not be mandatory in service file
+        if (isset($profile['database']) && $profile['database'] != '') {
+            $str .= ' dbname=\''.$profile['database'].'\'';
+        }
+    }
+    else {
+        // we do a distinction because if the host is given == TCP/IP connection else unix socket
+        if($profile['host'] != '')
+            $str = 'host=\''.$profile['host'].'\''.$str;
+
+        if (isset($profile['port'])) {
+            $str .= ' port=\''.$profile['port'].'\'';
+        }
+
+        if ($profile['database'] != '') {
+            $str .= ' dbname=\''.$profile['database'].'\'';
+        }
+
+        // we do isset instead of equality test against an empty string, to allow to specify
+        // that we want to use configuration set in environment variables
+        if (isset($profile['user'])) {
+            $str .= ' user=\''.$profile['user'].'\'';
+        }
+
+        if (isset($profile['password'])) {
+            $str .= ' password=\''.$profile['password'].'\'';
+        }
+    }
+
+    if (isset($profile['timeout']) && $profile['timeout'] != '') {
+        $str .= ' connect_timeout=\''.$profile['timeout'].'\'';
+    }
+
+    if (isset($profile['pg_options']) && $profile['pg_options'] != '') {
+        $str .= ' options=\''.$profile['pg_options'].'\'';
+    }
+
+    if (isset($profile['force_new']) && $profile['force_new']) {
+        $cnx = pg_connect($str, PGSQL_CONNECT_FORCE_NEW);
+    }
+    else {
+        $cnx = pg_connect($str);
+    }
+
+    // let's do the connection
+    if ($cnx) {
+        pg_close($cnx);
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Try to connect to the postgresql database.
+ *
+ * @param jIniFileModifier $profilesConfig
+ * @param string $profileName The profile to use
+ * @param int $nbRetries
+ * @return bool
+ * @throws Exception
+ */
+function checkAndWaitPostgresql($profilesConfig, $profileName, $nbRetries=10)
+{
+    $origProfileName = $profileName;
+    $profileAlias = $profilesConfig->getValue($profileName, 'jdb');
+    if ($profileAlias != '') {
+        $profileName = $profileAlias;
+    }
+    $profile = $profilesConfig->getValues('jdb:'.$profileName);
+    if ($profile === null) {
+        throw new Exception("Database profile jdb:$profileName not found");
+    }
+    $profile = (new jDbParameters($profile))->getParameters();
+    if ($profile['driver'] != 'pgsql') {
+        return true;
+    }
+    $profile['timeout'] = 30;
+    echo "trying to connect to the Postgresql database ".$profile['database']." at ".$profile['host']." with the profile $origProfileName...\n";
+    for($i=0; $i < $nbRetries; $i++) {
+        if (pgSqlConnect($profile)) {
+            echo "  Ok, Postgresql is alive.\n";
+            return true;
+        }
+        // if there is nothing on the host/port, pg_connect fails immediately,
+        // it doesn't take account on timeout. So we're waiting a bit before retrying.
+        echo "  Cannot connect yet, wait a bit before retrying...\n";
+        sleep(2);
+        echo "  Retry...\n";
+    }
+    echo "Error: cannot connect to the Postgresql database.\n";
+    echo "Lizmap cannot starts.\n";
+    return false;
+}
+
+
 
 /** 
  * mainconfig.ini.php
@@ -127,6 +239,22 @@ load_include_config('LIZMAP_PROFILES_INCLUDE', $profilesConfig);
 
 $profilesConfig->save();
 
+$retries = intval(getenv('LIZMAP_DATABASE_CHECK_RETRIES'));
+if ($retries == 0) {
+    $retries = 10;
+}
+
+// Try to connect to the postgresql database, and retries if it does not ready yet
+// we should wait after Postgresql to be sure the Lizmap installer could create
+// its table and so on.
+// Try with the default profile
+if (!checkAndWaitPostgresql($profilesConfig, 'default', $retries)) {
+    exit (1);
+}
+// try with the lizlog profile, it may be a different database.
+if (!checkAndWaitPostgresql($profilesConfig, 'lizlog', $retries)) {
+    exit (1);
+}
 
 
 


### PR DESCRIPTION
During the startup, especially for the first start when the installer is launched for the first time and SQL table should be created, the container should wait after the Postgresql server, before launching the installer.

If the profiles.ini.php is configured to use a Postgresql database, the container tries to connect to the database 10 times before returning an error.


Funded by 3Liz
