### PR TITLE
PHPUnit - Fix version to 9.5.27, enum_exists in only in PHP 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
-          tools: php-cs-fixer, phpunit
+          # PHP unit 9.5.28 is using enum_exists from PHP 8
+          tools: php-cs-fixer, phpunit:9.5.27
 
       - name: Running tests
         run: make tests

--- a/tests/units/composer.json
+++ b/tests/units/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "phpunit/phpunit": "^9.5.7",
+        "phpunit/phpunit": "9.5.27",
         "phpstan/phpstan": "^1.5.0"
     },
     "autoload": {


### PR DESCRIPTION
Only on LWC 3.5