### PR TITLE
[Bugfix] WMS GetFeatureInfo Filter: the layer name has to be the same

### DIFF
--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -3199,7 +3199,7 @@ window.lizMap = function() {
                             rConfigLayer.request_params.filter !== '' )
                           wmsOptions['FILTER'] = rConfigLayer.request_params.filter+' AND "'+relation.referencingField+'" = \''+feat.properties[relation.referencedField]+'\'';
                       else
-                          wmsOptions['FILTER'] = clname+':"'+relation.referencingField+'" = \''+feat.properties[relation.referencedField]+'\'';
+                          wmsOptions['FILTER'] = wmsName+':"'+relation.referencingField+'" = \''+feat.properties[relation.referencedField]+'\'';
 
                     var parentDiv = self.parent();
 


### PR DESCRIPTION
The QGIS Server WMS Filter parameter has to start with the wms layername to identify the layer to apply filter. The layername has to be the same the one for LAYERS and QUERY_LAYERS parameters.

Funded by Terre de Provence Agglomération https://www.terredeprovence-agglo.com/