### PR TITLE
Editing - JS events now return the feature primary key(s) value(s) after save

### DIFF
--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -321,7 +321,10 @@ class QgisForm implements QgisFormControlsInterface
     }
 
     /**
-     * @param $ref
+     * Get the storage path of QGIS form control
+     * for a given form input.
+     *
+     * @param string $ref Name of the form input
      *
      * @return null|string[]
      */
@@ -765,7 +768,6 @@ class QgisForm implements QgisFormControlsInterface
             throw new \Exception('Save to database can\'t be done for the layer "'.$this->layer->getName().'"!');
         }
 
-        $cnx = $this->layer->getDatasourceConnection();
         // Update or Insert
         $updateAction = false;
         $insertAction = false;
@@ -929,14 +931,14 @@ class QgisForm implements QgisFormControlsInterface
         }
 
         switch ($this->formControls[$ref]->fieldDataType) {
-                case 'geometry':
-                    try {
-                        $value = $this->layer->getGeometryAsSql($value);
-                    } catch (\Exception $e) {
-                        $form->setErrorOn($geometryColumn, $e->getMessage());
+            case 'geometry':
+                try {
+                    $value = $this->layer->getGeometryAsSql($value);
+                } catch (\Exception $e) {
+                    $form->setErrorOn($geometryColumn, $e->getMessage());
 
-                        return false;
-                    }
+                    return false;
+                }
 
                 break;
 
@@ -1238,7 +1240,6 @@ class QgisForm implements QgisFormControlsInterface
      */
     private function fillControlFromValueRelationLayer($fieldName, $formControl)
     {
-
         // required
         if (array_key_exists('notNull', $formControl->valueRelationData)
                 and $formControl->valueRelationData['notNull']

--- a/lizmap/modules/view/templates/edition_close_feature_data.tpl
+++ b/lizmap/modules/view/templates/edition_close_feature_data.tpl
@@ -1,0 +1,8 @@
+<ul class="jelix-msg">
+    <li class="jelix-msg-item-success">{$closeFeatureMessage}</li>
+</ul>
+
+<form class="liz_close_feature_form" style="display: none;">
+    <input type="hidden" id="liz_close_feature_message" name="liz_close_feature_message" value="{$closeFeatureMessage}">
+    <input type="hidden" id="liz_close_feature_pk_vals" name="liz_close_feature_pk_vals" value="{$pkValsJson|eschtml}">
+</form>


### PR DESCRIPTION
This will allow the JS custom scripts to request the feature data after the form has been successfully saved.

The events `lizmapeditionfeaturecreated` and `lizmapeditionfeaturemodified` will now have a new property `primaryKeys` containing an object of the created/modified feature primary key(s) values, e.g. `{ id: "99" }`

Funded by [Parc naturel régional du Haut-Jura](http://www.parc-haut-jura.fr/)
