### PR TITLE
[JavaScript] Module State BaseLayer and Class state extends EventDispatcher

### DIFF
--- a/assets/src/modules/State.js
+++ b/assets/src/modules/State.js
@@ -1,20 +1,23 @@
-import { mainEventDispatcher } from '../modules/Globals.js';
+import EventDispatcher from './../utils/EventDispatcher.js';
 import { MapState } from './state/Map.js';
+import { BaseLayersState } from './state/BaseLayer.js';
 import { LayersAndGroupsCollection } from './state/Layer.js';
 import { MapGroupState } from './state/MapLayer.js';
 import { LayerTreeGroupState } from './state/LayerTree.js';
 
-export class State {
+export class State extends EventDispatcher {
     /**
      * @param {Config} initialCfg - the lizmap initial config instance
      */
     constructor(initialCfg) {
+        super()
         this._initialConfig = initialCfg;
         this._map = new MapState();
+        this._map.addListener(this.dispatch.bind(this), 'map.state.changed');
+        this._baseLayers = null;
         this._collection = null;
         this._rootMapGroup = null;
         this._layerTree = null;
-        mainEventDispatcher.addListener(this._map.update.bind(this._map), 'map.state.changing');
     }
 
     /**
@@ -27,13 +30,36 @@ export class State {
     }
 
     /**
-     * The map state
+     * The base layers state
      *
-     * @type {MapState}
+     * @type {BaseLayersState}
+     **/
+    get baseLayers() {
+        if (this._baseLayers == null) {
+            this._baseLayers = new BaseLayersState(this._initialConfig.baseLayers);
+            // Dispatch events from base layers
+            this._baseLayers.addListener(this.dispatch.bind(this), 'baselayers.selection.changed');
+        }
+        return this._baseLayers;
+    }
+
+    /**
+     * The layers and groups collection
+     *
+     * @type {LayersAndGroupsCollection}
      **/
     get layersAndGroupsCollection() {
         if (this._collection == null) {
             this._collection = new LayersAndGroupsCollection(this._initialConfig.layerTree, this._initialConfig.layersOrder);
+            // Dispatch events from groups and layers
+            this._collection.addListener(this.dispatch.bind(this), 'group.visibility.changed');
+            this._collection.addListener(this.dispatch.bind(this), 'layer.visibility.changed');
+            this._collection.addListener(this.dispatch.bind(this), 'layer.style.changed');
+            this._collection.addListener(this.dispatch.bind(this), 'layer.symbol.checked.changed');
+            this._collection.addListener(this.dispatch.bind(this), 'layer.selection.changed');
+            this._collection.addListener(this.dispatch.bind(this), 'layer.selection.token.changed');
+            this._collection.addListener(this.dispatch.bind(this), 'layer.filter.changed');
+            this._collection.addListener(this.dispatch.bind(this), 'layer.filter.token.changed');
         }
         return this._collection;
     }

--- a/assets/src/modules/state/BaseLayer.js
+++ b/assets/src/modules/state/BaseLayer.js
@@ -1,0 +1,121 @@
+import EventDispatcher from './../../utils/EventDispatcher.js';
+
+/**
+ * Class representing a base layers state
+ * @class
+ */
+export class BaseLayersState extends EventDispatcher {
+
+    /**
+     * Create a base layers state based on the base layers config
+     *
+     * @param {BaseLayersConfig} baseLayersCfg - the lizmap config object for base layers
+     */
+    constructor(baseLayersCfg) {
+        super()
+
+        this._baseLayersMap = new Map(baseLayersCfg.baseLayerConfigs.map(l => [l.name, l]));
+        this._selectedBaseLayerName = baseLayersCfg.startupBaselayerName;
+    }
+
+    /**
+     * Selected base layer name
+     *
+     * @type {String}
+     **/
+    get selectedBaseLayerName() {
+        return this._selectedBaseLayerName;
+    }
+
+    /**
+     * Set elected base layer name
+     *
+     * @param {String} name
+     *
+     * @throws {RangeError} When the base layer name is unknown!
+     **/
+    set selectedBaseLayerName(name) {
+        if (this._selectedBaseLayerName === name) {
+            return;
+        }
+        if (this._baseLayersMap.get(name) === undefined) {
+            throw new RangeError('The base layer name `'+ name +'` is unknown!');
+        }
+        this._selectedBaseLayerName = name;
+        this.dispatch({
+            type: 'baselayers.selection.changed',
+            name: this.selectedBaseLayerName
+        })
+    }
+
+    /**
+     * Selected base layer config
+     *
+     * @type {BaseLayerConfig}
+     **/
+    get selectedBaseLayerConfig() {
+        return this._baseLayersMap.get(this._selectedBaseLayerName);
+    }
+
+    /**
+     * Base layer names
+     *
+     * @type {String[]}
+     **/
+    get baseLayerNames() {
+        return [...this._baseLayersMap.keys()]
+    }
+
+    /**
+     * Base layer configs
+     *
+     * @type {BaseLayerConfig[]}
+     **/
+    get baseLayerConfigs() {
+        return [...this._baseLayersMap.values()]
+    }
+
+    /**
+     * Get a base layer config by base layer name
+     *
+     * @param {String} name - the base layer name
+     *
+     * @returns {BaseLayerConfig} The base layer config associated to the name
+     *
+     * @throws {RangeError} The base layer name is unknown
+     **/
+    getBaseLayerConfigByName(name) {
+        const layer = this._baseLayersMap.get(name);
+        if (layer !== undefined) {
+            if (layer.name !== name) {
+                throw 'The base layers state has been corrupted!'
+            }
+            return layer;
+        }
+        throw new RangeError('The base layer name `'+ name +'` is unknown!');
+    }
+
+    /**
+     * Iterate through base layer names
+     *
+     * @generator
+     * @yields {String} The next base layer name
+     **/
+    *getBaseLayerNames() {
+        for (const name of this._baseLayersMap.keys()) {
+            yield name;
+        }
+    }
+
+    /**
+     * Iterate through base layer configs
+     *
+     * @generator
+     * @yields {BaseLayerConfig} The next base layer config
+     **/
+    *getBaseLayerConfigs() {
+        for (const layer of this._baseLayersMap.values()) {
+            yield layer;
+        }
+    }
+}

--- a/assets/src/utils/EventDispatcher.js
+++ b/assets/src/utils/EventDispatcher.js
@@ -183,7 +183,10 @@ export default class EventDispatcher {
             });
         }
         if ('*' in this._listeners) {
-            this._listeners['*'].forEach((listener) => listener(event));
+            this._listeners['*'].forEach((item) => {
+                const [listener, ] = item;
+                listener(event);
+            });
         }
     }
 }

