### PR TITLE
Data filtering - Fix the filter not applied to the children layers

### DIFF
--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -2327,6 +2327,8 @@ var lizAttributeTable = function() {
                     typeNamePkeyValues.push('-99999');
 
                 if( aFilter ){
+                    // The values must be separated by comma AND spaces
+                    // since QGIS controls the syntax for the FILTER parameter
                     lFilter = layerN + ':"' + typeNamePkey + '" IN ( ' + typeNamePkeyValues.join( ' , ' ) + ' ) ';
 
                     // Try to use the simple filter ( for example myforeignkey = 4 )
@@ -2418,16 +2420,20 @@ var lizAttributeTable = function() {
                         // Build filter for children
                         // and add child to the typeNameFilter and typeNamePile objects
                         // only if typeName filter aFilter was originally set
-                        if( aFilter && cData['parentValues'].length > 0 && cascade != 'removeChildrenFilter' )
-                            cExpFilter = '"' + cData['fieldToFilter'] + '" IN ( ' + cData['parentValues'].join() + ' )';
-                        else if( aFilter && cascade != 'removeChildrenFilter' )
+                        if( aFilter && cData['parentValues'].length > 0 && cascade != 'removeChildrenFilter' ) {
+                            // The values must be separated by comma AND spaces
+                            // since QGIS controls the syntax for the FILTER parameter
+                            cExpFilter = '"' + cData['fieldToFilter'] + '" IN ( ' + cData['parentValues'].join( ' , ' ) + ' )';
+                        }
+                        else if( aFilter && cascade != 'removeChildrenFilter' ) {
                             cExpFilter = '"' + cData['fieldToFilter'] + '" IN ( -99999 )';
+                        }
                         cFilter = wmsCname + ':' + cExpFilter;
 
                         config.layers[cName]['request_params']['filter'] = cFilter;
                         config.layers[cName]['request_params']['exp_filter'] = cExpFilter;
 
-                        typeNameFilter[x] = cFilter;
+                        typeNameFilter[x] = cExpFilter;
                         typeNamePile.push( x );
 
                     }
@@ -2437,6 +2443,9 @@ var lizAttributeTable = function() {
                 if( pivotParam ){
                     // Add a Filter to the "other parent" layers
                     var cFilter = null;
+                    // The stored filter in this variable cExpFilter must not be prefixed by the layername
+                    // since it is used to build the EXP_FILTER parameter
+                    // the cFilter will be based on this value but with the layer name as prefix
                     var cExpFilter = null;
                     var orObj = null;
                     var pwmsName = pivotParam['otherParentTypeName'];
@@ -2448,7 +2457,9 @@ var lizAttributeTable = function() {
                     if( aFilter  ){
                         if( pivotParam['otherParentValues'].length > 0 ){
                             cExpFilter = '"' + pivotParam['otherParentRelation'].referencedField + '"';
-                            cExpFilter+= ' IN ( ' + pivotParam['otherParentValues'].join() + ' )';
+                            // The values must be separated by comma AND spaces
+                            // since QGIS controls the syntax for the FILTER parameter
+                            cExpFilter+= ' IN ( ' + pivotParam['otherParentValues'].join( ' , ' ) + ' )';
                             cFilter = pwmsName + ':' + cExpFilter;
                             orObj = {
                                 field: pivotParam['otherParentRelation'].referencedField,
@@ -2464,11 +2475,13 @@ var lizAttributeTable = function() {
                             }
                         }
                     }
-
                     config.layers[ pivotParam['otherParentTypeName'] ]['request_params']['filter'] = cFilter;
                     config.layers[ pivotParam['otherParentTypeName'] ]['request_params']['exp_filter'] = cExpFilter;
 
-                    typeNameFilter[ pivotParam['otherParentTypeName'] ] = cFilter;
+                    // The stored filter in this variable must not be prefixed by the layername
+                    // since it is used to build the EXP_FILTER parameter
+                    // the FILTER will be based on this value but with the layer name as prefix
+                    typeNameFilter[ pivotParam['otherParentTypeName'] ] = cExpFilter;
                     typeNamePile.push( pivotParam['otherParentTypeName'] );
                 }
 
@@ -2536,7 +2549,9 @@ var lizAttributeTable = function() {
                 if ( lConfig['filteredFeatures']
                     && lConfig['filteredFeatures'].length > 0
                 ){
-                    cFilter = '$id IN ( ' + lConfig['filteredFeatures'].join() + ' ) ';
+                    // The values must be separated by comma AND spaces
+                    // since QGIS controls the syntax for the FILTER parameter
+                    cFilter = '$id IN ( ' + lConfig['filteredFeatures'].join( ' , ' ) + ' ) ';
                 }
 
                 var wmsName = featureType;

--- a/tests/end2end/cypress/integration/attribute_table-ghaction.js
+++ b/tests/end2end/cypress/integration/attribute_table-ghaction.js
@@ -90,7 +90,7 @@ describe('Attribute table', () => {
 
         cy.get('#bottom-dock-window-buttons .btn-bottomdock-size').click()
 
-        // postgreSQL layer
+        // PostgreSQL layer
         cy.get('button[value="quartiers"].btn-open-attribute-layer').click({ force: true })
 
         // Wait for features
@@ -281,7 +281,7 @@ describe('Attribute table', () => {
                 .to.contain('REQUEST=GetFeature')
                 .to.contain('TYPENAME=quartiers')
                 .to.contain('OUTPUTFORMAT=GeoJSON')
-                .to.contain('EXP_FILTER=%24id+IN+(+2%2C4%2C6+)')
+                .to.contain('EXP_FILTER=%24id+IN+(+2+%2C+4+%2C+6+)')
             expect(interception.response.body)
                 .to.have.property('type')
             expect(interception.response.body.type).to.be.eq('FeatureCollection')
@@ -334,7 +334,7 @@ describe('Attribute table', () => {
                 .to.contain('REQUEST=GetFeature')
                 .to.contain('TYPENAME=quartiers')
                 .to.contain('OUTPUTFORMAT=GeoJSON')
-                .to.contain('EXP_FILTER=%24id+IN+%28+2%2C4%2C6+%29')
+                .to.contain('EXP_FILTER=%24id+IN+%28+2+%2C+4+%2C+6+%29+')
             expect(interception.response.body)
                 .to.have.property('type')
             expect(interception.response.body.type).to.be.eq('FeatureCollection')
@@ -525,7 +525,7 @@ describe('Attribute table', () => {
                 .to.contain('REQUEST=GetFeature')
                 .to.contain('TYPENAME=quartiers')
                 .to.contain('OUTPUTFORMAT=GeoJSON')
-                .to.contain('EXP_FILTER=%24id+IN+(+2%2C4%2C6+)')
+                .to.contain('EXP_FILTER=%24id+IN+(+2+%2C+4+%2C+6+)')
             expect(interception.response.body)
                 .to.have.property('type')
             expect(interception.response.body.type).to.be.eq('FeatureCollection')


### PR DESCRIPTION
The parameters sent to QGIS Server were not well formated which prevented the filter from beeing applied on the related layers

* Add spaces between the values in the SQL "IN" clause
* Remove the unneeded layer name as a prefix for the EXP_FILTER parameter

<!--
Add "fix" in front of "#" if it fixes the ticket or do nothing to only mention it.

Funded by NAME URL
-->

Ticket : # 

Funded by 3Liz
