### PR TITLE
[Bugfix] Apply editing context for requests in edition form

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisExpressionUtils.class.php
+++ b/lizmap/modules/lizmap/classes/qgisExpressionUtils.class.php
@@ -97,19 +97,29 @@ class qgisExpressionUtils
         }
 
         // get login filter
-        $loginFilter = $project->getLoginFilter($layer->getName(), $edition);
+        $loginFilterObj = $project->getLoginFilter($layer->getName(), $edition);
+        $loginFilter = '';
+        if (!empty($loginFilterObj) && array_key_exists('filter', $loginFilterObj)) {
+            $loginFilter = $loginFilterObj['filter'];
+        }
+        // get polygon filter
+        $polygonFilter = $layer->getPolygonFilterExpression($edition);
 
-        // login filters array is empty
+        // filters are empty
+        if (empty($loginFilter) && empty($polygonFilter)) {
+            return '';
+        }
+        // login filter is empty and not the polygon filter
+        if (!empty($loginFilter) && empty($polygonFilter)) {
+            return $loginFilter;
+        }
+        // polygon filter is empty and not the login filter
         if (empty($loginFilter)) {
-            return '';
+            return $polygonFilter;
         }
 
-        // layer not in login filters array
-        if (!array_key_exists('filter', $loginFilter)) {
-            return '';
-        }
-
-        return $loginFilter['filter'];
+        // Combine filters
+        return '('.$loginFilter.') AND ('.$polygonFilter.')';
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/Form/QgisFormValueRelationDynamicDatasource.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisFormValueRelationDynamicDatasource.php
@@ -79,7 +79,7 @@ class QgisFormValueRelationDynamicDatasource extends \jFormsDynamicDatasource
                 );
 
                 // Get Feature With Forms Scope
-                $features = \qgisExpressionUtils::getFeatureWithFormScope($layer, $filterExpression, $form_feature, array($keyColumn, $valueColumn));
+                $features = \qgisExpressionUtils::getFeatureWithFormScope($layer, $filterExpression, $form_feature, array($keyColumn, $valueColumn), true);
                 foreach ($features as $feat) {
                     if (property_exists($feat, 'properties')
                         and property_exists($feat->properties, $keyColumn)
@@ -99,8 +99,11 @@ class QgisFormValueRelationDynamicDatasource extends \jFormsDynamicDatasource
                     'GEOMETRYNAME' => 'none',
                 );
 
-                // Perform request
+                // Get request
                 $wfsRequest = new \Lizmap\Request\WFSRequest($lproj, $params, \lizmap::getServices());
+                // Set Editing context
+                $wfsRequest->setEditingContext(true);
+                // Process request
                 $wfsResult = $wfsRequest->process();
 
                 $data = $wfsResult->getBodyAsString();


### PR DESCRIPTION
The login and polygon filters can be applied only for edition. The editing context was not set for requests coming from edition form.

The polygon filter was not provided by `qgisExpressionUtils::getExpressionByUser`, so it was not applied for value relation with expression.

When checking the submitted feature, filter by login has to be tested without filter by polygon which was check by `checkFeatureAgainstPolygonFilter` method.

Funded by Conseil Départemental du Calvados https://www.calvados.fr/
