### PR TITLE
[Backport release_3_5] Fix: erase draw in localstorage

### DIFF
--- a/assets/src/modules/Digitizing.js
+++ b/assets/src/modules/Digitizing.js
@@ -415,7 +415,7 @@ export default class Digitizing {
         }
         this._drawLayer.destroyFeatures();
 
-        localStorage.removeItem(this._repoAndProjectString + '_drawLayer');
+        localStorage.removeItem(this._repoAndProjectString + '_' + this._context + '_drawLayer');
 
         this.isEdited = false;
 


### PR DESCRIPTION
Manually backport https://github.com/3liz/lizmap-web-client/commit/78871e37f2e94bd15c88b2207876da30f8237077
Authored by: @nboisteault
