### PR TITLE
use logPath instead of varPath()./log

### DIFF
--- a/lizmap/modules/admin/controllers/logs.classic.php
+++ b/lizmap/modules/admin/controllers/logs.classic.php
@@ -46,7 +46,7 @@ class logsCtrl extends jController
         $detailNumber = $dao->countBy($conditions);
 
         // Get last error log
-        $logPath = jApp::varPath('log/errors.log');
+        $logPath = jApp::logPath('errors.log');
         $errorLog = '';
         $lines = 50;
         if (is_file($logPath)) {


### PR DESCRIPTION
The log controller must use the `logPath()` method instead of assuming log are in `var/ `

Usefull when the `jApp::initPath` set a specific folder for logs (when creating multiple instances for example). 

Funded by 3Liz
