### PR TITLE
Editing - Add a new public method to check the form validity

### DIFF
--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -535,6 +535,19 @@ class QgisForm implements QgisFormControlsInterface
         return $form;
     }
 
+    /**
+     * Check the QGIS form data.
+     *
+     * A first jForms check is done
+     * Then some QGIS and Lizmap specific checks are run
+     * such as the upload target path,
+     * the QGIS expression constraints,
+     * the polygon and attribute filter, etc.
+     *
+     * @param mixed $feature The optional original feature
+     *
+     * @return array An array containing a boolean status and an array with fields errors if any
+     */
     public function check($feature = null)
     {
         $form = $this->form;
@@ -551,6 +564,10 @@ class QgisForm implements QgisFormControlsInterface
             $check = false;
             $form->setErrorOn($geometryColumn, $this->appContext->getLocale('view~edition.message.error.no.geometry'));
         }
+
+        // Test
+        $check = false;
+        $form->setErrorOn('liz_srid', 'Mauvais SRID');
 
         // Get values and form fields
         $values = array();
@@ -624,7 +641,7 @@ class QgisForm implements QgisFormControlsInterface
 
             if (!$results) {
                 // Evaluation failed
-                return $check;
+                return array($check, $form->getErrors());
             }
             $results = (array) $results;
             foreach ($results as $fieldName => $result) {
@@ -649,7 +666,7 @@ class QgisForm implements QgisFormControlsInterface
             }
         }
 
-        return $check;
+        return array($check, $form->getErrors());
     }
 
     public function getFieldValue($fieldName, $form)

--- a/tests/units/classes/Form/QgisFormTest.php
+++ b/tests/units/classes/Form/QgisFormTest.php
@@ -50,8 +50,17 @@ class dummyForm
     {
         return $this->controls[$ref];
     }
+
+    public function getErrors()
+    {
+    }
 }
 
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
 class QgisFormTest extends TestCase
 {
     protected $appContext;
@@ -70,6 +79,7 @@ class QgisFormTest extends TestCase
         $proj->setRepo(new \Lizmap\Project\Repository('key', array(), null, null, $appContext));
         $proj->setKey($projectKey);
         $layer->setProject($proj);
+
         return $layer;
     }
 
@@ -77,7 +87,7 @@ class QgisFormTest extends TestCase
     {
         $formCache = json_decode(file_get_contents($file), true);
         $properties = array();
-        foreach($formCache as $ref => $props) {
+        foreach ($formCache as $ref => $props) {
             $prop = new \Lizmap\Form\QgisFormControlProperties(
                 $ref,
                 $props['fieldEditType'],
@@ -89,10 +99,9 @@ class QgisFormTest extends TestCase
             }
             $properties[$ref] = $prop;
         }
+
         return $properties;
     }
-
-
 
     public function getConstructData()
     {
@@ -126,9 +135,9 @@ class QgisFormTest extends TestCase
         );
 
         return array(
-            array('test','date', $fields),
-            array('montpellier','line', $fields2),
-            array('not','existing', null),
+            array('test', 'date', $fields),
+            array('montpellier', 'line', $fields2),
+            array('not', 'existing', null),
         );
     }
 
@@ -137,6 +146,8 @@ class QgisFormTest extends TestCase
      *
      * @param mixed $file
      * @param mixed $fields
+     * @param mixed $projectKey
+     * @param mixed $layer
      */
     public function testConstruct($projectKey, $layer, $fields)
     {
@@ -255,6 +266,7 @@ class QgisFormTest extends TestCase
      * @param mixed $evaluateExpression
      * @param mixed $constraints
      * @param mixed $expectedResult
+     * @param mixed $allowWithoutGeom
      */
     public function testCheck($dbFieldsInfo, $check, $data, $evaluateExpression, $constraints, $allowWithoutGeom, $expectedResult)
     {
@@ -263,7 +275,7 @@ class QgisFormTest extends TestCase
         foreach ($mockFuncs as $method) {
             if ($method === 'evaluateExpression') {
                 $formMock->method($method)->willReturn($evaluateExpression);
-            } else if ($method === 'getConstraints') {
+            } elseif ($method === 'getConstraints') {
                 $formMock->method($method)->willReturn($constraints);
             } else {
                 $formMock->method($method)->willReturn(null);
@@ -275,14 +287,14 @@ class QgisFormTest extends TestCase
         $jForm->check = $check;
         $jForm->data = $data;
         $jForm->controls = array();
-        foreach(array_keys((array)$dbFieldsInfo->dataFields) as $key) {
+        foreach (array_keys((array) $dbFieldsInfo->dataFields) as $key) {
             $jForm->controls[$key] = new \jFormsControlInput($key);
         }
         $layer = new QgisLayerForTests();
         $layer->eCapabilities = (object) array('capabilities' => (object) array('modifyGeometry' => 'True', 'allow_without_geom' => $allowWithoutGeom));
         $layer->dbFieldValues = array();
 
-        $testCfg = new Project\ProjectConfig(new StdClass());
+        $testCfg = new Project\ProjectConfig(new stdClass());
 
         $proj = new ProjectForTests();
         $proj->setRepo(new \Lizmap\Project\Repository('key', array(), null, null, null));


### PR DESCRIPTION
This modification is a first step to improve the overall editing workflow, especially when creating child features for a not-yet existing parent object.

The future workflow could be

* open the creation form for a new parent object
* allow opening a creation form for 1 to many children
* validate the form data for each child to create, without having to save first the parent object (and the children). Do it also when modifying the child form data (we could keep the N forms in the DOM)
* Display the table of children "to be added or modified", with a look & feel like

|                  UID                 |    Feature ID   | Label (automatically generated based on QGIS display expression) | Edit   | Remove |
|:------------------------------------:|:---------------:|------------------------------------------------------------------|--------|--------|
| 96944c88-b947-4b69-a538-d9605193bd57 | to be generated | Lampadaire EEOOFG tungstène                                      | [edit] | [x]    |
| 96944c88-b947-4b69-a538-d96051923456 | 38              | Lampadaire AABBCC diode                                          | [edit] | [x]    |

* save the children form data in a single hidden text field, called for example `children_data_layer_XXX` which will store a table of JSON encoded form data
* when the user will Save the parent, in the PHP backend:
  * validate the new parent object
  * re-validate each child
  * save the parent, then save the children in batch. If a database error occurred, rollback all.

Funded by Commune d'Avignon
