### PR TITLE
Update the lizmap landing page title

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -28,6 +28,7 @@
 ### Changed
 
 * Avoid downloading default project image multiple times. This improves first load of projects page
+* Update landing page title
 
 ### Updated
 

--- a/lizmap/modules/view/classes/view.listener.php
+++ b/lizmap/modules/view/classes/view.listener.php
@@ -4,7 +4,7 @@ class viewListener extends jEventListener
 {
     public function onmasteradminGetInfoBoxContent($event)
     {
-        $home = new masterAdminMenuItem('home', jLocale::get('view~default.repository.list.title'), jUrl::get('view~default:index'));
+        $home = new masterAdminMenuItem('home', jLocale::get('view~default.home.title'), jUrl::get('view~default:index'));
         $home->icon = true;
         $event->add($home);
     }

--- a/lizmap/modules/view/controllers/default.classic.php
+++ b/lizmap/modules/view/controllers/default.classic.php
@@ -81,15 +81,17 @@ class defaultCtrl extends jController
             }
         }
 
-        $title = jLocale::get('view~default.repository.list.title').' - '.$services->appName;
+        $title = $services->appName;
+        $subTitle = jLocale::get('view~default.home.title');
 
         if ($repository) {
             $lrep = lizmap::getRepository($repository);
-            $title = $lrep->getLabel().' - '.$title;
+            $subTitle = $lrep->getLabel().' - '.jLocale::get('view~default.repository.list.title');
         }
-        $rep->title = $title;
+        $rep->title = $subTitle.' - '.$title;
 
-        $rep->body->assign('repositoryLabel', $title);
+        $rep->body->assign('title', $title);
+        $rep->body->assign('subTitle', $subTitle);
 
         $auth_url_return = jUrl::get('view~default:index');
         if ($repository) {

--- a/lizmap/modules/view/locales/en_US/default.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/default.UTF-8.properties
@@ -1,7 +1,8 @@
 repository.access.denied=You cannot access this repository.
-repository.list.title=Projects
+repository.list.title=Repository page
 
-home.title=Home
+home.title=Home page
+home.menu=Home
 
 server.information.error=This map cannot be displayed. Please contact the server administrator to check the server information panel.
 

--- a/lizmap/modules/view/templates/main.tpl
+++ b/lizmap/modules/view/templates/main.tpl
@@ -5,7 +5,8 @@
   <div id="logo">
   </div>
   <div id="title">
-    <h1>{$repositoryLabel}</h1>
+    <h1>{$title}</h1>
+    <h2>{$subTitle}</h2>
   </div>
 
   <div id="headermenu" class="navbar navbar-fixed-top">

--- a/lizmap/modules/view/templates/map_menu.tpl
+++ b/lizmap/modules/view/templates/map_menu.tpl
@@ -2,8 +2,8 @@
     <ul class="nav nav-list">
       {if $display_home}
       <li class="home">
-        <a href="{jurl 'view~default:index'}" rel="tooltip" data-original-title="{@view~default.home.title@}" data-placement="right" data-container="#content">
-          <span class="icon"></span><span class="menu-title">{@view~default.home.title@}</span>
+        <a href="{jurl 'view~default:index'}" rel="tooltip" data-original-title="{@view~default.home.menu@}" data-placement="right" data-container="#content">
+          <span class="icon"></span><span class="menu-title">{@view~default.home.menu@}</span>
         </a>
       </li>
       {/if}


### PR DESCRIPTION
Fixes #1073

* Let the application name alone in the landing page
* Add a new string to translate: Landing page
* Put the page title in the second title in the header

Old landing page

![lizmap-landing-page-old](https://user-images.githubusercontent.com/1575538/212685651-bb98bb37-02c8-4730-bb40-0ccce33fc7a2.png)

New landing page

![lizmap-landing-page-new](https://user-images.githubusercontent.com/1575538/213164673-12ced786-11d1-4e64-aba6-9029544967ff.png)


Funded by 3Liz