### PR TITLE
[Backport release_3_5] [Bugfix] The qgisVectorLayer::isFeatureEditable did not check edition capabilities

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -989,6 +989,18 @@ class qgisVectorLayer extends qgisMapLayer
      */
     public function isFeatureEditable($feature)
     {
+        if (!$this->isEditable()) {
+            return false;
+        }
+
+        // Get editLayer capabilities
+        $capabilities = $this->getRealEditionCapabilities();
+        if ($capabilities->modifyAttribute != 'True'
+            && $capabilities->modifyGeometry != 'True'
+            && $capabilities->deleteFeature != 'True') {
+            return false;
+        }
+
         // Get filter by login
         $expByUser = qgisExpressionUtils::getExpressionByUser($this, true);
         if ($expByUser !== '') {


### PR DESCRIPTION
Manually Backport https://github.com/3liz/lizmap-web-client/pull/3909
Authored by: @rldhont