### PR TITLE
Dataviz - Allow to post a JSON plot config to get the plot

### DIFF
--- a/lizmap/modules/dataviz/classes/datavizConfig.class.php
+++ b/lizmap/modules/dataviz/classes/datavizConfig.class.php
@@ -18,40 +18,48 @@ class datavizConfig
     public function __construct($repository, $project)
     {
         try {
-            $lproj = lizmap::getProject($repository.'~'.$project);
-            if (!$lproj) {
+            $lizmapProject = lizmap::getProject($repository.'~'.$project);
+            if (!$lizmapProject) {
                 $this->errors = array(
-                    'title' => 'Invalid Query Parameter',
-                    'detail' => 'The lizmap project '.strtoupper($project).' does not exist !',
+                    'code' => 404,
+                    'error_code' => 'project_not_found',
+                    'title' => jLocale::get('dataviz~dataviz.log.project_not_found.title'),
+                    'detail' => jLocale::get('dataviz~dataviz.log.project_not_found.detail', array($project)),
                 );
 
                 return;
             }
         } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
             $this->errors = array(
-                'title' => 'Invalid Query Parameter',
-                'detail' => 'The lizmap project '.strtoupper($project).' does not exist !',
+                'code' => 404,
+                'error_code' => 'project_not_found',
+                'title' => jLocale::get('dataviz~dataviz.log.project_not_found.title'),
+                'detail' => jLocale::get('dataviz~dataviz.log.project_not_found.detail', array($project)),
             );
 
             return;
         }
 
         // Check acl
-        if (!$lproj->checkAcl()) {
+        if (!$lizmapProject->checkAcl()) {
             $this->errors = array(
-                'title' => 'Access Denied',
-                'detail' => jLocale::get('view~default.repository.access.denied'),
+                'code' => 403,
+                'error_code' => 'access_denied',
+                'title' => jLocale::get('dataviz~dataviz.log.access_denied.title'),
+                'detail' => jLocale::get('dataviz~dataviz.log.access_denied.detail'),
             );
 
             return;
         }
 
         // Get config
-        $datavizConfig = $lproj->getDatavizLayersConfig();
+        $datavizConfig = $lizmapProject->getDatavizLayersConfig();
         if (!$datavizConfig) {
             $this->errors = array(
-                'title' => 'Dataviz Configuration not found',
-                'detail' => 'No dataviz configuration has been found for this project',
+                'code' => 404,
+                'error_code' => 'no_configuration',
+                'title' => jLocale::get('dataviz~dataviz.log.no_configuration.title'),
+                'detail' => jLocale::get('dataviz~dataviz.log.no_configuration.detail'),
             );
 
             return;
@@ -59,8 +67,10 @@ class datavizConfig
 
         if (empty($datavizConfig['layers'])) {
             $this->errors = array(
-                'title' => 'Dataviz Configuration: empty layers',
-                'detail' => 'No layers dataviz configuration has been found for this project',
+                'code' => 404,
+                'error_code' => 'no_layers',
+                'title' => jLocale::get('dataviz~dataviz.log.no_layers.title'),
+                'detail' => jLocale::get('dataviz~dataviz.log.no_layers.detail'),
             );
 
             return;

--- a/lizmap/modules/dataviz/classes/datavizPlot.class.php
+++ b/lizmap/modules/dataviz/classes/datavizPlot.class.php
@@ -83,7 +83,9 @@ class datavizPlot
         // Get main dataviz config
         $dv = new datavizConfig($repository, $project);
         $config = $dv->getConfig();
-        $this->theme = $config['dataviz']['theme'];
+        if ($config && array_key_exists('theme', $config)) {
+            $this->theme = $config['dataviz']['theme'];
+        }
 
         // Parse plot config
         $this->parsePlotConfig($plotConfig);
@@ -169,7 +171,7 @@ class datavizPlot
             }
         }
 
-        // Optionnal layout additionnal options (legacy code)
+        // Optional layout additional options (legacy code)
         if (array_key_exists('layout_config', $plotConfig['plot'])) {
             $this->layout = $plotConfig['plot']['layout_config'];
         }

--- a/lizmap/modules/dataviz/controllers/service.classic.php
+++ b/lizmap/modules/dataviz/controllers/service.classic.php
@@ -22,9 +22,24 @@ class serviceCtrl extends jController
     private $project;
 
     /**
+     * @var null|Lizmap\Project\Project the Lizmap project
+     */
+    private $lizmapProject;
+
+    /**
      * @var datavizConfig
      */
     private $config;
+
+    /**
+     * @var bool If the basic authentication is used
+     */
+    private $basicAuthUsed = false;
+
+    /**
+     * @var bool Debug mode
+     */
+    private $debugMode;
 
     /**
      * Redirect to the appropriate action depending on the REQUEST parameter.
@@ -37,19 +52,110 @@ class serviceCtrl extends jController
      */
     public function index()
     {
+        // Get the debug mode status
+        $services = lizmap::getServices();
+        $this->debugMode = $services->debugMode;
+
         // Check project
         $repository = $this->param('repository');
         $project = $this->param('project');
+        $plotConfigParameter = $this->param('plot_config');
 
-        // Check dataviz config
-        jClasses::inc('dataviz~datavizConfig');
-        $dv = new datavizConfig($repository, $project);
-        if (!$dv->getStatus()) {
-            return $this->error($dv->getErrors());
+        if ($this->debugMode == '1') {
+            \jLog::log('Dataviz - parameter repository  = '.$repository);
+            \jLog::log('Dataviz - parameter project     = '.$project);
         }
-        $config = $dv->getConfig();
-        if (empty($config)) {
-            return $this->error($dv->getErrors());
+
+        // Connect from auth basic if necessary
+        if (isset($_SERVER['PHP_AUTH_USER'])) {
+            $ok = jAuth::login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
+            if (!$ok) {
+                return $this->error(
+                    array(
+                        'code' => 403,
+                        'error_code' => 'wrong_credentials',
+                        'title' => jLocale::get('dataviz~dataviz.log.wrong_credentials.title'),
+                        'detail' => jLocale::get('dataviz~dataviz.log.wrong_credentials.detail'),
+                    )
+                );
+            }
+            $this->basicAuthUsed = true;
+        }
+
+        if ($this->debugMode == '1') {
+            \jLog::log('Dataviz - basic authentication  = '.json_encode($this->basicAuthUsed));
+        }
+
+        // Check the repository exists
+        $lizmapRepository = lizmap::getRepository($repository);
+        if (!$lizmapRepository) {
+            return $this->error(
+                array(
+                    'code' => 404,
+                    'error_code' => 'repository_not_found',
+                    'title' => jLocale::get('dataviz~dataviz.log.repository_not_found.title'),
+                    'detail' => jLocale::get('dataviz~dataviz.log.repository_not_found.detail', array($repository)),
+                )
+            );
+        }
+
+        // Check project
+        try {
+            $lizmapProject = lizmap::getProject($repository.'~'.$project);
+            if (!$lizmapProject) {
+                return $this->error(
+                    array(
+                        'code' => 404,
+                        'error_code' => 'project_not_found',
+                        'title' => jLocale::get('dataviz~dataviz.log.project_not_found.title'),
+                        'detail' => jLocale::get('dataviz~dataviz.log.project_not_found.detail', array($project)),
+                    )
+                );
+            }
+        } catch (\Lizmap\Project\UnknownLizmapProjectException $e) {
+            return $this->error(
+                array(
+                    'code' => 404,
+                    'error_code' => 'project_not_found',
+                    'title' => jLocale::get('dataviz~dataviz.log.project_not_found.title'),
+                    'detail' => jLocale::get('dataviz~dataviz.log.project_not_found.detail', array($project)),
+                )
+            );
+        }
+        $this->lizmapProject = $lizmapProject;
+
+        // Redirect if no rights to access this repository
+        if (!$lizmapProject->checkAcl()) {
+            return $this->error(
+                array(
+                    'code' => 403,
+                    'error_code' => 'access_denied',
+                    'title' => jLocale::get('dataviz~dataviz.log.access_denied.title'),
+                    'detail' => jLocale::get('dataviz~dataviz.log.access_denied.detail'),
+                )
+            );
+        }
+
+        // Check dataviz config only for plots configured for this project layers
+        // If a plot_config is given and basic authentication is used for the connected user,
+        // do not raise an error, as the dataviz configuration might be empty
+        jClasses::inc('dataviz~datavizConfig');
+        $datavizConfig = new datavizConfig($repository, $project);
+        if (empty($plotConfigParameter) && !$this->basicAuthUsed) {
+            if (!$datavizConfig->getStatus()) {
+                return $this->error(
+                    $datavizConfig->getErrors(),
+                );
+            }
+        }
+        // Get the content of dataviz configuration
+        $config = $datavizConfig->getConfig();
+
+        // Do not report errors also for dataviz API if there is an empty configuration
+        if (empty($config) && empty($plotConfigParameter) && !$this->basicAuthUsed) {
+            return $this->error(
+                $datavizConfig->getErrors(),
+            );
         }
         $this->repository = $repository;
         $this->project = $project;
@@ -63,8 +169,10 @@ class serviceCtrl extends jController
 
         return $this->error(
             array(
-                'title' => 'Not supported request',
-                'detail' => 'The request "'.$request.'" is not supported!',
+                'code' => 400,
+                'error_code' => 'request_not_supported',
+                'title' => jLocale::get('dataviz~dataviz.log.request_not_supported.title'),
+                'detail' => jLocale::get('dataviz~dataviz.log.request_not_supported.detail', array($request)),
             )
         );
     }
@@ -80,6 +188,15 @@ class serviceCtrl extends jController
     {
         /** @var jResponseJson $rep */
         $rep = $this->getResponse('json');
+
+        // HTTP status code
+        if (array_key_exists('code', $errors)) {
+            $code = (int) $errors['code'];
+            $rep->setHttpStatus(
+                $code,
+                \Lizmap\Request\Proxy::getHttpStatusMsg($code)
+            );
+        }
         $rep->data = array('errors' => $errors);
 
         return $rep;
@@ -97,18 +214,81 @@ class serviceCtrl extends jController
         $project = $this->project;
         $plot_id = $this->intParam('plot_id');
         $exp_filter = trim((string) $this->param('exp_filter'));
-        $color = null;
-        $color2 = null;
-        $layout = null;
+        $plotConfigParameter = $this->param('plot_config');
 
-        // Fins layer by id
-        if (array_key_exists($plot_id, $this->config['layers'])) {
+        if ($this->debugMode == '1') {
+            \jLog::log('Dataviz - parameter plot_id     = '.$plot_id);
+            \jLog::log('Dataviz - parameter exp_filter  = '.$exp_filter);
+            $logPlotConfigParameter = $plotConfigParameter;
+            if (is_array($plotConfigParameter)) {
+                $logPlotConfigParameter = json_encode($plotConfigParameter);
+            }
+            \jLog::log('Dataviz - parameter plot_config = '.$logPlotConfigParameter);
+        }
+
+        /** @var jResponseJson $rep */
+        $rep = $this->getResponse('json');
+
+        // Get the plot configuration from Lizmap config file
+        $plotConfig = null;
+        if ($this->config !== null && array_key_exists($plot_id, $this->config['layers'])) {
             $plotConfig = $this->config['layers'][$plot_id];
-        } else {
+            if ($this->debugMode == '1') {
+                \jLog::log('Dataviz - a plot configuration exists for this plot_id = '.$plot_id);
+            }
+        }
+
+        // Get the configuration from the parameter
+        // This allow to test the plot from outside LWC
+        // For example from the QGIS Lizmap plugin
+        // Only if basic authentication has been used*
+        if (!empty($plotConfigParameter) && !is_array($plotConfigParameter)) {
+            // Convert the given string to a PHP array if needed
+            if ($this->debugMode == '1') {
+                \jLog::log('Dataviz - the given plot_config must be converted to an Array');
+            }
+            $plotConfigParameter = json_decode($plotConfigParameter, true);
+        }
+        if (!empty($plotConfigParameter) && $this->basicAuthUsed && \jAuth::isConnected()) {
+            if ($this->debugMode == '1') {
+                \jLog::log('Dataviz - parameter plot_config is not empty & basic authentication is used');
+            }
+
+            // Transform back to object
+            $configObject = json_decode(json_encode($plotConfigParameter), false);
+
+            // Parse the plot configuration
+            $parsedPlotConfig = $this->lizmapProject->parseDatavizPlotConfig($configObject);
+            if (!empty($parsedPlotConfig)) {
+                $plotConfig = $parsedPlotConfig;
+                if ($this->debugMode == '1') {
+                    \jLog::log('Dataviz - plot_config is used to override the original plot configuration');
+                }
+            } else {
+                if (property_exists($configObject, 'layerId')) {
+                    $getLayer = $this->lizmapProject->findLayerByAnyName($configObject->layerId);
+                    if (!$getLayer) {
+                        return $this->error(
+                            array(
+                                'code' => 404,
+                                'error_code' => 'layer_not_found',
+                                'title' => jLocale::get('dataviz~dataviz.log.layer_not_found.title'),
+                                'detail' => jLocale::get('dataviz~dataviz.log.layer_not_found.detail', array($configObject->layerId)),
+                            )
+                        );
+                    }
+                }
+            }
+        }
+
+        // No valid configuration found, return the corresponding error
+        if (!$plotConfig) {
             return $this->error(
                 array(
-                    'title' => 'No corresponding plot',
-                    'detail' => 'No plot could be created for this request',
+                    'code' => 404,
+                    'error_code' => 'plot_configuration_not_found',
+                    'title' => jLocale::get('dataviz~dataviz.log.plot_configuration_not_found.title'),
+                    'detail' => jLocale::get('dataviz~dataviz.log.plot_configuration_not_found.detail'),
                 )
             );
         }
@@ -141,8 +321,10 @@ class serviceCtrl extends jController
         if (!$dplot) {
             return $this->error(
                 array(
-                    'title' => 'No corresponding plot',
-                    'detail' => 'No plot could be created for this request',
+                    'code' => 400,
+                    'error_code' => 'invalid_plot_type',
+                    'title' => jLocale::get('dataviz~dataviz.log.invalid_plot_type.title'),
+                    'detail' => jLocale::get('dataviz~dataviz.log.invalid_plot_type.detail', array($type)),
                 )
             );
         }
@@ -151,8 +333,10 @@ class serviceCtrl extends jController
         if (!$fd) {
             return $this->error(
                 array(
-                    'title' => 'Fetching plot data failed',
-                    'detail' => 'No data could be fetched for this request',
+                    'code' => 404,
+                    'error_code' => 'no_data',
+                    'title' => jLocale::get('dataviz~dataviz.log.no_data.title'),
+                    'detail' => jLocale::get('dataviz~dataviz.log.no_data.detail', array($plotConfig['layer_id'])),
                 )
             );
         }
@@ -162,8 +346,15 @@ class serviceCtrl extends jController
             'layout' => $dplot->getLayout(),
         );
 
-        /** @var jResponseJson $rep */
-        $rep = $this->getResponse('json');
+        // We also add the URL to access the Plotly JavaScript file
+        // to let the client use the same one
+        $basePath = jApp::config()->urlengine['basePath'];
+        $locale = substr(jApp::config()->locale, 0, 2);
+        $plot['plotly'] = array(
+            'script' => $basePath.'assets/js/dataviz/plotly-latest.min.js',
+            'locale' => $basePath.'assets/js/dataviz/plotly-locale-'.$locale.'-latest.js',
+        );
+
         $rep->data = $plot;
 
         return $rep;

--- a/lizmap/modules/dataviz/locales/en_US/dataviz.UTF-8.properties
+++ b/lizmap/modules/dataviz/locales/en_US/dataviz.UTF-8.properties
@@ -1,2 +1,25 @@
 dock.title=Dataviz
 dock.subtitle=Dataviz
+
+log.no_configuration.title=No dataviz configuration
+log.no_configuration.title=There is no dataviz configuration for this project yet.
+log.no_layers.title=Dataviz layers is empty
+log.no_layers.detail=The table of layers inside the dataviz configuration is empty.
+log.wrong_credentials.title=Wrong credentials
+log.wrong_credentials.detail=The given login and password are incorrect. Cannot authenticate.
+log.access_denied.title=Access denied
+log.access_denied.detail=You have no right to access this ressource. Have you used the right login ?
+log.repository_not_found.title=Lizmap repository not found
+log.repository_not_found.detail=The Lizmap repository %s does not exist or is not available.
+log.project_not_found.title=Lizmap project not found
+log.project_not_found.detail=The Lizmap project %s does not exist or is not available.
+log.request_not_supported.title=Request is not supported
+log.request_not_supported.detail=The given request %s is not supported by Lizmap dataviz API.
+log.layer_not_found.title=Layer not found
+log.layer_not_found.detail=The layer with the given id %s cannot be found in the published QGIS project.
+log.plot_configuration_not_found.title=Plot configuration not found
+log.plot_configuration_not_found.detail=The plot configuration cannot be found or parsed by Lizmap dataviz API.
+log.invalid_plot_type.title=Invalid plot type
+log.invalid_plot_type.detail=The given plot type %s is invalid.
+log.no_data.title=Plot data not available
+log.no_data.detail=The plot source data cannot be fetched from the vector layer %s.

--- a/lizmap/modules/lizmap/lib/Server/Server.php
+++ b/lizmap/modules/lizmap/lib/Server/Server.php
@@ -123,6 +123,15 @@ class Server
             $data['hosting'] = \jApp::config()->lizmap['hosting'];
         }
 
+        // Add information about available APIs
+        $data['api'] = array(
+            'dataviz' => array(
+                // Version of the dataviz API
+                // (allowing to get a plot data by posting the configuration)
+                'version' => '1.0.0',
+            ),
+        );
+
         return $data;
     }
 

--- a/tests/end2end/cypress/integration/dataviz-ghaction.js
+++ b/tests/end2end/cypress/integration/dataviz-ghaction.js
@@ -254,4 +254,98 @@ describe('Dataviz tests', function () {
         })
     })
 
+    it('Test the dataviz API as admin with basic auth to create a new plot', function () {
+        let json_body = {
+            "repository": "testsrepository",
+            "project": "dataviz",
+            "plot_config": {
+                "type": "bar",
+                "title": "Bakeries by district",
+                "layerId": "bakeries_1dbdac14_931c_4568_ad56_3a947a77d810",
+                "x_field": "polygons_name",
+                "aggregation": "count",
+                "traces": [
+                    {
+                        "color": "cyan",
+                        "colorfield": "",
+                        "y_field": "id",
+                        "z_field": ""
+                    }
+                ],
+                "popup_display_child_plot": "False",
+                "stacked": "False",
+                "horizontal": "False",
+                "only_show_child": "False",
+                "display_legend": "True",
+                "display_when_layer_visible": "False",
+                "order": 5
+            }
+        };
+
+        cy.request({
+            method: 'POST',
+            url: '/index.php/dataviz/service?',
+            headers:{
+                authorization:'Basic YWRtaW46YWRtaW4=',
+            },
+            json: true,
+            body: json_body
+        }).then((resp) => {
+            expect(resp.status).to.eq(200)
+            expect(resp.headers['content-type']).to.contain('application/json')
+            expect(resp.body).to.have.property('title', 'Bakeries by district')
+            expect(resp.body).to.have.property('data')
+            expect(resp.body.data).to.have.length(1)
+            expect(resp.body.data[0]).to.have.property('type', 'bar')
+            expect(resp.body.data[0].marker).to.have.property('color', 'cyan')
+            expect(resp.body.data[0].transforms[0].aggregations[0]).to.have.property('func', 'count')
+        })
+    })
+
+    it('Test the dataviz API as admin with a wrong layer id', function () {
+        let json_body = {
+            "repository": "testsrepository",
+            "project": "dataviz",
+            "plot_config": {
+                "type": "bar",
+                "title": "Bakeries by district",
+                "layerId": "bakeries_1dbdac14_931c_4568_ad56_3a947a77d810_WRONG_LAYER_ID",
+                "x_field": "polygons_name",
+                "aggregation": "count",
+                "traces": [
+                    {
+                        "color": "cyan",
+                        "colorfield": "",
+                        "y_field": "id",
+                        "z_field": ""
+                    }
+                ],
+                "popup_display_child_plot": "False",
+                "stacked": "False",
+                "horizontal": "False",
+                "only_show_child": "False",
+                "display_legend": "True",
+                "display_when_layer_visible": "False",
+                "order": 5
+            }
+        };
+
+        cy.request({
+            method: 'POST',
+            url: '/index.php/dataviz/service?',
+            headers:{
+                authorization:'Basic YWRtaW46YWRtaW4=',
+            },
+            json: true,
+            body: json_body,
+            failOnStatusCode: false
+        }).then((resp) => {
+            expect(resp.status).to.eq(404)
+            expect(resp.headers['content-type']).to.contain('application/json')
+            expect(resp.body).to.have.property('errors')
+            expect(resp.body.errors).to.have.property('code', 404)
+            expect(resp.body.errors).to.have.property('error_code', 'layer_not_found')
+        })
+    })
+
 })


