### PR TITLE
[JavaScript] Extract layers order from config and WMS Capabilities

### DIFF
--- a/assets/src/modules/Config.js
+++ b/assets/src/modules/Config.js
@@ -12,6 +12,7 @@ import { TimeManagerLayersConfig } from './config/TimeManager.js';
 import { FormFilterConfig } from './config/FormFilter.js';
 import { DatavizOptionsConfig, DatavizLayersConfig } from './config/Dataviz.js';
 import { buildLayerTreeConfig } from './config/LayerTree.js';
+import { buildLayersOrder } from './config/LayersOrder.js';
 
 export class Config {
 
@@ -42,6 +43,7 @@ export class Config {
         this._layers = null;
         this._layerTree = null;
         this._baselayers = null;
+        this._layersOrder = null;
         this._hasMetadata = true;
         this._metadata = null;
         this._hasLocateByLayer = true;
@@ -172,6 +174,21 @@ export class Config {
         }
         this._baselayers = new BaseLayersConfig(baseLayersCfg, this._theConfig.options, this.layers, baseLayerTreeItem);
         return this._baselayers;
+    }
+
+    /**
+     * Layer names displaying order like in QGIS
+     *
+     * The first one in this list is the top one in the map
+     * The last one in this list is the bottom one in the map
+     *
+     * @type {String[]}
+     **/
+    get layersOrder() {
+        if (this._layersOrder == null) {
+            this._layersOrder = buildLayersOrder(this._theConfig, this.layerTree);
+        }
+        return [...this._layersOrder];
     }
 
     /**

--- a/assets/src/modules/config/LayersOrder.js
+++ b/assets/src/modules/config/LayersOrder.js
@@ -1,0 +1,27 @@
+function layersOrderFromLayerTreeGroup(layerTreeGroupCfg) {
+    let layersOrder = [];
+    for (const layerTreeItem of layerTreeGroupCfg.getChildren()) {
+        const cfg = layerTreeItem.layerConfig;
+        if (cfg == null) {
+            throw new RangeError('The layer `'+ layerTreeItem.name +'` has no config!');
+        }
+        if ((layerTreeItem.type == 'layer')) {
+            if (cfg.geometryType == null || (cfg.geometryType != 'none' && cfg.geometryType != 'none')) {
+                layersOrder.push(layerTreeItem.name);
+            }
+        } else {
+            layersOrder = layersOrder.concat(layersOrderFromLayerTreeGroup(layerTreeItem))
+        }
+    }
+    return layersOrder;
+}
+
+export function buildLayersOrder(initialConfig, rootLayerTreeCfg) {
+    if (initialConfig.hasOwnProperty('layersOrder')) {
+        return Object.keys(initialConfig.layersOrder).sort(function(a, b) {
+            initialConfig.layersOrder[a] - initialConfig.layersOrder[b];
+        });
+    }
+
+    return layersOrderFromLayerTreeGroup(rootLayerTreeCfg);
+}

--- a/tests/js-units/node/config.test.js
+++ b/tests/js-units/node/config.test.js
@@ -88,6 +88,26 @@ describe('Config', function () {
         expect(initialConfig.layers).to.be.instanceOf(LayersConfig)
         expect(initialConfig.layerTree).to.be.instanceOf(LayerTreeGroupConfig)
         expect(initialConfig.baseLayers).to.be.instanceOf(BaseLayersConfig)
+        expect(initialConfig.layersOrder).to.have.ordered.members([
+            "points_of_interest",
+            "edition_line",
+            "areas_of_interest",
+            "bus_stops",
+            "bus",
+            //"tramway_ref",
+            //"tramway_pivot",
+            //"tram_stop_work",
+            "tramstop",
+            "tramway",
+            "publicbuildings",
+            //"publicbuildings_tramstop",
+            //"donnes_sociodemo_sous_quartiers",
+            "SousQuartiers",
+            "Quartiers",
+            "VilleMTP_MTP_Quartiers_2011_4326",
+            "osm-mapnik",
+            "osm-stamen-toner"
+        ])
         expect(initialConfig.metadata).to.be.instanceOf(MetadataConfig)
         expect(initialConfig.hasLocateByLayer).to.be.true
         expect(initialConfig.locateByLayer).to.be.instanceOf(LocateByLayerConfig)

--- a/tests/js-units/node/config/layersOrder.test.js
+++ b/tests/js-units/node/config/layersOrder.test.js
@@ -1,0 +1,61 @@
+import { expect } from 'chai';
+
+import { readFileSync } from 'fs';
+
+import { LayersConfig } from '../../../../assets/src/modules/config/Layer.js';
+import { buildLayerTreeConfig } from '../../../../assets/src/modules/config/LayerTree.js';
+import {buildLayersOrder} from '../../../../assets/src/modules/config/LayersOrder.js';
+
+describe('buildLayersOrder', function () {
+    it('From config', function () {
+        const layersOrder = buildLayersOrder({
+            "layersOrder": {
+                "tramway_stops":0,
+                "tramway_lines":1,
+                "parent_layer":2,
+                "parent_layer_without_attribute_table":3,
+                "tramway stop (with parenthesis) and spaces":4
+            }
+        })
+        expect(layersOrder).to.have.ordered.members([
+            "tramway_stops",
+            "tramway_lines",
+            "parent_layer",
+            "parent_layer_without_attribute_table",
+            "tramway stop (with parenthesis) and spaces"
+        ])
+    })
+    it('From layer tree', function () {
+        const capabilities = JSON.parse(readFileSync('./data/montpellier-capabilities.json', 'utf8'));
+        expect(capabilities).to.not.be.undefined
+        expect(capabilities.Capability).to.not.be.undefined
+        const config = JSON.parse(readFileSync('./data/montpellier-config.json', 'utf8'));
+        expect(config).to.not.be.undefined
+
+        const layers = new LayersConfig(config.layers);
+
+        const root = buildLayerTreeConfig(capabilities.Capability.Layer, layers);
+
+        const layersOrder = buildLayersOrder(config, root);
+        expect(layersOrder).to.have.ordered.members([
+            "points_of_interest",
+            "edition_line",
+            "areas_of_interest",
+            "bus_stops",
+            "bus",
+            //"tramway_ref",
+            //"tramway_pivot",
+            //"tram_stop_work",
+            "tramstop",
+            "tramway",
+            "publicbuildings",
+            //"publicbuildings_tramstop",
+            //"donnes_sociodemo_sous_quartiers",
+            "SousQuartiers",
+            "Quartiers",
+            "VilleMTP_MTP_Quartiers_2011_4326",
+            "osm-mapnik",
+            "osm-stamen-toner"
+        ])
+    })
+})


### PR DESCRIPTION
Continuing to build the JavaScript API by defining a way to access layers order.

The `Config.layersOrder` provides the layer names displaying order like in QGIS:
* The first one in this list is the top one in the map
* The last one in this list is the bottom one in the map