### PR TITLE
add XML header to WMTS capabilities

### DIFF
--- a/lizmap/modules/lizmap/templates/wmts_capabilities.tpl
+++ b/lizmap/modules/lizmap/templates/wmts_capabilities.tpl
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Capabilities version="1.0.0" xmlns="http://www.opengis.net/wmts/1.0"
                 xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows/1.1"
                 xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
 
This PR add the mandatory xml head `<?xml .. ` to the generated WMTS Capabilities response  (assuming UTF-8 encoding) 

it prevent browser to detect error as above

![Wrong XML](https://user-images.githubusercontent.com/43475951/214240033-2562860c-236d-45df-a03d-ac4c28b8192d.png)


 

Funded by 3liz
