### PR TITLE
[ci] php-stan github-action output fix

### DIFF
--- a/.github/workflows/php-stan.yml
+++ b/.github/workflows/php-stan.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Get composer cache directory
         id: get-composer-cache-dir
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "composer_cache_dir=$(composer config cache-files-dir)" >> $GITHUB_ENV
 
       - name: Setup PHP with tools
         uses: shivammathur/setup-php@v2
@@ -35,7 +35,7 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
-          path: ${{ steps.get-composer-cache-dir.outputs.dir }}
+          path: ${{ env.composer_cache_dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 


### PR DESCRIPTION
see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
 
Funded by 3Liz
 
