### PR TITLE
Mailer: set the replyTo parameter

### DIFF
--- a/lizmap/app/system/mainconfig.ini.php
+++ b/lizmap/app/system/mainconfig.ini.php
@@ -55,6 +55,8 @@ mapCSPHeader=
 ; CSP header for the admin interface
 adminCSPHeader=
 
+setAdminContactEmailAsReplyTo=off
+
 [modules]
 jelix.enabled=on
 jelix.installparam[wwwfiles]=copy

--- a/lizmap/modules/lizmap/classes/lizmapServices.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapServices.class.php
@@ -434,6 +434,9 @@ class lizmapServices
                 $liveIni->setValue($key, $this->{$prop}, $section);
             } elseif ($this->{$prop} != '') {
                 $ini->setValue($prop, $this->{$prop}, 'services');
+                if ($prop == 'adminContactEmail' && $this->globalConfig->lizmap['setAdminContactEmailAsReplyTo']) {
+                    $liveIni->setValue('replyTo', $this->{$prop}, 'mailer');
+                }
             } else {
                 $ini->removeValue($prop, 'services');
             }

--- a/lizmap/modules/lizmap/install/upgrade_replyto.php
+++ b/lizmap/modules/lizmap/install/upgrade_replyto.php
@@ -1,0 +1,26 @@
+<?php
+
+class lizmapModuleUpgrader_replyto extends jInstallerModule
+{
+    public $targetVersions = array(
+        '3.7.0-alpha.2',
+        '3.6.5',
+        '3.5.14',
+    );
+    public $date = '2023-07-27';
+
+    public function install()
+    {
+        if (isset($this->entryPoint->getConfigObj()->lizmap['setAdminContactEmailAsReplyTo'])
+            && $this->entryPoint->getConfigObj()->lizmap['setAdminContactEmailAsReplyTo']
+        ) {
+            $lizmapConfFile = jApp::varConfigPath('lizmapConfig.ini.php');
+            $ini = new \Jelix\IniFile\IniModifier($lizmapConfFile);
+            $replyTo = $ini->getValue('adminContactEmail', 'services');
+
+            $liveIni = new \Jelix\IniFile\IniModifier(jApp::varConfigPath('liveconfig.ini.php'));
+            $liveIni->setValue('replyTo', $replyTo, 'mailer');
+            $liveIni->save();
+        }
+    }
+}

--- a/tests/units/classes/lizmapServicesTest.php
+++ b/tests/units/classes/lizmapServicesTest.php
@@ -323,7 +323,14 @@ class lizmapServicesTest extends TestCase
             'cacheRedisPort',
         );
 
-        $testLizmapServices = new LizmapServices(array('hideSensitiveServicesProperties' => $hide), (object) array(), false, '', null);
+        $testLizmapServices = new LizmapServices(
+            array('hideSensitiveServicesProperties' => $hide),
+            (object) array(
+                'lizmap' => [
+                    'setAdminContactEmailAsReplyTo' => false
+                ]
+            ),
+            false, '', null);
 
         foreach ($defaultPropList as $prop) {
             $testLizmapServices->{$prop} = '';


### PR DESCRIPTION
Set it with the adminContactEmail value only if the new parameter `setAdminContactEmailAsReplyTo` is true.

It allows for jCommunity and Jelix to send emails with a default `Reply-To` header that could be different from the "webmaster" email.

Funded by 3Liz
