### PR TITLE
add lizmap version to proxy request

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapServices.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapServices.class.php
@@ -281,14 +281,15 @@ class lizmapServices
             $this->allowUserAccountRequests = false;
         }
 
-        // set it for external requests, needed for file_get_contents
-        $userAgent = 'Lizmap';
+        $appInfos = \Jelix\Core\Infos\AppInfos::load();
+        // set user_agent for external requests, needed for file_get_contents
+        $userAgent = 'Lizmap '.$appInfos->version;
         if (isset($readConfigPath['services']['userAgent'])) {
             // may be set to false if already set in the php.ini
             $userAgent = $readConfigPath['services']['userAgent'];
         }
-        if ($userAgent) {
-            ini_set('user_agent', 'Lizmap');
+        if ($userAgent && !ini_get('user_agent')) {
+            ini_set('user_agent', $userAgent);
         }
     }
 
@@ -323,7 +324,7 @@ class lizmapServices
     {
         if (isset($this->data['hideSensitiveServicesProperties'])
           && $this->data['hideSensitiveServicesProperties'] != '0'
-      ) {
+        ) {
             return true;
         }
 

--- a/lizmap/modules/lizmap/classes/lizmapServices.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapServices.class.php
@@ -281,12 +281,14 @@ class lizmapServices
             $this->allowUserAccountRequests = false;
         }
 
-        $appInfos = \Jelix\Core\Infos\AppInfos::load();
         // set user_agent for external requests, needed for file_get_contents
-        $userAgent = 'Lizmap '.$appInfos->version;
         if (isset($readConfigPath['services']['userAgent'])) {
             // may be set to false if already set in the php.ini
             $userAgent = $readConfigPath['services']['userAgent'];
+        } elseif (property_exists($globalConfig, 'lizmap')) {
+            $userAgent = $globalConfig->lizmap['version'];
+        } else {
+            $userAgent = 'lizmap';
         }
         if ($userAgent && !ini_get('user_agent')) {
             ini_set('user_agent', $userAgent);

--- a/lizmap/modules/lizmap/lib/Request/Proxy.php
+++ b/lizmap/modules/lizmap/lib/Request/Proxy.php
@@ -298,7 +298,7 @@ class Proxy
 
         $options['headers'] = array_merge(array(
             'Connection' => 'close',
-            'User-Agent' => ini_get('user_agent') ?: 'Lizmap',
+            'User-Agent' => ini_get('user_agent'),
             'Accept' => '*/*',
         ), $options['headers']);
 

--- a/lizmap/plugins/configcompiler/lizmapconfig/lizmapconfig.configcompiler.php
+++ b/lizmap/plugins/configcompiler/lizmapconfig/lizmapconfig.configcompiler.php
@@ -27,6 +27,13 @@ class lizmapconfigConfigCompilerPlugin implements \jelix\core\ConfigCompilerPlug
 
     public function onModule($config, $moduleName, $modulePath, $xml)
     {
+        if ($moduleName == 'lizmap') {
+            // we store the version into the configuration file, it avoids
+            // to read it from the project.xml file, as it is an heavy process.
+            if (property_exists($config, 'lizmap')) {
+                $config->lizmap['version'] = (string) $xml->info->version;
+            }
+        }
     }
 
     public function atEnd($config)

--- a/tests/units/bootstrap.php
+++ b/tests/units/bootstrap.php
@@ -9,8 +9,10 @@ spl_autoload_register(function($class) {
     }
 });
 
-
-
+// set user_agent with Lizmap Version
+$appInfos = \Jelix\Core\Infos\AppInfos::load();
+$userAgent = 'Lizmap '.$appInfos->version; 
+ini_set('user_agent', $userAgent); 
 
 jApp::setEnv('lizmaptests');
 if (file_exists(jApp::tempPath())) {

--- a/tests/units/classes/Project/ProjectTest.php
+++ b/tests/units/classes/Project/ProjectTest.php
@@ -84,7 +84,7 @@ class ProjectTest extends TestCase
             array('services' =>
                       array('relativeWMSPath' => $relative,
                             'rootRepositories' => $root)
-            ), null, false, null, null);
+            ), (object) array(), false, null, null);
         $proj = new ProjectForTests();
         $proj->setRepo(new Project\Repository(null, array('path' => ''), null, null, null));
         $proj->setServices($services);

--- a/tests/units/classes/lizmapServicesTest.php
+++ b/tests/units/classes/lizmapServicesTest.php
@@ -253,7 +253,7 @@ class lizmapServicesTest extends TestCase
      */
     public function testModifyLocal($localConfig, $newConfig, $changedProperty, $changedValue, $expectedReturnValue)
     {
-        $testLizmapServices = new LizmapServices($localConfig, null, false, '', null);
+        $testLizmapServices = new LizmapServices($localConfig, (object) array(), false, '', null);
         $this->assertEquals($expectedReturnValue, $testLizmapServices->modify($newConfig));
         if (isset($changedProperty)) {
             $this->assertEquals($changedValue, $testLizmapServices->{$changedProperty});
@@ -327,7 +327,8 @@ class lizmapServicesTest extends TestCase
             array('hideSensitiveServicesProperties' => $hide),
             (object) array(
                 'lizmap' => [
-                    'setAdminContactEmailAsReplyTo' => false
+                    'setAdminContactEmailAsReplyTo' => false,
+                    'version' => 'unit-test-3'
                 ]
             ),
             false, '', null);
@@ -445,8 +446,8 @@ class lizmapServicesTest extends TestCase
     public function testGetMetricsEnabled($testValue, $expectedValue)
     {
         $ini_tab = array('hideSensitiveServicesProperties' => '0',
-                         'services' => array(
-                             'appName' => 'Lizmap' ),
+            'services' => array(
+                'appName' => 'Lizmap', ),
         );
 
         if ($testValue !== null) {

--- a/tests/units/testslib/QgisProjectForTests.php
+++ b/tests/units/testslib/QgisProjectForTests.php
@@ -7,7 +7,7 @@ class QgisProjectForTests extends QgisProject
     public function __construct($data = null)
     {
         if ($data) {
-            parent::__construct(null, new lizmapServices(null, null, false, '', ''), new ContextForTests(), $data);
+            parent::__construct(null, new lizmapServices(null, (object) array(), false, '', ''), new ContextForTests(), $data);
         }
     }
 


### PR DESCRIPTION
Proxy Request currently use "Lizmap" as user-agent in request header, that can be usefull for OGC service

the PR add the current lizmap Version



Fix : #2044

Funded by 3liz