--- a/tests/js-units/node/state.test.js
+++ b/tests/js-units/node/state.test.js
@@ -1,0 +1,156 @@
+import { expect } from 'chai';
+
+import { readFileSync } from 'fs';
+
+import { Config } from '../../../assets/src/modules/Config.js';
+import { MapState } from '../../../assets/src/modules/state/Map.js';
+import { BaseLayersState } from '../../../assets/src/modules/state/BaseLayer.js';
+import { LayersAndGroupsCollection } from '../../../assets/src/modules/state/Layer.js';
+import { MapGroupState, MapLayerState } from '../../../assets/src/modules/state/MapLayer.js';
+import { LayerTreeGroupState } from '../../../assets/src/modules/state/LayerTree.js';
+
+import { State } from '../../../assets/src/modules/State.js';
+
+describe('State', function () {
+
+    it('Initialisation', function () {
+        const capabilities = JSON.parse(readFileSync('./data/montpellier-capabilities.json', 'utf8'));
+        expect(capabilities).to.not.be.undefined
+        expect(capabilities.Capability).to.not.be.undefined
+        const config = JSON.parse(readFileSync('./data/montpellier-config.json', 'utf8'));
+        expect(config).to.not.be.undefined
+
+        const initialConfig = new Config(config, capabilities);
+
+        const state = new State(initialConfig)
+        expect(state.map).to.be.instanceOf(MapState)
+        expect(state.baseLayers).to.be.instanceOf(BaseLayersState)
+        expect(state.layersAndGroupsCollection).to.be.instanceOf(LayersAndGroupsCollection)
+        expect(state.rootMapGroup).to.be.instanceOf(MapGroupState)
+        expect(state.layerTree).to.be.instanceOf(LayerTreeGroupState)
+    })
+
+    it('Events', function () {
+        const capabilities = JSON.parse(readFileSync('./data/montpellier-capabilities.json', 'utf8'));
+        expect(capabilities).to.not.be.undefined
+        expect(capabilities.Capability).to.not.be.undefined
+        const config = JSON.parse(readFileSync('./data/montpellier-config.json', 'utf8'));
+        expect(config).to.not.be.undefined
+
+        const initialConfig = new Config(config, capabilities);
+
+        const state = new State(initialConfig)
+        expect(state.map).to.be.instanceOf(MapState)
+        expect(state.baseLayers).to.be.instanceOf(BaseLayersState)
+        expect(state.layersAndGroupsCollection).to.be.instanceOf(LayersAndGroupsCollection)
+
+        let eventLogs = []
+        state.addListener(evt => {
+            eventLogs.push(evt)
+        }, '*');
+
+        // Update map state
+        state.map.update({
+            "type": "map.state.changing",
+            "projection": "EPSG:3857",
+            "center": [
+              432082.33132450003,
+              5404877.667855
+            ],
+            "size": [
+              1822,
+              634
+            ],
+            "extent": [
+              397265.26494544884,
+              5392762.398873487,
+              466899.3977035512,
+              5416992.936836514
+            ],
+            "resolution": 38.218514137268066,
+            "scaleDenominator": 144447.63855208742,
+            "pointResolution": 27.673393466176645,
+            "pointScaleDenominator": 104592.14407328397
+        });
+        expect(eventLogs).to.have.length(1)
+        expect(eventLogs[0].type).to.be.eq('map.state.changed')
+
+        expect(state.baseLayers.baseLayerNames).to.be.an('array').that.have.length(3).that.ordered.members([
+            'empty',
+            'osm-mapnik',
+            'osm-stamen-toner',
+        ])
+        expect(state.baseLayers.selectedBaseLayerName).to.be.eq('osm-stamen-toner')
+        expect(state.baseLayers.selectedBaseLayerConfig).to.not.be.undefined
+        expect(state.baseLayers.selectedBaseLayerConfig.name).to.be.eq('osm-stamen-toner')
+
+        eventLogs = []
+        // Update selected base layer
+        state.baseLayers.selectedBaseLayerName = 'osm-mapnik'
+        expect(eventLogs).to.have.length(1)
+        expect(eventLogs[0].type).to.be.eq('baselayers.selection.changed')
+
+        const sousquartiers = state.rootMapGroup.children[2]
+        expect(sousquartiers).to.be.instanceOf(MapLayerState)
+
+        expect(sousquartiers.checked).to.be.false
+        expect(sousquartiers.visibility).to.be.false
+
+        eventLogs = []
+        // Change SousQuartiers checked value
+        sousquartiers.checked = true
+        expect(eventLogs).to.have.length(1)
+        expect(eventLogs[0].type).to.be.eq('layer.visibility.changed')
+
+        eventLogs = []
+        sousquartiers.checked = true
+        expect(eventLogs).to.have.length(0)
+
+        const edition = state.rootMapGroup.children[0];
+        expect(edition).to.be.instanceOf(MapGroupState)
+
+        expect(edition.checked).to.be.true
+        expect(edition.visibility).to.be.true
+
+        const poi = edition.children[0];
+        expect(poi).to.be.instanceOf(MapLayerState)
+
+        expect(poi.checked).to.be.false
+        expect(poi.visibility).to.be.false
+
+        eventLogs = []
+        // Change poi checked value
+        poi.checked = true;
+        expect(eventLogs).to.have.length(1)
+        expect(eventLogs[0].type).to.be.eq('layer.visibility.changed')
+        expect(eventLogs[0].name).to.be.eq('points_of_interest')
+
+        eventLogs = []
+        // Change edition group checked value
+        edition.checked = false;
+        expect(eventLogs).to.have.length(3)
+        expect(eventLogs[0].type).to.be.eq('layer.visibility.changed')
+        expect(eventLogs[0].name).to.be.eq('points_of_interest')
+        expect(eventLogs[1].type).to.be.eq('layer.visibility.changed')
+        expect(eventLogs[1].name).to.be.eq('edition_line')
+        expect(eventLogs[2].type).to.be.eq('group.visibility.changed')
+        expect(eventLogs[2].name).to.be.eq('Edition')
+
+        eventLogs = []
+        // Change poi checked value but visibility does not
+        poi.checked = false;
+        expect(eventLogs).to.have.length(0)
+
+        eventLogs = []
+        // Change poi checked value then the group and children checked layers
+        poi.checked = true;
+        expect(eventLogs).to.have.length(3)
+        expect(eventLogs[0].type).to.be.eq('layer.visibility.changed')
+        expect(eventLogs[0].name).to.be.eq('points_of_interest')
+        expect(eventLogs[1].type).to.be.eq('layer.visibility.changed')
+        expect(eventLogs[1].name).to.be.eq('edition_line')
+        expect(eventLogs[2].type).to.be.eq('group.visibility.changed')
+        expect(eventLogs[2].name).to.be.eq('Edition')
+    })
+
+})

