### PR TITLE
Attribute table - Fix no display of table with value relation fields with no layer name

### DIFF
--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -305,16 +305,18 @@ var lizAttributeTable = function() {
                         // Use an integer as a placeholder for coming fetched key/values
                         allColumnsKeyValues[fieldName] = responseOrder;
                         responseOrder++;
-
+                        // Get the layer typename based on its id
+                        let getSourceLayer = lizMap.getLayerConfigById(fieldConf.source_layer_id);
+                        if( !getSourceLayer || getSourceLayer.length != 2) continue;
+                        let source_typename = getSourceLayer[1].typename;
                         fetchRequests.push(lizMap.mainLizmap.wfs.getFeature({
-                            TYPENAME: fieldConf.source_layer,
+                            TYPENAME: source_typename,
                             PROPERTYNAME: fieldConf.code_field + ',' + fieldConf.label_field,
                             // we must not use null for exp_filter but '' if no filter is active
                             EXP_FILTER: fieldConf.exp_filter ? fieldConf.exp_filter : ''
                         }));
                     }
                 }
-
 
                 document.body.style.cursor = 'progress';
                 Promise.all(fetchRequests).then(responses => {

--- a/assets/src/legacy/filter.js
+++ b/assets/src/legacy/filter.js
@@ -411,19 +411,24 @@ var lizLayerFilterTool = function () {
 
                 const layerName = lizMap.getLayerConfigById(field_item.layerId)[0];
                 const fieldConf = lizMap.keyValueConfig[layerName]?.[field_item.field];
-
                 if (fieldConf) {
                     if (fieldConf.type == 'ValueMap') {
                         keyValues = fieldConf.data;
                     } else {
-                        fetchRequests.push(
-                            lizMap.mainLizmap.wfs.getFeature({
-                                TYPENAME: fieldConf.source_layer,
-                                PROPERTYNAME: fieldConf.code_field + ',' + fieldConf.label_field,
-                                // we must not use null for exp_filter but '' if no filter is active
-                                EXP_FILTER: fieldConf.exp_filter ? fieldConf.exp_filter : ''
-                            })
-                        );
+                        // Get source layer typename from it ID
+                        let getSourceLayer = lizMap.getLayerConfigById(fieldConf.source_layer_id);
+                        if( getSourceLayer && getSourceLayer.length == 2) {
+                            let source_typename = getSourceLayer[1].typename;
+                            fetchRequests.push(
+                                lizMap.mainLizmap.wfs.getFeature({
+                                    TYPENAME: source_typename,
+                                    PROPERTYNAME: fieldConf.code_field + ',' + fieldConf.label_field,
+                                    // we must not use null for exp_filter but '' if no filter is active
+                                    EXP_FILTER: fieldConf.exp_filter ? fieldConf.exp_filter : ''
+                                })
+                            );
+                        }
+
                     }
                 }
 


### PR DESCRIPTION
In some unknown contexts, the `layerName` option is not present any more in the QGIS XML project file in the definition of the `ValueRelation` configuration for a form field.
When Lizmap Web Client displays the form filter or an attribute table, it tries to get the labels for the columns using a Value relation form field. This causes Lizmap to fail to open the attribute table. 

This PR uses the layer ID instead of the `layerName`, which is always present and is by the way a more robust method to get the QGIS layer.

Funded by 3liz
