### PR TITLE
[PHP] Using home page title in the login template

### DIFF
--- a/lizmap/app/themes/default/master_admin/index_login.tpl
+++ b/lizmap/app/themes/default/master_admin/index_login.tpl
@@ -23,9 +23,9 @@
     <div id="auth" class="navbar-inner">
       <ul class="nav pull-right">
         <li class="home">
-          <a href="{jurl 'view~default:index'}" rel="tooltip" data-original-title="{@view~default.repository.list.title@}" data-placement="bottom" href="#">
+          <a href="{jurl 'view~default:index'}" rel="tooltip" data-original-title="{@view~default.home.title@}" data-placement="bottom" href="#">
             <span class="icon"></span>
-            <span class="text"><b>{@view~default.repository.list.title@}</b></span>
+            <span class="text"><b>{@view~default.home.title@}</b></span>
           </a>
         </li>
     </div>


### PR DESCRIPTION
The login template uses `view~default.repository.list.title` and will be repaced by `view~default.home.title`

Funded by [Conseil Départemental du Calavdos](https://www.calvados.fr/accueil.html) & [SDEC Energie](https://www.sdec-energie.fr/)
