### PR TITLE
init FormControl property only if exists

### DIFF
--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -1356,7 +1356,9 @@ class QgisForm implements QgisFormControlsInterface
         // if ($this->ctrl->emptyItemLabel !== null || !$this->ctrl->required)
         // To add an empty value to ValueRelation displayed as menulist, we only
         // have to set an emptyItemLabel !== null
-        $formControl->ctrl->emptyItemLabel = '';
+        if (property_exists($formControl->ctrl, 'emptyItemLabel')) {
+            $formControl->ctrl->emptyItemLabel = '';
+        }
 
         // Create Datasource
         $dataSource = new QgisFormValueRelationDynamicDatasource($formControl->ref);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -413,11 +413,6 @@ parameters:
 			path: lizmap/modules/lizmap/lib/Form/QgisForm.php
 
 		-
-			message: "#^Access to an undefined property jFormsControl\\:\\:\\$emptyItemLabel\\.$#"
-			count: 1
-			path: lizmap/modules/lizmap/lib/Form/QgisForm.php
-
-		-
 			message: "#^Access to an undefined property jICoordPlugin\\:\\:\\$config\\.$#"
 			count: 2
 			path: lizmap/modules/lizmap/lib/Form/QgisForm.php

--- a/tests/docker-conf/phpfpm/Dockerfile
+++ b/tests/docker-conf/phpfpm/Dockerfile
@@ -1,4 +1,4 @@
-ARG php_version=8.1
+ARG php_version=8.2
 
 FROM 3liz/liz-php-fpm:${php_version}
 


### PR DESCRIPTION
To prevent deprecated notice on php8.2


Funded by 3Liz
