### PR TITLE
UX - Do not display atlasprint anymore if it is not installed

### DIFF
--- a/lizmap/modules/admin/controllers/server_information.classic.php
+++ b/lizmap/modules/admin/controllers/server_information.classic.php
@@ -71,6 +71,22 @@ class server_informationCtrl extends jController
             $displayPluginActionColumn = true;
         }
 
+        // atlasPrint is not needed anymore starting from 3.7
+        // but Lizmap server QGIS plugin is not aware if the current LWC version
+        // and it's still providing 'atlasPrint' with a 'not found' value
+        // Lizmap server will stop when LWC 3.6 will be retired
+        $removeAtlasPrintPlugin = false;
+        if (array_key_exists('atlasprint', $data['qgis_server_info']['plugins'])) {
+            if ($data['qgis_server_info']['plugins']['atlasprint']['version'] == 'not found') {
+                unset($data['qgis_server_info']['plugins']['atlasprint']);
+            }
+            // Show the deprecated warning
+            // Add the else statement again
+            // Temporary disabled, let's wait a little
+            // $displayPluginActionColumn = true;
+            // $removeAtlasPrintPlugin = true;
+        }
+
         // Set the HTML content
         $tpl = new jTpl();
         $assign = array(
@@ -81,6 +97,7 @@ class server_informationCtrl extends jController
             'displayPluginActionColumn' => $displayPluginActionColumn,
             'lizmapQgisServerNeedsUpdate' => $lizmapQgisServerNeedsUpdate,
             'lizmapPluginUpdate' => $updateLizmapPlugin,
+            'removeAtlasPrintPlugin' => $removeAtlasPrintPlugin,
             'minimumQgisVersion' => $qgisMinimumVersionRequired,
             'minimumLizmapServer' => $lizmapPluginMinimumVersionRequired,
         );

--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -262,6 +262,7 @@ server.information.qgis.plugins.version=Version number
 server.information.qgis.plugin=Plugin
 server.information.qgis.plugin.version=Version
 server.information.qgis.plugin.action=Action
+server.information.qgis.plugin.atlasprint=The plugin is not used anymore and is deprecated. It can be removed.
 
 server.information.qgis.test.ok=QGIS Server is correctly installed and returns the expected response for OGC requests.
 server.information.qgis.test.error=QGIS Server is not correctly installed in your server or the URL for OGC requests given in Lizmap configuration is not correct.

--- a/lizmap/modules/admin/templates/server_information.tpl
+++ b/lizmap/modules/admin/templates/server_information.tpl
@@ -167,6 +167,8 @@
             {if $displayPluginActionColumn }
                 {if $name == 'lizmap_server' && $lizmapQgisServerNeedsUpdate}
                     <td style="background-color:lightcoral;"><strong>{$lizmapPluginUpdate}</strong></td>
+                {elseif $name == 'atlasprint' && $removeAtlasPrintPlugin}
+                    <td>{@admin.server.information.qgis.plugin.atlasprint@}</td>
                 {else}
                 <td></td>
                 {/if}


### PR DESCRIPTION
Follow up from PR #3483 and commit a813bd6bb23a6c840f395217625d91652965c33c

* Do not display "Atlasprint : not found" if it's wasn't installed
* Invite the user to remove it ? The only drawback of this is if the user really wants it, using some direct call to QGIS server to the AtlasPrint API ? But I think we really want to not maintain it anymore, so it should be fine according to me.

Before merging this, snap and prod server mustn't install the plugin. Let's wait before removing.
