### PR TITLE
e2e: Cypress executed w/ electron

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -134,7 +134,6 @@ jobs:
         if: always()
         uses: cypress-io/github-action@v5.8.3
         with:
-          browser: chrome
           working-directory: tests/end2end
           spec: cypress/integration/*-ghaction.js
           wait-on: http://localhost:8130


### PR DESCRIPTION
There is a bug w/ Cypress and Chrome 117 : https://github.com/cypress-io/cypress/issues/19122

Let's use electron until we totally migrate to Playwright.

Funded by 3Liz
