### PR TITLE
[Bugfix] lizmapWkt class does not well check point as numeric values

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapWkt.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapWkt.class.php
@@ -132,7 +132,7 @@ class lizmapWkt
     protected static function parsePoint($str)
     {
         $coords = preg_split(self::$regExes['spaces'], trim($str));
-        if (count($coords) < 2 || !is_numeric($coords[0]) || !is_numeric($coords[0])) {
+        if (count($coords) < 2 || !is_numeric($coords[0]) || !is_numeric($coords[1])) {
             return null;
         }
 

--- a/tests/units/classes/lizmapWktTest.php
+++ b/tests/units/classes/lizmapWktTest.php
@@ -33,6 +33,8 @@ class lizmapWktTest extends TestCase {
             'POINT ',
             'POINT()',
             'POINT(A)',
+            'POINT(A 10)',
+            'POINT(30 A)',
         );
         foreach($notWktArray as $wkt) {
             $this->assertFalse(lizmapWkt::check($wkt), 'The '.$wkt.' has been checked!');


### PR DESCRIPTION
PHPStan - PHP Static Analysis Tool 1.10.1 provides an error message on lizmapWkt class:

```bash
Error: Negated boolean expression is always false.
 ------ --------------------------------------------------------------------
  Line   lizmap/classes/lizmapWkt.class.php
 ------ --------------------------------------------------------------------
  135    Negated boolean expression is always false.
         💡 Because the type is coming from a PHPDoc, you can turn off this
            check by setting treatPhpDocTypesAsCertain: false in your
            ../phpstan.neon.
 ------ --------------------------------------------------------------------
```

The error is due to a double `is_numeric` check on the same value. lizmapWkt::parsePoint was checking twice if the first coordinates is a numeric and not if the two coordinates are numerics.

Funded by 3liz https://3liz.com

<!-- Add "fix" in front of "#" if it fixes the ticket or do nothing to only mention it.

This PR will be harvested on changelog.lizmap.com if there is a "changelog" label.
Funded by NAME URL
-->

Ticket : # 

Funded by
