### PR TITLE
[Fix] uncaught exception on layerFilterParamChanged event

### DIFF
--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -2480,7 +2480,7 @@ window.lizMap = function() {
                 }
 
                 for ( var  lName in config.layers ) {
-                    var lConfig = config.layers[lName];
+                    let lConfig = config.layers[lName];
 
                     // Do not request if the layer has no popup
                     if ( lConfig.popup != 'True' )


### PR DESCRIPTION
When a user filters a feature from `pupup`, LWC tries to loop through each layer to check if any filter expression is set on it and tries to get the corresponding `FILTERTOKEN` to update the map accordingly.

Since the ajax call for the filter token is placed inside a loop, the layer configuration used in the ajax callback to set the value of the `filtertoken` on the current `lName-layer` always matches with the last occurrence of the `for loop`.

As side effect, in most cases the `mainLizmap.state.layersAndGroupsCollection.getLayerByName` method called in the callback generates an error in the console because the last occurrence of the layer often matches a `baselayer`, which is not included in the `layerAndGroupsCollection` object.

see https://demo.lizmap.com/lizmap/index.php/view/map?repository=features&project=cats 


Funded by Faunalia
