### PR TITLE
Fix: Ip into logs is not the real ip

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapLog.listener.php
+++ b/lizmap/modules/lizmap/classes/lizmapLog.listener.php
@@ -78,7 +78,7 @@ class lizmapLogListener extends jEventListener
 
             // Add IP if needed
             if ($logItem->getData('logIp')) {
-                $data['ip'] = $_SERVER['REMOTE_ADDR'];
+                $data['ip'] = jApp::coord()->request->getIP();
             }
 
             // Insert log


### PR DESCRIPTION
When Lizmap is behind a reverse proxy (this is often the case when running nginx + php-fpm), REMOTE_ADDR does not contain the user IP but the server IP.

We should use the method `jRequest::getIP()` which returns the real ip of the user.

Funded by 3Liz
