### PR TITLE
[Bugfix] Set Guzzle timeout greater than 2 seconds

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/Proxy.php
+++ b/lizmap/modules/lizmap/lib/Request/Proxy.php
@@ -537,7 +537,7 @@ class Proxy
 
         $client = new Client(array(
             // You can set any number of default request options.
-            'timeout' => 2.0,
+            'timeout' => max(10.0, floatval(ini_get('max_execution_time')) - 5.0),
         ));
 
         $request = new Request(

--- a/tests/end2end/cypress/integration/requests-wfs-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-wfs-ghaction.js
@@ -1181,6 +1181,45 @@ describe('Request service', function () {
         })
     })
 
+    it('WFS GetFeature with wfsOutputExtension', function () {
+        cy.request({
+            method: 'POST',
+            url: '/index.php/lizmap/service/?repository=testsrepository&project=selection',
+            qs: {
+                'SERVICE': 'WFS',
+                'VERSION': '1.0.0',
+                'REQUEST': 'GetFeature',
+                'TYPENAME': 'selection_polygon',
+                'OUTPUTFORMAT': 'CSV',
+            },
+        }).then((resp) => {
+            expect(resp.status).to.eq(200)
+            expect(resp.headers['content-type']).to.contain('text/csv')
+            expect(resp.body).to.contain('gml_id')
+            expect(resp.body).to.contain('selection_polygon.1')
+            expect(resp.body).to.contain('selection_polygon.2')
+        })
+
+        cy.request({
+            method: 'POST',
+            url: '/index.php/lizmap/service/?repository=testsrepository&project=selection',
+            qs: {
+                'SERVICE': 'WFS',
+                'VERSION': '1.0.0',
+                'REQUEST': 'GetFeature',
+                'TYPENAME': 'selection_polygon',
+                'OUTPUTFORMAT': 'KML',
+            },
+        }).then((resp) => {
+            expect(resp.status).to.eq(200)
+            expect(resp.headers['content-type']).to.contain('application/vnd.google-earth.kml+xml')
+            expect(resp.body).to.contain('Folder')
+            expect(resp.body).to.contain('Placemark')
+            expect(resp.body).to.contain('<SimpleData name="gml_id">selection_polygon.1</SimpleData>')
+            expect(resp.body).to.contain('<SimpleData name="gml_id">selection_polygon.2</SimpleData>')
+        })
+    })
+
     it('Version parameter is mandatory except for GetCapabilities request', function () {
         cy.request({
             method: 'POST',


### PR DESCRIPTION
Guzzle HTTP is used in Lizmap Web Client to stream WFS GetFeature Request.

For some requests like those based on wfsOutputExtension plugin, the time to perform the request is greater than 2 seconds.

To fix it the Guzzle timeout is based on PHP `max_execution_time`

Funded by 3Liz
