### PR TITLE
[Bugfix] Hiding some digitizing buttons

### DIFF
--- a/assets/src/components/Digitizing.js
+++ b/assets/src/components/Digitizing.js
@@ -111,7 +111,7 @@ export default class Digitizing extends HTMLElement {
                     <path d="M7 16l-1.5 -1.5"></path>
                 </svg>
             </button>
-            <button type="button" class="digitizing-save btn ${mainLizmap.digitizing.isSaved ? 'active btn-primary' : ''}" @click=${()=> mainLizmap.digitizing.toggleSave()} data-original-title="${lizDict['digitizing.toolbar.save']}">
+            <button type="button" class="digitizing-save btn ${mainLizmap.digitizing.isSaved ? 'active btn-primary' : ''} ${this.hasAttribute('save') ? '' : 'hide'}" @click=${()=> mainLizmap.digitizing.toggleSave()} data-original-title="${lizDict['digitizing.toolbar.save']}">
                 <svg>
                     <use xlink:href="#save" />
                 </svg>
@@ -142,7 +142,7 @@ export default class Digitizing extends HTMLElement {
                             <use xlink:href="#file-upload"></use>
                         </svg>
                         <input class="hide" type="file" accept=".kml, .geojson, .json, .gpx" @change=${
-                            (event) => 
+                            (event) =>
                                     {
                                         if (event.target.files.length > 0){
                                             event.target.parentElement.parentElement.querySelector('.file-name').textContent = event.target.files[0].name;

--- a/lizmap/modules/view/templates/map_draw.tpl
+++ b/lizmap/modules/view/templates/map_draw.tpl
@@ -11,6 +11,6 @@
     </h3>
 
     <div class="menu-content">
-        <lizmap-digitizing import-export></lizmap-digitizing>
+        <lizmap-digitizing save import-export></lizmap-digitizing>
     </div>
 </div>

--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -2553,6 +2553,10 @@ lizmap-selection-invert svg {
   min-width: 260px;
 }
 
+.digitizing .hide{
+  display: none;
+}
+
 .digitizing .btn {
   width: 34px;
   height: 34px;


### PR DESCRIPTION
* Bootstrap `hide` CSS class are overwrite by digitizing specific CSS
* Save button was not hidable

Funded by 3Liz
