### PR TITLE
Fix address search when results are empty

### DIFF
--- a/CHANGELOG-3.5.md
+++ b/CHANGELOG-3.5.md
@@ -8,6 +8,11 @@ with some extra keywords : backend, tests, test, translation, funders, important
 
 ## Unreleased
 
+### Fixed
+
+- Fix address search when results of the query to api-adresse.data.gouv.fr are empty 
+
+
 ## 3.5.14 - 2023-07-31
 
 ### Important

--- a/lizmap/modules/lizmap/controllers/ban.classic.php
+++ b/lizmap/modules/lizmap/controllers/ban.classic.php
@@ -3,7 +3,7 @@
  * Php proxy to access OpenStreetMap services.
  *
  * @author    3liz
- * @copyright 2011-2019 3liz
+ * @copyright 2011-2023 3liz
  *
  * @see      http://3liz.com
  *
@@ -56,24 +56,24 @@ class banCtrl extends jController
         ));
 
         $var = json_decode($content);
-        if ($var === null) {
+        if ($var === null || !is_object($var) || !isset($var->features)) {
             $rep->content = '[]';
 
             return $rep;
         }
-        $obj = $var->features;
+
         // $licence = 'Data © '.$obj->attribution.', '.$obj->licence;
         $res = array();
         $res['search_name'] = 'BAN';
         $res['layer_name'] = 'ban';
         $res['srid'] = 'EPSG:4326';
         $res['features'] = array();
-        foreach ($obj as $key) {
+        foreach ($var->features as $feat) {
             /*
-            $lat = $key->geometry->coordinates[1];
-            $lon = $key->geometry->coordinates[0];
+            $lat = $feat->geometry->coordinates[1];
+            $lon = $feat->geometry->coordinates[0];
             $boundingbox = [strval($lat),strval($lat),strval($lon),strval($lon)];
-            $display_name = $key->properties->label.', '.$key->properties->context;
+            $display_name = $feat->properties->label.', '.$feat->properties->context;
             $return["licence"]= $licence;
             $return["display_name"]= $display_name;
             $return["lat"] = strval($lat);
@@ -81,9 +81,9 @@ class banCtrl extends jController
             $return["boundingbox"]= $boundingbox;
             array_push($res,$return);
             */
-            $lat = $key->geometry->coordinates[1];
-            $lon = $key->geometry->coordinates[0];
-            $display_name = $key->properties->label.', '.$key->properties->context;
+            $lat = $feat->geometry->coordinates[1];
+            $lon = $feat->geometry->coordinates[0];
+            $display_name = $feat->properties->label.', '.$feat->properties->context;
 
             $d = array();
             $d['label'] = $display_name;


### PR DESCRIPTION
Sometimes api-adresse.data.gouv.fr doesn't return a "features" array and it causes PHP errors. The JSON content should be checked before processing list of features.

Funded by 3Liz
