### PR TITLE
database migrate commands in console.php

### DIFF
--- a/lizmap/modules/lizmap/commands.php
+++ b/lizmap/modules/lizmap/commands.php
@@ -2,4 +2,6 @@
 
 if (isset($application)) {
     $application->add(new \Lizmap\Commands\CreateRepository());
+    $application->add(new \Lizmap\Commands\DbMigrateLog());
+    $application->add(new \Lizmap\Commands\DbMigrateUsers());
 }

--- a/lizmap/modules/lizmap/controllers/database.cmdline.php
+++ b/lizmap/modules/lizmap/controllers/database.cmdline.php
@@ -62,6 +62,8 @@ class databaseCtrl extends jControllerCmdLine
         /** @var jResponseCmdline $rep */
         $rep = $this->getResponse();
         $logMigrator = new \Lizmap\Logger\MigratorFromSqlite();
+        $rep->addContent("Using this command is deprecated, all commands are now unified in console.php
+        In lizmap folder, use 'php console.php database:migratelog'\n\n");
 
         try {
             $res = $logMigrator->migrateLog('lizlog', $this->option('-resetbefore'));
@@ -103,6 +105,8 @@ class databaseCtrl extends jControllerCmdLine
         /** @var jResponseCmdline $rep */
         $rep = $this->getResponse();
         $logMigrator = new \Lizmap\Users\MigratorFromSqlite();
+        $rep->addContent("Using this command is deprecated, all commands are now unified in console.php
+        In lizmap folder, use 'php console.php database:migrateusers'\n\n");
 
         try {
             $res = $logMigrator->migrateUsersAndRights($this->option('-resetbefore'));

--- a/lizmap/modules/lizmap/lib/Commands/DbMigrateLog.php
+++ b/lizmap/modules/lizmap/lib/Commands/DbMigrateLog.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Lizmap\Commands;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+// See controllers/database.cmdline.php
+class DbMigrateLog extends \Jelix\Scripts\ModuleCommandAbstract
+{
+    protected function configure()
+    {
+        $this
+            ->setName('database:migratelog')
+            ->setDescription('Migrate log data from a sqlite database to the current database')
+            ->setHelp('')
+            ->addOption('resetbefore', null, InputOption::VALUE_NONE, 'Delete target db before migrating')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $logMigrator = new \Lizmap\Logger\MigratorFromSqlite();
+
+        try {
+            $res = $logMigrator->migrateLog('lizlog', $input->getOption('resetbefore'));
+        } catch (\UnexpectedValueException $e) {
+            $output->writeln('Error during the migration: '.$e->getMessage());
+
+            return 1;
+        }
+
+        switch ($res) {
+            case $logMigrator::MIGRATE_RES_ALREADY_MIGRATED:
+                $output->writeln('It seems already migrated, there are some data into logCounter or logDetail table');
+
+                break;
+
+            case $logMigrator::MIGRATE_RES_OK:
+                $output->writeln('Migration done');
+
+                break;
+
+            case 0:
+                $output->writeln('Unknown error');
+
+                break;
+
+            default:
+                $output->writeln('Unknown result');
+        }
+
+        return 0;
+    }
+}

--- a/lizmap/modules/lizmap/lib/Commands/DbMigrateUsers.php
+++ b/lizmap/modules/lizmap/lib/Commands/DbMigrateUsers.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Lizmap\Commands;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+// See controllers/database.cmdline.php
+class DbMigrateUsers extends \Jelix\Scripts\ModuleCommandAbstract
+{
+    protected function configure()
+    {
+        $this
+            ->setName('database:migrateusers')
+            ->setDescription('Migrate users data from a sqlite database to the current database (experimental)')
+            ->setHelp('')
+            ->addOption('resetbefore', null, InputOption::VALUE_NONE, 'Delete target db before migrating')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $logMigrator = new \Lizmap\Users\MigratorFromSqlite();
+
+        try {
+            $res = $logMigrator->migrateUsersAndRights($input->getOption('resetbefore'));
+        } catch (\UnexpectedValueException $e) {
+            $output->writeln('Error during the migration: '.$e->getMessage());
+
+            return 1;
+        }
+
+        switch ($res) {
+            case $logMigrator::MIGRATE_RES_ALREADY_MIGRATED:
+                $output->writeln('It seems already migrated, there are some data into existing users tables');
+
+                break;
+
+            case $logMigrator::MIGRATE_RES_OK:
+                $output->writeln('Migration done');
+
+                break;
+
+            case 0:
+                $output->writeln('Unknown error');
+
+                break;
+
+            default:
+                $output->writeln('Unknown result');
+        }
+
+        return 0;
+    }
+}


### PR DESCRIPTION
`database:migratelog` and `database:migrateuser` jelixcommand alternative for `console.php`

 

Funded by 3liz https://www.3liz.com/
