### PR TITLE
UX - Transfrom _ and - to a space when creating a repository

### DIFF
--- a/lizmap/www/assets/js/admin/config_section.js
+++ b/lizmap/www/assets/js/admin/config_section.js
@@ -5,7 +5,7 @@ window.onload = () => {
     }
     document.getElementById('jforms_admin_config_section_path').addEventListener('change', (evt) => {
         const repVal = evt.target.value;
-        const repName = repVal.trim().replace(/^\/+/, '').replace(/\/+$/, '').split('/').pop();
+        const repName = repVal.trim().replace('_', ' ').replace('-', ' ').replace(/^\/+/, '').replace(/\/+$/, '').split('/').pop();
         document.getElementById('jforms_admin_config_section_label').value = repName[0].toUpperCase() + repName.slice(1).toLowerCase();
         document.getElementById('jforms_admin_config_section_repository').value = repName.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replaceAll(/[^a-z0-9]/g, '');
     });


### PR DESCRIPTION
Transfrom `_` and `-` to a space when creating a repository for the label

![image](https://user-images.githubusercontent.com/1609292/225679719-149bdf4c-9511-4b3d-8167-83162f1fa619.png)

Follow up from #3416