### PR TITLE
[Bugfix] getPivotParam method was not well used

### DIFF
--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -2144,7 +2144,7 @@ var lizAttributeTable = function() {
 
             // ** ** If typeName is a pivot, add some info about the otherParent
             // If pivot, re-loop relations to find configuration for other parents (go up)
-            var pivotParam = getPivotParam( typeNameId, attributeLayerConfig, attributeLayerConfig, typeNameDone );
+            var pivotParam = getPivotParam( typeNameId, attributeLayerConfig, typeNameDone );
 
             // **3** Apply filter to the typeName and redraw if necessary
             var layer = lizMap.map.getLayersByName( lizMap.cleanName(typeName) )[0];


### PR DESCRIPTION
The getPivotParam has only 3 parameters not 4. The attributeLayerConfig was provided twice.

Funded by 3Liz