### PR DESCRIPTION
When you configure a plot in QGIS Lizmap plugin, you cannot yet test how the plot will be rendered. 
This modification allows any client, like a Python script, to use the Lizmap Web Client `dataviz` service as an API.

This API is only available for authenticated users. You can at present only use **Basic authentication**.

The client is able to request Lizmap Web Client and get the plot data ready to be directly used with the Plotly JavaScript or Python library.

If LWC main URL is `http://lizmap.local:8130/` The **URL** of the dataviz API is : `http://lizmap.local:8130/index.php/dataviz/service?`

The preferred request method is **POST**, and the data should be sent in the body as a JSON object, 
with the keys `repository` (Lizmap repository code), `project` (the Lizmap project code) 
and the plot configuration in `plot_config`. Here is an example of JSON file `plot_config.json` :

```json
{
    "repository": "testsrepository",
    "project": "dataviz",
    "plot_config": {
        "type": "bar",
        "title": "Communes",
        "layerId": "polygons_1e227060_6105_4a4a_92f2_11863ebe65f1",
        "x_field": "name",
        "aggregation": "sum",
        "traces": [
            {
                "color": "cyan",
                "colorfield": "",
                "y_field": "id",
                "z_field": ""
            }
        ],
        "popup_display_child_plot": "False",
        "stacked": "False",
        "horizontal": "False",
        "only_show_child": "False",
        "display_legend": "True",
        "display_when_layer_visible": "False",
        "order": 0
    }
}
```

