### PR TITLE
[Bugfix] The qgisVectorLayer::editableFeatures did not check edition capabilities

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -1360,11 +1360,11 @@ class qgisVectorLayer extends qgisMapLayer
     public function isEditable()
     {
         $layerName = $this->name;
-        $eLayer = $this->project->getEditionLayerByName($layerName);
-        if ($eLayer->capabilities->modifyGeometry != 'True'
-           && $eLayer->capabilities->modifyAttribute != 'True'
-           && $eLayer->capabilities->deleteFeature != 'True'
-           && $eLayer->capabilities->createFeature != 'True'
+        $capabilities = $this->getRealEditionCapabilities();
+        if ($capabilities->modifyGeometry != 'True'
+           && $capabilities->modifyAttribute != 'True'
+           && $capabilities->deleteFeature != 'True'
+           && $capabilities->createFeature != 'True'
         ) {
             return false;
         }

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -1118,6 +1118,25 @@ class qgisVectorLayer extends qgisMapLayer
      */
     public function editableFeatures()
     {
+        // Editable features are a restricted list
+        $restricted_empty_data = array(
+            'status' => 'restricted',
+            'features' => array(),
+        );
+
+        if (!$this->isEditable()) {
+            return $restricted_empty_data;
+        }
+
+        // Get editLayer capabilities
+        $capabilities = $this->getRealEditionCapabilities();
+        if ($capabilities->modifyAttribute != 'True'
+            && $capabilities->modifyGeometry != 'True'
+            && $capabilities->deleteFeature != 'True') {
+            return $restricted_empty_data;
+        }
+
+        // All features are editable
         $unrestricted_empty_data = array(
             'status' => 'unrestricted',
             'features' => array(),
@@ -1148,12 +1167,6 @@ class qgisVectorLayer extends qgisMapLayer
         if (!$loginRestricted && !$polygonRestricted) {
             return $unrestricted_empty_data;
         }
-
-        // Editable features are a restricted list
-        $restricted_empty_data = array(
-            'status' => 'restricted',
-            'features' => array(),
-        );
 
         // Get layer WFS typename
         $typename = $this->getWfsTypeName();

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -1401,7 +1401,7 @@ class qgisVectorLayer extends qgisMapLayer
     public function getRealEditionCapabilities()
     {
         $eLayer = $this->project->getEditionLayerByName($this->name);
-        if (property_exists($eLayer, 'capabilities')) {
+        if ($eLayer && property_exists($eLayer, 'capabilities')) {
             return $eLayer->capabilities;
         }
 


### PR DESCRIPTION
The qgisVectorLayer::editableFeatures was able to return every feature of the layer when the layer is not editable.

Funded by [Conseil Départemental du Calvados](https://www.calvados.fr)