### PR TITLE
[Bugfix] lizUrls.service does not exist

### DIFF
--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -3419,9 +3419,12 @@ window.lizMap = function() {
           });
 
       }
-
+      var fiurl = OpenLayers.Util.urlAppend(
+        lizUrls.wms,
+        OpenLayers.Util.getParameterString(lizUrls.params)
+      );
       var WMSGetFeatureInfo = new OpenLayers.Control.WMSGetFeatureInfo({
-            url: lizUrls.service,
+            url: fiurl,
             title: 'Identify features by clicking',
             type:OpenLayers.Control.TYPE_TOGGLE,
             queryVisible: true,
@@ -3591,7 +3594,7 @@ window.lizMap = function() {
                         typename: lName,
                         filter: lConfig['request_params']['filter']
                     };
-                    $.post(lizUrls.service, sdata, function(){
+                    $.post(surl, sdata, function(){
                         refreshGetFeatureInfo(evt);
                     });
                 }else{


### PR DESCRIPTION
lizUrls.Service has been introduced in Lizmap Web Client 3.7

2 requests are concren by this:
* GetFeatreuInfo
* GetFilterToken

Funded by WPD France