You can use `curl`, Python request or any other request library to send the data and get the plot as the response.
For example with curl

```bash
curl --verbose -X POST \
     -H 'Content-Type: application/json' \
     --user admin:admin \
     -d @plot_config.json \
     "http://lizmap.local:8130/index.php/dataviz/service?"
```

The API returns a JSON response, which can be used in a Web viewer with the necessary HTML/JavaScript code using the Plotly library:

```json
{
  "title": "Communes",
  "data": [
    {
      "type": "bar",
      "name": "id",
      "y": [
        0,
        1,
        2,
        3,
        4,
        5,
        6,
        7,
        8,
        9
      ],
      "x": [
        "Grabels",
        "Clapiers",
        "Montferrier-sur-Lez",
        "Saint-Jean-de-Védas",
        "Lattes",
        "Montpellier",
        "Lavérune",
        "Juvignac",
        "Le Crès",
        "Castelnau-le-Lez"
      ],
      "ids": null,
      "text": [],
      "marker": {
        "color": "cyan",
        "colorscale": null,
        "showscale": false,
        "reversescale": false,
        "colorbar": {
          "len": "0.8"
        },
        "line": {
          "color": null,
          "width": null
        }
      },
      "textinfo": "none",
      "orientation": "v",
      "transforms": [
        {
          "type": "aggregate",
          "groups": "x",
          "aggregations": [
            {
              "target": "y",
              "func": "sum",
              "enabled": true
            }
          ]
        }
      ]
    }
  ],
  "layout": {
    "showlegend": true,
    "legend": {
      "orientation": "h",
      "x": "-0.1",
      "y": "1.15"
    },
    "autosize": true,
    "plot_bgcolor": "rgba(0,0,0,0)",
    "paper_bgcolor": "rgba(0,0,0,0)",
    "margin": {
      "t": 10,
      "b": 30,
      "l": 30,
      "r": 30,
      "pad": 1
    },
    "xaxis": {
      "tickfont": {
        "size": 10
      },
      "automargin": true
    },
    "yaxis": {
      "tickfont": {
        "size": 10
      },
      "automargin": true
    }
  }
}
```

Here is a very simple Python script illustrating the possible usage 
(you need to have the variable `plot_json` set with the data coming from the API):

```python
# Plot data returned by the API
plot_json = {}

# plot configuration
plot_config = {
    "showLink": False,
    "scrollZoom": False,
    "locale": "en",
    "responsive": True,
}

# Compute the HTML content
html = f"""
    <head>
      <!-- Load plotly.js into the DOM -->
      <script src='https://cdn.plot.ly/plotly-2.16.1.min.js'></script>
    <script type="text/javascript">
        function plotLizmap() {{
            Plotly.newPlot(
                "lizmap-plot",
                {json.dumps(plot_json['data'])},
                {json.dumps(plot_json['layout'])},
                {json.dumps(plot_config)}
            );
        }}
        window.addEventListener('load', function () {{
          plotLizmap();
        }});
      </script>
    </head>

    <body>
      <div id='lizmap-plot' style="width:100%; height: 100%;">
        <!-- Plotly chart will be drawn inside this DIV -->
      </div>
    </body>
"""

```
Funded by 3liz https://3liz.com

