### PR TITLE
UI admin: Change anchor color for selected line in projects table

### DIFF
--- a/lizmap/www/assets/css/admin.css
+++ b/lizmap/www/assets/css/admin.css
@@ -120,6 +120,13 @@ table.lizmap_project_list tr {
 table.lizmap_project_list tr.selected {
     background-color: lightskyblue;
 }
+table.lizmap_project_list tr.active a,
+table.lizmap_project_list tr.active a:hover,
+table.lizmap_project_list tr.selected a,
+table.lizmap_project_list tr.selected a:hover{
+  color: white;
+  text-decoration: underline dotted;
+}
 
 #lizmap_project_list_sidebar dt {
     margin-top: 5px;


### PR DESCRIPTION
The anchor color in the projects table is the same as the background selected line.

Old UI

![css-admin-table-project-anchor-old](https://user-images.githubusercontent.com/1575538/215774246-c4ecf231-e4d6-4086-bda0-54c0bd08b6a5.png)

New UI

![css-admin-table-project-anchor-new](https://user-images.githubusercontent.com/1575538/215782248-3e8662dc-19c5-463d-9acf-0ab05b55c870.png)

Funded by 3liz
