### PR TITLE
Editing & Filter - Fix editing right access from popup

### DIFF
--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -112,7 +112,6 @@ class editionCtrl extends jController
      */
     private function getEditionParameters($save = false)
     {
-
         // Get the project
         if ($save) {
             $project = $this->param('liz_project');
@@ -386,7 +385,6 @@ class editionCtrl extends jController
      */
     public function createFeature()
     {
-
         // Get repository, project data and do some right checking
         if (!$this->getEditionParameters()) {
             return $this->serviceAnswer();
@@ -434,7 +432,6 @@ class editionCtrl extends jController
      */
     public function modifyFeature()
     {
-
         // Get repository, project data and do some right checking
         if (!$this->getEditionParameters()) {
             return $this->serviceAnswer();
@@ -492,7 +489,6 @@ class editionCtrl extends jController
      */
     public function editFeature()
     {
-
         // Get repository, project data and do some right checking
         if (!$this->getEditionParameters()) {
             return $this->serviceAnswer();
@@ -618,7 +614,6 @@ class editionCtrl extends jController
      */
     public function saveFeature()
     {
-
         // Get repository, project data and do some right checking
         $save = true;
         if (!$this->getEditionParameters($save)) {
@@ -792,7 +787,6 @@ class editionCtrl extends jController
      */
     public function closeFeature()
     {
-
         // Get repository, project data and do some right checking
         if (!$this->getEditionParameters()) {
             return $this->serviceAnswer();


### PR DESCRIPTION
This PR fixes two bugs

* The request made by LWC to lizmap server plugin was sent  using GET instead of POST. This triggered issues for heavy polygon filters
* The method `isFeatureEditable` of the `qgisVectorLayer` class, which detected that a feature was editable or not for the authenticated user, did not take into account the new behaviour of the method `qgisExpressionUtils::getExpressionByUser` which now combines the attribute and the spatial filter

Funded by [Valabre](https://www.valabre.com)
