### PR TITLE
check project scales and replace scale 0 with scale 1

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapTiler.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapTiler.class.php
@@ -219,9 +219,7 @@ class lizmapTiler
             $rootExtent[3] = $geoExtent[3];
         }
 
-        $scales = array_merge(array(), $project->getOption('mapScales'));
-        rsort($scales);
-
+        $scales = self::normalizeProjectScales($project);
         $projection = $project->getOption('projection');
 
         $tileMatrixSetList = array();
@@ -421,8 +419,7 @@ class lizmapTiler
             $rootExtent[3] = $geoExtent[3];
         }
 
-        $scales = array_merge(array(), $project->getOption('mapScales'));
-        rsort($scales);
+        $scales = self::normalizeProjectScales($project);
 
         $layers = $project->getLayers();
         $layer = $layers->{$layerName};
@@ -601,5 +598,17 @@ class lizmapTiler
         $maxy = $tileMatrix->top - ((int) $tileRow + 1) * ($tileHeight * $res);
 
         return (string) $minx.','.(string) $miny.','.(string) $maxx.','.(string) $maxy;
+    }
+
+    private static function normalizeProjectScales($project)
+    {
+        $scales = array_merge(array(), $project->getOption('mapScales'));
+        if (reset($scales) == 0) {
+            $scales[0] = 1;
+            trigger_error('The minimum scale cannot have a value of 0, redefined as 1.', E_USER_NOTICE);
+        }
+        rsort($scales);
+
+        return $scales;
     }
 }

--- a/lizmap/modules/lizmap/classes/lizmapTiler.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapTiler.class.php
@@ -603,7 +603,7 @@ class lizmapTiler
     private static function normalizeProjectScales($project)
     {
         $scales = array_merge(array(), $project->getOption('mapScales'));
-        if (reset($scales) == 0) {
+        if ($scales[0] == 0) {
             $scales[0] = 1;
             trigger_error('The minimum scale cannot have a value of 0, redefined as 1.', E_USER_NOTICE);
         }


### PR DESCRIPTION
When the user set the projects min scale to 0, it leads to a fatal "Division by zero" error : 

see https://github.com/3liz/lizmap-web-client/blob/68ab4107642a9cb7baf106891faf108e9e2220e6/lizmap/modules/lizmap/classes/lizmapTiler.class.php#L256
scaledenomiator will be divided  until having out of bound value : 0

Fix is done on the plugin side https://github.com/3liz/lizmap-plugin/commit/392299aa54875c4e409ef5b7e31f39371d4f6292, but old projects conf may still have the 0 value

Funded by 3Liz
