### PR TITLE
Popup/Editing - Add a combobox in the popup to allow creating a new child feature

### DIFF
--- a/CHANGELOG-3.7.md
+++ b/CHANGELOG-3.7.md
@@ -10,7 +10,10 @@ with some extra keywords : backend, tests, test, translation, funders, important
 
 ### Added
 
-* Editing - Better user experience with 1-n relations
+* Editing - Better user experience with 1-n relations: the data tables of the related child layers
+  now respect the position configured in the QGIS editing drag&drop designer.
+* Popup/Editing - Add a combobox in the popup to allow creating a new child feature for the related
+  layers. This will allow to create child features directly from the parent popup.
 * New display for measurements on the map when drawing
 * Better management of **QGIS projects** about versions (desktop, plugin versions, etc.)
 * **Form filter**: Allow to use a second field for the numeric type like it is already possible for dates.

--- a/tests/end2end/cypress/integration/feature_toolbar-ghaction.js
+++ b/tests/end2end/cypress/integration/feature_toolbar-ghaction.js
@@ -489,7 +489,7 @@ describe('Feature Toolbar in popup', function () {
 
     })
 
-    it('should start child edition linked to a parent feature', function () {
+    it('should start child edition linked to a parent feature from the child feature toolbar', function () {
         // Click feature with id=2 on the map
         cy.mapClick(1055, 437)
         cy.wait('@getFeatureInfo')
@@ -509,8 +509,33 @@ describe('Feature Toolbar in popup', function () {
         // Start child edition
         cy.get('#edition-children-container lizmap-feature-toolbar[value="children_layer_358cb5a3_0c83_4a6c_8f2f_950e7459d9d0.1"] .feature-edit').click()
 
+        cy.wait(300)
+
         // Parent_id is disabled in form when edition is started from parent form
         cy.get('#jforms_view_edition_parent_id').should('be.disabled')
+
+        // Parent_id input should have the value 2 selected
+        cy.get('#jforms_view_edition_parent_id').find('option:selected').should('have.value', '2');
+    })
+
+
+
+    it('should start child creation from the parent feature toolbar', function () {
+        // Click feature with id=2 on the map
+        cy.mapClick(1055, 437)
+        cy.wait('@getFeatureInfo')
+
+        // Start child creation
+        cy.get('#popupcontent lizmap-feature-toolbar[value="parent_layer_d3dc849b_9622_4ad0_8401_ef7d75950111.2"] .feature-create-child ul li a[data-child-layer-id="children_layer_358cb5a3_0c83_4a6c_8f2f_950e7459d9d0"]').click({ force: true })
+
+        cy.wait(300)
+
+        // Parent_id is disabled in form when edition is started from parent form
+        cy.get('#jforms_view_edition_parent_id').should('be.disabled')
+
+        // Parent_id input should have the value 2 selected
+        cy.get('#jforms_view_edition_parent_id').find('option:selected').should('have.value', '2');
+
     })
 })
 


### PR DESCRIPTION
When a "parent" layer is in relationship with "child" layers, and when new objects can be created for these child layers with the editing tool, a new button is added in the popup toolbar of each parent object. This button will allow to select the child layer and then create a new item related to the popup parent object. 

![image](https://github.com/3liz/lizmap-web-client/assets/3492210/2bb47115-4e33-485b-bcf3-af50971fe83e)

Ticket : #1958 

Funded by [Valabre](https://www.valabre.com) & [SDEC Energie](https://www.sdec-energie.fr/)
