### PR TITLE
Container does not start with non-standard UID/GID - attempt to fix #3370

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,8 @@ RUN apk update && apk upgrade && \
     php8-xmlreader \
     php8-xmlwriter \
     php8-zip \
-    composer
+    composer \
+    shadow
 
 COPY --from=build /lizmap_web_client /www
 ## Rename original config files so that they wont be overriden at startup

--- a/docker/lizmap-entrypoint.sh
+++ b/docker/lizmap-entrypoint.sh
@@ -26,10 +26,10 @@ if [ "$CURRENT_USER_ID" == "0" ]; then
   USERID=$(id -u $LIZMAP_USER)
 
   if [ "$LIZMAP_GROUP_ID" != "$GROUPID" ]; then
-     groupmod -g $APP_GROUP_ID $LIZMAP_GROUP
+     groupmod -g $LIZMAP_GROUP_ID $LIZMAP_GROUP
   fi
   if [ "$LIZMAP_USER_ID" != "$USERID" ]; then
-     usermod -u $APP_USER_ID $LIZMAP_USER
+     usermod -u $LIZMAP_USER_ID $LIZMAP_USER
   fi
 fi
 


### PR DESCRIPTION
This is an attempt to fix #3370 

Updating to 3.6.0 when using a non-standard (not 1000) UID and GID, the container does not start.
I also tried this on a clean stack.

The first error I'm getting is:

`/bin/lizmap-entrypoint.sh: line 29: groupmod: not found`

lizmap-entrypoint.sh is calling, in some cases, for `groupmod` and `usermod`, which are not installed in the base image used. Those can be installed with the package `shadow`.

Once they are installed, I'm getting a different error:

`groupmod: invalid group ID 'groupphp'`

I assume, and this is a long shot, that this is due to a typo in the entrypoint, which refers to APP_GROUP_ID and APP_USER_ID instead of LIZMAP_GROUP_ID and LIZMAP_USER_ID

Those two variables should be empty, and as such the command that runs is `groupmod -g groupphp`, which fits the error.

I hope that this can help, otherwise feel free to disregard.

Thank you!