### PR TITLE
Remove deprecated call to the Lizmap server plugin

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapProject.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapProject.class.php
@@ -214,14 +214,6 @@ class lizmapProject
         return $this->proj->hasAtlasEnabled();
     }
 
-    /**
-     * @return mixed
-     */
-    public function getQgisServerPlugins()
-    {
-        return $this->proj->getQgisServerPlugins();
-    }
-
     public function hasTooltipLayers()
     {
         return $this->proj->hasTooltipLayers();

--- a/lizmap/modules/lizmap/classes/qgisExpressionUtils.class.php
+++ b/lizmap/modules/lizmap/classes/qgisExpressionUtils.class.php
@@ -155,40 +155,37 @@ class qgisExpressionUtils
     {
         // Evaluate the expression by qgis
         $project = $layer->getProject();
-        $plugins = $project->getQgisServerPlugins();
-        if (array_key_exists('Lizmap', $plugins)) {
-            $params = array(
-                'service' => 'EXPRESSION',
-                'request' => 'Evaluate',
-                'map' => $project->getRelativeQgisPath(),
-                'layer' => $layer->getName(),
-                'expressions' => json_encode($expressions),
-            );
-            if ($form_feature) {
-                $params['feature'] = json_encode($form_feature);
-                $params['form_scope'] = 'true';
-            }
+        $params = array(
+            'service' => 'EXPRESSION',
+            'request' => 'Evaluate',
+            'map' => $project->getRelativeQgisPath(),
+            'layer' => $layer->getName(),
+            'expressions' => json_encode($expressions),
+        );
+        if ($form_feature) {
+            $params['feature'] = json_encode($form_feature);
+            $params['form_scope'] = 'true';
+        }
 
-            // Request evaluate expression
-            $json = self::request($params, $project);
-            if (!$json) {
-                return null;
-            }
-            if (property_exists($json, 'status')
-                && $json->status == 'success'
-                && property_exists($json, 'results')) {
-                // Get results
-                return $json->results[0];
-            }
-            if (property_exists($json, 'data')) {
-                // TODO parse errors
-                // if (property_exists($json, 'errors')) {
-                // }
-                jLog::log($json->data, 'error');
-            } else {
-                // Data not well formed
-                jLog::log(json_encode($json), 'error');
-            }
+        // Request evaluate expression
+        $json = self::request($params, $project);
+        if (!$json) {
+            return null;
+        }
+        if (property_exists($json, 'status')
+            && $json->status == 'success'
+            && property_exists($json, 'results')) {
+            // Get results
+            return $json->results[0];
+        }
+        if (property_exists($json, 'data')) {
+            // TODO parse errors
+            // if (property_exists($json, 'errors')) {
+            // }
+            jLog::log($json->data, 'error');
+        } else {
+            // Data not well formed
+            jLog::log(json_encode($json), 'error');
         }
 
         return null;
@@ -209,29 +206,24 @@ class qgisExpressionUtils
     public static function getFeatureWithFormScope($layer, $expression, $form_feature, $fields, $edition = false)
     {
         $project = $layer->getProject();
-        $plugins = $project->getQgisServerPlugins();
-        if (array_key_exists('Lizmap', $plugins)) {
-            // build parameters
-            $params = array(
-                'service' => 'EXPRESSION',
-                'request' => 'getFeatureWithFormScope',
-                'map' => $project->getRelativeQgisPath(),
-                'layer' => $layer->getName(),
-                'filter' => self::updateExpressionByUser($layer, $expression, $edition),
-                'form_feature' => json_encode($form_feature),
-                'fields' => implode(',', $fields),
-            );
+        // build parameters
+        $params = array(
+            'service' => 'EXPRESSION',
+            'request' => 'getFeatureWithFormScope',
+            'map' => $project->getRelativeQgisPath(),
+            'layer' => $layer->getName(),
+            'filter' => self::updateExpressionByUser($layer, $expression, $edition),
+            'form_feature' => json_encode($form_feature),
+            'fields' => implode(',', $fields),
+        );
 
-            // Request getFeatureWithFormsScope
-            $json = self::request($params, $project);
-            if (!$json || !property_exists($json, 'features')) {
-                return array();
-            }
-
-            return $json->features;
+        // Request getFeatureWithFormsScope
+        $json = self::request($params, $project);
+        if (!$json || !property_exists($json, 'features')) {
+            return array();
         }
 
-        return array();
+        return $json->features;
     }
 
     /**

--- a/lizmap/modules/lizmap/classes/qgisServer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisServer.class.php
@@ -22,36 +22,4 @@ class qgisServer
     {
         $this->services = lizmap::getServices();
     }
-
-    public function getPlugins($project)
-    {
-        $key = 'qgis/server/plugins';
-        $key = jCache::normalizeKey($key);
-        $plugins = jCache::get($key);
-        if ($plugins !== false && $plugins !== null) {
-            return $plugins;
-        }
-
-        $plugins = array();
-
-        // Check Lizmap plugin
-        $params = array(
-            'service' => 'LIZMAP',
-            'request' => 'GetServerSettings',
-            'map' => $project->getRelativeQgisPath(),
-        );
-        $url = \Lizmap\Request\Proxy::constructUrl($params, $this->services);
-        list($data, $mime, $code) = \Lizmap\Request\Proxy::getRemoteData($url);
-        if (strpos($mime, 'text/json') === 0 || strpos($mime, 'application/json') === 0) {
-            $json = json_decode($data);
-            if (property_exists($json, 'lizmap')) {
-                $metadata = $json->lizmap;
-                $plugins[$metadata->name] = array('version' => $metadata->version);
-            }
-        }
-
-        jCache::set($key, $plugins, 3600);
-
-        return $plugins;
-    }
 }

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -1428,14 +1428,6 @@ class qgisVectorLayer extends qgisMapLayer
             'polygon' => 'SRID=2154;POLYGON((0 0.1,0.1 0.1,0.1 0,0 0.1))',
         );
 
-        // No filter if Lizmap plugin is not installed server side
-        $plugins = $this->project->getQgisServerPlugins();
-        if (!array_key_exists('Lizmap', $plugins)) {
-            \jLog::log('requestPolygonFilter: no lizmap plugin installed for QGIS Server');
-
-            return $no_data_array;
-        }
-
         // Check if the current user is connected
         $appContext = $this->project->getAppContext();
         $is_connected = $appContext->UserIsConnected();

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -783,16 +783,6 @@ class Project
         return false;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getQgisServerPlugins()
-    {
-        $qgisServer = new \qgisServer();
-
-        return $qgisServer->getPlugins($this);
-    }
-
     public function hasTooltipLayers()
     {
         $tooltip = $this->cfg->getTooltipLayers();
@@ -1772,9 +1762,6 @@ class Project
                 unset($configJson->datavizLayers);
             }
         }
-
-        // Get server plugins
-        $configJson->qgisServerPlugins = $this->getQgisServerPlugins();
 
         // Check layers group visibility
         $userGroups = array('');


### PR DESCRIPTION
Since LWC 3.6, we know that the plugin is installed and updated before we open a map, so we can remove some code...

The idea is to remove the GET request to QGIS server : `SERVICE=LIZMAP&REQUEST=GetServerSettings`
It's handled by the JSON metadata.
