### PR TITLE
UX - Improve debug messages about the QGIS server installation

### DIFF
--- a/lizmap/modules/admin/controllers/server_information.classic.php
+++ b/lizmap/modules/admin/controllers/server_information.classic.php
@@ -66,15 +66,8 @@ class server_informationCtrl extends jController
             'displayPluginActionColumn' => $displayPluginActionColumn,
             'lizmapQgisServerNeedsUpdate' => $lizmapQgisServerNeedsUpdate,
             'lizmapPluginUpdate' => $updateLizmapPlugin,
-            'errorQgisPlugin' => jLocale::get(
-                'admin.server.information.qgis.error.fetching.information.detail',
-                array(
-                    $qgisMinimumVersionRequired,
-                    $lizmapPluginMinimumVersionRequired,
-                    $qgisMinimumVersionRequired,
-                    $lizmapPluginMinimumVersionRequired,
-                )
-            ),
+            'minimumQgisVersion' => $qgisMinimumVersionRequired,
+            'minimumLizmapServer' => $lizmapPluginMinimumVersionRequired,
         );
         $tpl->assign($assign);
         $rep->body->assign('MAIN', $tpl->fetch('server_information'));

--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -263,10 +263,11 @@ server.information.qgis.plugin.action=Action
 server.information.qgis.test.ok=QGIS Server is correctly installed and returns the expected response for OGC requests.
 server.information.qgis.test.error=QGIS Server is not correctly installed in your server or the URL for OGC requests given in Lizmap configuration is not correct.
 server.information.qgis.error.fetching.information=We cannot get the details about your QGIS Server installation (version, plugins, etc.).
-server.information.qgis.error.fetching.information.detail=Either the version of the installed QGIS Server is under %s, or \
-the Lizmap server plugin is not detected in your server, or is installed with a version under %s. \
-Please upgrade QGIS Server to minimum %s and install or upgrade the Lizmap server plugin to \
-minimum %s by reading the documentation about the environment variable
+server.information.qgis.error.fetching.information.description=You must check that the followings steps are done :
+server.information.qgis.error.fetching.information.qgis.version.html=<strong>QGIS Server</strong> is above or equal to <strong>%s</strong>
+server.information.qgis.error.fetching.information.plugin.version.html=The <strong>Lizmap QGIS server plugin</strong> is installed on the server with a version above or equal to <strong>%s</strong>
+server.information.qgis.error.fetching.information.environment.variable=The <strong>environment variable</strong> described in the documentation link below is correctly set in your configuration
+server.information.qgis.error.fetching.information.help=Your QGIS server <strong>logs</strong> does not contain any warnings about the Lizmap server plugin (at QGIS server startup and when loading this webpage). You might need to increase debug level.
 server.information.qgis.error.fetching.information.detail.NO_ACCESS=You don't have access to information about QGIS Server
 server.information.qgis.error.fetching.information.detail.HTTP_ERROR=QGIS Server returns an HTTP error about the Lizmap plugin:
 server.information.qgis.update=QGIS Server needs to be updated at least to version %s for this version of Lizmap Web Client.

--- a/lizmap/modules/admin/templates/server_information.tpl
+++ b/lizmap/modules/admin/templates/server_information.tpl
@@ -48,7 +48,13 @@
         {if $data['qgis_server_info']['error'] == 'NO_ACCESS'}
             <i>{@admin.server.information.qgis.error.fetching.information.detail.NO_ACCESS@}</i><br>
         {else}
-            <i>{$errorQgisPlugin}</i>
+            <p>{@admin.server.information.qgis.error.fetching.information.description@}</p>
+            <ul>
+                <li>{jlocale "admin.server.information.qgis.error.fetching.information.qgis.version.html", array($minimumQgisVersion)}</li>
+                <li>{jlocale "admin.server.information.qgis.error.fetching.information.plugin.version.html", array($minimumLizmapServer)}</li>
+                <li>{@admin.server.information.qgis.error.fetching.information.environment.variable@}</li>
+                <li>{@admin.server.information.qgis.error.fetching.information.help@}</li>
+            </ul>
             <br>
             <a href="{$linkDocumentation}" target="_blank">{$linkDocumentation}</a>
             <br>


### PR DESCRIPTION
Fix #3486

From 
![image](https://user-images.githubusercontent.com/1609292/219596637-bcb26ec6-5eda-4724-8991-f67f0ea76ae1.png)

To 

![image](https://user-images.githubusercontent.com/1609292/219596716-3544afde-9f20-414c-8e49-19b114166fb7.png)


having a kind of checklist help the end user.

@nworr Maybe I'm missing a tiny thing ?
As soon as I switch from 

```
<li>{jlocale "admin.server.information.qgis.error.fetching.information.qgis.version", array($minimumQgisVersion)}</li>
```
to
```
<li>{jlocale "admin.server.information.qgis.error.fetching.information.qgis.version.html", array($minimumQgisVersion)}</li>
```

I got
![image](https://user-images.githubusercontent.com/1609292/219597837-0ab7d8d5-65b1-4064-bcf0-b5381486e08f.png)


it looks like a copy/paste from https://github.com/3liz/lizmap-web-client/blob/450bf0bbe2551e76734e32c31ca3fc65f1ccee39/lizmap/modules/admin/templates/project_list_zone.tpl#L241