### PR TITLE
use layer name as option label for locate-by-layer selector in mobile

### DIFF
--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -1475,7 +1475,8 @@ window.lizMap = function() {
         }
     }
     // create the option list
-    var options = '<option value="-1"></option>';
+    const placeHolder = config.layers[aName].title;
+    var options = '<option value="-1" label="'+placeHolder+'"></option>';
     for (var fid in features) {
       var feat = features[fid];
       options += '<option value="'+feat.id+'">'+feat.properties[locate.fieldName]+'</option>';
@@ -1774,6 +1775,7 @@ window.lizMap = function() {
         }
       });
       $('#locate-layer-'+layerName+' ~ span > input').attr('placeholder', placeHolder).val('');
+      $('#locate-layer-'+layerName+' option[value=-1]').attr('label', placeHolder);
       $('#locate-layer-'+layerName+' ~ span > input').autocomplete('close');
       if ( ('minLength' in locate) && locate.minLength > 0 )
         $('#locate-layer-'+layerName).parent().addClass('no-toggle');


### PR DESCRIPTION
In desktop view, the locate by layer feature use layername as a placeholder for the autocomplete .

In mobile mode : no autocomplete, only select/options

this PR add the layer name as an option label for the 1st option (value=-1, unselected) to behave like a placholder

fix #3725 
fix #3209

From this :
Funded by 3Liz
![Screenshot 2023-06-20 at 17-06-12 Bug On the mobile app layers name defined in location are not displayed · Issue #3209 · 3liz_lizmap-web-client](https://github.com/3liz/lizmap-web-client/assets/43475951/150b6a1a-ccc8-4fa3-83d8-798819fadf91)

To : 
![Screenshot 2023-06-20 at 16-14-46 Montpellier - Transports - Demo - Lizmap](https://github.com/3liz/lizmap-web-client/assets/43475951/39053a7e-880e-454d-8925-7eb7b57802af)
