### PR TITLE
Admin : Projects Panel convert lizmap plugin version from int to sortable string

### DIFF
--- a/lizmap/modules/admin/templates/project_list_zone.tpl
+++ b/lizmap/modules/admin/templates/project_list_zone.tpl
@@ -38,7 +38,7 @@
                 <th>{@admin.project.list.column.memory.usage.label@}</th>
             {/if}
             <th>{@admin.project.list.column.qgis.desktop.version.label@}</th>
-            <th>{@admin.project.list.column.lizmap.plugin.version.label@}</th>
+            <th class='lzmplugv'>{@admin.project.list.column.lizmap.plugin.version.label@}</th>
             <th>{@admin.project.list.column.target.lizmap.version.label@}</th>
             <th>{@admin.project.list.column.authorized.groups.label@}</th>
             <th>{@admin.project.list.column.hidden.project.label@}</th>

--- a/lizmap/modules/admin/zones/project_list.zone.php
+++ b/lizmap/modules/admin/zones/project_list.zone.php
@@ -150,7 +150,8 @@ class project_listZone extends jZone
                 array('repository' => $projectMetadata->getRepository(), 'project' => $projectMetadata->getId())
             ),
             'lizmap_web_client_target_version' => $projectMetadata->getLizmapWebClientTargetVersion(),
-            'lizmap_plugin_version' => $projectMetadata->getLizmapPluginVersion(),
+            // convert int to string orderable
+            'lizmap_plugin_version' => $this->pluginIntVersionToSortableString($projectMetadata->getLizmapPluginVersion()),
             'file_time' => $projectMetadata->getFileTime(),
             'layer_count' => $projectMetadata->getLayerCount(),
             'acl_groups' => $projectMetadata->getAclGroups(),
@@ -277,5 +278,31 @@ class project_listZone extends jZone
     {
         // NOTE Will work as long a Major version is on 1 Digit
         return substr($qgisIntVersion, 0, 1).'.'.substr($qgisIntVersion, -2);
+    }
+    /**
+     * Transform int formatted version (from 5 or 6 integer) to sortable string .
+     *
+     * Transform "10102" into "01.01.02"
+     * Transform "050912" into "05.09.12"
+     *
+     * @param string $intVersion the lizmap QGIS plugin version (not always int !!)
+     *
+     * @return string the version as sortable string
+     */
+    private function pluginIntVersionToSortableString(string $intVersion): string
+    {
+        // in some old plugin the version is already human readable
+        if (strpos($intVersion, '.') != false) {
+            list($majorVersion, $minorVersion, $patchVersion) = explode('.', $intVersion);
+            // add 0 to 1 digit version
+            $majorVersion = (strlen($majorVersion) == 1 ? '0'.$majorVersion : $majorVersion);
+            $minorVersion = (strlen($minorVersion) == 1 ? '0'.$minorVersion : $minorVersion);
+            $patchVersion = (strlen($patchVersion) == 1 ? '0'.$patchVersion : $patchVersion);
+        } else {
+            $intVersion6Digit = (strlen($intVersion) == 6 ? $intVersion : '0'.$intVersion);
+            list($majorVersion, $minorVersion, $patchVersion) = str_split($intVersion6Digit, 2);
+        }
+
+        return $majorVersion.'.'.$minorVersion.'.'.$patchVersion;
     }
 }

--- a/lizmap/modules/admin/zones/project_list.zone.php
+++ b/lizmap/modules/admin/zones/project_list.zone.php
@@ -279,6 +279,7 @@ class project_listZone extends jZone
         // NOTE Will work as long a Major version is on 1 Digit
         return substr($qgisIntVersion, 0, 1).'.'.substr($qgisIntVersion, -2);
     }
+
     /**
      * Transform int formatted version (from 5 or 6 integer) to sortable string .
      *

--- a/lizmap/www/assets/js/admin/activate_datatable.js
+++ b/lizmap/www/assets/js/admin/activate_datatable.js
@@ -11,7 +11,15 @@ $(document).ready(function () {
                 "targets": [2, 3],
                 "visible": false,
                 "searchable": false
-            },
+            },{
+                "targets": 'lzmplugv',
+                "render": function ( data, type, row, meta ) {
+                    if (type == 'display') {
+                        return data.replace(/\.0/g,'.').replace(/^0/,'');
+                    }
+                    return data;
+                }
+            }
         ];
         if ($('table.lizmap_project_list').hasClass('has_inspection_data')) {
             columnDefs.push(


### PR DESCRIPTION
Convert lizmap plugin  Version to unified string sortable (0X.0Y.0Z) , datatables render as human readable  

From 
![Screenshot 2023-02-01 at 12-24-18 Admin - Lizmap projects - Administration](https://user-images.githubusercontent.com/43475951/216030933-0ea3267f-0e36-46ec-aa7a-dff602a61376.png)


![Screenshot 2023-02-01 at 11-49-36 Admin - Lizmap projects - Administration](https://user-images.githubusercontent.com/43475951/216030965-fe3f0ba3-90c0-4584-a0a1-2f0844b573e3.png)

Funded by 3liz
