### PR TITLE
Config: Add layerType and extract xyz and WMTS 3857 datasource parameters

### DIFF
--- a/assets/src/modules/config/BaseLayer.js
+++ b/assets/src/modules/config/BaseLayer.js
@@ -49,10 +49,14 @@ export class BaseLayerConfig extends BaseObjectConfig {
 
         this._hasAttribution = false;
         this._attribution = null;
-        if (cfg.hasOwnProperty('attribution')
-            && Object.getOwnPropertyNames(cfg['attribution']).length != 0) {
-            this._attribution = new AttributionConfig(cfg['attribution']);
-            this._hasAttribution = true;
+        if (cfg.hasOwnProperty('attribution')) {
+            if (cfg['attribution'] instanceof AttributionConfig) {
+                this._attribution = cfg['attribution'];
+                this._hasAttribution = true;
+            } else if (Object.getOwnPropertyNames(cfg['attribution']).length != 0) {
+                this._attribution = new AttributionConfig(cfg['attribution']);
+                this._hasAttribution = true;
+            }
         }
     }
 
@@ -165,12 +169,12 @@ export class EmptyBaseLayerConfig extends BaseLayerConfig {
 const xyzProperties = {
     'title': { type: 'string' },
     'url': { type: 'string' },
-    'zmin': { type: 'number' },
-    'zmax': { type: 'number' },
     'crs': { type: 'string' }
 }
 
 const xyzOptionalProperties = {
+    'zmin': { type: 'number', default: 0 },
+    'zmax': { type: 'number', default: 20 },
     'key': { type: 'string', nullable: true }
 }
 
@@ -186,9 +190,9 @@ export class XyzBaseLayerConfig extends BaseLayerConfig {
      * @param {Object} cfg               - the lizmap config object for XYZ base layer
      * @param {String} cfg.title         - the base layer title
      * @param {String} cfg.url           - the base layer url
-     * @param {Number} cfg.zmin          - the base layer zmin
-     * @param {Number} cfg.zmax          - the base layer zmax
      * @param {String} cfg.crs           - the base layer crs
+     * @param {Number} [cfg.zmin]        - the base layer zmin
+     * @param {Number} [cfg.zmax]        - the base layer zmax
      * @param {String} [cfg.key]         - the base layer key
      * @param {Object} [cfg.attribution] - the base layer attribution config object
      */
@@ -314,11 +318,11 @@ const wmtsProperties = {
     'format': { type: 'string' },
     'style': { type: 'string' },
     'matrixSet': { type: 'string' },
-    'crs': { type: 'string' },
-    'numZoomLevels': { type: 'number' }
+    'crs': { type: 'string' }
 }
 
 const wmtsOptionalProperties = {
+    'numZoomLevels': { type: 'number', default: 19 },
     'key': { type: 'string', nullable: true }
 }
 
@@ -330,18 +334,18 @@ const wmtsOptionalProperties = {
 export class WmtsBaseLayerConfig extends BaseLayerConfig {
     /**
      * Create a WMTS base layer config based on a config object
-     * @param {String} name              - the base layer name
-     * @param {Object} cfg               - the lizmap config object for WMTS base layer
-     * @param {String} cfg.title         - the base layer title
-     * @param {String} cfg.url           - the base layer url
-     * @param {String} cfg.layer         - the base layer layer
-     * @param {String} cfg.format        - the base layer format
-     * @param {String} cfg.style         - the base layer style
-     * @param {String} cfg.matrixSet     - the base layer matrixSet
-     * @param {String} cfg.crs           - the base layer crs
-     * @param {Number} cfg.numZoomLevels - the base layer numZoomLevels
-     * @param {String} [cfg.key]         - the base layer key
-     * @param {Object} [cfg.attribution] - the base layer attribution config object
+     * @param {String} name                - the base layer name
+     * @param {Object} cfg                 - the lizmap config object for WMTS base layer
+     * @param {String} cfg.title           - the base layer title
+     * @param {String} cfg.url             - the base layer url
+     * @param {String} cfg.layer           - the base layer layer
+     * @param {String} cfg.format          - the base layer format
+     * @param {String} cfg.style           - the base layer style
+     * @param {String} cfg.matrixSet       - the base layer matrixSet
+     * @param {String} cfg.crs             - the base layer crs
+     * @param {Number} [cfg.numZoomLevels] - the base layer numZoomLevels
+     * @param {String} [cfg.key]           - the base layer key
+     * @param {Object} [cfg.attribution]   - the base layer attribution config object
      */
     constructor(name, cfg) {
         if (!cfg || typeof cfg !== "object") {
@@ -679,6 +683,8 @@ export class BaseLayersConfig {
                 if ( !extendedCfg.hasOwnProperty(layerTreeItem.name) ) {
                     if ( defaultCompleteBaseLayersCfg.hasOwnProperty(layerTreeItem.name) ) {
                         extendedCfg[layerTreeItem.name] = structuredClone(defaultCompleteBaseLayersCfg[layerTreeItem.name]);
+                    } else if ( layerTreeItem.layerCfg.externalWmsToggle ){
+                        extendedCfg[layerTreeItem.name] = structuredClone(defaultCompleteBaseLayersCfg[layerTreeItem.layerCfg.externalAccess]);
                     } else {
                         extendedCfg[layerTreeItem.name] = {
                             "type": "lizmap",
@@ -688,6 +694,10 @@ export class BaseLayersConfig {
                 // Override title and set layer config
                 extendedCfg[layerTreeItem.name].title = layerTreeItem.wmsTitle;
                 extendedCfg[layerTreeItem.name].layerConfig = layerTreeItem.layerConfig;
+                const wmsAttribution = layerTreeItem.wmsAttribution;
+                if (wmsAttribution != null) {
+                    extendedCfg[layerTreeItem.name].attribution = wmsAttribution;
+                }
                 names.push(layerTreeItem.name);
             }
         }
@@ -702,6 +712,8 @@ export class BaseLayersConfig {
                     extendedCfg[layerCfg.name] = structuredClone(defaultCompleteBaseLayersCfg[layerCfg.name]);
                     // Override title
                     extendedCfg[layerCfg.name].title = layerCfg.title;
+                } else if ( layerCfg.externalWmsToggle ){
+                    extendedCfg[layerCfg.name] = structuredClone(defaultCompleteBaseLayersCfg[layerCfg.externalAccess]);
                 } else {
                     extendedCfg[layerCfg.name] = {
                         "type": "lizmap",

--- a/assets/src/modules/config/BaseLayer.js
+++ b/assets/src/modules/config/BaseLayer.js
@@ -357,6 +357,23 @@ export class WmtsBaseLayerConfig extends BaseLayerConfig {
         }
 
         super('wmts', name, cfg, wmtsProperties, wmtsOptionalProperties);
+
+        // Remove unnecessary parameters
+        let wmtsUrl = new URL(this._url);
+        let keysToRemove = []
+        for (const [key, ] of wmtsUrl.searchParams) {
+            if (key.toLowerCase() == 'service'
+                || key.toLowerCase() == 'version'
+                || key.toLowerCase() == 'request') {
+                keysToRemove.push(key);
+            }
+        }
+        if (keysToRemove.length != 0) {
+            for (const key of keysToRemove) {
+                wmtsUrl.searchParams.delete(key);
+            }
+            this._url = wmtsUrl.toString();
+        }
     }
 
     /**

--- a/assets/src/modules/config/Layer.js
+++ b/assets/src/modules/config/Layer.js
@@ -29,12 +29,14 @@ const requiredProperties = {
 
 const optionalProperties = {
     'shortname': {type: 'string'},
+    'layerType': {type: 'string', nullable: true},
     'geometryType': {type: 'string', nullable: true},
     'extent': {type: 'extent', nullable: true},
     'crs': {type: 'string', nullable: true},
     'popupFrame': {type: 'string', nullable: true},
     'serverFrame': {type: 'string', nullable: true},
     'mutuallyExclusive': {type: 'boolean', default: false},
+    'externalWmsToggle': {type: 'boolean', default: false},
 };
 
 /**
@@ -69,12 +71,15 @@ export class LayerConfig extends BaseObjectConfig {
      * @param {Boolean}  cfg.cached                - the layer cached activation
      * @param {Number}   cfg.clientCacheExpiration - the layer client cache expiration
      * @param {String}   [cfg.shortname]           - the layer short name
-     * @param {String}   [cfg.geometryType]        - the layer geometry type (only layer type)
-     * @param {Number[]} [cfg.extent]              - the layer extent (only layer type)
-     * @param {String}   [cfg.crs]                 - the layer crs (only layer type)
+     * @param {String}   [cfg.layerType]           - the layer layer type (layer only)
+     * @param {String}   [cfg.geometryType]        - the layer geometry type (layer only)
+     * @param {Number[]} [cfg.extent]              - the layer extent (layer only)
+     * @param {String}   [cfg.crs]                 - the layer crs (layer only)
      * @param {String}   [cfg.popupFrame]          - the layer popup frame
      * @param {String}   [cfg.serverFrame]         - the layer server frame
-     * @param {Boolean}  [cfg.mutuallyExclusive]   - the layer mutuallyExclusive
+     * @param {Boolean}  [cfg.mutuallyExclusive]   - the layer mutuallyExclusive (only group type)
+     * @param {Boolean}  [cfg.externalWmsToggle]   - the layer provides parameters for external access
+     * @param {Object}   [cfg.externalAccess]      - the layer external access
      */
     constructor(cfg) {
         super(cfg, requiredProperties, optionalProperties)
@@ -162,7 +167,16 @@ export class LayerConfig extends BaseObjectConfig {
     }
 
     /**
-     * The layer geometry type (only layer type)
+     * The layer type (layer only)
+     *
+     * @type {?String}
+     **/
+    get layerType() {
+        return this._layerType;
+    }
+
+    /**
+     * The layer geometry type (layer only)
      *
      * @type {?String}
      **/
@@ -171,7 +185,7 @@ export class LayerConfig extends BaseObjectConfig {
     }
 
     /**
-     * The layer extent (only layer type)
+     * The layer extent (layer only)
      *
      * @type {?Extent}
      **/
@@ -180,7 +194,7 @@ export class LayerConfig extends BaseObjectConfig {
     }
 
     /**
-     * The layer crs (only layer type)
+     * The layer crs (layer only)
      *
      * @type {?String}
      **/
@@ -261,7 +275,7 @@ export class LayerConfig extends BaseObjectConfig {
     }
 
     /**
-     * The layer as group as layer activation (only group type)
+     * The layer as group as layer activation (group only)
      *
      * @type {Boolean}
      **/
@@ -339,6 +353,24 @@ export class LayerConfig extends BaseObjectConfig {
      **/
     get mutuallyExclusive() {
         return this._mutuallyExclusive;
+    }
+
+    /**
+     * The layer provides parameters for external access (layer only)
+     *
+     * @type {Boolean}
+     **/
+    get externalWmsToggle() {
+        return this._externalWmsToggle;
+    }
+
+    /**
+     * The layer layer external access (layer only)
+     *
+     * @type {?Object}
+     **/
+    get externalAccess() {
+        return this._externalAccess;
     }
 }
 

--- a/tests/js-units/data/montpellier-config.json
+++ b/tests/js-units/data/montpellier-config.json
@@ -1,1527 +1,1557 @@
 {
-    "locateByLayer": {
-      "Quartiers": {
-        "layerId": "VilleMTP_MTP_Quartiers_2011_432620130116112610876",
-        "fieldName": "LIBQUART",
-        "displayGeom": "True",
-        "minLength": 1,
-        "filterOnLocate": "False",
-        "order": 0,
-        "fieldAlias": "Name"
-      },
-      "SousQuartiers": {
-        "layerId": "SousQuartiers20160121124316563",
-        "fieldName": "LIBSQUART",
-        "displayGeom": "True",
-        "minLength": 0,
-        "filterOnLocate": "False",
-        "order": 1,
-        "fieldAlias": "Name",
-        "vectorjoins": [
-          {
-            "joinFieldName": "QUARTMNO",
-            "targetFieldName": "QUARTMNO",
-            "joinLayerId": "VilleMTP_MTP_Quartiers_2011_432620130116112610876"
-          }
-        ]
-      },
-      "tramway": {
-        "layerId": "tramway20150328114206278",
-        "fieldName": "name",
-        "displayGeom": "False",
-        "minLength": 0,
-        "filterOnLocate": "True",
-        "order": 2,
-        "fieldAlias": "Line"
-      }
+  "locateByLayer": {
+    "Quartiers": {
+      "layerId": "VilleMTP_MTP_Quartiers_2011_432620130116112610876",
+      "fieldName": "LIBQUART",
+      "displayGeom": "True",
+      "minLength": 1,
+      "filterOnLocate": "False",
+      "order": 0,
+      "fieldAlias": "Name"
     },
-    "formFilterLayers": {},
-    "attributeLayers": {
-      "tramstop": {
-        "layerId": "tramstop20150328114203878",
-        "primaryKey": "osm_id",
-        "pivot": "False",
-        "hideAsChild": "False",
-        "hideLayer": "False",
-        "custom_config": "False",
-        "order": 0
-      },
-      "tramway_pivot": {
-        "layerId": "jointure_tram_stop20150328114216806",
-        "primaryKey": "OGC_FID",
-        "pivot": "True",
-        "hideAsChild": "False",
-        "hideLayer": "False",
-        "custom_config": "False",
-        "order": 1
-      },
-      "tram_stop_work": {
-        "layerId": "tram_stop_work20150416102656130",
-        "primaryKey": "work_id",
-        "pivot": "False",
-        "hideAsChild": "False",
-        "hideLayer": "True",
-        "custom_config": "False",
-        "order": 2
-      },
-      "publicbuildings": {
-        "layerId": "publicbuildings20150420100958543",
-        "primaryKey": "b_id",
-        "pivot": "False",
-        "hideAsChild": "False",
-        "hideLayer": "False",
-        "custom_config": "False",
-        "order": 3
-      },
-      "publicbuildings_tramstop": {
-        "layerId": "publicbuildings_tramstop20150420095614071",
-        "primaryKey": "r_id",
-        "pivot": "True",
-        "hideAsChild": "False",
-        "hideLayer": "False",
-        "custom_config": "False",
-        "order": 4
-      },
-      "tramway_ref": {
-        "layerId": "tramway_ref20150612171109044",
-        "primaryKey": "ref_id",
-        "pivot": "False",
-        "hideAsChild": "False",
-        "hideLayer": "True",
-        "custom_config": "False",
-        "order": 5
-      },
-      "tramway": {
-        "layerId": "tramway20150328114206278",
-        "primaryKey": "osm_id",
-        "pivot": "False",
-        "hideAsChild": "True",
-        "hideLayer": "False",
-        "custom_config": "False",
-        "order": 6
-      },
-      "Quartiers": {
-        "layerId": "VilleMTP_MTP_Quartiers_2011_432620130116112610876",
-        "primaryKey": "QUARTMNO",
-        "pivot": "False",
-        "hideAsChild": "False",
-        "hideLayer": "False",
-        "custom_config": "True",
-        "order": 7,
-        "attributetableconfig": {
-          "attributes": {
-            "sortExpression": "",
-            "actionWidgetStyle": "dropDown",
-            "sortOrder": "0"
-          },
-          "columns": {
-            "column": [
-              {
-                "attributes": {
-                  "hidden": "1",
-                  "name": "QUARTIER",
-                  "type": "field",
-                  "width": "-1"
-                }
-              },
-              {
-                "attributes": {
-                  "hidden": "1",
-                  "name": "QUARTMNO",
-                  "type": "field",
-                  "width": "-1"
-                }
-              },
-              {
-                "attributes": {
-                  "hidden": "1",
-                  "name": "SQUARTMNO",
-                  "type": "field",
-                  "width": "-1"
-                }
-              }
-            ]
-          }
-        }
-      },
-      "SousQuartiers": {
-        "layerId": "SousQuartiers20160121124316563",
-        "primaryKey": "SQUARTMNO",
-        "pivot": "False",
-        "hideAsChild": "False",
-        "hideLayer": "True",
-        "custom_config": "False",
-        "order": 8
-      },
-      "points_of_interest": {
-        "layerId": "edition_point20130118171631518",
-        "primaryKey": "pkuid",
-        "pivot": "False",
-        "hideAsChild": "False",
-        "hideLayer": "False",
-        "custom_config": "True",
-        "order": 9,
-        "attributetableconfig": {
-          "attributes": {
-            "sortExpression": "",
-            "actionWidgetStyle": "dropDown",
-            "sortOrder": "0"
-          },
-          "columns": {
-            "column": [
-              {
-                "attributes": {
-                  "hidden": "1",
-                  "name": "user",
-                  "type": "field",
-                  "width": "-1"
-                }
-              },
-              {
-                "attributes": {
-                  "hidden": "0",
-                  "name": "pkuid",
-                  "type": "field",
-                  "width": "-1"
-                }
-              },
-              {
-                "attributes": {
-                  "hidden": "0",
-                  "name": "name",
-                  "type": "field",
-                  "width": "-1"
-                }
-              },
-              {
-                "attributes": {
-                  "hidden": "0",
-                  "name": "description",
-                  "type": "field",
-                  "width": "-1"
-                }
-              },
-              {
-                "attributes": {
-                  "hidden": "0",
-                  "name": "date",
-                  "type": "field",
-                  "width": "-1"
-                }
-              },
-              {
-                "attributes": {
-                  "hidden": "0",
-                  "name": "type",
-                  "type": "field",
-                  "width": "-1"
-                }
-              },
-              {
-                "attributes": {
-                  "hidden": "0",
-                  "name": "photo",
-                  "type": "field",
-                  "width": "-1"
-                }
-              },
-              {
-                "attributes": {
-                  "hidden": "1",
-                  "type": "actions",
-                  "width": "-1"
-                }
-              }
-            ]
-          }
-        }
-      }
-    },
-    "layers": {
-      "Edition": {
-        "id": "Edition",
-        "name": "Edition",
-        "type": "group",
-        "title": "Edition layers",
-        "abstract": "",
-        "link": "",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "True",
-        "popup": "False",
-        "popupFrame": null,
-        "popupSource": "lizmap",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "False",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 300
-      },
-      "points_of_interest": {
-        "id": "edition_point20130118171631518",
-        "name": "points_of_interest",
-        "type": "layer",
-        "geometryType": "point",
-        "extent": [
-          3.8454151330219495,
-          43.594383,
-          3.8956343529661015,
-          43.64203625857223
-        ],
-        "crs": "EPSG:4326",
-        "title": "Points of interest",
-        "abstract": "",
-        "link": "",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "False",
-        "popup": "False",
-        "popupFrame": null,
-        "popupSource": "auto",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "True",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 300
-      },
-      "edition_line": {
-        "id": "edition_line20130409161630329",
-        "name": "edition_line",
-        "type": "layer",
-        "geometryType": "line",
-        "extent": [
-          3.831298,
-          43.571914305945946,
-          3.907530105945947,
-          43.670510184864874
-        ],
-        "crs": "EPSG:4326",
-        "title": "Bicycle rides",
-        "abstract": "",
-        "link": "",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "True",
-        "popup": "True",
-        "popupFrame": null,
-        "popupSource": "auto",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "False",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 0
-      },
-      "areas_of_interest": {
-        "id": "edition_polygon20130409114333776",
-        "name": "areas_of_interest",
-        "type": "layer",
-        "geometryType": "polygon",
-        "extent": [
-          3.862278,
-          43.606014,
-          3.8948940000000003,
-          43.649005999999986
-        ],
-        "crs": "EPSG:4326",
-        "title": "Areas of interest",
-        "abstract": "",
-        "link": "",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "False",
-        "popup": "False",
-        "popupFrame": null,
-        "popupSource": "lizmap",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "False",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 300
-      },
-      "datalayers": {
-        "id": "datalayers",
-        "name": "datalayers",
-        "type": "group",
-        "title": "Transport",
-        "abstract": "",
-        "link": "media/pdf/transport_map.pdf",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "True",
-        "popup": "False",
-        "popupFrame": null,
-        "popupSource": "lizmap",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "False",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 300
-      },
-      "Bus": {
-        "id": "Bus",
-        "name": "Bus",
-        "type": "group",
-        "title": "Bus",
-        "abstract": "Lignes et arrêts de bus de Montpellier",
-        "link": "http://www.montpellier-agglo.com/tam/page.php?id_rubrique=29",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "True",
-        "popup": "False",
-        "popupFrame": null,
-        "popupSource": "lizmap",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "False",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 300
-      },
-      "bus_stops": {
-        "id": "bus_stops20121106170806413",
-        "name": "bus_stops",
-        "type": "layer",
-        "geometryType": "point",
-        "extent": [
-          3.55326,
-          43.526928,
-          4.039131,
-          43.752341
-        ],
-        "crs": "EPSG:4326",
-        "title": "Stops",
-        "abstract": "",
-        "link": "",
-        "minScale": 0,
-        "maxScale": 15000,
-        "toggled": "False",
-        "popup": "True",
-        "popupFrame": null,
-        "popupSource": "auto",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "True",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "True",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 3600
-      },
-      "bus": {
-        "id": "bus20121102133611751",
-        "name": "bus",
-        "type": "layer",
-        "geometryType": "line",
-        "extent": [
-          3.698123,
-          43.5265,
-          4.081239,
-          43.761579
-        ],
-        "crs": "EPSG:4326",
-        "title": "Bus lines",
-        "abstract": "",
-        "link": "",
-        "minScale": 0,
-        "maxScale": 40001,
-        "toggled": "False",
-        "popup": "True",
-        "popupFrame": null,
-        "popupSource": "lizmap",
-        "popupTemplate": "<div style=\"background-color:#44433E; color:white; height:100%;\">\n\n  <p style=\"background-color:{$color}\">\n  <b>LINE</b> : {$ref} - {$name}\n  <p/>\n  \n  <p><b>Operator</b> : {$operator}</p>\n\n  <p>\n  <img width=\"60px\"  src=\"media/image/logo_bus.png\" border=\"0\"/>\n  </p>\n\n</div>",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "True",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 3600
-      },
-      "Tramway": {
-        "id": "Tramway",
-        "name": "Tramway",
-        "type": "group",
-        "title": "Tramway",
-        "abstract": "Lignes et arrêts de tramway de montpellier",
-        "link": "http://www.montpellier-agglo.com/tam/page.php?id_rubrique=32",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "False",
-        "popup": "False",
-        "popupFrame": null,
-        "popupSource": "lizmap",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "False",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 300
-      },
-      "tramway_ref": {
-        "id": "tramway_ref20150612171109044",
-        "name": "tramway_ref",
-        "type": "layer",
-        "geometryType": "none",
-        "extent": [
-          1.7976931348623157e+308,
-          1.7976931348623157e+308,
-          -1.7976931348623157e+308,
-          -1.7976931348623157e+308
-        ],
-        "crs": "EPSG:4326",
-        "title": "tramway_ref",
-        "abstract": "",
-        "link": "",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "True",
-        "popup": "False",
-        "popupFrame": null,
-        "popupSource": "lizmap",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "False",
-        "singleTile": "False",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 300
-      },
-      "tramway_pivot": {
-        "id": "jointure_tram_stop20150328114216806",
-        "name": "tramway_pivot",
-        "type": "layer",
-        "geometryType": "none",
-        "extent": [
-          1.7976931348623157e+308,
-          1.7976931348623157e+308,
-          -1.7976931348623157e+308,
-          -1.7976931348623157e+308
-        ],
-        "crs": "EPSG:4326",
-        "title": "Table pivot tramway",
-        "abstract": "",
-        "link": "",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "False",
-        "popup": "True",
-        "popupFrame": null,
-        "popupSource": "auto",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "False",
-        "singleTile": "False",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 300
-      },
-      "tram_stop_work": {
-        "id": "tram_stop_work20150416102656130",
-        "name": "tram_stop_work",
-        "type": "layer",
-        "geometryType": "none",
-        "extent": [
-          1.7976931348623157e+308,
-          1.7976931348623157e+308,
-          -1.7976931348623157e+308,
-          -1.7976931348623157e+308
-        ],
-        "crs": "EPSG:4326",
-        "title": "Tram stop works",
-        "abstract": "",
-        "link": "",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "False",
-        "popup": "False",
-        "popupFrame": null,
-        "popupSource": "lizmap",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "False",
-        "singleTile": "False",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 300
-      },
-      "tramstop": {
-        "id": "tramstop20150328114203878",
-        "name": "tramstop",
-        "type": "layer",
-        "geometryType": "point",
-        "extent": [
-          3.8101056,
-          43.5579423,
-          3.9636474,
-          43.6545596
-        ],
-        "crs": "EPSG:4326",
-        "title": "Tram stops",
-        "abstract": "",
-        "link": "",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "True",
-        "popup": "True",
-        "popupFrame": null,
-        "popupSource": "auto",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "True",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 0
-      },
-      "tramway": {
-        "id": "tramway20150328114206278",
-        "name": "tramway",
-        "type": "layer",
-        "geometryType": "line",
-        "extent": [
-          3.8097468,
-          43.5576091,
-          3.9639244,
-          43.6546121
-        ],
-        "crs": "EPSG:4326",
-        "styles": [
-          "black",
-          "colored"
-        ],
-        "title": "Tram lines",
-        "abstract": "",
-        "link": "",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "True",
-        "popup": "True",
-        "popupFrame": null,
-        "popupSource": "lizmap",
-        "popupTemplate": "{$html}",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "True",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 0,
-        "showFeatureCount": "True"
-      },
-      "Buildings": {
-        "id": "Buildings",
-        "name": "Buildings",
-        "type": "group",
-        "title": "Buildings",
-        "abstract": "",
-        "link": "",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "True",
-        "popup": "False",
-        "popupFrame": null,
-        "popupSource": "lizmap",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "False",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 300
-      },
-      "publicbuildings": {
-        "id": "publicbuildings20150420100958543",
-        "name": "publicbuildings",
-        "type": "layer",
-        "geometryType": "point",
-        "extent": [
-          431114.8420873464,
-          5403527.322277083,
-          433783.14982034185,
-          5406274.451355163
-        ],
-        "crs": "EPSG:3857",
-        "title": "public buildings",
-        "abstract": "",
-        "link": "",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "True",
-        "popup": "True",
-        "popupFrame": null,
-        "popupSource": "auto",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "True",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 0
-      },
-      "publicbuildings_tramstop": {
-        "id": "publicbuildings_tramstop20150420095614071",
-        "name": "publicbuildings_tramstop",
-        "type": "layer",
-        "geometryType": "none",
-        "extent": [
-          1.7976931348623157e+308,
-          1.7976931348623157e+308,
-          -1.7976931348623157e+308,
-          -1.7976931348623157e+308
-        ],
-        "crs": "EPSG:4326",
-        "title": "Pivot tramstops / Buildings",
-        "abstract": "",
-        "link": "",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "True",
-        "popup": "True",
-        "popupFrame": null,
-        "popupSource": "auto",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "False",
-        "singleTile": "False",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 300
-      },
-      "donnes_sociodemo_sous_quartiers": {
-        "id": "donnes_sociodemo_sous_quartiers20160121144525075",
-        "name": "donnes_sociodemo_sous_quartiers",
-        "type": "layer",
-        "geometryType": "none",
-        "extent": [
-          1.7976931348623157e+308,
-          1.7976931348623157e+308,
-          -1.7976931348623157e+308,
-          -1.7976931348623157e+308
-        ],
-        "crs": "EPSG:4326",
-        "title": "Repartition of owners and tenants",
-        "abstract": "This plot shows the repartition of owners and tenants per subdistrict in Montpellier, France.",
-        "link": "",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "True",
-        "popup": "False",
-        "popupFrame": null,
-        "popupSource": "lizmap",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "False",
-        "singleTile": "True",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 300
-      },
-      "SousQuartiers": {
-        "id": "SousQuartiers20160121124316563",
-        "name": "SousQuartiers",
-        "type": "layer",
-        "geometryType": "polygon",
-        "extent": [
-          765145.8823,
-          6274561.2223,
-          776031.667,
-          6284189.5206
-        ],
-        "crs": "EPSG:2154",
-        "title": "Sous-Quartiers",
-        "abstract": "",
-        "link": "",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "False",
-        "popup": "True",
-        "popupFrame": null,
-        "popupSource": "auto",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "True",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 300
-      },
-      "Quartiers": {
-        "id": "VilleMTP_MTP_Quartiers_2011_432620130116112610876",
-        "name": "Quartiers",
-        "type": "layer",
-        "geometryType": "polygon",
-        "extent": [
-          3.807070366959713,
-          43.5667040954502,
-          3.941330680605673,
-          43.653371224492886
-        ],
-        "crs": "EPSG:4326",
-        "title": "Quartiers",
-        "abstract": "<b>Districts of Montpellier</b>",
-        "link": "http://opendata.montpelliernumerique.fr/Quartiers",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "True",
-        "popup": "True",
-        "popupFrame": null,
-        "popupSource": "auto",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "True",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "True",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 300
-      },
-      "Overview": {
-        "id": "Overview",
-        "name": "Overview",
-        "type": "group",
-        "title": "Overview",
-        "abstract": "",
-        "link": "",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "True",
-        "popup": "False",
-        "popupFrame": null,
-        "popupSource": "lizmap",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "False",
-        "imageFormat": "image/png",
-        "cached": "True",
-        "serverFrame": null,
-        "cacheExpiration": 0,
-        "clientCacheExpiration": 3600
-      },
-      "VilleMTP_MTP_Quartiers_2011_4326": {
-        "id": "VilleMTP_MTP_Quartiers_2011_432620130116112351546",
-        "name": "VilleMTP_MTP_Quartiers_2011_4326",
-        "type": "layer",
-        "geometryType": "polygon",
-        "extent": [
-          3.807070366959713,
-          43.5667040954502,
-          3.941330680605673,
-          43.653371224492886
-        ],
-        "crs": "EPSG:4326",
-        "title": "VilleMTP_MTP_Quartiers_2011_4326",
-        "abstract": "",
-        "link": "",
-        "minScale": 0,
-        "maxScale": 100000000,
-        "toggled": "False",
-        "popup": "False",
-        "popupFrame": null,
-        "popupSource": "lizmap",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "False",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 300
-      },
-      "Hidden": {
-        "id": "Hidden",
-        "name": "Hidden",
-        "type": "group",
-        "title": "Hidden",
-        "abstract": "",
-        "link": "",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "True",
-        "popup": "False",
-        "popupFrame": null,
-        "popupSource": "lizmap",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "False",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 300,
-        "mutuallyExclusive": "True"
-      },
-      "osm-mapnik": {
-        "id": "osm_mapnik20180315181738526",
-        "name": "osm-mapnik",
-        "type": "layer",
-        "extent": [
-          -20037508.342789244,
-          -20037508.342789255,
-          20037508.342789244,
-          20037508.342789244
-        ],
-        "crs": "EPSG:3857",
-        "title": "osm-mapnik",
-        "abstract": "",
-        "link": "",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "True",
-        "popup": "False",
-        "popupFrame": null,
-        "popupSource": "lizmap",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "False",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 300
-      },
-      "osm-stamen-toner": {
-        "id": "osm_stamen_toner20180315181710198",
-        "name": "osm-stamen-toner",
-        "type": "layer",
-        "extent": [
-          -20037508.342789244,
-          -20037508.342789255,
-          20037508.342789244,
-          20037508.342789244
-        ],
-        "crs": "EPSG:3857",
-        "title": "osm-stamen-toner",
-        "abstract": "",
-        "link": "",
-        "minScale": 1,
-        "maxScale": 1000000000000,
-        "toggled": "True",
-        "popup": "False",
-        "popupFrame": null,
-        "popupSource": "lizmap",
-        "popupTemplate": "",
-        "popupMaxFeatures": 10,
-        "popupDisplayChildren": "False",
-        "popup_allow_download": true,
-        "noLegendImage": "False",
-        "groupAsLayer": "False",
-        "baseLayer": "False",
-        "displayInLegend": "True",
-        "singleTile": "False",
-        "imageFormat": "image/png",
-        "cached": "False",
-        "serverFrame": null,
-        "clientCacheExpiration": 300
-      }
-    },
-    "timemanagerLayers": {},
-    "atlas": {},
-    "tooltipLayers": {
-      "tramstop": {
-        "layerId": "tramstop20150328114203878",
-        "fields": "osm_id,name",
-        "displayGeom": "True",
-        "colorGeom": "red",
-        "order": 0
-      },
-      "Quartiers": {
-        "layerId": "VilleMTP_MTP_Quartiers_2011_432620130116112610876",
-        "fields": "LIBQUART",
-        "displayGeom": "True",
-        "colorGeom": "black",
-        "order": 1
-      }
-    },
-    "layouts": {},
-    "loginFilteredLayers": {},
-    "filter_by_polygon": {
-      "config": {
-        "polygon_layer_id": "SousQuartiers20160121124316563",
-        "group_field": ""
-      },
-      "layers": []
-    },
-    "datavizLayers": {
-      "layers": [
+    "SousQuartiers": {
+      "layerId": "SousQuartiers20160121124316563",
+      "fieldName": "LIBSQUART",
+      "displayGeom": "True",
+      "minLength": 0,
+      "filterOnLocate": "False",
+      "order": 1,
+      "fieldAlias": "Name",
+      "vectorjoins": [
         {
-          "plot_id": 0,
-          "layer_id": "SousQuartiers20160121124316563",
-          "title": "Average income (€)",
-          "plot": {
-            "type": "bar",
-            "x_field": "LIBSQUART",
-            "aggregation": "sum",
-            "display_when_layer_visible": "False",
-            "traces": [
-              {
-                "color": "#00aaff",
-                "colorfield": "",
-                "y_field": "socio_average_income"
-              }
-            ],
-            "display_legend": true,
-            "stacked": false,
-            "horizontal": false
-          },
-          "popup_display_child_plot": "True",
-          "only_show_child": "False",
-          "abstract": ""
-        },
-        {
-          "plot_id": 1,
-          "layer_id": "SousQuartiers20160121124316563",
-          "title": "Repartition between tenants & owners",
-          "plot": {
-            "type": "bar",
-            "x_field": "LIBSQUART",
-            "aggregation": "sum",
-            "display_when_layer_visible": "False",
-            "traces": [
-              {
-                "color": "blue",
-                "colorfield": "",
-                "y_field": "socio_prop_percentage"
-              },
-              {
-                "color": "orange",
-                "colorfield": "",
-                "y_field": "socio_loc_percentage"
-              }
-            ],
-            "display_legend": true,
-            "stacked": false,
-            "horizontal": false
-          },
-          "popup_display_child_plot": "False",
-          "only_show_child": "False",
-          "abstract": ""
-        },
-        {
-          "plot_id": 2,
-          "layer_id": "SousQuartiers20160121124316563",
-          "title": "Population box plot",
-          "plot": {
-            "type": "box",
-            "aggregation": "",
-            "display_when_layer_visible": "False",
-            "traces": [
-              {
-                "color": "#f938ff",
-                "colorfield": "",
-                "y_field": "socio_population_2009"
-              }
-            ],
-            "display_legend": true,
-            "stacked": false,
-            "horizontal": false
-          },
-          "popup_display_child_plot": "False",
-          "only_show_child": "False",
-          "abstract": ""
-        }
-      ],
-      "dataviz": {
-        "location": "bottomdock",
-        "theme": "light"
-      },
-      "locale": "fr_FR"
-    },
-    "metadata": {
-      "qgis_desktop_version": 31615,
-      "lizmap_plugin_version": "3.7.7",
-      "lizmap_web_client_target_version": 30500,
-      "project_valid": true
-    },
-    "options": {
-      "projection": {
-        "proj4": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +type=crs",
-        "ref": ""
-      },
-      "bbox": [
-        "417006.61373760335845873",
-        "5394910.34090302512049675",
-        "447158.04891100589884445",
-        "5414844.99480544030666351"
-      ],
-      "mapScales": [
-        1000,
-        2500,
-        5000,
-        10000,
-        25000,
-        50000,
-        100000,
-        150000
-      ],
-      "minScale": 1000,
-      "maxScale": 150000,
-      "initialExtent": [
-        417006.613738,
-        5394910.3409,
-        447158.048911,
-        5414844.99481
-      ],
-      "osmMapnik": "True",
-      "osmStamenToner": "True",
-      "hideGroupCheckbox": "True",
-      "popupLocation": "dock",
-      "print": "True",
-      "measure": "True",
-      "zoomHistory": "True",
-      "geolocation": "True",
-      "pointTolerance": 25,
-      "lineTolerance": 10,
-      "polygonTolerance": 5,
-      "tmTimeFrameSize": 10,
-      "tmTimeFrameType": "seconds",
-      "tmAnimationFrameLength": 1000,
-      "emptyBaselayer": "True",
-      "startupBaselayer": "osm-stamen-toner",
-      "datavizLocation": "bottomdock",
-      "datavizTemplate": "<div class=\"container-fluid\">   \n    <div class=\"row-fluid\"> \n       <div class=\"span6\">$0</div>\n       <div class=\"span6\">$2</div>\n    </div>     \n<div class=\"row-fluid\"> \n       <div class=\"span12\">$1</div>\n    </div></div>",
-      "theme": "light",
-      "fixed_scale_overview_map": true,
-      "atlasLayer": "VilleMTP_MTP_Quartiers_2011_432620130116112610876",
-      "atlasPrimaryKey": "QUARTMNO",
-      "atlasDisplayLayerDescription": "True",
-      "atlasFeatureLabel": "LIBQUART",
-      "atlasSortField": "LIBQUART",
-      "atlasHighlightGeometry": "True",
-      "atlasZoom": "center",
-      "atlasDisplayPopup": "True",
-      "atlasTriggerFilter": "True",
-      "atlasDuration": 5,
-      "atlasEnabled": "True",
-      "atlasMaxWidth": 25,
-      "removeCache": "True",
-      "exportLayers": "True",
-      "wmsMaxWidth": "3000",
-      "wmsMaxHeight": "3000",
-      "searches": [
-        {
-          "type": "externalSearch",
-          "service": "nominatim",
-          "url": "/index.php/lizmap/osm/nominatim"
-        },
-        {
-          "type": "QuickFinder",
-          "service": "lizmapQuickFinder",
-          "url": "/index.php/lizmap/search/get"
-        },
-        {
-          "type": "Fts",
-          "service": "lizmapFts",
-          "url": "/index.php/lizmap/searchFts/get"
+          "joinFieldName": "QUARTMNO",
+          "targetFieldName": "QUARTMNO",
+          "joinLayerId": "VilleMTP_MTP_Quartiers_2011_432620130116112610876"
         }
       ]
     },
-    "printTemplates": [
-      {
-        "title": "Landscape A4",
-        "width": 297,
-        "height": 210,
-        "maps": [
-          {
-            "id": "map0",
-            "uuid": "{2ebf76e3-6f6b-4c34-95f1-3d642932cfb3}",
-            "width": 60,
-            "height": 45,
-            "overviewMap": "{2835ecbd-6089-4454-b22e-707b558ecef1}"
-          },
-          {
-            "id": "map1",
-            "uuid": "{2835ecbd-6089-4454-b22e-707b558ecef1}",
-            "width": 237,
-            "height": 191
-          }
-        ],
-        "labels": [
-          {
-            "id": "description",
-            "htmlState": 0,
-            "text": "Description"
-          },
-          {
-            "id": "title",
-            "htmlState": 0,
-            "text": "Map's title"
-          }
-        ],
-        "atlas": {
-          "enabled": "0",
-          "coverageLayer": ""
-        }
-      },
-      {
-        "title": "District card",
-        "width": 297,
-        "height": 210,
-        "maps": [
-          {
-            "id": "map0",
-            "uuid": "{a50537f9-5e73-4610-955e-31b092d81b94}",
-            "width": 60,
-            "height": 45,
-            "overviewMap": "{a228885d-4d7a-4ae0-af9b-02a4fe7cd814}"
-          },
-          {
-            "id": "map1",
-            "uuid": "{a228885d-4d7a-4ae0-af9b-02a4fe7cd814}",
-            "width": 237,
-            "height": 191
-          }
-        ],
-        "labels": [
-          {
-            "id": "description",
-            "htmlState": 0,
-            "text": "Description"
-          }
-        ],
-        "atlas": {
-          "enabled": "1",
-          "coverageLayer": "VilleMTP_MTP_Quartiers_2011_432620130116112610876"
-        }
-      }
-    ],
-    "relations": {
-      "VilleMTP_MTP_Quartiers_2011_432620130116112610876": [
-        {
-          "referencingLayer": "SousQuartiers20160121124316563",
-          "referencedField": "QUARTMNO",
-          "referencingField": "QUARTMNO",
-          "previewField": "LIBQUART",
-          "relationName": "Subdistricts by district",
-          "relationId": "SousQuartiers20160121124316563_QUARTMNO_VilleMTP_MTP_Quartiers_2011_432620130116112610876_QUARTMNO"
-        }
-      ],
-      "tramstop20150328114203878": [
-        {
-          "referencingLayer": "jointure_tram_stop20150328114216806",
-          "referencedField": "osm_id",
-          "referencingField": "stop_id",
-          "previewField": "unique_name",
-          "relationName": "Tram stop -> pivot tram stop/tram line",
-          "relationId": "jointure_tram_stop20150328114216806_stop_id_tramstop20150328114203878_osm_id"
+    "tramway": {
+      "layerId": "tramway20150328114206278",
+      "fieldName": "name",
+      "displayGeom": "False",
+      "minLength": 0,
+      "filterOnLocate": "True",
+      "order": 2,
+      "fieldAlias": "Line"
+    }
+  },
+  "formFilterLayers": {},
+  "attributeLayers": {
+    "tramstop": {
+      "layerId": "tramstop20150328114203878",
+      "primaryKey": "osm_id",
+      "pivot": "False",
+      "hideAsChild": "False",
+      "hideLayer": "False",
+      "custom_config": "False",
+      "order": 0
+    },
+    "tramway_pivot": {
+      "layerId": "jointure_tram_stop20150328114216806",
+      "primaryKey": "OGC_FID",
+      "pivot": "True",
+      "hideAsChild": "False",
+      "hideLayer": "False",
+      "custom_config": "False",
+      "order": 1
+    },
+    "tram_stop_work": {
+      "layerId": "tram_stop_work20150416102656130",
+      "primaryKey": "work_id",
+      "pivot": "False",
+      "hideAsChild": "False",
+      "hideLayer": "True",
+      "custom_config": "False",
+      "order": 2
+    },
+    "publicbuildings": {
+      "layerId": "publicbuildings20150420100958543",
+      "primaryKey": "b_id",
+      "pivot": "False",
+      "hideAsChild": "False",
+      "hideLayer": "False",
+      "custom_config": "False",
+      "order": 3
+    },
+    "publicbuildings_tramstop": {
+      "layerId": "publicbuildings_tramstop20150420095614071",
+      "primaryKey": "r_id",
+      "pivot": "True",
+      "hideAsChild": "False",
+      "hideLayer": "False",
+      "custom_config": "False",
+      "order": 4
+    },
+    "tramway_ref": {
+      "layerId": "tramway_ref20150612171109044",
+      "primaryKey": "ref_id",
+      "pivot": "False",
+      "hideAsChild": "False",
+      "hideLayer": "True",
+      "custom_config": "False",
+      "order": 5
+    },
+    "tramway": {
+      "layerId": "tramway20150328114206278",
+      "primaryKey": "osm_id",
+      "pivot": "False",
+      "hideAsChild": "True",
+      "hideLayer": "False",
+      "custom_config": "False",
+      "order": 6
+    },
+    "Quartiers": {
+      "layerId": "VilleMTP_MTP_Quartiers_2011_432620130116112610876",
+      "primaryKey": "QUARTMNO",
+      "pivot": "False",
+      "hideAsChild": "False",
+      "hideLayer": "False",
+      "custom_config": "True",
+      "order": 7,
+      "attributetableconfig": {
+        "attributes": {
+          "sortExpression": "",
+          "actionWidgetStyle": "dropDown",
+          "sortOrder": "0"
         },
-        {
-          "referencingLayer": "publicbuildings_tramstop20150420095614071",
-          "referencedField": "osm_id",
-          "referencingField": "stop_id",
-          "previewField": "unique_name",
-          "relationName": "Tram stops -> pivot tram stop/building",
-          "relationId": "publicbuildings_tramstop20150420095614071_stop_id_tramstop20150328114203878_osm_id"
-        },
-        {
-          "referencingLayer": "tram_stop_work20150416102656130",
-          "referencedField": "osm_id",
-          "referencingField": "tram_stop_id",
-          "previewField": "unique_name",
-          "relationName": "Tram stops -> tram stop works",
-          "relationId": "tram_stop_work20150416102656130_tram_stop_id_tramstop20150328114203878_osm_id"
-        }
-      ],
-      "tramway20150328114206278": [
-        {
-          "referencingLayer": "jointure_tram_stop20150328114216806",
-          "referencedField": "osm_id",
-          "referencingField": "tram_id",
-          "previewField": "name",
-          "relationName": "Tramway -> pivot tram stop/tram line",
-          "relationId": "jointure_tram_stop20150328114216806_tram_id_tramway20150328114206278_osm_id"
-        }
-      ],
-      "publicbuildings20150420100958543": [
-        {
-          "referencingLayer": "publicbuildings_tramstop20150420095614071",
-          "referencedField": "b_id",
-          "referencingField": "b_id",
-          "previewField": "b_name",
-          "relationName": "Public buildings -> pivot tram stop/building",
-          "relationId": "publicbuildings_tramstop20150420095614071_b_id_publicbuildings20150420100958543_b_id"
-        }
-      ],
-      "tramway_ref20150612171109044": [
-        {
-          "referencingLayer": "tramway20150328114206278",
-          "referencedField": "ref_id",
-          "referencingField": "ref",
-          "previewField": "ref_id",
-          "relationName": "Tramway Ref / tramway",
-          "relationId": "tramway20150328114206278_ref_tramway_ref20150612171109044_ref_id"
-        }
-      ],
-      "pivot": {
-        "jointure_tram_stop20150328114216806": {
-          "tramstop20150328114203878": "stop_id",
-          "tramway20150328114206278": "tram_id"
-        },
-        "publicbuildings_tramstop20150420095614071": {
-          "publicbuildings20150420100958543": "b_id",
-          "tramstop20150328114203878": "stop_id"
+        "columns": {
+          "column": [
+            {
+              "attributes": {
+                "hidden": "1",
+                "name": "QUARTIER",
+                "type": "field",
+                "width": "-1"
+              }
+            },
+            {
+              "attributes": {
+                "hidden": "1",
+                "name": "QUARTMNO",
+                "type": "field",
+                "width": "-1"
+              }
+            },
+            {
+              "attributes": {
+                "hidden": "1",
+                "name": "SQUARTMNO",
+                "type": "field",
+                "width": "-1"
+              }
+            }
+          ]
         }
       }
     },
-    "themes": {
-      "Administrative": {
-        "layers": {
-          "SousQuartiers20160121124316563": {
-            "style": "default",
-            "expanded": "1"
-          },
-          "donnes_sociodemo_sous_quartiers20160121144525075": {
-            "style": "default",
-            "expanded": "1"
-          },
-          "publicbuildings20150420100958543": {
-            "style": "default",
-            "expanded": "1"
-          },
-          "VilleMTP_MTP_Quartiers_2011_432620130116112610876": {
-            "style": "default",
-            "expanded": "0"
-          }
+    "SousQuartiers": {
+      "layerId": "SousQuartiers20160121124316563",
+      "primaryKey": "SQUARTMNO",
+      "pivot": "False",
+      "hideAsChild": "False",
+      "hideLayer": "True",
+      "custom_config": "False",
+      "order": 8
+    },
+    "points_of_interest": {
+      "layerId": "edition_point20130118171631518",
+      "primaryKey": "pkuid",
+      "pivot": "False",
+      "hideAsChild": "False",
+      "hideLayer": "False",
+      "custom_config": "True",
+      "order": 9,
+      "attributetableconfig": {
+        "attributes": {
+          "sortExpression": "",
+          "actionWidgetStyle": "dropDown",
+          "sortOrder": "0"
         },
-        "expandedGroupNode": [
-          "Edition",
-          "datalayers/Tramway",
-          "datalayers/Bus",
-          "datalayers/Buildings",
-          "Overview",
-          "datalayers",
-          "Hidden"
-        ]
-      },
-      "Editable layers": {
-        "layers": {
-          "SousQuartiers20160121124316563": {
-            "style": "default",
-            "expanded": "1"
-          },
-          "donnes_sociodemo_sous_quartiers20160121144525075": {
-            "style": "default",
-            "expanded": "1"
-          },
-          "publicbuildings20150420100958543": {
-            "style": "default",
-            "expanded": "1"
-          },
-          "edition_polygon20130409114333776": {
-            "style": "default",
-            "expanded": "0"
-          },
-          "edition_line20130409161630329": {
-            "style": "default",
-            "expanded": "0"
-          },
-          "edition_point20130118171631518": {
-            "style": "default",
-            "expanded": "0"
-          }
-        },
-        "expandedGroupNode": [
-          "Edition",
-          "datalayers/Tramway",
-          "datalayers/Bus",
-          "datalayers/Buildings",
-          "Overview",
-          "datalayers",
-          "Hidden"
-        ]
-      },
-      "Transport": {
-        "layers": {
-          "tramway20150328114206278": {
-            "style": "black",
-            "expanded": "1"
-          },
-          "donnes_sociodemo_sous_quartiers20160121144525075": {
-            "style": "default",
-            "expanded": "1"
-          },
-          "tramway_ref20150612171109044": {
-            "style": "default",
-            "expanded": "1"
-          },
-          "jointure_tram_stop20150328114216806": {
-            "style": "default",
-            "expanded": "1"
-          },
-          "tramstop20150328114203878": {
-            "style": "default",
-            "expanded": "1"
-          },
-          "tram_stop_work20150416102656130": {
-            "style": "default",
-            "expanded": "1"
-          },
-          "bus_stops20121106170806413": {
-            "style": "default",
-            "expanded": "0"
-          },
-          "bus20121102133611751": {
-            "style": "default",
-            "expanded": "0"
-          }
-        },
-        "expandedGroupNode": [
-          "Edition",
-          "datalayers/Tramway",
-          "datalayers/Bus",
-          "datalayers/Buildings",
-          "Overview",
-          "datalayers",
-          "Hidden"
-        ]
+        "columns": {
+          "column": [
+            {
+              "attributes": {
+                "hidden": "1",
+                "name": "user",
+                "type": "field",
+                "width": "-1"
+              }
+            },
+            {
+              "attributes": {
+                "hidden": "0",
+                "name": "pkuid",
+                "type": "field",
+                "width": "-1"
+              }
+            },
+            {
+              "attributes": {
+                "hidden": "0",
+                "name": "name",
+                "type": "field",
+                "width": "-1"
+              }
+            },
+            {
+              "attributes": {
+                "hidden": "0",
+                "name": "description",
+                "type": "field",
+                "width": "-1"
+              }
+            },
+            {
+              "attributes": {
+                "hidden": "0",
+                "name": "date",
+                "type": "field",
+                "width": "-1"
+              }
+            },
+            {
+              "attributes": {
+                "hidden": "0",
+                "name": "type",
+                "type": "field",
+                "width": "-1"
+              }
+            },
+            {
+              "attributes": {
+                "hidden": "0",
+                "name": "photo",
+                "type": "field",
+                "width": "-1"
+              }
+            },
+            {
+              "attributes": {
+                "hidden": "1",
+                "type": "actions",
+                "width": "-1"
+              }
+            }
+          ]
+        }
       }
     }
+  },
+  "layers": {
+    "Edition": {
+      "id": "Edition",
+      "name": "Edition",
+      "type": "group",
+      "title": "Edition layers",
+      "abstract": "",
+      "link": "",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "True",
+      "popup": "False",
+      "popupFrame": null,
+      "popupSource": "lizmap",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "False",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 300
+    },
+    "points_of_interest": {
+      "id": "edition_point20130118171631518",
+      "name": "points_of_interest",
+      "type": "layer",
+      "geometryType": "point",
+      "extent": [
+        3.8454151330219495,
+        43.594383,
+        3.8956343529661015,
+        43.64203625857223
+      ],
+      "crs": "EPSG:4326",
+      "title": "Points of interest",
+      "abstract": "",
+      "link": "",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "False",
+      "popup": "False",
+      "popupFrame": null,
+      "popupSource": "auto",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "True",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 300,
+      "layerType": "vector"
+    },
+    "edition_line": {
+      "id": "edition_line20130409161630329",
+      "name": "edition_line",
+      "type": "layer",
+      "geometryType": "line",
+      "extent": [
+        3.831298,
+        43.571914305945946,
+        3.907530105945947,
+        43.670510184864874
+      ],
+      "crs": "EPSG:4326",
+      "title": "Bicycle rides",
+      "abstract": "",
+      "link": "",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "True",
+      "popup": "True",
+      "popupFrame": null,
+      "popupSource": "auto",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "False",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 0,
+      "layerType": "vector"
+    },
+    "areas_of_interest": {
+      "id": "edition_polygon20130409114333776",
+      "name": "areas_of_interest",
+      "type": "layer",
+      "geometryType": "polygon",
+      "extent": [
+        3.862278,
+        43.606014,
+        3.8948940000000003,
+        43.649005999999986
+      ],
+      "crs": "EPSG:4326",
+      "title": "Areas of interest",
+      "abstract": "",
+      "link": "",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "False",
+      "popup": "False",
+      "popupFrame": null,
+      "popupSource": "lizmap",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "False",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 300,
+      "layerType": "vector"
+    },
+    "datalayers": {
+      "id": "datalayers",
+      "name": "datalayers",
+      "type": "group",
+      "title": "Transport",
+      "abstract": "",
+      "link": "media/pdf/transport_map.pdf",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "True",
+      "popup": "False",
+      "popupFrame": null,
+      "popupSource": "lizmap",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "False",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 300
+    },
+    "Bus": {
+      "id": "Bus",
+      "name": "Bus",
+      "type": "group",
+      "title": "Bus",
+      "abstract": "Lignes et arrêts de bus de Montpellier",
+      "link": "http://www.montpellier-agglo.com/tam/page.php?id_rubrique=29",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "True",
+      "popup": "False",
+      "popupFrame": null,
+      "popupSource": "lizmap",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "False",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 300
+    },
+    "bus_stops": {
+      "id": "bus_stops20121106170806413",
+      "name": "bus_stops",
+      "type": "layer",
+      "geometryType": "point",
+      "extent": [
+        3.55326,
+        43.526928,
+        4.039131,
+        43.752341
+      ],
+      "crs": "EPSG:4326",
+      "title": "Stops",
+      "abstract": "",
+      "link": "",
+      "minScale": 0,
+      "maxScale": 15000,
+      "toggled": "False",
+      "popup": "True",
+      "popupFrame": null,
+      "popupSource": "auto",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "True",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "True",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 3600,
+      "layerType": "vector"
+    },
+    "bus": {
+      "id": "bus20121102133611751",
+      "name": "bus",
+      "type": "layer",
+      "geometryType": "line",
+      "extent": [
+        3.698123,
+        43.5265,
+        4.081239,
+        43.761579
+      ],
+      "crs": "EPSG:4326",
+      "title": "Bus lines",
+      "abstract": "",
+      "link": "",
+      "minScale": 0,
+      "maxScale": 40001,
+      "toggled": "False",
+      "popup": "True",
+      "popupFrame": null,
+      "popupSource": "lizmap",
+      "popupTemplate": "<div style=\"background-color:#44433E; color:white; height:100%;\">\n\n  <p style=\"background-color:{$color}\">\n  <b>LINE</b> : {$ref} - {$name}\n  <p/>\n  \n  <p><b>Operator</b> : {$operator}</p>\n\n  <p>\n  <img width=\"60px\"  src=\"media/image/logo_bus.png\" border=\"0\"/>\n  </p>\n\n</div>",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "True",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 3600,
+      "layerType": "vector"
+    },
+    "Tramway": {
+      "id": "Tramway",
+      "name": "Tramway",
+      "type": "group",
+      "title": "Tramway",
+      "abstract": "Lignes et arrêts de tramway de montpellier",
+      "link": "http://www.montpellier-agglo.com/tam/page.php?id_rubrique=32",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "False",
+      "popup": "False",
+      "popupFrame": null,
+      "popupSource": "lizmap",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "False",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 300
+    },
+    "tramway_ref": {
+      "id": "tramway_ref20150612171109044",
+      "name": "tramway_ref",
+      "type": "layer",
+      "geometryType": "none",
+      "extent": [
+        1.7976931348623157e+308,
+        1.7976931348623157e+308,
+        -1.7976931348623157e+308,
+        -1.7976931348623157e+308
+      ],
+      "crs": "EPSG:4326",
+      "title": "tramway_ref",
+      "abstract": "",
+      "link": "",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "True",
+      "popup": "False",
+      "popupFrame": null,
+      "popupSource": "lizmap",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "False",
+      "singleTile": "False",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 300,
+      "layerType": "vector"
+    },
+    "tramway_pivot": {
+      "id": "jointure_tram_stop20150328114216806",
+      "name": "tramway_pivot",
+      "type": "layer",
+      "geometryType": "none",
+      "extent": [
+        1.7976931348623157e+308,
+        1.7976931348623157e+308,
+        -1.7976931348623157e+308,
+        -1.7976931348623157e+308
+      ],
+      "crs": "EPSG:4326",
+      "title": "Table pivot tramway",
+      "abstract": "",
+      "link": "",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "False",
+      "popup": "True",
+      "popupFrame": null,
+      "popupSource": "auto",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "False",
+      "singleTile": "False",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 300,
+      "layerType": "vector"
+    },
+    "tram_stop_work": {
+      "id": "tram_stop_work20150416102656130",
+      "name": "tram_stop_work",
+      "type": "layer",
+      "geometryType": "none",
+      "extent": [
+        1.7976931348623157e+308,
+        1.7976931348623157e+308,
+        -1.7976931348623157e+308,
+        -1.7976931348623157e+308
+      ],
+      "crs": "EPSG:4326",
+      "title": "Tram stop works",
+      "abstract": "",
+      "link": "",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "False",
+      "popup": "False",
+      "popupFrame": null,
+      "popupSource": "lizmap",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "False",
+      "singleTile": "False",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 300,
+      "layerType": "vector"
+    },
+    "tramstop": {
+      "id": "tramstop20150328114203878",
+      "name": "tramstop",
+      "type": "layer",
+      "geometryType": "point",
+      "extent": [
+        3.8101056,
+        43.5579423,
+        3.9636474,
+        43.6545596
+      ],
+      "crs": "EPSG:4326",
+      "title": "Tram stops",
+      "abstract": "",
+      "link": "",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "True",
+      "popup": "True",
+      "popupFrame": null,
+      "popupSource": "auto",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "True",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 0,
+      "layerType": "vector"
+    },
+    "tramway": {
+      "id": "tramway20150328114206278",
+      "name": "tramway",
+      "type": "layer",
+      "geometryType": "line",
+      "extent": [
+        3.8097468,
+        43.5576091,
+        3.9639244,
+        43.6546121
+      ],
+      "crs": "EPSG:4326",
+      "styles": [
+        "black",
+        "colored"
+      ],
+      "title": "Tram lines",
+      "abstract": "",
+      "link": "",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "True",
+      "popup": "True",
+      "popupFrame": null,
+      "popupSource": "lizmap",
+      "popupTemplate": "{$html}",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "True",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 0,
+      "showFeatureCount": "True",
+      "layerType": "vector"
+    },
+    "Buildings": {
+      "id": "Buildings",
+      "name": "Buildings",
+      "type": "group",
+      "title": "Buildings",
+      "abstract": "",
+      "link": "",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "True",
+      "popup": "False",
+      "popupFrame": null,
+      "popupSource": "lizmap",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "False",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 300
+    },
+    "publicbuildings": {
+      "id": "publicbuildings20150420100958543",
+      "name": "publicbuildings",
+      "type": "layer",
+      "geometryType": "point",
+      "extent": [
+        431114.8420873464,
+        5403527.322277083,
+        433783.14982034185,
+        5406274.451355163
+      ],
+      "crs": "EPSG:3857",
+      "title": "public buildings",
+      "abstract": "",
+      "link": "",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "True",
+      "popup": "True",
+      "popupFrame": null,
+      "popupSource": "auto",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "True",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 0,
+      "layerType": "vector"
+    },
+    "publicbuildings_tramstop": {
+      "id": "publicbuildings_tramstop20150420095614071",
+      "name": "publicbuildings_tramstop",
+      "type": "layer",
+      "geometryType": "none",
+      "extent": [
+        1.7976931348623157e+308,
+        1.7976931348623157e+308,
+        -1.7976931348623157e+308,
+        -1.7976931348623157e+308
+      ],
+      "crs": "EPSG:4326",
+      "title": "Pivot tramstops / Buildings",
+      "abstract": "",
+      "link": "",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "True",
+      "popup": "True",
+      "popupFrame": null,
+      "popupSource": "auto",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "False",
+      "singleTile": "False",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 300,
+      "layerType": "vector"
+    },
+    "donnes_sociodemo_sous_quartiers": {
+      "id": "donnes_sociodemo_sous_quartiers20160121144525075",
+      "name": "donnes_sociodemo_sous_quartiers",
+      "type": "layer",
+      "geometryType": "none",
+      "extent": [
+        1.7976931348623157e+308,
+        1.7976931348623157e+308,
+        -1.7976931348623157e+308,
+        -1.7976931348623157e+308
+      ],
+      "crs": "EPSG:4326",
+      "title": "Repartition of owners and tenants",
+      "abstract": "This plot shows the repartition of owners and tenants per subdistrict in Montpellier, France.",
+      "link": "",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "True",
+      "popup": "False",
+      "popupFrame": null,
+      "popupSource": "lizmap",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "False",
+      "singleTile": "True",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 300,
+      "layerType": "vector"
+    },
+    "SousQuartiers": {
+      "id": "SousQuartiers20160121124316563",
+      "name": "SousQuartiers",
+      "type": "layer",
+      "geometryType": "polygon",
+      "extent": [
+        765145.8823,
+        6274561.2223,
+        776031.667,
+        6284189.5206
+      ],
+      "crs": "EPSG:2154",
+      "title": "Sous-Quartiers",
+      "abstract": "",
+      "link": "",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "False",
+      "popup": "True",
+      "popupFrame": null,
+      "popupSource": "auto",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "True",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 300,
+      "layerType": "vector"
+    },
+    "Quartiers": {
+      "id": "VilleMTP_MTP_Quartiers_2011_432620130116112610876",
+      "name": "Quartiers",
+      "type": "layer",
+      "geometryType": "polygon",
+      "extent": [
+        3.807070366959713,
+        43.5667040954502,
+        3.941330680605673,
+        43.653371224492886
+      ],
+      "crs": "EPSG:4326",
+      "title": "Quartiers",
+      "abstract": "<b>Districts of Montpellier</b>",
+      "link": "http://opendata.montpelliernumerique.fr/Quartiers",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "True",
+      "popup": "True",
+      "popupFrame": null,
+      "popupSource": "auto",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "True",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "True",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 300,
+      "layerType": "vector"
+    },
+    "Overview": {
+      "id": "Overview",
+      "name": "Overview",
+      "type": "group",
+      "title": "Overview",
+      "abstract": "",
+      "link": "",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "True",
+      "popup": "False",
+      "popupFrame": null,
+      "popupSource": "lizmap",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "False",
+      "imageFormat": "image/png",
+      "cached": "True",
+      "serverFrame": null,
+      "cacheExpiration": 0,
+      "clientCacheExpiration": 3600
+    },
+    "VilleMTP_MTP_Quartiers_2011_4326": {
+      "id": "VilleMTP_MTP_Quartiers_2011_432620130116112351546",
+      "name": "VilleMTP_MTP_Quartiers_2011_4326",
+      "type": "layer",
+      "geometryType": "polygon",
+      "extent": [
+        3.807070366959713,
+        43.5667040954502,
+        3.941330680605673,
+        43.653371224492886
+      ],
+      "crs": "EPSG:4326",
+      "title": "VilleMTP_MTP_Quartiers_2011_4326",
+      "abstract": "",
+      "link": "",
+      "minScale": 0,
+      "maxScale": 100000000,
+      "toggled": "False",
+      "popup": "False",
+      "popupFrame": null,
+      "popupSource": "lizmap",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "False",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 300,
+      "layerType": "vector"
+    },
+    "Hidden": {
+      "id": "Hidden",
+      "name": "Hidden",
+      "type": "group",
+      "title": "Hidden",
+      "abstract": "",
+      "link": "",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "True",
+      "popup": "False",
+      "popupFrame": null,
+      "popupSource": "lizmap",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "False",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 300,
+      "mutuallyExclusive": "True"
+    },
+    "osm-mapnik": {
+      "id": "osm_mapnik20180315181738526",
+      "name": "osm-mapnik",
+      "type": "layer",
+      "extent": [
+        -20037508.342789244,
+        -20037508.342789255,
+        20037508.342789244,
+        20037508.342789244
+      ],
+      "crs": "EPSG:3857",
+      "title": "osm-mapnik",
+      "abstract": "",
+      "link": "",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "True",
+      "popup": "False",
+      "popupFrame": null,
+      "popupSource": "lizmap",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "False",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 300,
+      "layerType": "raster",
+      "externalWmsToggle": "True",
+      "externalAccess": {
+        "crs": "EPSG:3857",
+        "format": "",
+        "type": "xyz",
+        "url": "http://tile.openstreetmap.org/{z}/{x}/{y}.png"
+      }
+    },
+    "osm-stamen-toner": {
+      "id": "osm_stamen_toner20180315181710198",
+      "name": "osm-stamen-toner",
+      "type": "layer",
+      "extent": [
+        -20037508.342789244,
+        -20037508.342789255,
+        20037508.342789244,
+        20037508.342789244
+      ],
+      "crs": "EPSG:3857",
+      "title": "osm-stamen-toner",
+      "abstract": "",
+      "link": "",
+      "minScale": 1,
+      "maxScale": 1000000000000,
+      "toggled": "True",
+      "popup": "False",
+      "popupFrame": null,
+      "popupSource": "lizmap",
+      "popupTemplate": "",
+      "popupMaxFeatures": 10,
+      "popupDisplayChildren": "False",
+      "popup_allow_download": true,
+      "noLegendImage": "False",
+      "groupAsLayer": "False",
+      "baseLayer": "False",
+      "displayInLegend": "True",
+      "singleTile": "False",
+      "imageFormat": "image/png",
+      "cached": "False",
+      "serverFrame": null,
+      "clientCacheExpiration": 300,
+      "layerType": "raster",
+      "externalWmsToggle": "True",
+      "externalAccess": {
+        "crs": "EPSG:3857",
+        "format": "",
+        "type": "xyz",
+        "url": "http://tile.stamen.com/toner-lite/{z}/{x}/{y}.png"
+      }
+    }
+  },
+  "timemanagerLayers": {},
+  "atlas": {},
+  "tooltipLayers": {
+    "tramstop": {
+      "layerId": "tramstop20150328114203878",
+      "fields": "osm_id,name",
+      "displayGeom": "True",
+      "colorGeom": "red",
+      "order": 0
+    },
+    "Quartiers": {
+      "layerId": "VilleMTP_MTP_Quartiers_2011_432620130116112610876",
+      "fields": "LIBQUART",
+      "displayGeom": "True",
+      "colorGeom": "black",
+      "order": 1
+    }
+  },
+  "layouts": {},
+  "loginFilteredLayers": {},
+  "filter_by_polygon": {
+    "config": {
+      "polygon_layer_id": "SousQuartiers20160121124316563",
+      "group_field": ""
+    },
+    "layers": []
+  },
+  "datavizLayers": {
+    "layers": [
+      {
+        "plot_id": 0,
+        "layer_id": "SousQuartiers20160121124316563",
+        "title": "Average income (€)",
+        "plot": {
+          "type": "bar",
+          "x_field": "LIBSQUART",
+          "aggregation": "sum",
+          "display_when_layer_visible": "False",
+          "traces": [
+            {
+              "color": "#00aaff",
+              "colorfield": "",
+              "y_field": "socio_average_income"
+            }
+          ],
+          "display_legend": true,
+          "stacked": false,
+          "horizontal": false
+        },
+        "popup_display_child_plot": "True",
+        "only_show_child": "False",
+        "abstract": ""
+      },
+      {
+        "plot_id": 1,
+        "layer_id": "SousQuartiers20160121124316563",
+        "title": "Repartition between tenants & owners",
+        "plot": {
+          "type": "bar",
+          "x_field": "LIBSQUART",
+          "aggregation": "sum",
+          "display_when_layer_visible": "False",
+          "traces": [
+            {
+              "color": "blue",
+              "colorfield": "",
+              "y_field": "socio_prop_percentage"
+            },
+            {
+              "color": "orange",
+              "colorfield": "",
+              "y_field": "socio_loc_percentage"
+            }
+          ],
+          "display_legend": true,
+          "stacked": false,
+          "horizontal": false
+        },
+        "popup_display_child_plot": "False",
+        "only_show_child": "False",
+        "abstract": ""
+      },
+      {
+        "plot_id": 2,
+        "layer_id": "SousQuartiers20160121124316563",
+        "title": "Population box plot",
+        "plot": {
+          "type": "box",
+          "aggregation": "",
+          "display_when_layer_visible": "False",
+          "traces": [
+            {
+              "color": "#f938ff",
+              "colorfield": "",
+              "y_field": "socio_population_2009"
+            }
+          ],
+          "display_legend": true,
+          "stacked": false,
+          "horizontal": false
+        },
+        "popup_display_child_plot": "False",
+        "only_show_child": "False",
+        "abstract": ""
+      }
+    ],
+    "dataviz": {
+      "location": "bottomdock",
+      "theme": "light"
+    },
+    "locale": "fr_FR"
+  },
+  "metadata": {
+    "qgis_desktop_version": 31615,
+    "lizmap_plugin_version": "3.7.7",
+    "lizmap_web_client_target_version": 30500,
+    "project_valid": true
+  },
+  "options": {
+    "projection": {
+      "proj4": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +type=crs",
+      "ref": ""
+    },
+    "bbox": [
+      "417006.61373760335845873",
+      "5394910.34090302512049675",
+      "447158.04891100589884445",
+      "5414844.99480544030666351"
+    ],
+    "mapScales": [
+      1000,
+      2500,
+      5000,
+      10000,
+      25000,
+      50000,
+      100000,
+      150000
+    ],
+    "minScale": 1000,
+    "maxScale": 150000,
+    "initialExtent": [
+      417006.613738,
+      5394910.3409,
+      447158.048911,
+      5414844.99481
+    ],
+    "osmMapnik": "True",
+    "osmStamenToner": "True",
+    "hideGroupCheckbox": "True",
+    "popupLocation": "dock",
+    "print": "True",
+    "measure": "True",
+    "zoomHistory": "True",
+    "geolocation": "True",
+    "pointTolerance": 25,
+    "lineTolerance": 10,
+    "polygonTolerance": 5,
+    "tmTimeFrameSize": 10,
+    "tmTimeFrameType": "seconds",
+    "tmAnimationFrameLength": 1000,
+    "emptyBaselayer": "True",
+    "startupBaselayer": "osm-stamen-toner",
+    "datavizLocation": "bottomdock",
+    "datavizTemplate": "<div class=\"container-fluid\">   \n    <div class=\"row-fluid\"> \n       <div class=\"span6\">$0</div>\n       <div class=\"span6\">$2</div>\n    </div>     \n<div class=\"row-fluid\"> \n       <div class=\"span12\">$1</div>\n    </div></div>",
+    "theme": "light",
+    "fixed_scale_overview_map": true,
+    "atlasLayer": "VilleMTP_MTP_Quartiers_2011_432620130116112610876",
+    "atlasPrimaryKey": "QUARTMNO",
+    "atlasDisplayLayerDescription": "True",
+    "atlasFeatureLabel": "LIBQUART",
+    "atlasSortField": "LIBQUART",
+    "atlasHighlightGeometry": "True",
+    "atlasZoom": "center",
+    "atlasDisplayPopup": "True",
+    "atlasTriggerFilter": "True",
+    "atlasDuration": 5,
+    "atlasEnabled": "True",
+    "atlasMaxWidth": 25,
+    "wmsMaxWidth": "3000",
+    "wmsMaxHeight": "3000",
+    "searches": [
+      {
+        "type": "externalSearch",
+        "service": "nominatim",
+        "url": "/index.php/lizmap/osm/nominatim"
+      },
+      {
+        "type": "QuickFinder",
+        "service": "lizmapQuickFinder",
+        "url": "/index.php/lizmap/search/get"
+      },
+      {
+        "type": "Fts",
+        "service": "lizmapFts",
+        "url": "/index.php/lizmap/searchFts/get"
+      }
+    ]
+  },
+  "printTemplates": [
+    {
+      "title": "Landscape A4",
+      "width": 297,
+      "height": 210,
+      "maps": [
+        {
+          "id": "map0",
+          "uuid": "{2ebf76e3-6f6b-4c34-95f1-3d642932cfb3}",
+          "width": 60,
+          "height": 45,
+          "overviewMap": "{2835ecbd-6089-4454-b22e-707b558ecef1}"
+        },
+        {
+          "id": "map1",
+          "uuid": "{2835ecbd-6089-4454-b22e-707b558ecef1}",
+          "width": 237,
+          "height": 191
+        }
+      ],
+      "labels": [
+        {
+          "id": "description",
+          "htmlState": 0,
+          "text": "Description"
+        },
+        {
+          "id": "title",
+          "htmlState": 0,
+          "text": "Map's title"
+        }
+      ],
+      "atlas": {
+        "enabled": "0",
+        "coverageLayer": ""
+      }
+    },
+    {
+      "title": "District card",
+      "width": 297,
+      "height": 210,
+      "maps": [
+        {
+          "id": "map0",
+          "uuid": "{a50537f9-5e73-4610-955e-31b092d81b94}",
+          "width": 60,
+          "height": 45,
+          "overviewMap": "{a228885d-4d7a-4ae0-af9b-02a4fe7cd814}"
+        },
+        {
+          "id": "map1",
+          "uuid": "{a228885d-4d7a-4ae0-af9b-02a4fe7cd814}",
+          "width": 237,
+          "height": 191
+        }
+      ],
+      "labels": [
+        {
+          "id": "description",
+          "htmlState": 0,
+          "text": "Description"
+        }
+      ],
+      "atlas": {
+        "enabled": "1",
+        "coverageLayer": "VilleMTP_MTP_Quartiers_2011_432620130116112610876"
+      }
+    }
+  ],
+  "relations": {
+    "VilleMTP_MTP_Quartiers_2011_432620130116112610876": [
+      {
+        "referencingLayer": "SousQuartiers20160121124316563",
+        "referencedField": "QUARTMNO",
+        "referencingField": "QUARTMNO",
+        "previewField": "LIBQUART",
+        "relationName": "Subdistricts by district",
+        "relationId": "SousQuartiers20160121124316563_QUARTMNO_VilleMTP_MTP_Quartiers_2011_432620130116112610876_QUARTMNO"
+      }
+    ],
+    "tramstop20150328114203878": [
+      {
+        "referencingLayer": "jointure_tram_stop20150328114216806",
+        "referencedField": "osm_id",
+        "referencingField": "stop_id",
+        "previewField": "unique_name",
+        "relationName": "Tram stop -> pivot tram stop/tram line",
+        "relationId": "jointure_tram_stop20150328114216806_stop_id_tramstop20150328114203878_osm_id"
+      },
+      {
+        "referencingLayer": "publicbuildings_tramstop20150420095614071",
+        "referencedField": "osm_id",
+        "referencingField": "stop_id",
+        "previewField": "unique_name",
+        "relationName": "Tram stops -> pivot tram stop/building",
+        "relationId": "publicbuildings_tramstop20150420095614071_stop_id_tramstop20150328114203878_osm_id"
+      },
+      {
+        "referencingLayer": "tram_stop_work20150416102656130",
+        "referencedField": "osm_id",
+        "referencingField": "tram_stop_id",
+        "previewField": "unique_name",
+        "relationName": "Tram stops -> tram stop works",
+        "relationId": "tram_stop_work20150416102656130_tram_stop_id_tramstop20150328114203878_osm_id"
+      }
+    ],
+    "tramway20150328114206278": [
+      {
+        "referencingLayer": "jointure_tram_stop20150328114216806",
+        "referencedField": "osm_id",
+        "referencingField": "tram_id",
+        "previewField": "name",
+        "relationName": "Tramway -> pivot tram stop/tram line",
+        "relationId": "jointure_tram_stop20150328114216806_tram_id_tramway20150328114206278_osm_id"
+      }
+    ],
+    "publicbuildings20150420100958543": [
+      {
+        "referencingLayer": "publicbuildings_tramstop20150420095614071",
+        "referencedField": "b_id",
+        "referencingField": "b_id",
+        "previewField": "b_name",
+        "relationName": "Public buildings -> pivot tram stop/building",
+        "relationId": "publicbuildings_tramstop20150420095614071_b_id_publicbuildings20150420100958543_b_id"
+      }
+    ],
+    "tramway_ref20150612171109044": [
+      {
+        "referencingLayer": "tramway20150328114206278",
+        "referencedField": "ref_id",
+        "referencingField": "ref",
+        "previewField": "ref_id",
+        "relationName": "Tramway Ref / tramway",
+        "relationId": "tramway20150328114206278_ref_tramway_ref20150612171109044_ref_id"
+      }
+    ],
+    "pivot": {
+      "jointure_tram_stop20150328114216806": {
+        "tramstop20150328114203878": "stop_id",
+        "tramway20150328114206278": "tram_id"
+      },
+      "publicbuildings_tramstop20150420095614071": {
+        "publicbuildings20150420100958543": "b_id",
+        "tramstop20150328114203878": "stop_id"
+      }
+    }
+  },
+  "themes": {
+    "Administrative": {
+      "layers": {
+        "SousQuartiers20160121124316563": {
+          "style": "default",
+          "expanded": "1"
+        },
+        "donnes_sociodemo_sous_quartiers20160121144525075": {
+          "style": "default",
+          "expanded": "1"
+        },
+        "publicbuildings20150420100958543": {
+          "style": "default",
+          "expanded": "1"
+        },
+        "VilleMTP_MTP_Quartiers_2011_432620130116112610876": {
+          "style": "default",
+          "expanded": "0"
+        }
+      },
+      "expandedGroupNode": [
+        "Edition",
+        "datalayers/Tramway",
+        "datalayers/Bus",
+        "datalayers/Buildings",
+        "Overview",
+        "datalayers",
+        "Hidden"
+      ]
+    },
+    "Editable layers": {
+      "layers": {
+        "SousQuartiers20160121124316563": {
+          "style": "default",
+          "expanded": "1"
+        },
+        "donnes_sociodemo_sous_quartiers20160121144525075": {
+          "style": "default",
+          "expanded": "1"
+        },
+        "publicbuildings20150420100958543": {
+          "style": "default",
+          "expanded": "1"
+        },
+        "edition_polygon20130409114333776": {
+          "style": "default",
+          "expanded": "0"
+        },
+        "edition_line20130409161630329": {
+          "style": "default",
+          "expanded": "0"
+        },
+        "edition_point20130118171631518": {
+          "style": "default",
+          "expanded": "0"
+        }
+      },
+      "expandedGroupNode": [
+        "Edition",
+        "datalayers/Tramway",
+        "datalayers/Bus",
+        "datalayers/Buildings",
+        "Overview",
+        "datalayers",
+        "Hidden"
+      ]
+    },
+    "Transport": {
+      "layers": {
+        "tramway20150328114206278": {
+          "style": "black",
+          "expanded": "1"
+        },
+        "donnes_sociodemo_sous_quartiers20160121144525075": {
+          "style": "default",
+          "expanded": "1"
+        },
+        "tramway_ref20150612171109044": {
+          "style": "default",
+          "expanded": "1"
+        },
+        "jointure_tram_stop20150328114216806": {
+          "style": "default",
+          "expanded": "1"
+        },
+        "tramstop20150328114203878": {
+          "style": "default",
+          "expanded": "1"
+        },
+        "tram_stop_work20150416102656130": {
+          "style": "default",
+          "expanded": "1"
+        },
+        "bus_stops20121106170806413": {
+          "style": "default",
+          "expanded": "0"
+        },
+        "bus20121102133611751": {
+          "style": "default",
+          "expanded": "0"
+        }
+      },
+      "expandedGroupNode": [
+        "Edition",
+        "datalayers/Tramway",
+        "datalayers/Bus",
+        "datalayers/Buildings",
+        "Overview",
+        "datalayers",
+        "Hidden"
+      ]
+    }
   }
+}

--- a/tests/js-units/node/config/baselayer.test.js
+++ b/tests/js-units/node/config/baselayer.test.js
@@ -89,6 +89,75 @@ describe('BaseLayerConfig', function () {
     })
 })
 
+describe('WmtsBaseLayerConfig', function () {
+    it('Valid', function () {
+        const ignPhotoBl = new WmtsBaseLayerConfig("ign-photo", {
+            "type": "wmts",
+            "title": "IGN Orthophoto",
+            "url": "https://wxs.ign.fr/ortho/geoportail/wmts",
+            "layer": "ORTHOIMAGERY.ORTHOPHOTOS",
+            "format": "image/jpeg",
+            "style": "normal",
+            "matrixSet": "PM",
+            "crs": "EPSG:3857",
+            "numZoomLevels": 22,
+            "attribution": {
+                "title": "Institut national de l'information géographique et forestière",
+                "url": "https://www.ign.fr/"
+            }
+        })
+        expect(ignPhotoBl).to.be.instanceOf(BaseLayerConfig)
+        expect(ignPhotoBl.type).to.be.eq('wmts')
+        expect(ignPhotoBl).to.be.instanceOf(WmtsBaseLayerConfig)
+        expect(ignPhotoBl.name).to.be.eq('ign-photo')
+        expect(ignPhotoBl.title).to.be.eq('IGN Orthophoto')
+        expect(ignPhotoBl.layerConfig).to.be.null
+        expect(ignPhotoBl.url).to.be.eq('https://wxs.ign.fr/ortho/geoportail/wmts')
+        expect(ignPhotoBl.hasKey).to.be.false
+        expect(ignPhotoBl.key).to.be.null
+        expect(ignPhotoBl.layer).to.be.eq('ORTHOIMAGERY.ORTHOPHOTOS')
+        expect(ignPhotoBl.format).to.be.eq('image/jpeg')
+        expect(ignPhotoBl.style).to.be.eq('normal')
+        expect(ignPhotoBl.matrixSet).to.be.eq('PM')
+        expect(ignPhotoBl.crs).to.be.eq('EPSG:3857')
+        expect(ignPhotoBl.numZoomLevels).to.be.eq(22)
+        expect(ignPhotoBl.hasAttribution).to.be.true
+        expect(ignPhotoBl.attribution).to.be.instanceOf(AttributionConfig)
+        expect(ignPhotoBl.attribution.title).to.be.eq('Institut national de l\'information géographique et forestière')
+        expect(ignPhotoBl.attribution.url).to.be.eq('https://www.ign.fr/')
+
+
+        const lizmapBl = new WmtsBaseLayerConfig("Quartiers", {
+            "type": "wmts",
+            "title": "Quartiers",
+            "url": "http://localhost:8130/index.php/lizmap/service?repository=testsrepository&project=cache&SERVICE=WMTS&VERSION=1.0.0&REQUEST=GetCapabilities",
+            "layer": "Quartiers",
+            "format": "image/png",
+            "style": "default",
+            "matrixSet": "EPSG:3857",
+            "crs": "EPSG:3857",
+            "numZoomLevels": 16
+        })
+        expect(lizmapBl).to.be.instanceOf(BaseLayerConfig)
+        expect(lizmapBl.type).to.be.eq('wmts')
+        expect(lizmapBl).to.be.instanceOf(WmtsBaseLayerConfig)
+        expect(lizmapBl.name).to.be.eq('Quartiers')
+        expect(lizmapBl.title).to.be.eq('Quartiers')
+        expect(lizmapBl.layerConfig).to.be.null
+        expect(lizmapBl.url).to.be.eq('http://localhost:8130/index.php/lizmap/service?repository=testsrepository&project=cache')
+        expect(lizmapBl.hasKey).to.be.false
+        expect(lizmapBl.key).to.be.null
+        expect(lizmapBl.layer).to.be.eq('Quartiers')
+        expect(lizmapBl.format).to.be.eq('image/png')
+        expect(lizmapBl.style).to.be.eq('default')
+        expect(lizmapBl.matrixSet).to.be.eq('EPSG:3857')
+        expect(lizmapBl.crs).to.be.eq('EPSG:3857')
+        expect(lizmapBl.numZoomLevels).to.be.eq(16)
+        expect(lizmapBl.hasAttribution).to.be.false
+        expect(lizmapBl.attribution).to.be.null
+    })
+})
+
 describe('BaseLayersConfig', function () {
     it('From Options', function () {
         const options = {

--- a/tests/js-units/node/config/layer.test.js
+++ b/tests/js-units/node/config/layer.test.js
@@ -35,19 +35,19 @@ describe('LayerConfig', function () {
         });
         expect(group.id).to.be.eq('IGN')
         expect(group.name).to.be.eq('IGN')
-        expect(group.shortname).to.be.eq(null)
+        expect(group.shortname).to.be.null
         expect(group.title).to.be.eq('IGN')
         expect(group.abstract).to.be.eq('')
         expect(group.link).to.be.eq('')
         expect(group.type).to.be.eq('group')
         expect(group.minScale).to.be.eq(1)
         expect(group.maxScale).to.be.eq(1000000000000)
-        expect(group.geometryType).to.be.eq(null)
-        expect(group.extent).to.be.eq(null)
-        expect(group.crs).to.be.eq(null)
+        expect(group.geometryType).to.be.null
+        expect(group.extent).to.be.null
+        expect(group.crs).to.be.null
         expect(group.toggled).to.be.eq(true)
         expect(group.popup).to.be.eq(false)
-        expect(group.popupFrame).to.be.eq(null)
+        expect(group.popupFrame).to.be.null
         expect(group.popupSource).to.be.eq('auto')
         expect(group.popupTemplate).to.be.eq('')
         expect(group.popupMaxFeatures).to.be.eq(10)
@@ -59,7 +59,7 @@ describe('LayerConfig', function () {
         expect(group.singleTile).to.be.eq(true)
         expect(group.imageFormat).to.be.eq('image/png')
         expect(group.cached).to.be.eq(false)
-        expect(group.serverFrame).to.be.eq(null)
+        expect(group.serverFrame).to.be.null
         expect(group.clientCacheExpiration).to.be.eq(300)
         expect(group.mutuallyExclusive).to.be.eq(true)
 
@@ -96,7 +96,8 @@ describe('LayerConfig', function () {
             "cached": "False",
             "serverFrame": null,
             "clientCacheExpiration": 300,
-            "shortname": "null_island_qgis_info"
+            "shortname": "null_island_qgis_info",
+            "layerType": 'vector'
         });
         expect(layer1.id).to.be.eq('null_island20200414115730489')
         expect(layer1.name).to.be.eq('null_island OGRGeoJSON Point')
@@ -107,6 +108,7 @@ describe('LayerConfig', function () {
         expect(layer1.type).to.be.eq('layer')
         expect(layer1.minScale).to.be.eq(1)
         expect(layer1.maxScale).to.be.eq(1000000000000)
+        expect(layer1.layerType).to.be.eq('vector')
         expect(layer1.geometryType).to.be.eq('point')
         expect(layer1.extent).to.be.instanceOf(Extent)
         expect(layer1.extent.length).to.be.eq(4)
@@ -117,7 +119,7 @@ describe('LayerConfig', function () {
         expect(layer1.crs).to.be.eq('EPSG:4326')
         expect(layer1.toggled).to.be.eq(true)
         expect(layer1.popup).to.be.eq(true)
-        expect(layer1.popupFrame).to.be.eq(null)
+        expect(layer1.popupFrame).to.be.null
         expect(layer1.popupSource).to.be.eq('auto')
         expect(layer1.popupTemplate).to.be.eq('')
         expect(layer1.popupMaxFeatures).to.be.eq(10)
@@ -129,7 +131,7 @@ describe('LayerConfig', function () {
         expect(layer1.singleTile).to.be.eq(true)
         expect(layer1.imageFormat).to.be.eq('image/png')
         expect(layer1.cached).to.be.eq(false)
-        expect(layer1.serverFrame).to.be.eq(null)
+        expect(layer1.serverFrame).to.be.null
         expect(layer1.clientCacheExpiration).to.be.eq(300)
         expect(layer1.mutuallyExclusive).to.be.eq(false)
 
@@ -163,17 +165,19 @@ describe('LayerConfig', function () {
             "maxScale": 1000000000000,
             "popupSource": "auto",
             "imageFormat": "image/png",
-            "minScale": 1
+            "minScale": 1,
+            "layerType": 'vector'
         });
         expect(layer2.id).to.be.eq('france_parts_8d8d649f_7748_43cc_8bde_b013e17ede29')
         expect(layer2.name).to.be.eq('france_parts')
-        expect(layer2.shortname).to.be.eq(null)
+        expect(layer2.shortname).to.be.null
         expect(layer2.title).to.be.eq('france_parts')
         expect(layer2.abstract).to.be.eq('')
         expect(layer2.link).to.be.eq('')
         expect(layer2.type).to.be.eq('layer')
         expect(layer2.minScale).to.be.eq(1)
         expect(layer2.maxScale).to.be.eq(1000000000000)
+        expect(layer2.layerType).to.be.eq('vector')
         expect(layer2.geometryType).to.be.eq('polygon')
         expect(layer2.extent).to.be.instanceOf(Extent)
         expect(layer2.extent.length).to.be.eq(4)
@@ -184,7 +188,7 @@ describe('LayerConfig', function () {
         expect(layer2.crs).to.be.eq('EPSG:4326')
         expect(layer2.toggled).to.be.eq(true)
         expect(layer2.popup).to.be.eq(true)
-        expect(layer2.popupFrame).to.be.eq(null)
+        expect(layer2.popupFrame).to.be.null
         expect(layer2.popupSource).to.be.eq('auto')
         expect(layer2.popupTemplate).to.be.eq('')
         expect(layer2.popupMaxFeatures).to.be.eq(10)
@@ -196,7 +200,7 @@ describe('LayerConfig', function () {
         expect(layer2.singleTile).to.be.eq(true)
         expect(layer2.imageFormat).to.be.eq('image/png')
         expect(layer2.cached).to.be.eq(false)
-        expect(layer2.serverFrame).to.be.eq(null)
+        expect(layer2.serverFrame).to.be.null
         expect(layer2.clientCacheExpiration).to.be.eq(300)
         expect(layer2.mutuallyExclusive).to.be.eq(false)
     })
@@ -253,7 +257,8 @@ describe('LayersConfig', function () {
                 "cached": "False",
                 "serverFrame": null,
                 "clientCacheExpiration": 300,
-                "shortname": "null_island_qgis_info"
+                "shortname": "null_island_qgis_info",
+                "layerType": 'vector'
             }
         })
         expect(simpleLayers.layerNames.length).to.be.eq(1)
@@ -302,7 +307,8 @@ describe('LayersConfig', function () {
                 "maxScale": 1000000000000,
                 "popupSource": "lizmap",
                 "imageFormat": "image/png",
-                "minScale": 1
+                "minScale": 1,
+                "layerType": 'vector'
             },
             "france_parts tuilé en cache": {
                 "abstract": "",
@@ -335,7 +341,8 @@ describe('LayersConfig', function () {
                 "maxScale": 1000000000000,
                 "popupSource": "lizmap",
                 "imageFormat": "image/png",
-                "minScale": 1
+                "minScale": 1,
+                "layerType": 'vector'
             },
             "france_parts": {
                 "abstract": "",
@@ -367,7 +374,8 @@ describe('LayersConfig', function () {
                 "maxScale": 1000000000000,
                 "popupSource": "auto",
                 "imageFormat": "image/png",
-                "minScale": 1
+                "minScale": 1,
+                "layerType": 'vector'
             }
         })
         const francePartsLayerNames = francePartsLayers.layerNames;
@@ -454,7 +462,8 @@ describe('LayersConfig', function () {
                 "imageFormat": "image/jpeg",
                 "cached": "False",
                 "serverFrame": null,
-                "clientCacheExpiration": 300
+                "clientCacheExpiration": 300,
+                "layerType": 'raster'
             },
             "Plan IGN clé essentiels": {
                 "id": "Plan_essentiels_0cdc425e_0e3f_45b7_b439_f090fb8a02ea",
@@ -487,7 +496,8 @@ describe('LayersConfig', function () {
                 "imageFormat": "image/jpeg",
                 "cached": "False",
                 "serverFrame": null,
-                "clientCacheExpiration": 300
+                "clientCacheExpiration": 300,
+                "layerType": 'raster'
             },
             "Orthophotos clé essentiels": {
                 "id": "Orthophotos_essentiels_993e18ab_ef98_422d_aced_d82d4264b27b",
@@ -520,7 +530,8 @@ describe('LayersConfig', function () {
                 "imageFormat": "image/jpeg",
                 "cached": "False",
                 "serverFrame": null,
-                "clientCacheExpiration": 300
+                "clientCacheExpiration": 300,
+                "layerType": 'raster'
             },
             "OpenStreetMap": {
                 "id": "OpenStreetMap_098d6629_1ec4_4c2c_9489_9a44ae09223e",
@@ -553,7 +564,8 @@ describe('LayersConfig', function () {
                 "imageFormat": "image/png",
                 "cached": "False",
                 "serverFrame": null,
-                "clientCacheExpiration": 300
+                "clientCacheExpiration": 300,
+                "layerType": 'raster'
             },
             "Hidden": {
                 "id": "Hidden",


### PR DESCRIPTION
The external access property of layer config can contain XYZ and WMTS 3857 parameters, extracted dynamically from QGIS XML.

layerType is also added to layer config information.
