### PR TITLE
[Bugfix] Edition: Apply centroid is config for checking geometry

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -673,6 +673,11 @@ class qgisVectorLayer extends qgisMapLayer
                 $spatial_relationship = 'ST_'.$polygonFilterConfig['spatial_relationship'];
             }
         }
+        // And apply use_centroid
+        if (array_key_exists('use_centroid', $polygonFilterConfig)
+            && strtolower($polygonFilterConfig['use_centroid']) == 'true') {
+            $geometry_sql = 'ST_Centroid('.$geometry_sql.')';
+        }
 
         // Query PostgreSQL to get the intersection between the geometry and the polygons
         $sql = "


### PR DESCRIPTION
The user filter based on geometry can be configure to be applied on centroid. The geometry checking for edition was not applying centroid.

Funded by 3liz https://3liz.com