### PR TITLE
[Tests] Fix PHP unit and replace deprecated assert

### DIFF
--- a/tests/units/classes/Project/QgisProjectTest.php
+++ b/tests/units/classes/Project/QgisProjectTest.php
@@ -422,7 +422,7 @@ class QgisProjectTest extends TestCase
         if ($sname) {
             $this->assertEquals($sname, $layer->{$lname}->shortname);
         } else {
-            $this->assertObjectNotHasAttribute('shortname', $layer->{$lname});
+            $this->assertFalse(property_exists($layer->{$lname}, 'shortname'));
         }
     }
 

--- a/tests/units/classes/lizmapServicesTest.php
+++ b/tests/units/classes/lizmapServicesTest.php
@@ -284,6 +284,7 @@ class lizmapServicesTest extends TestCase
         $evalTab2 = array(
             'adminSenderEmail' => 'test.test@test.com',
             'adminSenderName' => 'Adrien',
+            'webmasterName' => 'Adrien',
         );
 
         return array(


### PR DESCRIPTION
The https://github.com/3liz/lizmap-web-client/pull/3502 Admin: allow to edit the name for the sender email introduces a regression in PHP unit tests.

Replace assertObjectNotHasAttributebecause it is deprecated and will be removed in PHPUnit 10.

