### PR TITLE
GH Action - Experiment cron for all release branches

### DIFF
--- a/.github/workflows/cron_e2e.yml
+++ b/.github/workflows/cron_e2e.yml
@@ -1,0 +1,29 @@
+name: "⏰ End2end"
+on:
+  workflow_dispatch:
+  schedule:
+    # Run every monday at 3:00
+    - cron:  '0 3 * * 1'
+
+jobs:
+  cron-e2e:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Branch master
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          event-type: run-e2e-branches
+          client-payload: '{"branch": "master"}'
+
+      - name: Branch 3.6
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          event-type: run-e2e-branches
+          client-payload: '{"branch": "release_3_6"}'
+
+      - name: Branch 3.5
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          event-type: run-e2e-branches
+          client-payload: '{"branch": "release_3_5"}'

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -5,21 +5,20 @@ on:
     branches:
       - master
       - release_3_*
-  schedule:
-    # Run every monday at 3:00
-    - cron:  '0 3 * * 1'
   workflow_dispatch:
+  repository_dispatch:
+    types: [ run-e2e-branches ]
 
 jobs:
   end2end:
     # The first condition is triggered when we set the new label
     # The second one when we update the PR with new commits without changing labels
-    # The third one when it's a cron job
+    # The third one when external workflow
     # The fourth one is for the manual button
     if: |
       github.event.label.name == 'run end2end' ||
       contains(github.event.pull_request.labels.*.name, 'run end2end') ||
-      github.event_name == 'schedule' ||
+      github.event_name == 'repository_dispatch' ||
       github.event_name == 'workflow_dispatch'
     name: "End-to-end"
     runs-on: ubuntu-latest
@@ -29,8 +28,25 @@ jobs:
     env:
       CYPRESS_CI: TRUE
     steps:
+
+      - name: Define branch name
+        working-directory: .
+        run: |
+          if ${{ github.event_name == 'repository_dispatch' }}
+          then
+            echo "Set branch from manual input: ${{ github.event.client_payload.branch }}"
+            BRANCH="${{ github.event.client_payload.branch }}"
+          else
+            echo "Set branch from default value : ${{ github.head_ref || github.ref_name }} "
+            BRANCH="${{ github.head_ref || github.ref_name }} "
+          fi
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${BRANCH}
+          token: ${{ secrets.BOT_HUB_TOKEN }}  # Important to launch CI on a commit from a bot
 
       - name: Branch name
         run: echo running on branch ${GITHUB_REF##*/} with ${CYPRESS_CI}


### PR DESCRIPTION
Before, we could only run E2E on the default branch of GH, aka master.
Now, we are able to run E2E on master, release 3.6 and release 3.5.

Funded by 3Liz

@nboisteault Ok for you ?
