### PR TITLE
Form filter - Date range: add a day to the max values when requesting data

### DIFF
--- a/assets/src/legacy/filter.js
+++ b/assets/src/legacy/filter.js
@@ -651,7 +651,16 @@ var lizLayerFilterTool = function () {
 
                 // max date filter
                 if (max_val && Date.parse(max_val)) {
-                    filters.push('( "' + startField + '"' + " <= '" + max_val + "'" + " OR " + ' "' + endField + '"' + " <= '" + max_val + "' )");
+                    // Add one day to the max values as we cannot select hours
+                    // This allow to select features with the max value. Eg a feature with 2023-10-25 12:20:01
+                    // must be selected if max date is 2023-10-25 wich is indeed 2023-10-25 00:00:00
+                    let max_val_new = new Date(Date.parse(max_val));
+                    // Add a day
+                    max_val_new.setDate(max_val_new.getDate() + 1);
+                    // Truncate to keep only date & transform into string
+                    let max_val_new_str = formatDT(max_val_new, 'yy-mm-dd');
+                    // We use strict < instead of <= because we just add a day to the max value
+                    filters.push('( "' + startField + '"' + " < '" + max_val_new_str + "'" + " OR " + ' "' + endField + '"' + " < '" + max_val_new_str + "' )");
                 } else {
                     max_val = null;
                 }


### PR DESCRIPTION
In Lizmap form filter, we should add a day in the max date when requesting the data to be able to get the features with the same date as the max date. Since we use a date picker and there is no way to set the time, using only the max date as the filter will exclude all features of that day but with a defined hour. E.g `<= '2023-10-25'` will exclude features with a field date containing the time such as `2023-10-25 10:34:49`

This PR replaces for example `<= '2023-10-25'` by  `< '2023-10-26'` 

Ticket : #3571

Funded by 3liz
