### PR TITLE
Using Guzzle Stream to speed up WFS GetFeature

### DIFF
--- a/lizmap/composer.json
+++ b/lizmap/composer.json
@@ -12,7 +12,8 @@
     "jelix/jcommunity-module": "~1.3.15",
     "jelix/ldapdao-module": "~2.2.1",
     "proj4php/proj4php": "~2.0.0",
-    "violet/streaming-json-encoder": "^1.1"
+    "violet/streaming-json-encoder": "^1.1",
+    "guzzlehttp/guzzle": "^7.4.5"
   },
   "require-dev": {
     "gettext/gettext": "^4.6.1"

--- a/lizmap/modules/dataviz/classes/datavizPlot.class.php
+++ b/lizmap/modules/dataviz/classes/datavizPlot.class.php
@@ -486,27 +486,26 @@ class datavizPlot
             }
 
             $wfsrequest = new \Lizmap\Request\WFSRequest($this->lproj, $wfsparams, lizmap::getServices());
-            // FIXME no support of the case where $wfsresponse is the content of serviceException?
+
             $wfsresponse = $wfsrequest->process();
             $features = null;
 
-            // Check data
-            $featureData = null;
-            if (property_exists($wfsresponse, 'data')) {
-                $data = $wfsresponse->data;
-
-                // is the data a file ?
-                if (substr($data, 0, 7) == 'file://' && is_file(substr($data, 7))) {
-                    $data = \jFile::read(substr($data, 7));
-                }
-
-                // decode features
-                $featureData = json_decode($data);
-
-                if (empty($featureData) || empty($featureData->features)) {
-                    $featureData = null;
-                }
+            // Check code
+            if (floor($wfsresponse->getCode() / 100) >= 4) {
+                return false;
             }
+            // Check mime/type
+            if (in_array(strtolower($wfsresponse->getMime()), array('text/html', 'text/xml'))) {
+                return false;
+            }
+
+            // decode features
+            $featureData = json_decode($wfsresponse->getBodyAsString());
+
+            if (empty($featureData) || empty($featureData->features)) {
+                $featureData = null;
+            }
+
             if (!$featureData) {
                 return false;
             }

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -1058,20 +1058,17 @@ class qgisVectorLayer extends qgisMapLayer
         $result = $wfsRequest->process();
 
         // Check code
-        if (floor($result->code / 100) >= 4) {
+        if (floor($result->getCode() / 100) >= 4) {
             return true;
         }
 
         // Check mime/type
-        if (in_array(strtolower($result->mime), array('text/html', 'text/xml'))) {
+        if (in_array(strtolower($result->getMime()), array('text/html', 'text/xml'))) {
             return true;
         }
 
         // Get data
-        $wfsData = $result->data;
-        if (substr($wfsData, 0, 7) == 'file://' && is_file(substr($wfsData, 7))) {
-            $wfsData = \jFile::read(substr($wfsData, 7));
-        }
+        $wfsData = $result->getBodyAsString();
 
         // Check data: if there is no data returned by WFS, the user has not access to it
         if (!$wfsData) {
@@ -1168,20 +1165,17 @@ class qgisVectorLayer extends qgisMapLayer
         $result = $wfsRequest->process();
 
         // Check code
-        if (floor($result->code / 100) >= 4) {
+        if (floor($result->getCode() / 100) >= 4) {
             return $restricted_empty_data;
         }
 
         // Check mime/type
-        if (in_array(strtolower($result->mime), array('text/html', 'text/xml'))) {
+        if (in_array(strtolower($result->getMime()), array('text/html', 'text/xml'))) {
             return $restricted_empty_data;
         }
 
         // Get data
-        $wfsData = $result->data;
-        if (substr($wfsData, 0, 7) == 'file://' && is_file(substr($wfsData, 7))) {
-            $wfsData = \jFile::read(substr($wfsData, 7));
-        }
+        $wfsData = $result->getBodyAsString();
 
         // Check data: if there is no data returned by WFS, the user has not access to it
         if (!$wfsData) {

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -32,7 +32,7 @@ class editionCtrl extends jController
     /** @var int|string an integer or an array of integers */
     private $featureId;
 
-    /** @var object feature data as a PHP object from GeoJSON via json_decode */
+    /** @var null|object feature data as a PHP object from GeoJSON via json_decode */
     private $featureData;
 
     /** @var SimpleXMLElement Layer data as simpleXml object */
@@ -286,19 +286,24 @@ class editionCtrl extends jController
                 $wfs_params,
                 lizmap::getServices()
             );
-            // FIXME no support of the case where $wfs_response is the content of serviceException?
+
+            $this->featureData = null;
+
             $wfs_response = $wfs_request->process();
-            if (property_exists($wfs_response, 'data')) {
-                $data = $wfs_response->data;
-                if (substr($data, 0, 7) == 'file://' && is_file(substr($data, 7))) {
-                    $data = \jFile::read(substr($data, 7));
-                }
-                $this->featureData = json_decode($data);
-                if (empty($this->featureData)) {
-                    $this->featureData = null;
-                } elseif (empty($this->featureData->features)) {
-                    $this->featureData = null;
-                }
+            // Check code
+            if (floor($wfs_response->getCode() / 100) >= 4) {
+                return;
+            }
+            // Check mime/type
+            if (in_array(strtolower($wfs_response->getMime()), array('text/html', 'text/xml'))) {
+                return;
+            }
+
+            $this->featureData = json_decode($wfs_response->getBodyAsString());
+            if (empty($this->featureData)) {
+                $this->featureData = null;
+            } elseif (empty($this->featureData->features)) {
+                $this->featureData = null;
             }
         }
     }

--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -1470,14 +1470,11 @@ class QgisForm implements QgisFormControlsInterface
         // Perform request
         $result = $wfsRequest->process();
 
-        $wfsData = $result->data;
-        if (substr($wfsData, 0, 7) == 'file://' && is_file(substr($wfsData, 7))) {
-            $wfsData = \jFile::read(substr($wfsData, 7));
-        }
-        $mime = $result->mime;
+        $wfsData = $result->getBodyAsString();
+        $mime = $result->getMime();
 
         // Used data
-        if ($wfsData and !in_array(strtolower($mime), array('text/html', 'text/xml'))) {
+        if ($wfsData && !in_array(strtolower($mime), array('text/html', 'text/xml'))) {
             $wfsData = json_decode($wfsData);
             // Get data from layer
             $features = $wfsData->features;

--- a/lizmap/modules/lizmap/lib/Form/QgisFormValueRelationDynamicDatasource.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisFormValueRelationDynamicDatasource.php
@@ -103,11 +103,8 @@ class QgisFormValueRelationDynamicDatasource extends \jFormsDynamicDatasource
                 $wfsRequest = new \Lizmap\Request\WFSRequest($lproj, $params, \lizmap::getServices());
                 $wfsResult = $wfsRequest->process();
 
-                $data = $wfsResult->data;
-                if (substr($data, 0, 7) == 'file://' && is_file(substr($data, 7))) {
-                    $data = \jFile::read(substr($data, 7));
-                }
-                $mime = $wfsResult->mime;
+                $data = $wfsResult->getBodyAsString();
+                $mime = $wfsResult->getMime();
 
                 if ($data && (strpos($mime, 'text/json') === 0
                             || strpos($mime, 'application/json') === 0

--- a/lizmap/modules/lizmap/lib/Request/OGCRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/OGCRequest.php
@@ -188,12 +188,13 @@ abstract class OGCRequest
     /**
      * Request QGIS Server.
      *
-     * @param bool $post Force to use POST request
+     * @param bool $post   Force to use POST request
+     * @param bool $stream Get data as stream
      *
      * @return OGCResponse The request result with HTTP code, response mime-type and response data
      *                     (properties $code, $mime, $data)
      */
-    protected function request($post = false)
+    protected function request($post = false, $stream = false)
     {
         $querystring = $this->constructUrl();
 
@@ -210,6 +211,12 @@ abstract class OGCRequest
 
         // Add login filtered override info
         $options['loginFilteredOverride'] = \jAcl2::check('lizmap.tools.loginFilteredLayers.override', $this->repository->getKey());
+
+        if ($stream) {
+            $response = \Lizmap\Request\Proxy::getRemoteDataAsStream($querystring, $options);
+
+            return new OGCResponse($response->getCode(), $response->getMime(), $response->getBodyAsStream());
+        }
 
         list($data, $mime, $code) = \Lizmap\Request\Proxy::getRemoteData($querystring, $options);
 

--- a/lizmap/modules/lizmap/lib/Request/OGCResponse.php
+++ b/lizmap/modules/lizmap/lib/Request/OGCResponse.php
@@ -3,7 +3,7 @@
  * Manage OGC response.
  *
  * @author    3liz
- * @copyright 2015-2022 3liz
+ * @copyright 2015-2023 3liz
  *
  * @see      http://3liz.com
  *
@@ -11,6 +11,9 @@
  */
 
 namespace Lizmap\Request;
+
+use GuzzleHttp\Psr7;
+use Psr\Http\Message\StreamInterface;
 
 class OGCResponse
 {
@@ -25,7 +28,7 @@ class OGCResponse
     public $mime;
 
     /**
-     * @var string the response body as a string
+     * @var iterable|StreamInterface|string the response body as a stream, an iterable or a string
      */
     public $data;
 
@@ -35,18 +38,18 @@ class OGCResponse
     public $cached = false;
 
     /**
-     * @var array
+     * @var array the response headers
      */
     public $headers = array();
 
     /**
      * constructor.
      *
-     * @param int    $code    the HTTP status code of the response
-     * @param string $mime    the MIME type of the response
-     * @param string $data    the response body as a string
-     * @param bool   $cached  the response has been cached, default value false
-     * @param array  $headers default value an empty array
+     * @param int                             $code    the HTTP status code of the response
+     * @param string                          $mime    the MIME type of the response
+     * @param iterable|StreamInterface|string $data    the response body as a string
+     * @param bool                            $cached  the response has been cached, default value false
+     * @param array                           $headers default value an empty array
      */
     public function __construct($code, $mime, $data, $cached = false, $headers = array())
     {
@@ -55,5 +58,97 @@ class OGCResponse
         $this->data = $data;
         $this->cached = $cached;
         $this->headers = $headers;
+    }
+
+    /**
+     * Get the HTTP status code of the response.
+     *
+     * @return int
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * Get the MIME type of the response.
+     *
+     * @return string
+     */
+    public function getMime()
+    {
+        return $this->mime;
+    }
+
+    /**
+     * Get is the response has been cached.
+     *
+     * @return bool
+     */
+    public function isCached()
+    {
+        return $this->cached;
+    }
+
+    /**
+     * Get the response's headers.
+     *
+     * @return array
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    /**
+     * Get the response's body as string.
+     *
+     * @return string
+     */
+    public function getBodyAsString()
+    {
+        if (is_string($this->data)) {
+            if (substr($this->data, 0, 7) == 'file://' && is_file(substr($this->data, 7))) {
+                return $this->getBodyAsStream()->getContents();
+            }
+
+            return $this->data;
+        }
+        if (is_iterable($this->data)) {
+            $body = '';
+            foreach ($this->data as $d) {
+                $body .= $d;
+            }
+
+            return $body;
+        }
+        if ($this->data->isSeekable()) {
+            $this->data->rewind();
+        }
+
+        return $this->data->getContents();
+    }
+
+    /**
+     * Get the response's body as stream.
+     *
+     * @return StreamInterface
+     */
+    public function getBodyAsStream()
+    {
+        if (is_string($this->data)) {
+            if (substr($this->data, 0, 7) == 'file://' && is_file(substr($this->data, 7))) {
+                $resource = Psr7\Utils::tryFopen(substr($this->data, 7), 'r');
+
+                return Psr7\Utils::streamFor($resource);
+            }
+
+            return Psr7\Utils::streamFor($this->data);
+        }
+        if (is_iterable($this->data)) {
+            return Psr7\Utils::streamFor($this->data);
+        }
+
+        return $this->data;
     }
 }

--- a/lizmap/modules/lizmap/lib/Request/Proxy.php
+++ b/lizmap/modules/lizmap/lib/Request/Proxy.php
@@ -12,6 +12,8 @@
 
 namespace Lizmap\Request;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
 use Lizmap\App;
 
 class Proxy
@@ -512,6 +514,75 @@ class Proxy
         }
         // With file_get_contents
         return self::fileProxy($url, $options);
+    }
+
+    /**
+     * Sends a request, and return the body response as a stream.
+     *
+     * @param string     $url     url of the remote data to fetch
+     * @param null|array $options list of options for the http request.
+     *                            Option items can be: "method", "referer", "proxyHttpBackend",
+     *                            "headers" (array of headers strings), "body", "debug".
+     *
+     * @return ProxyResponse
+     */
+    public static function getRemoteDataAsStream($url, $options = null)
+    {
+        $options = self::buildOptions($options, 'get', null);
+        list($url, $options) = self::buildHeaders($url, $options);
+
+        if ($options['referer']) {
+            $options['headers']['Referer'] = $options['referer'];
+        }
+
+        $client = new Client(array(
+            // You can set any number of default request options.
+            'timeout' => 2.0,
+        ));
+
+        $request = new Request(
+            $options['method'],
+            $url,
+            $options['headers'],
+            $options['body'],
+        );
+
+        $reqOptions = array(
+            'stream' => true,
+        );
+        $services = self::getServices();
+        if ($services->requestProxyEnabled && $services->requestProxyHost != '') {
+            if ($services->requestProxyType == 'socks5') {
+                $proxy = 'socks5://';
+            } else {
+                $proxy = 'http://';
+            }
+
+            if ($services->requestProxyUser) {
+                $proxy .= urlencode($services->requestProxyUser).':'.urlencode($services->requestProxyPassword).'@';
+            }
+
+            $proxy .= $services->requestProxyHost;
+            if ($services->requestProxyPort) {
+                $proxy .= ':'.$services->requestProxyPort;
+            }
+
+            $noProxy = preg_split('/\s*,\s*/', $services->requestProxyNotForDomain);
+
+            $reqOptions['proxy'] = array(
+                'http' => $proxy, // Use this proxy with "http"
+                'https' => $proxy, // Use this proxy with "https",
+                'no' => $noProxy,    // Don't use a proxy with these
+            );
+        }
+
+        $response = $client->send($request, $reqOptions);
+
+        return new ProxyResponse(
+            $response->getStatusCode(),
+            $response->getHeader('Content-Type')[0],
+            $response->getBody()
+        );
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/Request/ProxyResponse.php
+++ b/lizmap/modules/lizmap/lib/Request/ProxyResponse.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Manage OGC response.
+ *
+ * @author    3liz
+ * @copyright 2015-2023 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+namespace Lizmap\Request;
+
+use Psr\Http\Message\StreamInterface;
+
+class ProxyResponse
+{
+    /**
+     * @var int the HTTP status code of the response
+     */
+    protected $code;
+
+    /**
+     * @var string the MIME type of the response
+     */
+    protected $mime;
+
+    /**
+     * @var StreamInterface the response body as a stream
+     */
+    protected $body;
+
+    /**
+     * constructor.
+     *
+     * @param int             $code the HTTP status code of the response
+     * @param string          $mime the MIME type of the response
+     * @param StreamInterface $body the response body as a string
+     */
+    public function __construct($code, $mime, $body)
+    {
+        $this->code = $code;
+        $this->mime = $mime;
+        $this->body = $body;
+    }
+
+    /**
+     * Get the HTTP status code of the response.
+     *
+     * @return int
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * Get the MIME type of the response.
+     *
+     * @return string
+     */
+    public function getMime()
+    {
+        return $this->mime;
+    }
+
+    /**
+     * Get the response's body as string.
+     *
+     * @return string
+     */
+    public function getBodyAsString()
+    {
+        if ($this->body->isSeekable()) {
+            $this->body->rewind();
+        }
+
+        return $this->body->getContents();
+    }
+
+    /**
+     * Get the response's body as stream.
+     *
+     * @return StreamInterface
+     */
+    public function getBodyAsStream()
+    {
+        return $this->body;
+    }
+}

--- a/lizmap/modules/lizmap/lib/Request/WFSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WFSRequest.php
@@ -315,7 +315,7 @@ class WFSRequest extends OGCRequest
         // add outputformat if not provided
         $output = $this->param('outputformat');
         if (!$output) {
-            $this->params['outputformat'] = 'GML2';
+            $output = $this->params['outputformat'] = 'GML2';
         }
 
         // Get Lizmap layer config

--- a/lizmap/modules/lizmap/lib/Request/WFSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WFSRequest.php
@@ -411,19 +411,6 @@ class WFSRequest extends OGCRequest
         $mime = $response->mime;
         $data = $response->data;
 
-        if ($mime == 'text/plain' && strtolower($this->param('outputformat')) == 'geojson') {
-            $mime = 'application/vnd.geo+json; charset=utf-8';
-            $layer = $this->project->findLayerByAnyName($this->requestedTypename());
-            if ($layer != null) {
-                /** @var \qgisVectorLayer $layer The QGIS vector layer instance */
-                $layer = $this->project->getLayer($layer->id);
-                $aliases = $layer->getAliasFields();
-                $layer = json_decode($data);
-                $layer->aliases = (object) $aliases;
-                $data = json_encode($layer);
-            }
-        }
-
         return new OGCResponse($code, $mime, $data);
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -383,17 +383,7 @@ parameters:
 
 		-
 			message: "#^Negated boolean expression is always false\\.$#"
-			count: 12
-			path: lizmap/modules/lizmap/controllers/edition.classic.php
-
-		-
-			message: "#^Property editionCtrl\\:\\:\\$featureData \\(object\\) does not accept null\\.$#"
-			count: 2
-			path: lizmap/modules/lizmap/controllers/edition.classic.php
-
-		-
-			message: "#^Property editionCtrl\\:\\:\\$featureData \\(object\\) in empty\\(\\) is not falsy\\.$#"
-			count: 1
+			count: 9
 			path: lizmap/modules/lizmap/controllers/edition.classic.php
 
 		-
@@ -418,16 +408,6 @@ parameters:
 
 		-
 			message: "#^Property editionCtrl\\:\\:\\$layerXml is never read, only written\\.$#"
-			count: 1
-			path: lizmap/modules/lizmap/controllers/edition.classic.php
-
-		-
-			message: "#^Result of && is always false\\.$#"
-			count: 1
-			path: lizmap/modules/lizmap/controllers/edition.classic.php
-
-		-
-			message: "#^Right side of && is always true\\.$#"
 			count: 1
 			path: lizmap/modules/lizmap/controllers/edition.classic.php
 


### PR DESCRIPTION
QGIS Server send WFS GetFeature response by chunck.
Lizmap performs WFS GetFeature request on PostGIS layers whitout sending request to QGIS Server.

To speedup WFS GetFeature request and reducing its memory footprint, we decide to stream response to client and to use Guzzle Stream to transfer the response from QGIS Server

Funded by 3liz https://3liz.com