### PR TITLE
[Backport release_3_6] Dataviz - Do not display child plot in Popup when there is no data

### DIFF
--- a/lizmap/www/assets/js/dataviz/dataviz.js
+++ b/lizmap/www/assets/js/dataviz/dataviz.js
@@ -114,8 +114,16 @@ var lizDataviz = function() {
         }
     }
 
-    function getPlot(plot_id, exp_filter, target_id){
-        if ( $('#'+target_id).length == 0) return;
+    /**
+     * Get the plot data from the backend
+     * and draw the plot with the buildPlot method
+     *
+     * @param {integer} plot_id The id of the plot.
+     * @param {string} exp_filter The optional data filter.
+     * @param {string} target_id The ID of the target dom element.
+     *
+     */
+    async function getPlot(plot_id, exp_filter, target_id) {
 
         exp_filter = typeof exp_filter !== 'undefined' ?  exp_filter : null;
         target_id = typeof target_id !== 'undefined' ?  target_id : new Date().valueOf()+btoa(Math.random()).substring(0,12);
@@ -153,44 +161,70 @@ var lizDataviz = function() {
         }
 
         // No cache -> get data
-        $.getJSON(datavizConfig.url,
-            lparams,
-            function(json){
-                if( 'errors' in json ){
-                    console.log('Dataviz configuration error');
-                    console.log(json.errors);
-                    return false;
-                }
-                // Store json only if no filter
-                // Because we use cache for the full data
-                // and we do not want to override it
-                if (!exp_filter) {
-                    dv.plots[plot_id]['cache'] = json;
-                }
-                dv.plots[plot_id]['json'] = json;
+        try {
+            const response = await fetch(datavizConfig.url, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(lparams),
+            });
 
-                // Store filter
-                dv.plots[plot_id]['filter'] = exp_filter;
-
-                // Hide container if no data
-                if( !json.data || json.data.length < 1){
-                    // hide full container
-                    $('#' + target_id + '_container').hide();
-                    $('#'+target_id).prev('.dataviz-waiter:first').hide();
-                    $('#'+target_id).parents('div.lizdataviz.lizmapPopupChildren:first').hide();
-                    return false;
-                }
-                // Show container if needed
-                if (dv.plots[plot_id]['show_plot']) {
-                    $('#' + target_id + '_container').show();
-                }
-
-                // Build plot
-                // Pass plot_id to inherit custom configurations in child charts
-                var plot = buildPlot(target_id, json, plot_id);
-                $('#'+target_id).prev('.dataviz-waiter:first').hide();
+            // Check content type
+            const contentType = response.headers.get("content-type");
+            if (!contentType || !contentType.includes("application/json")) {
+                throw new TypeError("Wrong content-type. JSON Expected !");
             }
-        );
+
+            // Get the JSON response
+            const jsonData = await response.json();
+
+            // Process the JSON data
+            if ('errors' in jsonData) {
+                console.log('Dataviz error');
+                console.log(jsonData.errors);
+            }
+
+            // Store json only if no filter
+            // Because we use cache for the full data
+            // and we do not want to override it
+            if (!exp_filter && !('errors' in jsonData)) {
+                dv.plots[plot_id]['cache'] = jsonData;
+                dv.plots[plot_id]['json'] = jsonData;
+            }
+
+            // Store filter
+            dv.plots[plot_id]['filter'] = exp_filter;
+
+            // Hide container if no data
+            if (!jsonData.data || jsonData.data.length < 1) {
+                // hide the full container
+                $('#' + target_id + '_container').hide();
+                // Hide the infinite progress bar
+                $('#' + target_id).prev('.dataviz-waiter:first').hide();
+                $('#' + target_id).parents('div.lizdataviz.lizmapPopupChildren:first').hide();
+
+                return false;
+            }
+
+            // Show container if needed
+            if (dv.plots[plot_id]['show_plot']) {
+                $('#' + target_id + '_container').show();
+            }
+
+            // The data has been successfully fetched
+            dv.plots[plot_id]['data_fetched'] = true;
+
+            // Build plot
+            // Pass plot_id to inherit custom configurations in child charts
+            buildPlot(target_id, jsonData, plot_id);
+
+            // Hide the infinite progress bar
+            $('#' + target_id).prev('.dataviz-waiter:first').hide();
+
+        } catch (error) {
+            console.error("Error:", error);
+        }
     }
 
     function buildHtmlPlot(id, data, layout) {

--- a/tests/end2end/cypress/integration/dataviz-ghaction.js
+++ b/tests/end2end/cypress/integration/dataviz-ghaction.js
@@ -10,15 +10,15 @@ describe('Dataviz tests', function () {
                 })
             }).as('getMap')
 