--- a/tests/js-units/node/state/baselayer.test.js
+++ b/tests/js-units/node/state/baselayer.test.js
@@ -1,0 +1,88 @@
+import { expect } from 'chai';
+
+import { readFileSync } from 'fs';
+
+import { LayersConfig } from '../../../../assets/src/modules/config/Layer.js';
+import { LayerTreeGroupConfig, buildLayerTreeConfig } from '../../../../assets/src/modules/config/LayerTree.js';
+import { BaseLayersConfig } from '../../../../assets/src/modules/config/BaseLayer.js';
+
+import { BaseLayersState } from '../../../../assets/src/modules/state/BaseLayer.js';
+
+describe('BaseLayersState', function () {
+
+    it('From options and layers tree', function () {
+        const capabilities = JSON.parse(readFileSync('./data/montpellier-capabilities.json', 'utf8'));
+        expect(capabilities).to.not.be.undefined
+        expect(capabilities.Capability).to.not.be.undefined
+        const config = JSON.parse(readFileSync('./data/montpellier-config.json', 'utf8'));
+        expect(config).to.not.be.undefined
+
+        // Update capabilities change Hidden group to Baselayers group
+        const blName = 'Baselayers';
+        capabilities.Capability.Layer.Layer[6].Name = blName;
+        const blGroupCfg = structuredClone(config.layers.Hidden);
+        blGroupCfg.id = blName;
+        blGroupCfg.name = blName;
+        blGroupCfg.title = blName;
+        delete config.layers.Hidden;
+        config.layers[blName] = blGroupCfg;
+
+        const layers = new LayersConfig(config.layers);
+        const root = buildLayerTreeConfig(capabilities.Capability.Layer, layers);
+
+        const blGroup = root.children[6];
+        expect(blGroup).to.be.instanceOf(LayerTreeGroupConfig)
+
+        const options = {
+            emptyBaselayer: 'True'
+        };
+        const baseLayersConfig = new BaseLayersConfig({}, options, layers, blGroup)
+
+        const baseLayers = new BaseLayersState(baseLayersConfig)
+        expect(baseLayers.selectedBaseLayerName).to.be.eq('osm-mapnik')
+        expect(baseLayers.selectedBaseLayerConfig).to.not.be.undefined
+        expect(baseLayers.selectedBaseLayerConfig.name).to.be.eq('osm-mapnik')
+        expect(baseLayers.baseLayerNames).to.be.an('array').that.have.length(3).that.ordered.members([
+            'osm-mapnik',
+            'osm-stamen-toner',
+            'empty'
+        ])
+        expect(baseLayers.baseLayerConfigs).to.be.an('array').that.have.length(3)
+        expect(baseLayers.baseLayerConfigs.map(l => l.name)).to.be.an('array').that.have.length(3).that.ordered.members([
+            'osm-mapnik',
+            'osm-stamen-toner',
+            'empty'
+        ])
+        expect(baseLayers.baseLayerConfigs.map(l => l.type)).to.be.an('array').that.have.length(3).that.ordered.members([
+            'xyz',
+            'xyz',
+            'empty'
+        ])
+
+        baseLayers.selectedBaseLayerName = 'osm-stamen-toner'
+        expect(baseLayers.selectedBaseLayerName).to.be.eq('osm-stamen-toner')
+        expect(baseLayers.selectedBaseLayerConfig).to.not.be.undefined
+        expect(baseLayers.selectedBaseLayerConfig.name).to.be.eq('osm-stamen-toner')
+
+        // Try set an unknown base layer
+        try {
+            baseLayers.selectedBaseLayerName = 'project-background-layer'
+        } catch (error) {
+            expect(error.name).to.be.eq('RangeError')
+            expect(error.message).to.be.eq('The base layer name `project-background-layer` is unknown!')
+            expect(error).to.be.instanceOf(RangeError)
+        }
+
+        expect(baseLayers.getBaseLayerConfigByName('empty').type).to.be.eq('empty')
+
+        // Try get an unknown base layer
+        try {
+            baseLayers.getBaseLayerConfigByName('project-background-layer')
+        } catch (error) {
+            expect(error.name).to.be.eq('RangeError')
+            expect(error.message).to.be.eq('The base layer name `project-background-layer` is unknown!')
+            expect(error).to.be.instanceOf(RangeError)
+        }
+    });
+
+})

