### PR TITLE
[Bugfix] fixed typo qsgmtime

### DIFF
--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -174,7 +174,7 @@ class Project
                 ) {
                     $qgsProj = new QgisProject($layer['file'], $services, $this->appContext);
                     $newLayer = $qgsProj->getLayerDefinition($layer['id']);
-                    $newLayer['qsgmtime'] = filemtime($layer['file']);
+                    $newLayer['qgsmtime'] = filemtime($layer['file']);
                     $newLayer['file'] = $layer['file'];
                     $newLayer['embedded'] = 1;
                     $newLayer['projectPath'] = $layer['projectPath'];

--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -1493,7 +1493,7 @@ class QgisProject
                 $xmlFile = realpath(dirname($this->path).DIRECTORY_SEPARATOR.(string) $attributes->project);
                 $qgsProj = new QgisProject($xmlFile, $this->services, $this->appContext);
                 $layer = $qgsProj->getLayerDefinition((string) $attributes->id);
-                $layer['qsgmtime'] = filemtime($xmlFile);
+                $layer['qgsmtime'] = filemtime($xmlFile);
                 $layer['file'] = $xmlFile;
                 $layer['embedded'] = 1;
                 $layer['projectPath'] = (string) $attributes->project;


### PR DESCRIPTION
Fixed a typo that prevented projects with embedded layers from being read correctly from the `ProjectCache`

Funded by Faunalia
