### PR TITLE
[Bugfix] Selection by Point - The bbox is empty

### DIFF
--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -5442,7 +5442,16 @@ window.lizMap = function() {
           // add BBox to restrict to geom bbox but not with some geometry operator
           if (geomOperator !== 'disjoint'){
             var geomBounds = selectionFeature.geometry.clone().transform(lizMap.map.getProjection(), aProj).getBounds();
+            if (geomBounds.getWidth() == 0 || geomBounds.getHeight() == 0) {
+              geomBounds.extend(new OpenLayers.Bounds(
+                  geomBounds.left - 0.000001,
+                  geomBounds.bottom - 0.000001,
+                  geomBounds.right + 0.000001,
+                  geomBounds.top + 0.000001
+              ));
+            }
             getFeatureUrlData['options']['BBOX'] = geomBounds.toBBOX();
+            getFeatureUrlData['options']['SRSNAME'] = lConfig.crs;
           }
 
           // get features
@@ -6130,7 +6139,7 @@ window.lizMap = function() {
         }
 
         getFeatureInfo = responses[6];
-        
+
         const domparser = new DOMParser();
 
         config.options.hasOverview = false;
@@ -6153,7 +6162,7 @@ window.lizMap = function() {
         // Parse WMS capabilities
         const wmsFormat =  new OpenLayers.Format.WMSCapabilities({version:'1.3.0'});
         capabilities = wmsFormat.read(wmsCapaData);
-    
+
         if (!capabilities.capability) {
           throw 'WMS Capabilities error';
         }
@@ -6546,7 +6555,7 @@ window.lizMap = function() {
 
         // Display getFeatureInfo if requested
         if(getFeatureInfo){
-          displayGetFeatureInfo(getFeatureInfo, 
+          displayGetFeatureInfo(getFeatureInfo,
             {
               x: map.size.w / 2,
               y: map.size.h / 2

--- a/tests/end2end/cypress/integration/selectionTool-ghaction.js
+++ b/tests/end2end/cypress/integration/selectionTool-ghaction.js
@@ -53,6 +53,74 @@ describe('Selection tool', function () {
         })
     })
 
+    it('selects features intersecting a line', function () {
+        cy.get('#button-selectiontool').click()
+
+        // Activate polygon tool
+        cy.get('#selectiontool .digitizing-buttons .dropdown-toggle').first().click()
+        cy.get('#selectiontool .digitizing-line').click()
+
+        // Select single layer and intersects geom operator
+        cy.get('lizmap-selection-tool .selectiontool-layer-list').select('selection_polygon')
+        cy.get('lizmap-selection-tool .selection-geom-operator').select('intersects')
+
+
+        // It should select two features
+        cy.get('#map')
+            .click(200, 350)
+            .dblclick(850, 350)
+
+        cy.get('.selectiontool-results').should(($div) => {
+            const text = $div.text()
+
+            expect(text).to.match(/^2/)
+        })
+
+        // It should not select any features
+        cy.get('#map')
+            .click(750, 350)
+            .dblclick(700, 400)
+
+        cy.get('.selectiontool-results').should(($div) => {
+            const text = $div.text()
+
+            expect(text).not.to.match(/^[0-9]/)
+        })
+    })
+
+    it('selects features intersecting a point', function () {
+        cy.get('#button-selectiontool').click()
+
+        // Activate polygon tool
+        cy.get('#selectiontool .digitizing-buttons .dropdown-toggle').first().click()
+        cy.get('#selectiontool .digitizing-point').click()
+
+        // Select single layer and intersects geom operator
+        cy.get('lizmap-selection-tool .selectiontool-layer-list').select('selection_polygon')
+        cy.get('lizmap-selection-tool .selection-geom-operator').select('intersects')
+
+
+        // It should select one feature
+        cy.get('#map')
+            .click(850, 350)
+
+        cy.get('.selectiontool-results').should(($div) => {
+            const text = $div.text()
+
+            expect(text).to.match(/^1/)
+        })
+
+        // It should not select any features
+        cy.get('#map')
+            .click(750, 350)
+
+        cy.get('.selectiontool-results').should(($div) => {
+            const text = $div.text()
+
+            expect(text).not.to.match(/^[0-9]/)
+        })
+    })
+
     // TODO : tests other geom operators, unselection...
 })
 


### PR DESCRIPTION
To speed up WFS getFeature request to get selected features, the geometry bounds is provided by the BBOX parameter to restrict the request to this bounding box. But if the bounding box is empty, the request returns no features.

So to get feature in intersection with a Point the bounding box has to be extend to not be empty.

Funded by 3liz https://3liz.com