### PR TITLE
Raise QGIS minimum version to 3.22

### DIFF
--- a/lizmap/app/system/mainconfig.ini.php
+++ b/lizmap/app/system/mainconfig.ini.php
@@ -29,7 +29,7 @@ fallbackLocale=en_US
 [minimumRequiredVersion]
 ; Versions on the server, for the system administrator
 ; The minimum version required about external software to make Lizmap Web Client happy
-qgisServer="3.16"
+qgisServer="3.22"
 lizmapServerPlugin="2.8.1"
 
 ; Versions written in QGIS/CFG files, for the GIS administrator


### PR DESCRIPTION
Raise QGIS minimum version to 3.22 for the server.

It doesn't impact versions in projects for being visible.

It means we jumped from QGIS 3.10 to 3.22 for LWC 3.7