### PR TITLE
Fix form control properties allow null

### DIFF
--- a/lizmap/modules/lizmap/lib/Form/QgisFormControlProperties.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisFormControlProperties.php
@@ -36,6 +36,11 @@ class QgisFormControlProperties
     protected $attributes = array();
 
     /**
+     * @var array
+     */
+    protected $attributeLowerNames = array();
+
+    /**
      * @var bool
      */
     protected $editable = true;
@@ -93,6 +98,10 @@ class QgisFormControlProperties
         }
 
         $this->attributes = $attributes;
+
+        foreach (array_keys($attributes) as $name) {
+            $this->attributeLowerNames[strtolower($name)] = $name;
+        }
     }
 
     /**
@@ -127,6 +136,11 @@ class QgisFormControlProperties
     {
         if (isset($this->attributes[$attrName])) {
             return $this->attributes[$attrName];
+        }
+
+        $lowerName = strtolower($attrName);
+        if (isset($this->attributeLowerNames[$lowerName])) {
+            return $this->attributes[$this->attributeLowerNames[$lowerName]];
         }
 
         return null;

--- a/tests/units/classes/Form/QgisFormControlPropertiesTest.php
+++ b/tests/units/classes/Form/QgisFormControlPropertiesTest.php
@@ -1,0 +1,167 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Lizmap\Form\QgisFormControlProperties;
+
+require_once __DIR__.'/../../../../lizmap/vendor/jelix/jelix/lib/jelix/forms/jFormsBase.class.php';
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class QgisFormControlPropertiesTest extends TestCase
+{
+    function testIsEditable() {
+        # TextEdit - editable
+        $properties = new QgisFormControlProperties(
+            'id',
+            'TextEdit',
+            'input',
+            array(
+                'IsMultiline' => false,
+                'UseHtml' => false,
+                'Editable' => true
+            )
+        );
+        $this->assertTrue($properties->isEditable());
+
+        # TextEdit - not editable
+        $properties = new QgisFormControlProperties(
+            'id',
+            'TextEdit',
+            'input',
+            array(
+                'IsMultiline' => false,
+                'UseHtml' => false,
+                'Editable' => false
+            )
+        );
+        $this->assertFalse($properties->isEditable());
+
+        # TextEdit - field editable
+        $properties = new QgisFormControlProperties(
+            'id',
+            'TextEdit',
+            'input',
+            array(
+                'IsMultiline' => false,
+                'UseHtml' => false,
+                'fieldEditable' => true
+            )
+        );
+        $this->assertTrue($properties->isEditable());
+
+        # TextEdit - field not editable
+        $properties = new QgisFormControlProperties(
+            'id',
+            'TextEdit',
+            'input',
+            array(
+                'IsMultiline' => false,
+                'UseHtml' => false,
+                'fieldEditable' => false
+            )
+        );
+        $this->assertFalse($properties->isEditable());
+
+        # UniqueValues - editable
+        $properties = new QgisFormControlProperties(
+            'author',
+            'UniqueValues',
+            'input',
+            array(
+                'Editable' => true
+            )
+        );
+        $this->assertTrue($properties->isEditable());
+
+        # UniqueValues - not editable
+        $properties = new QgisFormControlProperties(
+            'author',
+            'UniqueValues',
+            'input',
+            array(
+                'Editable' => false
+            )
+        );
+        $this->assertFalse($properties->isEditable());
+
+        # ValueMap
+        $properties = new QgisFormControlProperties(
+            'checked',
+            'ValueMap',
+            'menulist',
+            array(
+                'valueMap' => array(
+                     'true' => 'Yes',
+                     'false' => 'No',
+                     '{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}' => '<NULL>',
+                ),
+                'Editable' => 1
+            )
+        );
+        $this->assertTrue($properties->isEditable());
+    }
+
+    function testGetValueRelationData() {
+
+        $properties = new QgisFormControlProperties(
+            'tram_id',
+            'ValueRelation',
+            'menulist',
+            array(
+                'AllowMulti' => false,
+                'AllowNull' => true,
+                'FilterExpression' => '',
+                'Key' => 'osm_id',
+                'Layer' => 'tramway20150328114206278',
+                'OrderByValue' => true,
+                'UseCompleter' => false,
+                'Value' => 'test',
+            )
+        );
+
+        $valueRelationData = $properties->getValueRelationData();
+        $this->assertTrue(is_array($valueRelationData));
+        $this->assertTrue($valueRelationData['allowNull']);
+        $this->assertTrue($valueRelationData['orderByValue']);
+        $this->assertEquals($valueRelationData['layer'], 'tramway20150328114206278');
+        $this->assertEquals($valueRelationData['layerName'], '');
+        $this->assertEquals($valueRelationData['key'], 'osm_id');
+        $this->assertEquals($valueRelationData['value'], 'test');
+        $this->assertFalse($valueRelationData['allowMulti']);
+        $this->assertEquals($valueRelationData['filterExpression'], '');
+        $this->assertFalse($valueRelationData['useCompleter']);
+        $this->assertTrue($valueRelationData['fieldEditable']);
+    }
+
+    function testGetRelationReference() {
+
+        $properties = new QgisFormControlProperties(
+            'risque',
+            'RelationReference',
+            'menulist',
+            array(
+                'AllowNull' => true,
+                'OrderByValue' => false,
+                'Relation' => 'tab_demand_risque_risque_66c_risque',
+                'MapIdentification' => false,
+                'ReferencedLayerName' => 'risque',
+                'ReferencedLayerId' => 'risque_66cb8d43_86b7_4583_9217_f7ead54463c3',
+            )
+        );
+
+        $relationReferenceData = $properties->getRelationReference();
+        $this->assertTrue(is_array($relationReferenceData));
+        $this->assertTrue($relationReferenceData['allowNull']);
+        $this->assertFalse($relationReferenceData['orderByValue']);
+        $this->assertEquals($relationReferenceData['relation'], 'tab_demand_risque_risque_66c_risque');
+        $this->assertFalse($relationReferenceData['mapIdentification']);
+        $this->assertTrue(is_array($relationReferenceData['filters']));
+        $this->assertCount(0, $relationReferenceData['filters']);
+        $this->assertEquals($relationReferenceData['filterExpression'], Null);
+        $this->assertFalse($relationReferenceData['chainFilters']);
+        $this->assertEquals($relationReferenceData['referencedLayerName'], 'risque');
+        $this->assertEquals($relationReferenceData['referencedLayerId'], 'risque_66cb8d43_86b7_4583_9217_f7ead54463c3');
+    }
+}

--- a/tests/units/classes/Form/QgisFormControlPropertiesTest.php
+++ b/tests/units/classes/Form/QgisFormControlPropertiesTest.php
@@ -103,6 +103,33 @@ class QgisFormControlPropertiesTest extends TestCase
         $this->assertTrue($properties->isEditable());
     }
 
+    function testGetEditAttribute() {
+
+        $properties = new QgisFormControlProperties(
+            'risque',
+            'RelationReference',
+            'menulist',
+            array(
+                'AllowNULL' => true,
+                'OrderByValue' => false,
+                'Relation' => 'tab_demand_risque_risque_66c_risque',
+                'MapIdentification' => false,
+                'ReferencedLayerName' => 'risque',
+                'ReferencedLayerId' => 'risque_66cb8d43_86b7_4583_9217_f7ead54463c3',
+            )
+        );
+
+        $this->assertTrue($properties->getEditAttribute('AllowNULL'));
+        $this->assertTrue($properties->getEditAttribute('AllowNull'));
+        $this->assertTrue($properties->getEditAttribute('allowNull'));
+        $this->assertTrue($properties->getEditAttribute('allownull'));
+
+        $this->assertEquals($properties->getEditAttribute('ReferencedLayerId'), 'risque_66cb8d43_86b7_4583_9217_f7ead54463c3');
+        $this->assertEquals($properties->getEditAttribute('referencedLayerId'), 'risque_66cb8d43_86b7_4583_9217_f7ead54463c3');
+        $this->assertEquals($properties->getEditAttribute('referencedLayerid'), 'risque_66cb8d43_86b7_4583_9217_f7ead54463c3');
+        $this->assertEquals($properties->getEditAttribute('referencedlayerid'), 'risque_66cb8d43_86b7_4583_9217_f7ead54463c3');
+    }
+
     function testGetValueRelationData() {
 
         $properties = new QgisFormControlProperties(
@@ -148,6 +175,36 @@ class QgisFormControlPropertiesTest extends TestCase
                 'MapIdentification' => false,
                 'ReferencedLayerName' => 'risque',
                 'ReferencedLayerId' => 'risque_66cb8d43_86b7_4583_9217_f7ead54463c3',
+            )
+        );
+
+        $relationReferenceData = $properties->getRelationReference();
+        $this->assertTrue(is_array($relationReferenceData));
+        $this->assertTrue($relationReferenceData['allowNull']);
+        $this->assertFalse($relationReferenceData['orderByValue']);
+        $this->assertEquals($relationReferenceData['relation'], 'tab_demand_risque_risque_66c_risque');
+        $this->assertFalse($relationReferenceData['mapIdentification']);
+        $this->assertTrue(is_array($relationReferenceData['filters']));
+        $this->assertCount(0, $relationReferenceData['filters']);
+        $this->assertEquals($relationReferenceData['filterExpression'], Null);
+        $this->assertFalse($relationReferenceData['chainFilters']);
+        $this->assertEquals($relationReferenceData['referencedLayerName'], 'risque');
+        $this->assertEquals($relationReferenceData['referencedLayerId'], 'risque_66cb8d43_86b7_4583_9217_f7ead54463c3');
+
+        # AllowNULL / not AllowNull
+        # referencedLayerName / not ReferencedLayerName
+        # referencedLayerId / not ReferencedLayerId
+        $properties = new QgisFormControlProperties(
+            'risque',
+            'RelationReference',
+            'menulist',
+            array(
+                'AllowNULL' => true,
+                'OrderByValue' => false,
+                'Relation' => 'tab_demand_risque_risque_66c_risque',
+                'MapIdentification' => false,
+                'referencedLayerName' => 'risque',
+                'referencedLayerId' => 'risque_66cb8d43_86b7_4583_9217_f7ead54463c3',
             )
         );
 

--- a/tests/units/classes/Project/QgisProjectTest.php
+++ b/tests/units/classes/Project/QgisProjectTest.php
@@ -656,7 +656,7 @@ class QgisProjectTest extends TestCase
         $prop = $props['type'];
         $this->assertEquals($prop->getFieldEditType(), 'Classification');
 
-        // DateTime widget
+        // ExternalResource widget
         $xmlStr = '
         <maplayer>
           <fieldConfiguration>
@@ -835,6 +835,77 @@ class QgisProjectTest extends TestCase
         $options = (object) $prop->getEditAttributes();
         $this->assertTrue(property_exists($options, 'FilterExpression'));
         $this->assertEquals($options->FilterExpression, 'intersects(@current_geometry , $geometry)');
+
+        // RelationReference widget
+        $xmlStr = '
+        <maplayer>
+          <fieldConfiguration>
+            <field configurationFlags="None" name="risque">
+              <editWidget type="RelationReference">
+                <config>
+                  <Option type="Map">
+                    <Option type="bool" value="false" name="AllowAddFeatures"/>
+                    <Option type="bool" value="true" name="AllowNULL"/>
+                    <Option type="bool" value="false" name="MapIdentification"/>
+                    <Option type="bool" value="false" name="OrderByValue"/>
+                    <Option type="bool" value="false" name="ReadOnly"/>
+                    <Option type="QString" value="service=lizmap sslmode=disable key=\'fid\' checkPrimaryKeyUnicity=\'0\' table=&quot;lizmap_data&quot;.&quot;risque&quot;" name="ReferencedLayerDataSource"/>
+                    <Option type="QString" value="risque_66cb8d43_86b7_4583_9217_f7ead54463c3" name="ReferencedLayerId"/>
+                    <Option type="QString" value="risque" name="ReferencedLayerName"/>
+                    <Option type="QString" value="postgres" name="ReferencedLayerProviderKey"/>
+                    <Option type="QString" value="tab_demand_risque_risque_66c_risque" name="Relation"/>
+                    <Option type="bool" value="false" name="ShowForm"/>
+                    <Option type="bool" value="true" name="ShowOpenFormButton"/>
+                  </Option>
+                </config>
+              </editWidget>
+            </field>
+          </fieldConfiguration>
+        </maplayer>
+        ';
+        $xml = simplexml_load_string($xmlStr);
+
+        $props = $testProj->getFieldConfigurationForTest($xml);
+        $this->assertTrue(is_array($props));
+        $this->assertCount(1, $props);
+        $this->assertTrue(array_key_exists('risque', $props));
+
+        $prop = $props['risque'];
+        $this->assertEquals($prop->getFieldEditType(), 'RelationReference');
+
+        $options = (object) $prop->getEditAttributes();
+        $this->assertTrue(property_exists($options, 'AllowNULL'));
+        $this->assertTrue($options->AllowNULL);
+        $this->assertTrue(property_exists($options, 'MapIdentification'));
+        $this->assertFalse($options->MapIdentification);
+        $this->assertTrue(property_exists($options, 'OrderByValue'));
+        $this->assertFalse($options->OrderByValue);
+        $this->assertTrue(property_exists($options, 'ReadOnly'));
+        $this->assertFalse($options->ReadOnly);
+        $this->assertTrue(property_exists($options, 'ReferencedLayerId'));
+        $this->assertEquals($options->ReferencedLayerId, 'risque_66cb8d43_86b7_4583_9217_f7ead54463c3');
+        $this->assertTrue(property_exists($options, 'ReferencedLayerName'));
+        $this->assertEquals($options->ReferencedLayerName, 'risque');
+        $this->assertTrue(property_exists($options, 'Relation'));
+        $this->assertEquals($options->Relation, 'tab_demand_risque_risque_66c_risque');
+        $this->assertTrue(property_exists($options, 'filters'));
+        $this->assertTrue(is_array($options->filters));
+        $this->assertCount(0, $options->filters);
+        $this->assertTrue(property_exists($options, 'chainFilters'));
+        $this->assertFalse($options->chainFilters);
+
+        $relationReferenceData = $prop->getRelationReference();
+        $this->assertTrue(is_array($relationReferenceData));
+        $this->assertTrue($relationReferenceData['allowNull']);
+        $this->assertFalse($relationReferenceData['orderByValue']);
+        $this->assertEquals($relationReferenceData['relation'], 'tab_demand_risque_risque_66c_risque');
+        $this->assertFalse($relationReferenceData['mapIdentification']);
+        $this->assertTrue(is_array($relationReferenceData['filters']));
+        $this->assertCount(0, $relationReferenceData['filters']);
+        $this->assertEquals($relationReferenceData['filterExpression'], Null);
+        $this->assertFalse($relationReferenceData['chainFilters']);
+        $this->assertEquals($relationReferenceData['referencedLayerName'], 'risque');
+        $this->assertEquals($relationReferenceData['referencedLayerId'], 'risque_66cb8d43_86b7_4583_9217_f7ead54463c3');
 
         // Range widget
         $xmlStr = '
@@ -1460,6 +1531,38 @@ class QgisProjectTest extends TestCase
         $props = $testProj->getFieldConfigurationForTest($xml);
         $this->assertTrue(array_key_exists('tram_id', $props));
         $this->assertEquals($props['tram_id']->getMarkup(), 'checkboxes');
+
+        // RelationReference widget
+        $xmlStr = '
+        <maplayer>
+          <fieldConfiguration>
+            <field configurationFlags="None" name="risque">
+              <editWidget type="RelationReference">
+                <config>
+                  <Option type="Map">
+                    <Option type="bool" value="false" name="AllowAddFeatures"/>
+                    <Option type="bool" value="true" name="AllowNULL"/>
+                    <Option type="bool" value="false" name="MapIdentification"/>
+                    <Option type="bool" value="false" name="OrderByValue"/>
+                    <Option type="bool" value="false" name="ReadOnly"/>
+                    <Option type="QString" value="service=lizmap sslmode=disable key=\'fid\' checkPrimaryKeyUnicity=\'0\' table=&quot;lizmap_data&quot;.&quot;risque&quot;" name="ReferencedLayerDataSource"/>
+                    <Option type="QString" value="risque_66cb8d43_86b7_4583_9217_f7ead54463c3" name="ReferencedLayerId"/>
+                    <Option type="QString" value="risque" name="ReferencedLayerName"/>
+                    <Option type="QString" value="postgres" name="ReferencedLayerProviderKey"/>
+                    <Option type="QString" value="tab_demand_risque_risque_66c_risque" name="Relation"/>
+                    <Option type="bool" value="false" name="ShowForm"/>
+                    <Option type="bool" value="true" name="ShowOpenFormButton"/>
+                  </Option>
+                </config>
+              </editWidget>
+            </field>
+          </fieldConfiguration>
+        </maplayer>
+        ';
+        $xml = simplexml_load_string($xmlStr);
+        $props = $testProj->getFieldConfigurationForTest($xml);
+        $this->assertTrue(array_key_exists('risque', $props));
+        $this->assertEquals($props['risque']->getMarkup(), 'menulist');
 
         // ValueMap widget
         $xmlStr = '


### PR DESCRIPTION
 [Bugfix] The QGIS Form Control Propertie names can change

For exemple the `AllowNull` option in QGIS `RelationReference` widget can be:

* `AllowNull`
* `allowNull`
* `AllowNULL`

We try to quickly fix it and add unit tests.

Funded by Cartophyl https://cartophyl.com/