### PR TITLE
[Bugfix] WMS GetLegendGraphic is the right request name not GetLegendGraphics

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -265,12 +265,15 @@ class WMSRequest extends OGCRequest
      *
      * @see https://en.wikipedia.org/wiki/Web_Map_Service#Requests.
      */
-    protected function process_getlegendgraphic()
+    protected function process_getlegendgraphics()
     {
-        return $this->process_getlegendgraphics();
+        // The right request name is GetLegendGraphic not GetLegendGraphics
+        $this->params['request'] = 'getlegendgraphic';
+
+        return $this->process_getlegendgraphic();
     }
 
-    protected function process_getlegendgraphics()
+    protected function process_getlegendgraphic()
     {
         $layers = $this->param('layers', $this->param('layer', ''));
         $layers = explode(',', $layers);


### PR DESCRIPTION
In OGC WMS standard the request `GetLegendGraphics` and `GetLegendGraphics` are the same, but the right name is `GetLegendGraphic` without an `s`.