### PR TITLE
Admin: allow to edit the name for the sender email

### DIFF
--- a/lizmap/modules/admin/controllers/config.classic.php
+++ b/lizmap/modules/admin/controllers/config.classic.php
@@ -52,7 +52,12 @@ class configCtrl extends jController
             foreach ($services->getSensitiveProperties() as $ser) {
                 /** @var null|jFormsControl $ctrl */
                 $ctrl = $form->getControl($ser);
-                if ($ctrl) {
+                if (!$ctrl) {
+                    continue;
+                }
+                if ($ser == 'adminSenderEmail') {
+                    $form->setReadOnly($ser, true);
+                } else {
                     $form->deactivate($ser);
                 }
             }
@@ -147,9 +152,12 @@ class configCtrl extends jController
             ) {
                 $form->getControl('adminSenderEmail')->required = true;
             }
-            if (lizmap::getServices()->hideSensitiveProperties() && !$hasSenderEmail) {
-                $form->getControl('allowUserAccountRequests')->setReadOnly();
-                $form->getControl('allowUserAccountRequests')->help = jLocale::get('admin~admin.config.services.allowUserAccountRequest.noemail');
+            if (lizmap::getServices()->hideSensitiveProperties()) {
+                if (!$hasSenderEmail) {
+                    $form->getControl('allowUserAccountRequests')->setReadOnly();
+                    $form->getControl('allowUserAccountRequests')->help = jLocale::get('admin~admin.config.services.allowUserAccountRequest.noemail');
+                }
+                $form->getControl('adminSenderEmail')->help = jLocale::get('admin~admin.form.admin_services.adminSenderEmail.readonly.help');
             }
 
             $qgisMinimumVersionRequired = jApp::config()->minimumRequiredVersion['qgisServer'];

--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -113,6 +113,7 @@ form.admin_services.adminContactEmail.label=E-mail where to send notifications
 form.admin_services.adminContactEmail.help=E-mail address to which notifications will be sent
 form.admin_services.adminSenderEmail.label=Sender address of e-mails
 form.admin_services.adminSenderEmail.help=E-mail address used to send e-mails. If empty, no emails will be sent by Lizmap. Be sure your server is allowed to send email with this address.
+form.admin_services.adminSenderEmail.readonly.help=E-mail address used to send e-mails. It cannot be modified.
 form.admin_services.adminSenderEmail.error.required=A sender e-mail address is required to send notification or requests for account creation
 form.admin_services.adminSenderName.label=Sender name of e-mails
 form.admin_services.adminSenderName.help=Name of the sender used to send e-mails.

--- a/lizmap/modules/lizmap/classes/lizmapServices.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapServices.class.php
@@ -91,7 +91,6 @@ class lizmapServices
         'cacheRedisDb',
         'cacheRedisKeyPrefix',
         'adminSenderEmail',
-        'adminSenderName',
         'proxyHttpBackend',
     );
 

--- a/lizmap/var/config/lizmapConfig.ini.php.dist
+++ b/lizmap/var/config/lizmapConfig.ini.php.dist
@@ -1,5 +1,5 @@
 ;<?php die(''); ?>
-;for security reasons , don't remove or modify the first line
+;for security reasons , don't remove or modify the previous line
 
 ;Services
 ;list the different map services (servers, generic parameters, etc.)


### PR DESCRIPTION
This property should not be considered as a sensitive parameter. We show also the email used to send emails, even if we keep as a non editable value in sensitive mode.

Funded by 3liz
