### PR TITLE
[Fix] round the 'I' and 'J' paramters of WMS GetFeatureInfo service

### DIFF
--- a/assets/src/modules/Popup.js
+++ b/assets/src/modules/Popup.js
@@ -77,8 +77,8 @@ export default class Popup {
                     FEATURE_COUNT: 10,
                     WIDTH: width,
                     HEIGHT: height,
-                    I: evt.xy.x,
-                    J: evt.xy.y,
+                    I: Math.round(evt.xy.x),
+                    J: Math.round(evt.xy.y),
                     FI_POINT_TOLERANCE: this._pointTolerance,
                     FI_LINE_TOLERANCE: this._lineTolerance,
                     FI_POLYGON_TOLERANCE: this._polygonTolerance


### PR DESCRIPTION
Round to integer `I` and `J` parameters of WMS `GetFeatureInfo` service accordingly to [OGC Documentation](https://portal.ogc.org/files/?artifact_id=14416) (see section 7.4.3.7) 

Ticket : #3971 

Funded by Faunalia
