### PR TITLE
[Bugfix] Casacade layer WMS Name

### DIFF
--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -2385,10 +2385,12 @@ var lizAttributeTable = function() {
                         else if( aFilter && cascade != 'removeChildrenFilter' ) {
                             cExpFilter = '"' + cData['fieldToFilter'] + '" IN ( -99999 )';
                         }
-                        cFilter = wmsName + ':' + cExpFilter;
+                        const cLayerConfig = config.layers[cName];
+                        const cWmsName = cLayerConfig?.shortname || cLayerConfig.name;
+                        cFilter = cWmsName + ':' + cExpFilter;
 
-                        config.layers[cName]['request_params']['filter'] = cFilter;
-                        config.layers[cName]['request_params']['exp_filter'] = cExpFilter;
+                        cLayerConfig['request_params']['filter'] = cFilter;
+                        cLayerConfig['request_params']['exp_filter'] = cExpFilter;
 
                         // Update layer state
                         lizMap.mainLizmap.state.layersAndGroupsCollection.getLayerByName(cName).expressionFilter = cExpFilter;


### PR DESCRIPTION
To fix #3675 with #3868 a regression has been introduced in cascade filter.
The cascade layer's filter use the parent WMS name instead of the layer name. 
So the filter is not applied on cascade layer.

Funded by WPD France