### PR TITLE
[Bugfix] Zoom to feature (from popup) goes to far away

### DIFF
--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -4468,10 +4468,10 @@ window.lizMap = function() {
   function zoomToFeature( featureType, fid, zoomAction ){
       zoomAction = typeof zoomAction !== 'undefined' ?  zoomAction : 'zoom';
 
-      var proj = new OpenLayers.Projection(config.layers[featureType].crs);
-      if( config.layers[featureType].featureCrs )
-          proj = new OpenLayers.Projection(config.layers[featureType].featureCrs);
       getLayerFeature(featureType, fid, function(feat) {
+        var proj = new OpenLayers.Projection(config.layers[featureType].crs);
+        if( config.layers[featureType].featureCrs )
+            proj = new OpenLayers.Projection(config.layers[featureType].featureCrs);
           zoomToOlFeature( feat, proj, zoomAction );
       });
   }


### PR DESCRIPTION
When you click on the zoom to feature button before a WFS GetFeature request has been performed on the layer, the zoom goes to far away.

Funded by Conseil Départemental du Calvados https://www.calvados.fr