### PR TITLE
GH Action - Upgrade cypress action to 4.2.0

### DIFF
--- a/.github/workflows/e2e_tests_cypress.yml
+++ b/.github/workflows/e2e_tests_cypress.yml
@@ -63,7 +63,7 @@ jobs:
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests
       - name: Cypress run
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4.2.0
         with:
           browser: chrome
           headless: true
@@ -72,7 +72,7 @@ jobs:
           wait-on: http://localhost:8130
 
       - name: Save screenshots as artifacts if a test fails to ease debug
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.1
         if: failure()
         with:
           name: cypress-screenshots


### PR DESCRIPTION
I guess to remove all warnings and deprecation notices on GH Action, CF https://github.com/3liz/lizmap-web-client/actions/runs/3386817243

I'm curious why dependabot didn't detect this action... We were on a old version.

@nboisteault I took the opportunity to look for cypress as well, ok for you ?
