### PR TITLE
Bugfix JS: Catch error from GetLegendGraphics

### DIFF
--- a/assets/src/modules/WMS.js
+++ b/assets/src/modules/WMS.js
@@ -50,6 +50,9 @@ export default class WMS {
                 ...options
             })
         });
-        return response.json();
+        if (response.ok) {
+            return response.json();
+        }
+        throw new Error(response.text);
     }
 }

--- a/assets/src/modules/action/Symbology.js
+++ b/assets/src/modules/action/Symbology.js
@@ -27,13 +27,14 @@ export async function updateLayerTreeLayersSymbology(treeLayers) {
         STYLES: wmsStyles,
     };
 
-    const response = await wms.getLegendGraphic(wmsParams);
-    for (const node of response.nodes) {
-        // If the layer has no symbology, there is no type property
-        if (node.hasOwnProperty('type')) {
-            treeLayersByName[node.name].symbology = node;
+    await wms.getLegendGraphic(wmsParams).then((response) => {
+        for (const node of response.nodes) {
+            // If the layer has no symbology, there is no type property
+            if (node.hasOwnProperty('type')) {
+                treeLayersByName[node.name].symbology = node;
+            }
         }
-    }
+    }).catch(console.error);
     return treeLayers;
 }
 


### PR DESCRIPTION
GetLegendGraphics can return response with code 400 and xml content like this
```xml
<?xml version="1.0" encoding="UTF-8"?>
<ServiceExceptionReport version="1.3.0" xmlns="http://www.opengis.net/ogc">
 <ServiceException code="LayerNotDefined">The layer ' routes et chemins' does not exist.</ServiceException>
</ServiceExceptionReport>
```

Funded by Conseil Départmental du Territoire de Belfort
