### PR TITLE
[Bugfix] Regression in view/media/getCssFile

### DIFF
--- a/lizmap/modules/view/controllers/media.classic.php
+++ b/lizmap/modules/view/controllers/media.classic.php
@@ -397,7 +397,6 @@ class mediaCtrl extends jController
         /** @var jResponseBinary $rep */
         $rep = $this->getResponse('binary');
         $rep->doDownload = false;
-        $rep->fileName = $abspath;
 
         // Get the name of the file
         $name = $path_parts['basename'].'.'.$path_parts['extension'];


### PR DESCRIPTION
Reset the fileName jResponseBinary property because Lizmap update the CSS content to replace url link.

Funded by AUDELOR