### PR TITLE
 remove hover:none rule (untrustable) 

### DIFF
--- a/lizmap/www/assets/css/media.css
+++ b/lizmap/www/assets/css/media.css
@@ -174,7 +174,7 @@ only screen and (                   max-device-height : 640px) {
   }
 }
 /* smartphones, touchscreens */
-@media (hover: none) and (pointer: coarse) {
+@media (pointer: coarse) {
   #navbar button.btn{
     height : 40px;
     width : 40px;
@@ -428,7 +428,7 @@ only screen and (                   max-device-height : 640px) {
   }
 }
 
-@media (hover: none) and (pointer: coarse) and (orientation: portrait){
+@media (pointer: coarse) and (orientation: portrait){
   #docks-wrapper{
     flex-direction: column;
   }


### PR DESCRIPTION
On some tablet browser (samsung) the `hover:none` css rule won't be match, so the left menu will be display in "desktop mode"

the PR remove the rule so the css une only `pointer: coarse` 

Ticket : #3829

Funded by 3Liz