-            cy.intercept('*request=getPlot*',
-                { middleware: true },
-                (req) => {
-                    req.on('before:response', (res) => {
-                        // force all API responses to not be cached
-                        // It is needed when launching tests multiple time in headed mode
-                        res.headers['cache-control'] = 'no-store'
-                    })
-                }).as('getPlot')
+        cy.intercept('*/dataviz/service*',
+            { middleware: true },
+            (req) => {
+                req.on('before:response', (res) => {
+                    // force all API responses to not be cached
+                    // It is needed when launching tests multiple time in headed mode
+                    res.headers['cache-control'] = 'no-store'
+                })
+            }).as('getPlot')
     })
 
     it('Test dataviz plots are rendered', function () {
@@ -28,7 +28,32 @@ describe('Dataviz tests', function () {
         // Wait for map displayed 2 layers are displayed
         cy.wait(['@getMap', '@getMap'])
 
+        // Click on the dataviz menu
         cy.get('#button-dataviz').click()
+
+        // Check the plots are organized as configured in plugin (HTML Drag & drop layout)
+        cy.get('#dataviz > #dataviz-container > #dataviz-content > div.tab-content > ul > li:nth-child(1) > a')
+            .should('have.text', 'First tab')
+        cy.get('#dataviz > #dataviz-container > #dataviz-content > div.tab-content > ul > li:nth-child(2) > a')
+            .should('have.text', 'Second tab')
+        cy.get('div#dataviz-dnd-0-39cdf0321d593be51760b8c205de3f3e > fieldset:nth-child(1) > legend')
+            .should('have.text', 'Group A')
+        cy.get('div#dataviz-dnd-0-39cdf0321d593be51760b8c205de3f3e > fieldset:nth-child(2) > legend')
+            .should('have.text', 'Group B')
+        cy.get('div#dataviz-dnd-0-39cdf0321d593be51760b8c205de3f3e > fieldset:nth-child(2) > div:nth-child(2) > ul:nth-child(1) > li:nth-child(1) > a:nth-child(1)')
+            .should('have.text', 'Sub-Tab X')
+        cy.get('div#dataviz-dnd-0-39cdf0321d593be51760b8c205de3f3e > fieldset:nth-child(2) > div:nth-child(2) > ul:nth-child(1) > li:nth-child(2) > a:nth-child(1)')
+            .should('have.text', 'Sub-tab Y')
+
+        // Click on the other tabs to make the other plots visible
+        // Sub tab Y
+        cy.get('#dataviz > #dataviz-container > #dataviz-content > div.tab-content > ul > li:nth-child(1) > a')
+        .click()
+        cy.get('div#dataviz-dnd-0-39cdf0321d593be51760b8c205de3f3e > fieldset:nth-child(2) > div:nth-child(2) > ul:nth-child(1) > li:nth-child(2) > a:nth-child(1)')
+        .click()
+        // Second tab
+        cy.get('#dataviz > #dataviz-container > #dataviz-content > div.tab-content > ul > li:nth-child(2) > a')
+        .click()
 
         // Wait for graphics displayed 4 plots are displayed
         cy.wait(['@getPlot', '@getPlot', '@getPlot', '@getPlot'])


### PR DESCRIPTION
Backport to release 3_6 https://github.com/3liz/lizmap-web-client/pull/3854

When displaying the popup of an object containing child plots, if the layer has no child data associated with a specific plot, the loading bar must not be displayed but the plot should be hidden.

Ticket : fix https://github.com/3liz/lizmap-web-client/issues/3799

Funded by Faunalia (https://www.faunalia.eu/)