--- a/tests/js-units/node/state/layerTree.test.js
+++ b/tests/js-units/node/state/layerTree.test.js
@@ -474,10 +474,10 @@ describe('LayerTreeGroupState', function () {
         const root = new LayerTreeGroupState(rootMapGroup);
         expect(root).to.be.instanceOf(LayerTreeGroupState)
 
-        let rootLayerVisibilityChangedEvt = null;
+        let rootLayerVisibilityChangedEvt = [];
         let rootGroupVisibilityChangedEvt = null;
         root.addListener(evt => {
-            rootLayerVisibilityChangedEvt = evt
+            rootLayerVisibilityChangedEvt.push(evt)
         }, 'layer.visibility.changed');
         root.addListener(evt => {
             rootGroupVisibilityChangedEvt = evt
@@ -504,18 +504,18 @@ describe('LayerTreeGroupState', function () {
         expect(sousquartiers.checked).to.be.true
         expect(sousquartiers.visibility).to.be.true
         // Events dispatched at root level
-        expect(rootLayerVisibilityChangedEvt).to.not.be.null
-        expect(rootLayerVisibilityChangedEvt).to.be.deep.equal(sousquartiersVisibilityChangedEvt)
+        expect(rootLayerVisibilityChangedEvt).to.have.length(1)
+        expect(rootLayerVisibilityChangedEvt[0]).to.be.deep.equal(sousquartiersVisibilityChangedEvt)
         expect(rootGroupVisibilityChangedEvt).to.be.null
 
         // Reset
         sousquartiersVisibilityChangedEvt = null;
-        rootLayerVisibilityChangedEvt = null;
+        rootLayerVisibilityChangedEvt = [];
         // Set same value
         sousquartiers.checked = true;
         // Nothing changed
         expect(sousquartiersVisibilityChangedEvt).to.be.null
-        expect(rootLayerVisibilityChangedEvt).to.be.null
+        expect(rootLayerVisibilityChangedEvt).to.have.length(0)
 
         // Change value
         sousquartiers.checked = false;
@@ -527,13 +527,13 @@ describe('LayerTreeGroupState', function () {
         expect(sousquartiers.checked).to.be.false
         expect(sousquartiers.visibility).to.be.false
         // Events dispatched at root level
-        expect(rootLayerVisibilityChangedEvt).to.not.be.null
-        expect(rootLayerVisibilityChangedEvt).to.be.deep.equal(sousquartiersVisibilityChangedEvt)
+        expect(rootLayerVisibilityChangedEvt).to.have.length(1)
+        expect(rootLayerVisibilityChangedEvt[0]).to.be.deep.equal(sousquartiersVisibilityChangedEvt)
         expect(rootGroupVisibilityChangedEvt).to.be.null
 
         // Reset
         sousquartiersVisibilityChangedEvt = null;
-        rootLayerVisibilityChangedEvt = null;
+        rootLayerVisibilityChangedEvt = [];
 
         const edition = root.children[0];
         expect(edition).to.be.instanceOf(LayerTreeGroupState)
@@ -572,13 +572,13 @@ describe('LayerTreeGroupState', function () {
         expect(edition.checked).to.be.true
         expect(edition.visibility).to.be.true
         // Events dispatched at root level
-        expect(rootLayerVisibilityChangedEvt).to.not.be.null
-        expect(rootLayerVisibilityChangedEvt).to.be.deep.equal(poiVisibilityChangedEvt)
+        expect(rootLayerVisibilityChangedEvt).to.have.length(1)
+        expect(rootLayerVisibilityChangedEvt[0]).to.be.deep.equal(poiVisibilityChangedEvt)
         expect(rootGroupVisibilityChangedEvt).to.be.null
 
         // Reset
         poiVisibilityChangedEvt = null;
-        rootLayerVisibilityChangedEvt = null;
+        rootLayerVisibilityChangedEvt = [];
         // Change edition group checked value
         edition.checked = false;
         // edition group event dispatched
@@ -594,15 +594,16 @@ describe('LayerTreeGroupState', function () {
         expect(poi.checked).to.be.true
         expect(poi.visibility).to.be.false
         // Events dispatched at root level
-        expect(rootLayerVisibilityChangedEvt).to.not.be.null
-        expect(rootLayerVisibilityChangedEvt).to.be.deep.equal(poiVisibilityChangedEvt)
+        expect(rootLayerVisibilityChangedEvt).to.have.length(2)
+        expect(rootLayerVisibilityChangedEvt[0]).to.be.deep.equal(poiVisibilityChangedEvt)
+        expect(rootLayerVisibilityChangedEvt[1].name).to.be.eq('edition_line')
         expect(rootGroupVisibilityChangedEvt).to.not.be.null
         expect(rootGroupVisibilityChangedEvt).to.be.deep.equal(editionVisibilityChangedEvt)
 
         // Reset
         editionVisibilityChangedEvt = null;
         poiVisibilityChangedEvt = null;
-        rootLayerVisibilityChangedEvt = null;
+        rootLayerVisibilityChangedEvt = [];
         rootGroupVisibilityChangedEvt = null;
 
         // Change poi checked value
@@ -617,7 +618,7 @@ describe('LayerTreeGroupState', function () {
         expect(poi.checked).to.be.false
         expect(poi.visibility).to.be.false
         // Events not dispatched at root level
-        expect(rootLayerVisibilityChangedEvt).to.be.null
+        expect(rootLayerVisibilityChangedEvt).to.have.length(0)
         expect(rootGroupVisibilityChangedEvt).to.be.null
 
         // Change poi checked value
@@ -632,17 +633,19 @@ describe('LayerTreeGroupState', function () {
         expect(poi.checked).to.be.true
         expect(poi.visibility).to.be.true
         // Events dispatched at root level
-        expect(rootLayerVisibilityChangedEvt).to.not.be.null
+        expect(rootLayerVisibilityChangedEvt).to.have.length(2)
+        expect(rootLayerVisibilityChangedEvt[0]).to.be.deep.equal(poiVisibilityChangedEvt)
+        expect(rootLayerVisibilityChangedEvt[1].name).to.be.eq('edition_line')
         expect(rootGroupVisibilityChangedEvt).to.not.be.null
 
         // Reset root
         //editionVisibilityChangedEvt = null;
         //poiVisibilityChangedEvt = null;
-        rootLayerVisibilityChangedEvt = null;
+        rootLayerVisibilityChangedEvt = [];
         rootGroupVisibilityChangedEvt = null;
         // Do not dispatch already dispatched event
         edition.dispatch(poiVisibilityChangedEvt);
-        expect(rootLayerVisibilityChangedEvt).to.be.null
+        expect(rootLayerVisibilityChangedEvt).to.have.length(0)
         edition.dispatch(editionVisibilityChangedEvt);
         expect(rootGroupVisibilityChangedEvt).to.be.null
     })

--- a/tests/js-units/node/state/maplayer.test.js
+++ b/tests/js-units/node/state/maplayer.test.js
@@ -336,10 +336,10 @@ describe('MapGroupState', function () {
         const root = new MapGroupState(collection.root);
         expect(root).to.be.instanceOf(MapGroupState)
 
-        let rootLayerVisibilityChangedEvt = null;
+        let rootLayerVisibilityChangedEvt = [];
         let rootGroupVisibilityChangedEvt = null;
         root.addListener(evt => {
-            rootLayerVisibilityChangedEvt = evt
+            rootLayerVisibilityChangedEvt.push(evt)
         }, 'layer.visibility.changed');
         root.addListener(evt => {
             rootGroupVisibilityChangedEvt = evt
@@ -366,18 +366,18 @@ describe('MapGroupState', function () {
         expect(sousquartiers.checked).to.be.true
         expect(sousquartiers.visibility).to.be.true
         // Events dispatched at root level
-        expect(rootLayerVisibilityChangedEvt).to.not.be.null
-        expect(rootLayerVisibilityChangedEvt).to.be.deep.equal(sousquartiersVisibilityChangedEvt)
+        expect(rootLayerVisibilityChangedEvt).to.have.length(1)
+        expect(rootLayerVisibilityChangedEvt[0]).to.be.deep.equal(sousquartiersVisibilityChangedEvt)
         expect(rootGroupVisibilityChangedEvt).to.be.null
 
         // Reset
         sousquartiersVisibilityChangedEvt = null;
-        rootLayerVisibilityChangedEvt = null;
+        rootLayerVisibilityChangedEvt = [];
         // Set same value
         sousquartiers.checked = true;
         // Nothing changed
         expect(sousquartiersVisibilityChangedEvt).to.be.null
-        expect(rootLayerVisibilityChangedEvt).to.be.null
+        expect(rootLayerVisibilityChangedEvt).to.have.length(0)
 
         // Change value
         sousquartiers.checked = false;
@@ -389,13 +389,13 @@ describe('MapGroupState', function () {
         expect(sousquartiers.checked).to.be.false
         expect(sousquartiers.visibility).to.be.false
         // Events dispatched at root level
-        expect(rootLayerVisibilityChangedEvt).to.not.be.null
-        expect(rootLayerVisibilityChangedEvt).to.be.deep.equal(sousquartiersVisibilityChangedEvt)
+        expect(rootLayerVisibilityChangedEvt).to.have.length(1)
+        expect(rootLayerVisibilityChangedEvt[0]).to.be.deep.equal(sousquartiersVisibilityChangedEvt)
         expect(rootGroupVisibilityChangedEvt).to.be.null
 
         // Reset
         sousquartiersVisibilityChangedEvt = null;
-        rootLayerVisibilityChangedEvt = null;
+        rootLayerVisibilityChangedEvt = [];
 
         const edition = root.children[0];
         expect(edition).to.be.instanceOf(MapGroupState)
@@ -434,13 +434,13 @@ describe('MapGroupState', function () {
         expect(edition.checked).to.be.true
         expect(edition.visibility).to.be.true
         // Events dispatched at root level
-        expect(rootLayerVisibilityChangedEvt).to.not.be.null
-        expect(rootLayerVisibilityChangedEvt).to.be.deep.equal(poiVisibilityChangedEvt)
+        expect(rootLayerVisibilityChangedEvt).to.have.length(1)
+        expect(rootLayerVisibilityChangedEvt[0]).to.be.deep.equal(poiVisibilityChangedEvt)
         expect(rootGroupVisibilityChangedEvt).to.be.null
 
         // Reset
         poiVisibilityChangedEvt = null;
-        rootLayerVisibilityChangedEvt = null;
+        rootLayerVisibilityChangedEvt = [];
         // Change edition group checked value
         edition.checked = false;
         // edition group event dispatched
@@ -456,15 +456,16 @@ describe('MapGroupState', function () {
         expect(poi.checked).to.be.true
         expect(poi.visibility).to.be.false
         // Events dispatched at root level
-        expect(rootLayerVisibilityChangedEvt).to.not.be.null
-        expect(rootLayerVisibilityChangedEvt).to.be.deep.equal(poiVisibilityChangedEvt)
+        expect(rootLayerVisibilityChangedEvt).to.have.length(2)
+        expect(rootLayerVisibilityChangedEvt[0]).to.be.deep.equal(poiVisibilityChangedEvt)
+        expect(rootLayerVisibilityChangedEvt[1].name).to.be.eq('edition_line')
         expect(rootGroupVisibilityChangedEvt).to.not.be.null
         expect(rootGroupVisibilityChangedEvt).to.be.deep.equal(editionVisibilityChangedEvt)
 
         // Reset
         editionVisibilityChangedEvt = null;
         poiVisibilityChangedEvt = null;
-        rootLayerVisibilityChangedEvt = null;
+        rootLayerVisibilityChangedEvt = [];
         rootGroupVisibilityChangedEvt = null;
 
         // Change poi checked value
@@ -479,7 +480,7 @@ describe('MapGroupState', function () {
         expect(poi.checked).to.be.false
         expect(poi.visibility).to.be.false
         // Events not dispatched at root level
-        expect(rootLayerVisibilityChangedEvt).to.be.null
+        expect(rootLayerVisibilityChangedEvt).to.have.length(0)
         expect(rootGroupVisibilityChangedEvt).to.be.null
 
         // Change poi checked value
@@ -494,17 +495,19 @@ describe('MapGroupState', function () {
         expect(poi.checked).to.be.true
         expect(poi.visibility).to.be.true
         // Events dispatched at root level
-        expect(rootLayerVisibilityChangedEvt).to.not.be.null
+        expect(rootLayerVisibilityChangedEvt).to.have.length(2)
+        expect(rootLayerVisibilityChangedEvt[0]).to.be.deep.equal(poiVisibilityChangedEvt)
+        expect(rootLayerVisibilityChangedEvt[1].name).to.be.eq('edition_line')
         expect(rootGroupVisibilityChangedEvt).to.not.be.null
 
         // Reset root
         //editionVisibilityChangedEvt = null;
         //poiVisibilityChangedEvt = null;
-        rootLayerVisibilityChangedEvt = null;
+        rootLayerVisibilityChangedEvt = [];
         rootGroupVisibilityChangedEvt = null;
         // Do not dispatch already dispatched event
         edition.dispatch(poiVisibilityChangedEvt);
-        expect(rootLayerVisibilityChangedEvt).to.be.null
+        expect(rootLayerVisibilityChangedEvt).to.have.length(0)
         edition.dispatch(editionVisibilityChangedEvt);
         expect(rootGroupVisibilityChangedEvt).to.be.null
     })


### PR DESCRIPTION
A new Module State BaseLayer has been provided to manage selected baselayer.

The `lizMap.mainLizmap.state` dispatches the events:
* `map.state.changed`
* `baselayers.selection.changed`
* `group.visibility.changed`
* `layer.visibility.changed`
* `layer.style.changed`
* `layer.symbol.checked.changed`
* `layer.selection.changed`
* `layer.selection.token.changed`
* `layer.filter.changed`
* `layer.filter.token.changed`