### PR TITLE
[Tests] e2e: Enhancing the way to check proj4 string

### DIFF
--- a/tests/end2end/cypress/integration/requests-service-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-service-ghaction.js
@@ -37,7 +37,21 @@ describe('Request service', function () {
             expect(resp.headers['cache-control']).to.eq('no-cache')
             expect(resp.headers['etag']).to.not.eq(undefined)
 
-            expect(resp.body).to.contain('+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs')
+            const projParams = resp.body.split(' ')
+            expect(projParams).to.have.lengthOf(11)
+            expect(projParams).to.include.members([
+                '+proj=lcc',
+                '+lat_1=49',
+                '+lat_2=44',
+                '+lat_0=46.5',
+                '+lon_0=3',
+                '+x_0=700000',
+                '+y_0=6600000',
+                '+ellps=GRS80',
+                '+towgs84=0,0,0,0,0,0,0',
+                '+units=m',
+                '+no_defs',
+            ])
 
             const etag = resp.headers['etag']
             cy.request({


### PR DESCRIPTION
The test about the proj4 string provided by lizmap was to strict.

Funded by 3liz https://3liz.com