### PR TITLE
Editing form - Upload fields: allow to use an expression to set up the storage path

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -418,11 +418,6 @@ parameters:
 			path: lizmap/modules/lizmap/lib/Form/QgisForm.php
 
 		-
-			message: "#^If condition is always true\\.$#"
-			count: 4
-			path: lizmap/modules/lizmap/lib/Form/QgisForm.php
-
-		-
 			message: "#^Method Lizmap\\\\Form\\\\QgisForm\\:\\:saveToDb\\(\\) should return array\\|int\\|false but returns true\\.$#"
 			count: 1
 			path: lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -641,5 +636,3 @@ parameters:
 			message: "#^Inner named functions are not supported by PHPStan\\. Consider refactoring to an anonymous function, class method, or a top\\-level\\-defined function\\. See issue \\#165 \\(https\\://github\\.com/phpstan/phpstan/issues/165\\) for more details\\.$#"
 			count: 1
 			path: lizmap/modules/view/controllers/lizMap.classic.php
-
-

--- a/tests/qgis-projects/tests/form_edition_all_field_type.qgs
+++ b/tests/qgis-projects/tests/form_edition_all_field_type.qgs
@@ -1,9 +1,8 @@
-<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="3.28.10-Firenze" saveDateTime="2023-09-07T11:21:36" projectname="" saveUser="etienne" saveUserFull="Etienne Trimaille">
-  <homePath path=""/>
+<qgis projectname="" saveDateTime="2024-01-08T13:28:56" saveUser="mdouchin" saveUserFull="mdouchin" version="3.28.14-Firenze">
+  <homePath path=""></homePath>
   <title></title>
-  <transaction mode="Disabled"/>
-  <projectFlags set=""/>
+  <transaction mode="Disabled"></transaction>
+  <projectFlags set="TrustStoredLayerStatistics"></projectFlags>
   <projectCrs>
     <spatialrefsys nativeFormat="Wkt">
       <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
@@ -19,47 +18,47 @@
   </projectCrs>
   <layer-tree-group>
     <customproperties>
-      <Option/>
+      <Option></Option>
     </customproperties>
-    <layer-tree-layer legend_exp="" patch_size="-1,-1" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;many_bool_formats&quot; (geom)" expanded="1" legend_split_behavior="0" providerKey="postgres" name="many_bool_formats" id="many_bool_formats_7aa4cb8a_09ae_4a5b_92e4_189a42ca3a2f" checked="Qt::Checked">
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="many_bool_formats_7aa4cb8a_09ae_4a5b_92e4_189a42ca3a2f" legend_exp="" legend_split_behavior="0" name="many_bool_formats" patch_size="-1,-1" providerKey="postgres" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;many_bool_formats&quot; (geom)">
       <customproperties>
-        <Option/>
+        <Option></Option>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer legend_exp="" patch_size="-1,-1" source="service='lizmapdb' sslmode=disable key='id' checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;many_date_formats&quot;" expanded="1" legend_split_behavior="0" providerKey="postgres" name="many_date_formats" id="many_date_formats_1a83b783_8ee0_49a8_bed3_480ecee12fb5" checked="Qt::Checked">
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="many_date_formats_1a83b783_8ee0_49a8_bed3_480ecee12fb5" legend_exp="" legend_split_behavior="0" name="many_date_formats" patch_size="-1,-1" providerKey="postgres" source="service='lizmapdb' sslmode=disable key='id' checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;many_date_formats&quot;">
       <customproperties>
-        <Option/>
+        <Option></Option>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer legend_exp="" patch_size="-1,-1" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;form_edition_upload&quot;" expanded="1" legend_split_behavior="0" providerKey="postgres" name="form_edition_upload" id="form_edition_upload_65de30e9_0bab_44f1_9a3d_b2bf9f47a204" checked="Qt::Checked">
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="form_edition_upload_65de30e9_0bab_44f1_9a3d_b2bf9f47a204" legend_exp="" legend_split_behavior="0" name="form_edition_upload" patch_size="-1,-1" providerKey="postgres" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;form_edition_upload&quot;">
       <customproperties>
-        <Option/>
+        <Option></Option>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer legend_exp="" patch_size="-1,-1" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='0' table=&quot;tests_projects&quot;.&quot;data_integers&quot;" expanded="1" legend_split_behavior="0" providerKey="postgres" name="data_integers" id="data_integers_ca1eb372_c518_4cc2_b2d8_c66d71b908a7" checked="Qt::Checked">
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="data_integers_ca1eb372_c518_4cc2_b2d8_c66d71b908a7" legend_exp="" legend_split_behavior="0" name="data_integers" patch_size="-1,-1" providerKey="postgres" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='0' table=&quot;tests_projects&quot;.&quot;data_integers&quot;">
       <customproperties>
-        <Option/>
+        <Option></Option>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer legend_exp="" patch_size="-1,-1" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='0' table=&quot;tests_projects&quot;.&quot;data_uids&quot;" expanded="1" legend_split_behavior="0" providerKey="postgres" name="data_uids" id="data_uids_43391461_e5ea_4a95_9167_7b24b713ba9b" checked="Qt::Checked">
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="data_uids_43391461_e5ea_4a95_9167_7b24b713ba9b" legend_exp="" legend_split_behavior="0" name="data_uids" patch_size="-1,-1" providerKey="postgres" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='0' table=&quot;tests_projects&quot;.&quot;data_uids&quot;">
       <customproperties>
-        <Option/>
+        <Option></Option>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer legend_exp="" patch_size="0,0" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;form_edition_all_fields_types&quot;" expanded="1" legend_split_behavior="0" providerKey="postgres" name="form_edition_all_fields_types" id="form_edition_all_fields_types_3821ea29_eb6d_4774_81ee_ad42a1e13b51" checked="Qt::Checked">
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="form_edition_all_fields_types_3821ea29_eb6d_4774_81ee_ad42a1e13b51" legend_exp="" legend_split_behavior="0" name="form_edition_all_fields_types" patch_size="0,0" providerKey="postgres" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;form_edition_all_fields_types&quot;">
       <customproperties>
-        <Option/>
+        <Option></Option>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-group expanded="1" groupLayer="" name="baselayers" checked="Qt::Checked">
+    <layer-tree-group checked="Qt::Checked" expanded="1" groupLayer="" name="baselayers">
       <customproperties>
         <Option type="Map">
-          <Option value="baselayers" name="wmsShortName" type="QString"/>
+          <Option name="wmsShortName" type="QString" value="baselayers"></Option>
         </Option>
       </customproperties>
-      <layer-tree-layer legend_exp="" patch_size="-1,-1" source="type=xyz&amp;url=https://tile.openstreetmap.org/{z}/{x}/{y}.png&amp;zmax=19&amp;zmin=0" expanded="1" legend_split_behavior="0" providerKey="wms" name="OpenStreetMap" id="OpenStreetMap_5d079313_31ef_4014_a205_0a0113ff12e7" checked="Qt::Checked">
+      <layer-tree-layer checked="Qt::Checked" expanded="1" id="OpenStreetMap_5d079313_31ef_4014_a205_0a0113ff12e7" legend_exp="" legend_split_behavior="0" name="OpenStreetMap" patch_size="-1,-1" providerKey="wms" source="crs=EPSG:3857&amp;format&amp;type=xyz&amp;url=https://tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&amp;zmax=19&amp;zmin=0">
         <customproperties>
-          <Option/>
+          <Option></Option>
         </customproperties>
       </layer-tree-layer>
     </layer-tree-group>
@@ -68,14 +67,14 @@
       <item>OpenStreetMap_5d079313_31ef_4014_a205_0a0113ff12e7</item>
     </custom-order>
   </layer-tree-group>
-  <snapping-settings mode="2" self-snapping="0" tolerance="12" scaleDependencyMode="0" minScale="0" maxScale="0" enabled="0" type="1" intersection-snapping="0" unit="1">
+  <snapping-settings enabled="0" intersection-snapping="0" maxScale="0" minScale="0" mode="2" scaleDependencyMode="0" self-snapping="0" tolerance="12" type="1" unit="1">
     <individual-layer-settings>
-      <layer-setting tolerance="12" units="1" minScale="0" maxScale="0" enabled="0" id="many_bool_formats_7aa4cb8a_09ae_4a5b_92e4_189a42ca3a2f" type="1"/>
+      <layer-setting enabled="0" id="many_bool_formats_7aa4cb8a_09ae_4a5b_92e4_189a42ca3a2f" maxScale="0" minScale="0" tolerance="12" type="1" units="1"></layer-setting>
     </individual-layer-settings>
   </snapping-settings>
-  <relations/>
-  <polymorphicRelations/>
-  <mapcanvas name="theMapCanvas" annotationsVisible="1">
+  <relations></relations>
+  <polymorphicRelations></polymorphicRelations>
+  <mapcanvas annotationsVisible="1" name="theMapCanvas">
     <units>meters</units>
     <extent>
       <xmin>817096.69666946167126298</xmin>
@@ -98,50 +97,50 @@
       </spatialrefsys>
     </destinationsrs>
     <rendermaptile>0</rendermaptile>
-    <expressionContextScope/>
+    <expressionContextScope></expressionContextScope>
   </mapcanvas>
-  <projectModels/>
+  <projectModels></projectModels>
   <legend updateDrawingOrder="true">
-    <legendlayer drawingOrder="-1" open="true" name="many_bool_formats" showFeatureCount="0" checked="Qt::Checked">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile layerid="many_bool_formats_7aa4cb8a_09ae_4a5b_92e4_189a42ca3a2f" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="many_bool_formats" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="many_bool_formats_7aa4cb8a_09ae_4a5b_92e4_189a42ca3a2f" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendlayer drawingOrder="-1" open="true" name="many_date_formats" showFeatureCount="0" checked="Qt::Checked">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile layerid="many_date_formats_1a83b783_8ee0_49a8_bed3_480ecee12fb5" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="many_date_formats" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="many_date_formats_1a83b783_8ee0_49a8_bed3_480ecee12fb5" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendlayer drawingOrder="-1" open="true" name="form_edition_upload" showFeatureCount="0" checked="Qt::Checked">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile layerid="form_edition_upload_65de30e9_0bab_44f1_9a3d_b2bf9f47a204" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="form_edition_upload" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="form_edition_upload_65de30e9_0bab_44f1_9a3d_b2bf9f47a204" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendlayer drawingOrder="-1" open="true" name="data_integers" showFeatureCount="0" checked="Qt::Checked">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile layerid="data_integers_ca1eb372_c518_4cc2_b2d8_c66d71b908a7" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="data_integers" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="data_integers_ca1eb372_c518_4cc2_b2d8_c66d71b908a7" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendlayer drawingOrder="-1" open="true" name="data_uids" showFeatureCount="0" checked="Qt::Checked">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile layerid="data_uids_43391461_e5ea_4a95_9167_7b24b713ba9b" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="data_uids" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="data_uids_43391461_e5ea_4a95_9167_7b24b713ba9b" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendlayer drawingOrder="-1" open="true" name="form_edition_all_fields_types" showFeatureCount="0" checked="Qt::Checked">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile layerid="form_edition_all_fields_types_3821ea29_eb6d_4774_81ee_ad42a1e13b51" visible="1" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="form_edition_all_fields_types" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="form_edition_all_fields_types_3821ea29_eb6d_4774_81ee_ad42a1e13b51" visible="1"></legendlayerfile>
       </filegroup>
     </legendlayer>
-    <legendgroup open="true" name="baselayers" checked="Qt::Checked">
-      <legendlayer drawingOrder="-1" open="true" name="OpenStreetMap" showFeatureCount="0" checked="Qt::Checked">
-        <filegroup open="true" hidden="false">
-          <legendlayerfile layerid="OpenStreetMap_5d079313_31ef_4014_a205_0a0113ff12e7" visible="1" isInOverview="0"/>
+    <legendgroup checked="Qt::Checked" name="baselayers" open="true">
+      <legendlayer checked="Qt::Checked" drawingOrder="-1" name="OpenStreetMap" open="true" showFeatureCount="0">
+        <filegroup hidden="false" open="true">
+          <legendlayerfile isInOverview="0" layerid="OpenStreetMap_5d079313_31ef_4014_a205_0a0113ff12e7" visible="1"></legendlayerfile>
         </filegroup>
       </legendlayer>
     </legendgroup>
   </legend>
-  <mapViewDocks/>
-  <main-annotation-layer autoRefreshEnabled="0" legendPlaceholderImage="" refreshOnNotifyMessage="" autoRefreshTime="0" type="annotation" refreshOnNotifyEnabled="0">
+  <mapViewDocks></mapViewDocks>
+  <main-annotation-layer autoRefreshEnabled="0" autoRefreshTime="0" legendPlaceholderImage="" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" type="annotation">
     <id>Annotations_eefc8023_c983_41a3_a6a5_64d52a30a0b7</id>
     <datasource></datasource>
     <keywordList>
@@ -168,7 +167,7 @@
       <type></type>
       <title></title>
       <abstract></abstract>
-      <links/>
+      <links></links>
       <fees></fees>
       <encoding></encoding>
       <crs>
@@ -184,15 +183,15 @@
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </crs>
-      <extent/>
+      <extent></extent>
     </resourceMetadata>
-    <items/>
+    <items></items>
     <layerOpacity>1</layerOpacity>
     <blendMode>0</blendMode>
-    <paintEffect/>
+    <paintEffect></paintEffect>
   </main-annotation-layer>
   <projectlayers>
-    <maplayer styleCategories="AllStyleCategories" autoRefreshEnabled="0" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="0" refreshOnNotifyMessage="" maxScale="0" minScale="1e+08" autoRefreshTime="0" type="raster" refreshOnNotifyEnabled="0">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" legendPlaceholderImage="" maxScale="0" minScale="1e+08" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" type="raster">
       <extent>
         <xmin>-20037508.34278924390673637</xmin>
         <ymin>-20037508.34278924763202667</ymin>
@@ -206,7 +205,7 @@
         <ymax>85.05112877980660357</ymax>
       </wgs84extent>
       <id>OpenStreetMap_5d079313_31ef_4014_a205_0a0113ff12e7</id>
-      <datasource>type=xyz&amp;url=https://tile.openstreetmap.org/{z}/{x}/{y}.png&amp;zmax=19&amp;zmin=0</datasource>
+      <datasource>crs=EPSG:3857&amp;format&amp;type=xyz&amp;url=https://tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&amp;zmax=19&amp;zmin=0</datasource>
       <shortname>OpenStreetMap</shortname>
       <keywordList>
         <value></value>
@@ -233,7 +232,7 @@
         <title>OpenStreetMap tiles</title>
         <abstract>OpenStreetMap is built by a community of mappers that contribute and maintain data about roads, trails, cafés, railway stations, and much more, all over the world.</abstract>
         <links>
-          <link size="" url="https://www.openstreetmap.org/" mimeType="" name="Source" description="" format="" type="WWW:LINK"/>
+          <link description="" format="" mimeType="" name="Source" size="" type="WWW:LINK" url="https://www.openstreetmap.org/"></link>
         </links>
         <fees></fees>
         <rights>Base map and data from OpenStreetMap and OpenStreetMap Foundation (CC-BY-SA). © https://www.openstreetmap.org and contributors.</rights>
@@ -254,114 +253,114 @@
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial crs="EPSG:4326" maxy="85.05112877980660357" dimensions="2" miny="-85.05112877980660357" maxx="180" maxz="0" minx="-180" minz="0"/>
+          <spatial crs="EPSG:4326" dimensions="2" maxx="180" maxy="85.05112877980660357" maxz="0" minx="-180" miny="-85.05112877980660357" minz="0"></spatial>
         </extent>
       </resourceMetadata>
       <provider>wms</provider>
       <noData>
-        <noDataList useSrcNoData="0" bandNo="1"/>
+        <noDataList bandNo="1" useSrcNoData="0"></noDataList>
       </noData>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <metadataUrls/>
+      <metadataUrls></metadataUrls>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal mode="0" enabled="0" fetchMode="0">
+      <temporal enabled="0" fetchMode="0" mode="0">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
-      <elevation zoffset="0" zscale="1" band="1" enabled="0" symbology="Line">
+      <elevation band="1" enabled="0" symbology="Line" zoffset="0" zscale="1">
         <data-defined-properties>
           <Option type="Map">
-            <Option value="" name="name" type="QString"/>
-            <Option name="properties"/>
-            <Option value="collection" name="type" type="QString"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </data-defined-properties>
         <profileLineSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="line" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleLine">
+            <layer class="SimpleLine" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="0" name="align_dash_pattern" type="QString"/>
-                <Option value="square" name="capstyle" type="QString"/>
-                <Option value="5;2" name="customdash" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
-                <Option value="MM" name="customdash_unit" type="QString"/>
-                <Option value="0" name="dash_pattern_offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
-                <Option value="0" name="draw_inside_polygon" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="231,113,72,255" name="line_color" type="QString"/>
-                <Option value="solid" name="line_style" type="QString"/>
-                <Option value="0.6" name="line_width" type="QString"/>
-                <Option value="MM" name="line_width_unit" type="QString"/>
-                <Option value="0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="0" name="ring_filter" type="QString"/>
-                <Option value="0" name="trim_distance_end" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
-                <Option value="MM" name="trim_distance_end_unit" type="QString"/>
-                <Option value="0" name="trim_distance_start" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
-                <Option value="MM" name="trim_distance_start_unit" type="QString"/>
-                <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
-                <Option value="0" name="use_custom_dash" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="231,113,72,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileLineSymbol>
         <profileFillSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="fill" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleFill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-                <Option value="231,113,72,255" name="color" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="0,0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="35,35,35,255" name="outline_color" type="QString"/>
-                <Option value="no" name="outline_style" type="QString"/>
-                <Option value="0.26" name="outline_width" type="QString"/>
-                <Option value="MM" name="outline_width_unit" type="QString"/>
-                <Option value="solid" name="style" type="QString"/>
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="231,113,72,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="35,35,35,255"></Option>
+                <Option name="outline_style" type="QString" value="no"></Option>
+                <Option name="outline_width" type="QString" value="0.26"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -370,22 +369,22 @@
       </elevation>
       <customproperties>
         <Option type="Map">
-          <Option value="Value" name="identify/format" type="QString"/>
+          <Option name="identify/format" type="QString" value="Value"></Option>
         </Option>
       </customproperties>
       <pipe-data-defined-properties>
         <Option type="Map">
-          <Option value="" name="name" type="QString"/>
-          <Option name="properties"/>
-          <Option value="collection" name="type" type="QString"/>
+          <Option name="name" type="QString" value=""></Option>
+          <Option name="properties"></Option>
+          <Option name="type" type="QString" value="collection"></Option>
         </Option>
       </pipe-data-defined-properties>
       <pipe>
         <provider>
-          <resampling zoomedInResamplingMethod="nearestNeighbour" zoomedOutResamplingMethod="nearestNeighbour" maxOversampling="2" enabled="false"/>
+          <resampling enabled="false" maxOversampling="2" zoomedInResamplingMethod="nearestNeighbour" zoomedOutResamplingMethod="nearestNeighbour"></resampling>
         </provider>
-        <rasterrenderer nodataColor="" band="1" alphaBand="-1" opacity="1" type="singlebandcolordata">
-          <rasterTransparency/>
+        <rasterrenderer alphaBand="-1" band="1" nodataColor="" opacity="1" type="singlebandcolordata">
+          <rasterTransparency></rasterTransparency>
           <minMaxOrigin>
             <limits>None</limits>
             <extent>WholeRaster</extent>
@@ -395,14 +394,14 @@
             <stdDevFactor>2</stdDevFactor>
           </minMaxOrigin>
         </rasterrenderer>
-        <brightnesscontrast gamma="1" brightness="0" contrast="0"/>
-        <huesaturation colorizeGreen="128" saturation="0" colorizeRed="255" colorizeBlue="128" colorizeOn="0" invertColors="0" grayscaleMode="0" colorizeStrength="100"/>
-        <rasterresampler maxOversampling="2"/>
+        <brightnesscontrast brightness="0" contrast="0" gamma="1"></brightnesscontrast>
+        <huesaturation colorizeBlue="128" colorizeGreen="128" colorizeOn="0" colorizeRed="255" colorizeStrength="100" grayscaleMode="0" invertColors="0" saturation="0"></huesaturation>
+        <rasterresampler maxOversampling="2"></rasterresampler>
         <resamplingStage>resamplingFilter</resamplingStage>
       </pipe>
       <blendMode>0</blendMode>
     </maplayer>
-    <maplayer styleCategories="AllStyleCategories" autoRefreshEnabled="0" geometry="No geometry" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="0" refreshOnNotifyMessage="" readOnly="0" maxScale="0" minScale="1e+08" autoRefreshTime="0" wkbType="NoGeometry" type="vector" refreshOnNotifyEnabled="0">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="No geometry" hasScaleBasedVisibilityFlag="0" legendPlaceholderImage="" maxScale="0" minScale="1e+08" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" type="vector" wkbType="NoGeometry">
       <id>data_integers_ca1eb372_c518_4cc2_b2d8_c66d71b908a7</id>
       <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='0' table="tests_projects"."data_integers"</datasource>
       <shortname>data_integers</shortname>
@@ -430,7 +429,7 @@
         <type>dataset</type>
         <title></title>
         <abstract></abstract>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
@@ -446,156 +445,156 @@
             <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
-        <extent/>
+        <extent></extent>
       </resourceMetadata>
       <provider encoding="">postgres</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
-      <metadataUrls/>
+      <auxiliaryLayer></auxiliaryLayer>
+      <metadataUrls></metadataUrls>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal mode="0" durationUnit="min" endField="" fixedDuration="0" startExpression="" enabled="0" startField="" limitMode="0" durationField="" accumulate="0" endExpression="">
+      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
-      <elevation zoffset="0" zscale="1" extrusionEnabled="0" showMarkerSymbolInSurfacePlots="0" extrusion="0" respectLayerSymbol="1" clamping="Terrain" type="IndividualFeatures" symbology="Line" binding="Centroid">
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
         <data-defined-properties>
           <Option type="Map">
-            <Option value="" name="name" type="QString"/>
-            <Option name="properties"/>
-            <Option value="collection" name="type" type="QString"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </data-defined-properties>
         <profileLineSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="line" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleLine">
+            <layer class="SimpleLine" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="0" name="align_dash_pattern" type="QString"/>
-                <Option value="square" name="capstyle" type="QString"/>
-                <Option value="5;2" name="customdash" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
-                <Option value="MM" name="customdash_unit" type="QString"/>
-                <Option value="0" name="dash_pattern_offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
-                <Option value="0" name="draw_inside_polygon" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="255,158,23,255" name="line_color" type="QString"/>
-                <Option value="solid" name="line_style" type="QString"/>
-                <Option value="0.6" name="line_width" type="QString"/>
-                <Option value="MM" name="line_width_unit" type="QString"/>
-                <Option value="0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="0" name="ring_filter" type="QString"/>
-                <Option value="0" name="trim_distance_end" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
-                <Option value="MM" name="trim_distance_end_unit" type="QString"/>
-                <Option value="0" name="trim_distance_start" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
-                <Option value="MM" name="trim_distance_start_unit" type="QString"/>
-                <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
-                <Option value="0" name="use_custom_dash" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="255,158,23,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileLineSymbol>
         <profileFillSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="fill" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleFill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-                <Option value="255,158,23,255" name="color" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="0,0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="182,113,16,255" name="outline_color" type="QString"/>
-                <Option value="solid" name="outline_style" type="QString"/>
-                <Option value="0.2" name="outline_width" type="QString"/>
-                <Option value="MM" name="outline_width_unit" type="QString"/>
-                <Option value="solid" name="style" type="QString"/>
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="255,158,23,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="182,113,16,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileFillSymbol>
         <profileMarkerSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="marker" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleMarker">
+            <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="0" name="angle" type="QString"/>
-                <Option value="square" name="cap_style" type="QString"/>
-                <Option value="255,158,23,255" name="color" type="QString"/>
-                <Option value="1" name="horizontal_anchor_point" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="diamond" name="name" type="QString"/>
-                <Option value="0,0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="182,113,16,255" name="outline_color" type="QString"/>
-                <Option value="solid" name="outline_style" type="QString"/>
-                <Option value="0.2" name="outline_width" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
-                <Option value="MM" name="outline_width_unit" type="QString"/>
-                <Option value="diameter" name="scale_method" type="QString"/>
-                <Option value="3" name="size" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
-                <Option value="MM" name="size_unit" type="QString"/>
-                <Option value="1" name="vertical_anchor_point" type="QString"/>
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="255,158,23,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="182,113,16,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -604,86 +603,86 @@
       </elevation>
       <customproperties>
         <Option type="Map">
-          <Option value="offline" name="QFieldSync/action" type="QString"/>
-          <Option value="{}" name="QFieldSync/attachment_naming" type="QString"/>
-          <Option value="offline" name="QFieldSync/cloud_action" type="QString"/>
-          <Option value="{}" name="QFieldSync/photo_naming" type="QString"/>
-          <Option value="{}" name="QFieldSync/relationship_maximum_visible" type="QString"/>
-          <Option value="&quot;id&quot;" name="dualview/previewExpressions" type="QString"/>
+          <Option name="QFieldSync/action" type="QString" value="offline"></Option>
+          <Option name="QFieldSync/attachment_naming" type="QString" value="{}"></Option>
+          <Option name="QFieldSync/cloud_action" type="QString" value="offline"></Option>
+          <Option name="QFieldSync/photo_naming" type="QString" value="{}"></Option>
+          <Option name="QFieldSync/relationship_maximum_visible" type="QString" value="{}"></Option>
+          <Option name="dualview/previewExpressions" type="QString" value="&quot;id&quot;"></Option>
         </Option>
       </customproperties>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks type="StringList">
-          <Option value="" type="QString"/>
+          <Option type="QString" value=""></Option>
         </activeChecks>
-        <checkConfiguration/>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
-      <legend showLabelLegend="0" type="default-vector"/>
-      <referencedLayers/>
+      <legend showLabelLegend="0" type="default-vector"></legend>
+      <referencedLayers></referencedLayers>
       <fieldConfiguration>
         <field configurationFlags="None" name="id">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field configurationFlags="None" name="label">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="id"/>
-        <alias name="" index="1" field="label"/>
+        <alias field="id" index="0" name=""></alias>
+        <alias field="label" index="1" name=""></alias>
       </aliases>
       <defaults>
-        <default expression="" applyOnUpdate="0" field="id"/>
-        <default expression="" applyOnUpdate="0" field="label"/>
+        <default applyOnUpdate="0" expression="" field="id"></default>
+        <default applyOnUpdate="0" expression="" field="label"></default>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" exp_strength="0" unique_strength="1" constraints="3" field="id"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="label"/>
+        <constraint constraints="3" exp_strength="0" field="id" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="label" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" desc="" field="id"/>
-        <constraint exp="" desc="" field="label"/>
+        <constraint desc="" exp="" field="id"></constraint>
+        <constraint desc="" exp="" field="label"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
-      <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column width="-1" hidden="0" name="id" type="field"/>
-          <column width="-1" hidden="0" name="label" type="field"/>
-          <column width="-1" hidden="1" type="actions"/>
+          <column hidden="0" name="id" type="field" width="-1"></column>
+          <column hidden="0" name="label" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1"></editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[]]></editforminitcode>
+      <editforminitcode></editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
-      <editable/>
-      <labelOnTop/>
-      <reuseLastValue/>
-      <dataDefinedFieldProperties/>
-      <widgets/>
+      <editable></editable>
+      <labelOnTop></labelOnTop>
+      <reuseLastValue></reuseLastValue>
+      <dataDefinedFieldProperties></dataDefinedFieldProperties>
+      <widgets></widgets>
       <previewExpression>"id"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer styleCategories="AllStyleCategories" autoRefreshEnabled="0" geometry="No geometry" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="0" refreshOnNotifyMessage="" readOnly="0" maxScale="0" minScale="1e+08" autoRefreshTime="0" wkbType="NoGeometry" type="vector" refreshOnNotifyEnabled="0">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="No geometry" hasScaleBasedVisibilityFlag="0" legendPlaceholderImage="" maxScale="0" minScale="1e+08" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" type="vector" wkbType="NoGeometry">
       <id>data_uids_43391461_e5ea_4a95_9167_7b24b713ba9b</id>
       <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='0' table="tests_projects"."data_uids"</datasource>
       <shortname>data_uids</shortname>
@@ -711,7 +710,7 @@
         <type>dataset</type>
         <title></title>
         <abstract></abstract>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
@@ -727,156 +726,156 @@
             <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
-        <extent/>
+        <extent></extent>
       </resourceMetadata>
       <provider encoding="">postgres</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="défaut">
-        <map-layer-style name="défaut"/>
+        <map-layer-style name="défaut"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
-      <metadataUrls/>
+      <auxiliaryLayer></auxiliaryLayer>
+      <metadataUrls></metadataUrls>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal mode="0" durationUnit="min" endField="" fixedDuration="0" startExpression="" enabled="0" startField="" limitMode="0" durationField="" accumulate="0" endExpression="">
+      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
-      <elevation zoffset="0" zscale="1" extrusionEnabled="0" showMarkerSymbolInSurfacePlots="0" extrusion="0" respectLayerSymbol="1" clamping="Terrain" type="IndividualFeatures" symbology="Line" binding="Centroid">
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
         <data-defined-properties>
           <Option type="Map">
-            <Option value="" name="name" type="QString"/>
-            <Option name="properties"/>
-            <Option value="collection" name="type" type="QString"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </data-defined-properties>
         <profileLineSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="line" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleLine">
+            <layer class="SimpleLine" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="0" name="align_dash_pattern" type="QString"/>
-                <Option value="square" name="capstyle" type="QString"/>
-                <Option value="5;2" name="customdash" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
-                <Option value="MM" name="customdash_unit" type="QString"/>
-                <Option value="0" name="dash_pattern_offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
-                <Option value="0" name="draw_inside_polygon" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="183,72,75,255" name="line_color" type="QString"/>
-                <Option value="solid" name="line_style" type="QString"/>
-                <Option value="0.6" name="line_width" type="QString"/>
-                <Option value="MM" name="line_width_unit" type="QString"/>
-                <Option value="0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="0" name="ring_filter" type="QString"/>
-                <Option value="0" name="trim_distance_end" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
-                <Option value="MM" name="trim_distance_end_unit" type="QString"/>
-                <Option value="0" name="trim_distance_start" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
-                <Option value="MM" name="trim_distance_start_unit" type="QString"/>
-                <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
-                <Option value="0" name="use_custom_dash" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="183,72,75,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileLineSymbol>
         <profileFillSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="fill" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleFill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-                <Option value="183,72,75,255" name="color" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="0,0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="131,51,54,255" name="outline_color" type="QString"/>
-                <Option value="solid" name="outline_style" type="QString"/>
-                <Option value="0.2" name="outline_width" type="QString"/>
-                <Option value="MM" name="outline_width_unit" type="QString"/>
-                <Option value="solid" name="style" type="QString"/>
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="183,72,75,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="131,51,54,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileFillSymbol>
         <profileMarkerSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="marker" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleMarker">
+            <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="0" name="angle" type="QString"/>
-                <Option value="square" name="cap_style" type="QString"/>
-                <Option value="183,72,75,255" name="color" type="QString"/>
-                <Option value="1" name="horizontal_anchor_point" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="diamond" name="name" type="QString"/>
-                <Option value="0,0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="131,51,54,255" name="outline_color" type="QString"/>
-                <Option value="solid" name="outline_style" type="QString"/>
-                <Option value="0.2" name="outline_width" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
-                <Option value="MM" name="outline_width_unit" type="QString"/>
-                <Option value="diameter" name="scale_method" type="QString"/>
-                <Option value="3" name="size" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
-                <Option value="MM" name="size_unit" type="QString"/>
-                <Option value="1" name="vertical_anchor_point" type="QString"/>
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="183,72,75,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="131,51,54,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -885,98 +884,98 @@
       </elevation>
       <customproperties>
         <Option type="Map">
-          <Option value="offline" name="QFieldSync/action" type="QString"/>
-          <Option value="{}" name="QFieldSync/attachment_naming" type="QString"/>
-          <Option value="offline" name="QFieldSync/cloud_action" type="QString"/>
-          <Option value="{}" name="QFieldSync/photo_naming" type="QString"/>
-          <Option value="{}" name="QFieldSync/relationship_maximum_visible" type="QString"/>
-          <Option value="&quot;id&quot;" name="dualview/previewExpressions" type="QString"/>
+          <Option name="QFieldSync/action" type="QString" value="offline"></Option>
+          <Option name="QFieldSync/attachment_naming" type="QString" value="{}"></Option>
+          <Option name="QFieldSync/cloud_action" type="QString" value="offline"></Option>
+          <Option name="QFieldSync/photo_naming" type="QString" value="{}"></Option>
+          <Option name="QFieldSync/relationship_maximum_visible" type="QString" value="{}"></Option>
+          <Option name="dualview/previewExpressions" type="QString" value="&quot;id&quot;"></Option>
         </Option>
       </customproperties>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks type="StringList">
-          <Option value="" type="QString"/>
+          <Option type="QString" value=""></Option>
         </activeChecks>
-        <checkConfiguration/>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
-      <legend showLabelLegend="0" type="default-vector"/>
-      <referencedLayers/>
+      <legend showLabelLegend="0" type="default-vector"></legend>
+      <referencedLayers></referencedLayers>
       <fieldConfiguration>
         <field configurationFlags="None" name="id">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field configurationFlags="None" name="uid">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
         <field configurationFlags="None" name="label">
           <editWidget type="">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="id"/>
-        <alias name="" index="1" field="uid"/>
-        <alias name="" index="2" field="label"/>
+        <alias field="id" index="0" name=""></alias>
+        <alias field="uid" index="1" name=""></alias>
+        <alias field="label" index="2" name=""></alias>
       </aliases>
       <defaults>
-        <default expression="" applyOnUpdate="0" field="id"/>
-        <default expression="" applyOnUpdate="0" field="uid"/>
-        <default expression="" applyOnUpdate="0" field="label"/>
+        <default applyOnUpdate="0" expression="" field="id"></default>
+        <default applyOnUpdate="0" expression="" field="uid"></default>
+        <default applyOnUpdate="0" expression="" field="label"></default>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" exp_strength="0" unique_strength="1" constraints="3" field="id"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="uid"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="label"/>
+        <constraint constraints="3" exp_strength="0" field="id" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="uid" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="label" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" desc="" field="id"/>
-        <constraint exp="" desc="" field="uid"/>
-        <constraint exp="" desc="" field="label"/>
+        <constraint desc="" exp="" field="id"></constraint>
+        <constraint desc="" exp="" field="uid"></constraint>
+        <constraint desc="" exp="" field="label"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
-      <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column width="-1" hidden="0" name="id" type="field"/>
-          <column width="-1" hidden="0" name="uid" type="field"/>
-          <column width="-1" hidden="0" name="label" type="field"/>
-          <column width="-1" hidden="1" type="actions"/>
+          <column hidden="0" name="id" type="field" width="-1"></column>
+          <column hidden="0" name="uid" type="field" width="-1"></column>
+          <column hidden="0" name="label" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1"></editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[]]></editforminitcode>
+      <editforminitcode></editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
-      <editable/>
-      <labelOnTop/>
-      <reuseLastValue/>
-      <dataDefinedFieldProperties/>
-      <widgets/>
+      <editable></editable>
+      <labelOnTop></labelOnTop>
+      <reuseLastValue></reuseLastValue>
+      <dataDefinedFieldProperties></dataDefinedFieldProperties>
+      <widgets></widgets>
       <previewExpression>"id"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer styleCategories="AllStyleCategories" autoRefreshEnabled="0" geometry="No geometry" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="0" refreshOnNotifyMessage="" readOnly="0" maxScale="0" minScale="1e+08" autoRefreshTime="0" wkbType="NoGeometry" type="vector" refreshOnNotifyEnabled="0">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="No geometry" hasScaleBasedVisibilityFlag="0" legendPlaceholderImage="" maxScale="0" minScale="1e+08" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" type="vector" wkbType="NoGeometry">
       <id>form_edition_all_fields_types_3821ea29_eb6d_4774_81ee_ad42a1e13b51</id>
       <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='1' table="tests_projects"."form_edition_all_fields_types"</datasource>
       <shortname>form_edition_all_fields_types</shortname>
@@ -1013,7 +1012,7 @@
           <email></email>
           <role></role>
         </contact>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
@@ -1030,7 +1029,7 @@
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial crs="" maxy="0" dimensions="2" miny="0" maxx="0" maxz="0" minx="0" minz="0"/>
+          <spatial crs="" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
           <temporal>
             <period>
               <start></start>
@@ -1040,153 +1039,153 @@
         </extent>
       </resourceMetadata>
       <provider encoding="">postgres</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
-      <metadataUrls/>
+      <auxiliaryLayer></auxiliaryLayer>
+      <metadataUrls></metadataUrls>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal mode="0" durationUnit="min" endField="" fixedDuration="0" startExpression="" enabled="0" startField="" limitMode="0" durationField="" accumulate="0" endExpression="">
+      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
-      <elevation zoffset="0" zscale="1" extrusionEnabled="0" showMarkerSymbolInSurfacePlots="0" extrusion="0" respectLayerSymbol="1" clamping="Terrain" type="IndividualFeatures" symbology="Line" binding="Centroid">
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
         <data-defined-properties>
           <Option type="Map">
-            <Option value="" name="name" type="QString"/>
-            <Option name="properties"/>
-            <Option value="collection" name="type" type="QString"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </data-defined-properties>
         <profileLineSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="line" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleLine">
+            <layer class="SimpleLine" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="0" name="align_dash_pattern" type="QString"/>
-                <Option value="square" name="capstyle" type="QString"/>
-                <Option value="5;2" name="customdash" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
-                <Option value="MM" name="customdash_unit" type="QString"/>
-                <Option value="0" name="dash_pattern_offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
-                <Option value="0" name="draw_inside_polygon" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="231,113,72,255" name="line_color" type="QString"/>
-                <Option value="solid" name="line_style" type="QString"/>
-                <Option value="0.6" name="line_width" type="QString"/>
-                <Option value="MM" name="line_width_unit" type="QString"/>
-                <Option value="0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="0" name="ring_filter" type="QString"/>
-                <Option value="0" name="trim_distance_end" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
-                <Option value="MM" name="trim_distance_end_unit" type="QString"/>
-                <Option value="0" name="trim_distance_start" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
-                <Option value="MM" name="trim_distance_start_unit" type="QString"/>
-                <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
-                <Option value="0" name="use_custom_dash" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="231,113,72,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileLineSymbol>
         <profileFillSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="fill" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleFill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-                <Option value="231,113,72,255" name="color" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="0,0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="165,81,51,255" name="outline_color" type="QString"/>
-                <Option value="solid" name="outline_style" type="QString"/>
-                <Option value="0.2" name="outline_width" type="QString"/>
-                <Option value="MM" name="outline_width_unit" type="QString"/>
-                <Option value="solid" name="style" type="QString"/>
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="231,113,72,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="165,81,51,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileFillSymbol>
         <profileMarkerSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="marker" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleMarker">
+            <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="0" name="angle" type="QString"/>
-                <Option value="square" name="cap_style" type="QString"/>
-                <Option value="231,113,72,255" name="color" type="QString"/>
-                <Option value="1" name="horizontal_anchor_point" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="diamond" name="name" type="QString"/>
-                <Option value="0,0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="165,81,51,255" name="outline_color" type="QString"/>
-                <Option value="solid" name="outline_style" type="QString"/>
-                <Option value="0.2" name="outline_width" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
-                <Option value="MM" name="outline_width_unit" type="QString"/>
-                <Option value="diameter" name="scale_method" type="QString"/>
-                <Option value="3" name="size" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
-                <Option value="MM" name="size_unit" type="QString"/>
-                <Option value="1" name="vertical_anchor_point" type="QString"/>
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="231,113,72,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="165,81,51,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -1195,28 +1194,28 @@
       </elevation>
       <customproperties>
         <Option type="Map">
-          <Option value="offline" name="QFieldSync/action" type="QString"/>
-          <Option value="{}" name="QFieldSync/attachment_naming" type="QString"/>
-          <Option value="offline" name="QFieldSync/cloud_action" type="QString"/>
-          <Option value="{}" name="QFieldSync/photo_naming" type="QString"/>
-          <Option value="{}" name="QFieldSync/relationship_maximum_visible" type="QString"/>
-          <Option value="&quot;id&quot;" name="dualview/previewExpressions" type="QString"/>
-          <Option value="0" name="embeddedWidgets/count" type="QString"/>
-          <Option name="variableNames" type="invalid"/>
-          <Option name="variableValues" type="invalid"/>
+          <Option name="QFieldSync/action" type="QString" value="offline"></Option>
+          <Option name="QFieldSync/attachment_naming" type="QString" value="{}"></Option>
+          <Option name="QFieldSync/cloud_action" type="QString" value="offline"></Option>
+          <Option name="QFieldSync/photo_naming" type="QString" value="{}"></Option>
+          <Option name="QFieldSync/relationship_maximum_visible" type="QString" value="{}"></Option>
+          <Option name="dualview/previewExpressions" type="QString" value="&quot;id&quot;"></Option>
+          <Option name="embeddedWidgets/count" type="QString" value="0"></Option>
+          <Option name="variableNames" type="invalid"></Option>
+          <Option name="variableValues" type="invalid"></Option>
         </Option>
       </customproperties>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
-        <activeChecks/>
-        <checkConfiguration/>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
-      <legend showLabelLegend="0" type="default-vector"/>
-      <referencedLayers/>
+      <legend showLabelLegend="0" type="default-vector"></legend>
+      <referencedLayers></referencedLayers>
       <fieldConfiguration>
         <field configurationFlags="None" name="id">
           <editWidget type="TextEdit">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
@@ -1224,12 +1223,12 @@
           <editWidget type="Range">
             <config>
               <Option type="Map">
-                <Option value="true" name="AllowNull" type="bool"/>
-                <Option value="200" name="Max" type="int"/>
-                <Option value="-200" name="Min" type="int"/>
-                <Option value="0" name="Precision" type="int"/>
-                <Option value="5" name="Step" type="int"/>
-                <Option value="SpinBox" name="Style" type="QString"/>
+                <Option name="AllowNull" type="bool" value="true"></Option>
+                <Option name="Max" type="int" value="200"></Option>
+                <Option name="Min" type="int" value="-200"></Option>
+                <Option name="Precision" type="int" value="0"></Option>
+                <Option name="Step" type="int" value="5"></Option>
+                <Option name="Style" type="QString" value="SpinBox"></Option>
               </Option>
             </config>
           </editWidget>
@@ -1240,13 +1239,13 @@
               <Option type="Map">
                 <Option name="map" type="List">
                   <Option type="Map">
-                    <Option value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" name="&lt;NULL>" type="QString"/>
+                    <Option name="&lt;NULL>" type="QString" value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option value="true" name="True" type="QString"/>
+                    <Option name="True" type="QString" value="true"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option value="false" name="False" type="QString"/>
+                    <Option name="False" type="QString" value="false"></Option>
                   </Option>
                 </Option>
               </Option>
@@ -1257,9 +1256,9 @@
           <editWidget type="CheckBox">
             <config>
               <Option type="Map">
-                <Option value="" name="CheckedState" type="QString"/>
-                <Option value="0" name="TextDisplayMethod" type="int"/>
-                <Option value="" name="UncheckedState" type="QString"/>
+                <Option name="CheckedState" type="QString" value=""></Option>
+                <Option name="TextDisplayMethod" type="int" value="0"></Option>
+                <Option name="UncheckedState" type="QString" value=""></Option>
               </Option>
             </config>
           </editWidget>
@@ -1268,9 +1267,9 @@
           <editWidget type="CheckBox">
             <config>
               <Option type="Map">
-                <Option value="" name="CheckedState" type="QString"/>
-                <Option value="0" name="TextDisplayMethod" type="int"/>
-                <Option value="" name="UncheckedState" type="QString"/>
+                <Option name="CheckedState" type="QString" value=""></Option>
+                <Option name="TextDisplayMethod" type="int" value="0"></Option>
+                <Option name="UncheckedState" type="QString" value=""></Option>
               </Option>
             </config>
           </editWidget>
@@ -1279,19 +1278,19 @@
           <editWidget type="ValueRelation">
             <config>
               <Option type="Map">
-                <Option value="true" name="AllowMulti" type="bool"/>
-                <Option value="false" name="AllowNull" type="bool"/>
-                <Option value="" name="Description" type="QString"/>
-                <Option value="" name="FilterExpression" type="QString"/>
-                <Option value="id" name="Key" type="QString"/>
-                <Option value="data_integers_ca1eb372_c518_4cc2_b2d8_c66d71b908a7" name="Layer" type="QString"/>
-                <Option value="data_integers" name="LayerName" type="QString"/>
-                <Option value="postgres" name="LayerProviderName" type="QString"/>
-                <Option value="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='0' table=&quot;tests_projects&quot;.&quot;data_integers&quot;" name="LayerSource" type="QString"/>
-                <Option value="1" name="NofColumns" type="int"/>
-                <Option value="false" name="OrderByValue" type="bool"/>
-                <Option value="false" name="UseCompleter" type="bool"/>
-                <Option value="label" name="Value" type="QString"/>
+                <Option name="AllowMulti" type="bool" value="true"></Option>
+                <Option name="AllowNull" type="bool" value="false"></Option>
+                <Option name="Description" type="QString" value=""></Option>
+                <Option name="FilterExpression" type="QString" value=""></Option>
+                <Option name="Key" type="QString" value="id"></Option>
+                <Option name="Layer" type="QString" value="data_integers_ca1eb372_c518_4cc2_b2d8_c66d71b908a7"></Option>
+                <Option name="LayerName" type="QString" value="data_integers"></Option>
+                <Option name="LayerProviderName" type="QString" value="postgres"></Option>
+                <Option name="LayerSource" type="QString" value="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='0' table=&quot;tests_projects&quot;.&quot;data_integers&quot;"></Option>
+                <Option name="NofColumns" type="int" value="1"></Option>
+                <Option name="OrderByValue" type="bool" value="false"></Option>
+                <Option name="UseCompleter" type="bool" value="false"></Option>
+                <Option name="Value" type="QString" value="label"></Option>
               </Option>
             </config>
           </editWidget>
@@ -1300,19 +1299,19 @@
           <editWidget type="ValueRelation">
             <config>
               <Option type="Map">
-                <Option value="true" name="AllowMulti" type="bool"/>
-                <Option value="false" name="AllowNull" type="bool"/>
-                <Option value="" name="Description" type="QString"/>
-                <Option value="" name="FilterExpression" type="QString"/>
-                <Option value="label" name="Key" type="QString"/>
-                <Option value="data_integers_ca1eb372_c518_4cc2_b2d8_c66d71b908a7" name="Layer" type="QString"/>
-                <Option value="data_integers" name="LayerName" type="QString"/>
-                <Option value="postgres" name="LayerProviderName" type="QString"/>
-                <Option value="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='0' table=&quot;tests_projects&quot;.&quot;data_integers&quot;" name="LayerSource" type="QString"/>
-                <Option value="1" name="NofColumns" type="int"/>
-                <Option value="false" name="OrderByValue" type="bool"/>
-                <Option value="false" name="UseCompleter" type="bool"/>
-                <Option value="label" name="Value" type="QString"/>
+                <Option name="AllowMulti" type="bool" value="true"></Option>
+                <Option name="AllowNull" type="bool" value="false"></Option>
+                <Option name="Description" type="QString" value=""></Option>
+                <Option name="FilterExpression" type="QString" value=""></Option>
+                <Option name="Key" type="QString" value="label"></Option>
+                <Option name="Layer" type="QString" value="data_integers_ca1eb372_c518_4cc2_b2d8_c66d71b908a7"></Option>
+                <Option name="LayerName" type="QString" value="data_integers"></Option>
+                <Option name="LayerProviderName" type="QString" value="postgres"></Option>
+                <Option name="LayerSource" type="QString" value="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='0' table=&quot;tests_projects&quot;.&quot;data_integers&quot;"></Option>
+                <Option name="NofColumns" type="int" value="1"></Option>
+                <Option name="OrderByValue" type="bool" value="false"></Option>
+                <Option name="UseCompleter" type="bool" value="false"></Option>
+                <Option name="Value" type="QString" value="label"></Option>
               </Option>
             </config>
           </editWidget>
@@ -1321,19 +1320,19 @@
           <editWidget type="ValueRelation">
             <config>
               <Option type="Map">
-                <Option value="true" name="AllowMulti" type="bool"/>
-                <Option value="false" name="AllowNull" type="bool"/>
-                <Option value="" name="Description" type="QString"/>
-                <Option value="" name="FilterExpression" type="QString"/>
-                <Option value="uid" name="Key" type="QString"/>
-                <Option value="data_uids_43391461_e5ea_4a95_9167_7b24b713ba9b" name="Layer" type="QString"/>
-                <Option value="data_uids" name="LayerName" type="QString"/>
-                <Option value="postgres" name="LayerProviderName" type="QString"/>
-                <Option value="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='0' table=&quot;tests_projects&quot;.&quot;data_uids&quot;" name="LayerSource" type="QString"/>
-                <Option value="1" name="NofColumns" type="int"/>
-                <Option value="true" name="OrderByValue" type="bool"/>
-                <Option value="false" name="UseCompleter" type="bool"/>
-                <Option value="label" name="Value" type="QString"/>
+                <Option name="AllowMulti" type="bool" value="true"></Option>
+                <Option name="AllowNull" type="bool" value="false"></Option>
+                <Option name="Description" type="QString" value=""></Option>
+                <Option name="FilterExpression" type="QString" value=""></Option>
+                <Option name="Key" type="QString" value="uid"></Option>
+                <Option name="Layer" type="QString" value="data_uids_43391461_e5ea_4a95_9167_7b24b713ba9b"></Option>
+                <Option name="LayerName" type="QString" value="data_uids"></Option>
+                <Option name="LayerProviderName" type="QString" value="postgres"></Option>
+                <Option name="LayerSource" type="QString" value="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='0' table=&quot;tests_projects&quot;.&quot;data_uids&quot;"></Option>
+                <Option name="NofColumns" type="int" value="1"></Option>
+                <Option name="OrderByValue" type="bool" value="true"></Option>
+                <Option name="UseCompleter" type="bool" value="false"></Option>
+                <Option name="Value" type="QString" value="label"></Option>
               </Option>
             </config>
           </editWidget>
@@ -1344,16 +1343,16 @@
               <Option type="Map">
                 <Option name="map" type="List">
                   <Option type="Map">
-                    <Option value="1" name="one" type="QString"/>
+                    <Option name="one" type="QString" value="1"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option value="2" name="two" type="QString"/>
+                    <Option name="two" type="QString" value="2"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option value="3" name="three" type="QString"/>
+                    <Option name="three" type="QString" value="3"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option value="4" name="four" type="QString"/>
+                    <Option name="four" type="QString" value="4"></Option>
                   </Option>
                 </Option>
               </Option>
@@ -1364,8 +1363,8 @@
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="true" name="IsMultiline" type="bool"/>
-                <Option value="false" name="UseHtml" type="bool"/>
+                <Option name="IsMultiline" type="bool" value="true"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -1374,95 +1373,95 @@
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="true" name="IsMultiline" type="bool"/>
-                <Option value="true" name="UseHtml" type="bool"/>
+                <Option name="IsMultiline" type="bool" value="true"></Option>
+                <Option name="UseHtml" type="bool" value="true"></Option>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="id"/>
-        <alias name="" index="1" field="integer_field"/>
-        <alias name="" index="2" field="boolean_nullable"/>
-        <alias name="" index="3" field="boolean_notnull_for_checkbox"/>
-        <alias name="" index="4" field="boolean_readonly"/>
-        <alias name="" index="5" field="integer_array"/>
-        <alias name="" index="6" field="text"/>
-        <alias name="uids" index="7" field="uids"/>
-        <alias name="" index="8" field="value_map_integer"/>
-        <alias name="Multiline text" index="9" field="html_text"/>
-        <alias name="HTML WYSIWYG widget" index="10" field="multiline_text"/>
+        <alias field="id" index="0" name=""></alias>
+        <alias field="integer_field" index="1" name=""></alias>
+        <alias field="boolean_nullable" index="2" name=""></alias>
+        <alias field="boolean_notnull_for_checkbox" index="3" name=""></alias>
+        <alias field="boolean_readonly" index="4" name=""></alias>
+        <alias field="integer_array" index="5" name=""></alias>
+        <alias field="text" index="6" name=""></alias>
+        <alias field="uids" index="7" name="uids"></alias>
+        <alias field="value_map_integer" index="8" name=""></alias>
+        <alias field="html_text" index="9" name="Multiline text"></alias>
+        <alias field="multiline_text" index="10" name="HTML WYSIWYG widget"></alias>
       </aliases>
       <defaults>
-        <default expression="" applyOnUpdate="0" field="id"/>
-        <default expression="" applyOnUpdate="0" field="integer_field"/>
-        <default expression="" applyOnUpdate="0" field="boolean_nullable"/>
-        <default expression="" applyOnUpdate="0" field="boolean_notnull_for_checkbox"/>
-        <default expression="" applyOnUpdate="0" field="boolean_readonly"/>
-        <default expression="" applyOnUpdate="0" field="integer_array"/>
-        <default expression="" applyOnUpdate="0" field="text"/>
-        <default expression="" applyOnUpdate="0" field="uids"/>
-        <default expression="" applyOnUpdate="0" field="value_map_integer"/>
-        <default expression="" applyOnUpdate="0" field="html_text"/>
-        <default expression="" applyOnUpdate="0" field="multiline_text"/>
+        <default applyOnUpdate="0" expression="" field="id"></default>
+        <default applyOnUpdate="0" expression="" field="integer_field"></default>
+        <default applyOnUpdate="0" expression="" field="boolean_nullable"></default>
+        <default applyOnUpdate="0" expression="" field="boolean_notnull_for_checkbox"></default>
+        <default applyOnUpdate="0" expression="" field="boolean_readonly"></default>
+        <default applyOnUpdate="0" expression="" field="integer_array"></default>
+        <default applyOnUpdate="0" expression="" field="text"></default>
+        <default applyOnUpdate="0" expression="" field="uids"></default>
+        <default applyOnUpdate="0" expression="" field="value_map_integer"></default>
+        <default applyOnUpdate="0" expression="" field="html_text"></default>
+        <default applyOnUpdate="0" expression="" field="multiline_text"></default>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" exp_strength="0" unique_strength="1" constraints="3" field="id"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="integer_field"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="boolean_nullable"/>
-        <constraint notnull_strength="1" exp_strength="0" unique_strength="0" constraints="1" field="boolean_notnull_for_checkbox"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="boolean_readonly"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="integer_array"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="text"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="uids"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="value_map_integer"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="html_text"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="multiline_text"/>
+        <constraint constraints="3" exp_strength="0" field="id" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="integer_field" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="boolean_nullable" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="1" exp_strength="0" field="boolean_notnull_for_checkbox" notnull_strength="1" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="boolean_readonly" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="integer_array" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="text" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="uids" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="value_map_integer" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="html_text" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="multiline_text" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" desc="" field="id"/>
-        <constraint exp="" desc="" field="integer_field"/>
-        <constraint exp="" desc="" field="boolean_nullable"/>
-        <constraint exp="" desc="" field="boolean_notnull_for_checkbox"/>
-        <constraint exp="" desc="" field="boolean_readonly"/>
-        <constraint exp="" desc="" field="integer_array"/>
-        <constraint exp="" desc="" field="text"/>
-        <constraint exp="" desc="" field="uids"/>
-        <constraint exp="" desc="" field="value_map_integer"/>
-        <constraint exp="" desc="" field="html_text"/>
-        <constraint exp="" desc="" field="multiline_text"/>
+        <constraint desc="" exp="" field="id"></constraint>
+        <constraint desc="" exp="" field="integer_field"></constraint>
+        <constraint desc="" exp="" field="boolean_nullable"></constraint>
+        <constraint desc="" exp="" field="boolean_notnull_for_checkbox"></constraint>
+        <constraint desc="" exp="" field="boolean_readonly"></constraint>
+        <constraint desc="" exp="" field="integer_array"></constraint>
+        <constraint desc="" exp="" field="text"></constraint>
+        <constraint desc="" exp="" field="uids"></constraint>
+        <constraint desc="" exp="" field="value_map_integer"></constraint>
+        <constraint desc="" exp="" field="html_text"></constraint>
+        <constraint desc="" exp="" field="multiline_text"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
-      <attributetableconfig sortExpression="&quot;id&quot;" actionWidgetStyle="dropDown" sortOrder="0">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="&quot;id&quot;" sortOrder="0">
         <columns>
-          <column width="-1" hidden="0" name="id" type="field"/>
-          <column width="-1" hidden="0" name="integer_field" type="field"/>
-          <column width="-1" hidden="1" type="actions"/>
-          <column width="184" hidden="0" name="boolean_nullable" type="field"/>
-          <column width="288" hidden="0" name="integer_array" type="field"/>
-          <column width="-1" hidden="0" name="text" type="field"/>
-          <column width="285" hidden="0" name="boolean_notnull_for_checkbox" type="field"/>
-          <column width="-1" hidden="0" name="uids" type="field"/>
-          <column width="-1" hidden="0" name="html_text" type="field"/>
-          <column width="-1" hidden="0" name="multiline_text" type="field"/>
-          <column width="-1" hidden="0" name="boolean_readonly" type="field"/>
-          <column width="-1" hidden="0" name="value_map_integer" type="field"/>
+          <column hidden="0" name="id" type="field" width="-1"></column>
+          <column hidden="0" name="integer_field" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
+          <column hidden="0" name="boolean_nullable" type="field" width="184"></column>
+          <column hidden="0" name="integer_array" type="field" width="288"></column>
+          <column hidden="0" name="text" type="field" width="-1"></column>
+          <column hidden="0" name="boolean_notnull_for_checkbox" type="field" width="285"></column>
+          <column hidden="0" name="uids" type="field" width="-1"></column>
+          <column hidden="0" name="html_text" type="field" width="-1"></column>
+          <column hidden="0" name="multiline_text" type="field" width="-1"></column>
+          <column hidden="0" name="boolean_readonly" type="field" width="-1"></column>
+          <column hidden="0" name="value_map_integer" type="field" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1"></editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -1478,56 +1477,56 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field editable="1" name="boolean_notnull_for_checkbox"/>
-        <field editable="1" name="boolean_nullable"/>
-        <field editable="1" name="boolean_nullable_for_checkbox"/>
-        <field editable="0" name="boolean_readonly"/>
-        <field editable="1" name="html_text"/>
-        <field editable="1" name="id"/>
-        <field editable="1" name="integer_array"/>
-        <field editable="1" name="integer_field"/>
-        <field editable="1" name="multiline_text"/>
-        <field editable="1" name="text"/>
-        <field editable="1" name="uids"/>
-        <field editable="1" name="value_map_integer"/>
+        <field editable="1" name="boolean_notnull_for_checkbox"></field>
+        <field editable="1" name="boolean_nullable"></field>
+        <field editable="1" name="boolean_nullable_for_checkbox"></field>
+        <field editable="0" name="boolean_readonly"></field>
+        <field editable="1" name="html_text"></field>
+        <field editable="1" name="id"></field>
+        <field editable="1" name="integer_array"></field>
+        <field editable="1" name="integer_field"></field>
+        <field editable="1" name="multiline_text"></field>
+        <field editable="1" name="text"></field>
+        <field editable="1" name="uids"></field>
+        <field editable="1" name="value_map_integer"></field>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="boolean_notnull_for_checkbox"/>
-        <field labelOnTop="0" name="boolean_nullable"/>
-        <field labelOnTop="0" name="boolean_nullable_for_checkbox"/>
-        <field labelOnTop="0" name="boolean_readonly"/>
-        <field labelOnTop="0" name="html_text"/>
-        <field labelOnTop="0" name="id"/>
-        <field labelOnTop="0" name="integer_array"/>
-        <field labelOnTop="0" name="integer_field"/>
-        <field labelOnTop="0" name="multiline_text"/>
-        <field labelOnTop="0" name="text"/>
-        <field labelOnTop="0" name="uids"/>
-        <field labelOnTop="0" name="value_map_integer"/>
+        <field labelOnTop="0" name="boolean_notnull_for_checkbox"></field>
+        <field labelOnTop="0" name="boolean_nullable"></field>
+        <field labelOnTop="0" name="boolean_nullable_for_checkbox"></field>
+        <field labelOnTop="0" name="boolean_readonly"></field>
+        <field labelOnTop="0" name="html_text"></field>
+        <field labelOnTop="0" name="id"></field>
+        <field labelOnTop="0" name="integer_array"></field>
+        <field labelOnTop="0" name="integer_field"></field>
+        <field labelOnTop="0" name="multiline_text"></field>
+        <field labelOnTop="0" name="text"></field>
+        <field labelOnTop="0" name="uids"></field>
+        <field labelOnTop="0" name="value_map_integer"></field>
       </labelOnTop>
       <reuseLastValue>
-        <field reuseLastValue="0" name="boolean_notnull_for_checkbox"/>
-        <field reuseLastValue="0" name="boolean_nullable"/>
-        <field reuseLastValue="0" name="boolean_readonly"/>
-        <field reuseLastValue="0" name="html_text"/>
-        <field reuseLastValue="0" name="id"/>
-        <field reuseLastValue="0" name="integer_array"/>
-        <field reuseLastValue="0" name="integer_field"/>
-        <field reuseLastValue="0" name="multiline_text"/>
-        <field reuseLastValue="0" name="text"/>
-        <field reuseLastValue="0" name="uids"/>
-        <field reuseLastValue="0" name="value_map_integer"/>
+        <field name="boolean_notnull_for_checkbox" reuseLastValue="0"></field>
+        <field name="boolean_nullable" reuseLastValue="0"></field>
+        <field name="boolean_readonly" reuseLastValue="0"></field>
+        <field name="html_text" reuseLastValue="0"></field>
+        <field name="id" reuseLastValue="0"></field>
+        <field name="integer_array" reuseLastValue="0"></field>
+        <field name="integer_field" reuseLastValue="0"></field>
+        <field name="multiline_text" reuseLastValue="0"></field>
+        <field name="text" reuseLastValue="0"></field>
+        <field name="uids" reuseLastValue="0"></field>
+        <field name="value_map_integer" reuseLastValue="0"></field>
       </reuseLastValue>
-      <dataDefinedFieldProperties/>
-      <widgets/>
+      <dataDefinedFieldProperties></dataDefinedFieldProperties>
+      <widgets></widgets>
       <previewExpression>"id"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer styleCategories="AllStyleCategories" autoRefreshEnabled="0" geometry="No geometry" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="0" refreshOnNotifyMessage="" readOnly="0" maxScale="0" minScale="1e+08" autoRefreshTime="0" wkbType="NoGeometry" type="vector" refreshOnNotifyEnabled="0">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="No geometry" hasScaleBasedVisibilityFlag="0" legendPlaceholderImage="" maxScale="0" minScale="1e+08" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" type="vector" wkbType="NoGeometry">
       <id>form_edition_upload_65de30e9_0bab_44f1_9a3d_b2bf9f47a204</id>
       <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true checkPrimaryKeyUnicity='1' table="tests_projects"."form_edition_upload"</datasource>
       <shortname>form_edition_upload</shortname>
@@ -1564,7 +1563,7 @@ def my_form_open(dialog, layer, feature):
           <email></email>
           <role></role>
         </contact>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
@@ -1581,7 +1580,7 @@ def my_form_open(dialog, layer, feature):
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial crs="" maxy="0" dimensions="2" miny="0" maxx="0" maxz="0" minx="0" minz="0"/>
+          <spatial crs="" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
           <temporal>
             <period>
               <start></start>
@@ -1591,153 +1590,153 @@ def my_form_open(dialog, layer, feature):
         </extent>
       </resourceMetadata>
       <provider encoding="">postgres</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="défaut">
-        <map-layer-style name="défaut"/>
+        <map-layer-style name="défaut"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
-      <metadataUrls/>
+      <auxiliaryLayer></auxiliaryLayer>
+      <metadataUrls></metadataUrls>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal mode="0" durationUnit="min" endField="" fixedDuration="0" startExpression="" enabled="0" startField="" limitMode="0" durationField="" accumulate="0" endExpression="">
+      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
-      <elevation zoffset="0" zscale="1" extrusionEnabled="0" showMarkerSymbolInSurfacePlots="0" extrusion="0" respectLayerSymbol="1" clamping="Terrain" type="IndividualFeatures" symbology="Line" binding="Centroid">
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
         <data-defined-properties>
           <Option type="Map">
-            <Option value="" name="name" type="QString"/>
-            <Option name="properties"/>
-            <Option value="collection" name="type" type="QString"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </data-defined-properties>
         <profileLineSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="line" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleLine">
+            <layer class="SimpleLine" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="0" name="align_dash_pattern" type="QString"/>
-                <Option value="square" name="capstyle" type="QString"/>
-                <Option value="5;2" name="customdash" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
-                <Option value="MM" name="customdash_unit" type="QString"/>
-                <Option value="0" name="dash_pattern_offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
-                <Option value="0" name="draw_inside_polygon" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="152,125,183,255" name="line_color" type="QString"/>
-                <Option value="solid" name="line_style" type="QString"/>
-                <Option value="0.6" name="line_width" type="QString"/>
-                <Option value="MM" name="line_width_unit" type="QString"/>
-                <Option value="0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="0" name="ring_filter" type="QString"/>
-                <Option value="0" name="trim_distance_end" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
-                <Option value="MM" name="trim_distance_end_unit" type="QString"/>
-                <Option value="0" name="trim_distance_start" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
-                <Option value="MM" name="trim_distance_start_unit" type="QString"/>
-                <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
-                <Option value="0" name="use_custom_dash" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="152,125,183,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileLineSymbol>
         <profileFillSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="fill" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleFill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-                <Option value="152,125,183,255" name="color" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="0,0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="109,89,131,255" name="outline_color" type="QString"/>
-                <Option value="solid" name="outline_style" type="QString"/>
-                <Option value="0.2" name="outline_width" type="QString"/>
-                <Option value="MM" name="outline_width_unit" type="QString"/>
-                <Option value="solid" name="style" type="QString"/>
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="152,125,183,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="109,89,131,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileFillSymbol>
         <profileMarkerSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="marker" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleMarker">
+            <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="0" name="angle" type="QString"/>
-                <Option value="square" name="cap_style" type="QString"/>
-                <Option value="152,125,183,255" name="color" type="QString"/>
-                <Option value="1" name="horizontal_anchor_point" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="diamond" name="name" type="QString"/>
-                <Option value="0,0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="109,89,131,255" name="outline_color" type="QString"/>
-                <Option value="solid" name="outline_style" type="QString"/>
-                <Option value="0.2" name="outline_width" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
-                <Option value="MM" name="outline_width_unit" type="QString"/>
-                <Option value="diameter" name="scale_method" type="QString"/>
-                <Option value="3" name="size" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
-                <Option value="MM" name="size_unit" type="QString"/>
-                <Option value="1" name="vertical_anchor_point" type="QString"/>
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="152,125,183,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="109,89,131,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -1746,27 +1745,28 @@ def my_form_open(dialog, layer, feature):
       </elevation>
       <customproperties>
         <Option type="Map">
-          <Option value="offline" name="QFieldSync/action" type="QString"/>
-          <Option value="{}" name="QFieldSync/attachment_naming" type="QString"/>
-          <Option value="offline" name="QFieldSync/cloud_action" type="QString"/>
-          <Option value="{&quot;generic_file&quot;: &quot;'DCIM/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '.jpg'&quot;, &quot;text_file&quot;: &quot;'DCIM/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '.jpg'&quot;, &quot;image_file&quot;: &quot;'DCIM/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '.jpg'&quot;, &quot;text_file_mandatory&quot;: &quot;'DCIM/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '.jpg'&quot;, &quot;image_file_mandatory&quot;: &quot;'DCIM/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '.jpg'&quot;}" name="QFieldSync/photo_naming" type="QString"/>
-          <Option value="{}" name="QFieldSync/relationship_maximum_visible" type="QString"/>
-          <Option value="0" name="embeddedWidgets/count" type="QString"/>
-          <Option name="variableNames" type="invalid"/>
-          <Option name="variableValues" type="invalid"/>
+          <Option name="QFieldSync/action" type="QString" value="offline"></Option>
+          <Option name="QFieldSync/attachment_naming" type="QString" value="{&quot;generic_file&quot;: &quot;'files/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '_{filename}'&quot;, &quot;text_file&quot;: &quot;'files/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '_{filename}'&quot;, &quot;image_file&quot;: &quot;'files/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '_{filename}'&quot;, &quot;text_file_mandatory&quot;: &quot;'files/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '_{filename}'&quot;, &quot;image_file_mandatory&quot;: &quot;'files/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '_{filename}'&quot;, &quot;image_file_specific_root_folder&quot;: &quot;'DCIM/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '.{extension}'&quot;, &quot;generic_file_expression_root_folder&quot;: &quot;'files/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '_{filename}'&quot;}"></Option>
+          <Option name="QFieldSync/cloud_action" type="QString" value="offline"></Option>
+          <Option name="QFieldSync/geometry_locked_expression" type="QString" value=""></Option>
+          <Option name="QFieldSync/photo_naming" type="QString" value="{&quot;generic_file&quot;: &quot;'DCIM/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '.jpg'&quot;, &quot;text_file&quot;: &quot;'DCIM/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '.jpg'&quot;, &quot;image_file&quot;: &quot;'DCIM/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '.jpg'&quot;, &quot;text_file_mandatory&quot;: &quot;'DCIM/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '.jpg'&quot;, &quot;image_file_mandatory&quot;: &quot;'DCIM/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '.jpg'&quot;, &quot;image_file_specific_root_folder&quot;: &quot;'DCIM/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '.{extension}'&quot;, &quot;generic_file_expression_root_folder&quot;: &quot;'files/form-edition-upload_' || format_date(now(),'yyyyMMddhhmmsszzz') || '_{filename}'&quot;}"></Option>
+          <Option name="QFieldSync/relationship_maximum_visible" type="QString" value="{}"></Option>
+          <Option name="embeddedWidgets/count" type="QString" value="0"></Option>
+          <Option name="variableNames"></Option>
+          <Option name="variableValues"></Option>
         </Option>
       </customproperties>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
-        <activeChecks/>
-        <checkConfiguration/>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
-      <legend showLabelLegend="0" type="default-vector"/>
-      <referencedLayers/>
+      <legend showLabelLegend="0" type="default-vector"></legend>
+      <referencedLayers></referencedLayers>
       <fieldConfiguration>
         <field configurationFlags="None" name="id">
           <editWidget type="Hidden">
             <config>
-              <Option/>
+              <Option></Option>
             </config>
           </editWidget>
         </field>
@@ -1774,19 +1774,21 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ExternalResource">
             <config>
               <Option type="Map">
-                <Option value="0" name="DocumentViewer" type="int"/>
-                <Option value="0" name="DocumentViewerHeight" type="int"/>
-                <Option value="0" name="DocumentViewerWidth" type="int"/>
-                <Option value="true" name="FileWidget" type="bool"/>
-                <Option value="true" name="FileWidgetButton" type="bool"/>
-                <Option value="" name="FileWidgetFilter" type="QString"/>
+                <Option name="DocumentViewer" type="int" value="0"></Option>
+                <Option name="DocumentViewerHeight" type="int" value="0"></Option>
+                <Option name="DocumentViewerWidth" type="int" value="0"></Option>
+                <Option name="FileWidget" type="bool" value="true"></Option>
+                <Option name="FileWidgetButton" type="bool" value="true"></Option>
+                <Option name="FileWidgetFilter" type="QString" value=""></Option>
                 <Option name="PropertyCollection" type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties" type="invalid"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties" type="invalid"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
-                <Option value="0" name="RelativeStorage" type="int"/>
-                <Option value="0" name="StorageMode" type="int"/>
+                <Option name="RelativeStorage" type="int" value="0"></Option>
+                <Option name="StorageAuthConfigId" type="QString" value=""></Option>
+                <Option name="StorageMode" type="int" value="0"></Option>
+                <Option name="StorageType" type="QString" value=""></Option>
               </Option>
             </config>
           </editWidget>
@@ -1795,19 +1797,21 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ExternalResource">
             <config>
               <Option type="Map">
-                <Option value="0" name="DocumentViewer" type="int"/>
-                <Option value="0" name="DocumentViewerHeight" type="int"/>
-                <Option value="0" name="DocumentViewerWidth" type="int"/>
-                <Option value="true" name="FileWidget" type="bool"/>
-                <Option value="true" name="FileWidgetButton" type="bool"/>
-                <Option value="Text files (*.txt)" name="FileWidgetFilter" type="QString"/>
+                <Option name="DocumentViewer" type="int" value="0"></Option>
+                <Option name="DocumentViewerHeight" type="int" value="0"></Option>
+                <Option name="DocumentViewerWidth" type="int" value="0"></Option>
+                <Option name="FileWidget" type="bool" value="true"></Option>
+                <Option name="FileWidgetButton" type="bool" value="true"></Option>
+                <Option name="FileWidgetFilter" type="QString" value="Text files (*.txt)"></Option>
                 <Option name="PropertyCollection" type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties" type="invalid"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties" type="invalid"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
-                <Option value="0" name="RelativeStorage" type="int"/>
-                <Option value="0" name="StorageMode" type="int"/>
+                <Option name="RelativeStorage" type="int" value="0"></Option>
+                <Option name="StorageAuthConfigId" type="QString" value=""></Option>
+                <Option name="StorageMode" type="int" value="0"></Option>
+                <Option name="StorageType" type="QString" value=""></Option>
               </Option>
             </config>
           </editWidget>
@@ -1816,19 +1820,21 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ExternalResource">
             <config>
               <Option type="Map">
-                <Option value="0" name="DocumentViewer" type="int"/>
-                <Option value="0" name="DocumentViewerHeight" type="int"/>
-                <Option value="0" name="DocumentViewerWidth" type="int"/>
-                <Option value="true" name="FileWidget" type="bool"/>
-                <Option value="true" name="FileWidgetButton" type="bool"/>
-                <Option value="Images (*.png *.jpg *.jpeg)" name="FileWidgetFilter" type="QString"/>
+                <Option name="DocumentViewer" type="int" value="0"></Option>
+                <Option name="DocumentViewerHeight" type="int" value="0"></Option>
+                <Option name="DocumentViewerWidth" type="int" value="0"></Option>
+                <Option name="FileWidget" type="bool" value="true"></Option>
+                <Option name="FileWidgetButton" type="bool" value="true"></Option>
+                <Option name="FileWidgetFilter" type="QString" value="Images (*.png *.jpg *.jpeg)"></Option>
                 <Option name="PropertyCollection" type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties" type="invalid"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties" type="invalid"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
-                <Option value="0" name="RelativeStorage" type="int"/>
-                <Option value="0" name="StorageMode" type="int"/>
+                <Option name="RelativeStorage" type="int" value="0"></Option>
+                <Option name="StorageAuthConfigId" type="QString" value=""></Option>
+                <Option name="StorageMode" type="int" value="0"></Option>
+                <Option name="StorageType" type="QString" value=""></Option>
               </Option>
             </config>
           </editWidget>
@@ -1837,19 +1843,21 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ExternalResource">
             <config>
               <Option type="Map">
-                <Option value="0" name="DocumentViewer" type="int"/>
-                <Option value="0" name="DocumentViewerHeight" type="int"/>
-                <Option value="0" name="DocumentViewerWidth" type="int"/>
-                <Option value="true" name="FileWidget" type="bool"/>
-                <Option value="true" name="FileWidgetButton" type="bool"/>
-                <Option value="*.txt" name="FileWidgetFilter" type="QString"/>
+                <Option name="DocumentViewer" type="int" value="0"></Option>
+                <Option name="DocumentViewerHeight" type="int" value="0"></Option>
+                <Option name="DocumentViewerWidth" type="int" value="0"></Option>
+                <Option name="FileWidget" type="bool" value="true"></Option>
+                <Option name="FileWidgetButton" type="bool" value="true"></Option>
+                <Option name="FileWidgetFilter" type="QString" value="*.txt"></Option>
                 <Option name="PropertyCollection" type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties" type="invalid"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties" type="invalid"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
-                <Option value="0" name="RelativeStorage" type="int"/>
-                <Option value="0" name="StorageMode" type="int"/>
+                <Option name="RelativeStorage" type="int" value="0"></Option>
+                <Option name="StorageAuthConfigId" type="QString" value=""></Option>
+                <Option name="StorageMode" type="int" value="0"></Option>
+                <Option name="StorageType" type="QString" value=""></Option>
               </Option>
             </config>
           </editWidget>
@@ -1858,19 +1866,21 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ExternalResource">
             <config>
               <Option type="Map">
-                <Option value="0" name="DocumentViewer" type="int"/>
-                <Option value="0" name="DocumentViewerHeight" type="int"/>
-                <Option value="0" name="DocumentViewerWidth" type="int"/>
-                <Option value="true" name="FileWidget" type="bool"/>
-                <Option value="true" name="FileWidgetButton" type="bool"/>
-                <Option value="Images png (*.png);;Images jpeg (*.jpg *.jpeg)" name="FileWidgetFilter" type="QString"/>
+                <Option name="DocumentViewer" type="int" value="0"></Option>
+                <Option name="DocumentViewerHeight" type="int" value="0"></Option>
+                <Option name="DocumentViewerWidth" type="int" value="0"></Option>
+                <Option name="FileWidget" type="bool" value="true"></Option>
+                <Option name="FileWidgetButton" type="bool" value="true"></Option>
+                <Option name="FileWidgetFilter" type="QString" value="Images png (*.png);;Images jpeg (*.jpg *.jpeg)"></Option>
                 <Option name="PropertyCollection" type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties" type="invalid"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties" type="invalid"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
-                <Option value="0" name="RelativeStorage" type="int"/>
-                <Option value="0" name="StorageMode" type="int"/>
+                <Option name="RelativeStorage" type="int" value="0"></Option>
+                <Option name="StorageAuthConfigId" type="QString" value=""></Option>
+                <Option name="StorageMode" type="int" value="0"></Option>
+                <Option name="StorageType" type="QString" value=""></Option>
               </Option>
             </config>
           </editWidget>
@@ -1879,87 +1889,138 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ExternalResource">
             <config>
               <Option type="Map">
-                <Option value="../media/specific_media_folder" name="DefaultRoot" type="QString"/>
-                <Option value="1" name="DocumentViewer" type="int"/>
-                <Option value="0" name="DocumentViewerHeight" type="int"/>
-                <Option value="0" name="DocumentViewerWidth" type="int"/>
-                <Option value="true" name="FileWidget" type="bool"/>
-                <Option value="true" name="FileWidgetButton" type="bool"/>
-                <Option value="" name="FileWidgetFilter" type="QString"/>
+                <Option name="DefaultRoot" type="QString" value="../media/specific_media_folder"></Option>
+                <Option name="DocumentViewer" type="int" value="1"></Option>
+                <Option name="DocumentViewerHeight" type="int" value="0"></Option>
+                <Option name="DocumentViewerWidth" type="int" value="0"></Option>
+                <Option name="FileWidget" type="bool" value="true"></Option>
+                <Option name="FileWidgetButton" type="bool" value="true"></Option>
+                <Option name="FileWidgetFilter" type="QString" value=""></Option>
                 <Option name="PropertyCollection" type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties" type="invalid"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties" type="invalid"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
-                <Option value="1" name="RelativeStorage" type="int"/>
-                <Option value="0" name="StorageMode" type="int"/>
+                <Option name="RelativeStorage" type="int" value="1"></Option>
+                <Option name="StorageAuthConfigId" type="QString" value=""></Option>
+                <Option name="StorageMode" type="int" value="0"></Option>
+                <Option name="StorageType" type="QString" value=""></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field configurationFlags="None" name="generic_file_expression_root_folder">
+          <editWidget type="ExternalResource">
+            <config>
+              <Option type="Map">
+                <Option name="DocumentViewer" type="int" value="1"></Option>
+                <Option name="DocumentViewerHeight" type="int" value="0"></Option>
+                <Option name="DocumentViewerWidth" type="int" value="0"></Option>
+                <Option name="FileWidget" type="bool" value="true"></Option>
+                <Option name="FileWidgetButton" type="bool" value="true"></Option>
+                <Option name="FileWidgetFilter" type="QString" value=""></Option>
+                <Option name="PropertyCollection" type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties" type="Map">
+                    <Option name="propertyRootPath" type="Map">
+                      <Option name="active" type="bool" value="true"></Option>
+                      <Option name="expression" type="QString" value="concat(&#xA;&#x9;'media/expression_root_folder/',&#xA;&#x9;CASE&#xA;&#x9;&#x9;WHEN lower(trim(to_string(current_value('feature_code')))) IN ('', 'null') OR current_value('feature_code') IS NULL &#xA;&#x9;&#x9;&#x9;THEN '0'&#xA;&#x9;&#x9;ELSE trim(to_string(current_value('feature_code')))&#xA;&#x9;END,&#xA;&#x9;'/'&#xA;)"></Option>
+                      <Option name="type" type="int" value="3"></Option>
+                    </Option>
+                  </Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+                <Option name="RelativeStorage" type="int" value="1"></Option>
+                <Option name="StorageAuthConfigId" type="QString" value=""></Option>
+                <Option name="StorageMode" type="int" value="0"></Option>
+                <Option name="StorageType" type="QString" value=""></Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field configurationFlags="None" name="feature_code">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="id"/>
-        <alias name="" index="1" field="generic_file"/>
-        <alias name="" index="2" field="text_file"/>
-        <alias name="" index="3" field="image_file"/>
-        <alias name="" index="4" field="text_file_mandatory"/>
-        <alias name="" index="5" field="image_file_mandatory"/>
-        <alias name="" index="6" field="image_file_specific_root_folder"/>
+        <alias field="id" index="0" name=""></alias>
+        <alias field="generic_file" index="1" name=""></alias>
+        <alias field="text_file" index="2" name=""></alias>
+        <alias field="image_file" index="3" name=""></alias>
+        <alias field="text_file_mandatory" index="4" name=""></alias>
+        <alias field="image_file_mandatory" index="5" name=""></alias>
+        <alias field="image_file_specific_root_folder" index="6" name=""></alias>
+        <alias field="generic_file_expression_root_folder" index="7" name=""></alias>
+        <alias field="feature_code" index="8" name=""></alias>
       </aliases>
       <defaults>
-        <default expression="" applyOnUpdate="0" field="id"/>
-        <default expression="" applyOnUpdate="0" field="generic_file"/>
-        <default expression="" applyOnUpdate="0" field="text_file"/>
-        <default expression="" applyOnUpdate="0" field="image_file"/>
-        <default expression="" applyOnUpdate="0" field="text_file_mandatory"/>
-        <default expression="" applyOnUpdate="0" field="image_file_mandatory"/>
-        <default expression="" applyOnUpdate="0" field="image_file_specific_root_folder"/>
+        <default applyOnUpdate="0" expression="" field="id"></default>
+        <default applyOnUpdate="0" expression="" field="generic_file"></default>
+        <default applyOnUpdate="0" expression="" field="text_file"></default>
+        <default applyOnUpdate="0" expression="" field="image_file"></default>
+        <default applyOnUpdate="0" expression="" field="text_file_mandatory"></default>
+        <default applyOnUpdate="0" expression="" field="image_file_mandatory"></default>
+        <default applyOnUpdate="0" expression="" field="image_file_specific_root_folder"></default>
+        <default applyOnUpdate="0" expression="" field="generic_file_expression_root_folder"></default>
+        <default applyOnUpdate="0" expression="" field="feature_code"></default>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" exp_strength="0" unique_strength="1" constraints="3" field="id"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="generic_file"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="text_file"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="image_file"/>
-        <constraint notnull_strength="1" exp_strength="0" unique_strength="0" constraints="1" field="text_file_mandatory"/>
-        <constraint notnull_strength="1" exp_strength="0" unique_strength="0" constraints="1" field="image_file_mandatory"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="image_file_specific_root_folder"/>
+        <constraint constraints="3" exp_strength="0" field="id" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="generic_file" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="text_file" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="image_file" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="1" exp_strength="0" field="text_file_mandatory" notnull_strength="1" unique_strength="0"></constraint>
+        <constraint constraints="1" exp_strength="0" field="image_file_mandatory" notnull_strength="1" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="image_file_specific_root_folder" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="generic_file_expression_root_folder" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="feature_code" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" desc="" field="id"/>
-        <constraint exp="" desc="" field="generic_file"/>
-        <constraint exp="" desc="" field="text_file"/>
-        <constraint exp="" desc="" field="image_file"/>
-        <constraint exp="" desc="" field="text_file_mandatory"/>
-        <constraint exp="" desc="" field="image_file_mandatory"/>
-        <constraint exp="" desc="" field="image_file_specific_root_folder"/>
+        <constraint desc="" exp="" field="id"></constraint>
+        <constraint desc="" exp="" field="generic_file"></constraint>
+        <constraint desc="" exp="" field="text_file"></constraint>
+        <constraint desc="" exp="" field="image_file"></constraint>
+        <constraint desc="" exp="" field="text_file_mandatory"></constraint>
+        <constraint desc="" exp="" field="image_file_mandatory"></constraint>
+        <constraint desc="" exp="" field="image_file_specific_root_folder"></constraint>
+        <constraint desc="" exp="" field="generic_file_expression_root_folder"></constraint>
+        <constraint desc="" exp="" field="feature_code"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
-      <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column width="-1" hidden="0" name="id" type="field"/>
-          <column width="-1" hidden="0" name="text_file" type="field"/>
-          <column width="-1" hidden="0" name="image_file" type="field"/>
-          <column width="-1" hidden="0" name="text_file_mandatory" type="field"/>
-          <column width="-1" hidden="0" name="image_file_mandatory" type="field"/>
-          <column width="-1" hidden="1" type="actions"/>
-          <column width="-1" hidden="0" name="generic_file" type="field"/>
-          <column width="-1" hidden="0" name="image_file_specific_root_folder" type="field"/>
+          <column hidden="0" name="id" type="field" width="-1"></column>
+          <column hidden="0" name="text_file" type="field" width="-1"></column>
+          <column hidden="0" name="image_file" type="field" width="-1"></column>
+          <column hidden="0" name="text_file_mandatory" type="field" width="-1"></column>
+          <column hidden="0" name="image_file_mandatory" type="field" width="57"></column>
+          <column hidden="1" type="actions" width="-1"></column>
+          <column hidden="0" name="generic_file" type="field" width="-1"></column>
+          <column hidden="0" name="generic_file_expression_root_folder" type="field" width="804"></column>
+          <column hidden="0" name="feature_code" type="field" width="-1"></column>
+          <column hidden="0" name="image_file_specific_root_folder" type="field" width="233"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1"></editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 Les formulaires QGIS peuvent avoir une fonction Python qui sera appelée à l'ouverture du formulaire.
 
@@ -1974,34 +2035,48 @@ def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
 
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field editable="1" name="generic_file"/>
-        <field editable="1" name="id"/>
-        <field editable="1" name="image_file"/>
-        <field editable="1" name="image_file_mandatory"/>
-        <field editable="1" name="image_file_specific_root_folder"/>
-        <field editable="1" name="text_file"/>
-        <field editable="1" name="text_file_mandatory"/>
+        <field editable="1" name="feature_code"></field>
+        <field editable="1" name="generic_file"></field>
+        <field editable="1" name="generic_file_expression_root_folder"></field>
+        <field editable="1" name="id"></field>
+        <field editable="1" name="image_file"></field>
+        <field editable="1" name="image_file_mandatory"></field>
+        <field editable="1" name="image_file_specific_root_folder"></field>
+        <field editable="1" name="text_file"></field>
+        <field editable="1" name="text_file_mandatory"></field>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="generic_file"/>
-        <field labelOnTop="0" name="id"/>
-        <field labelOnTop="0" name="image_file"/>
-        <field labelOnTop="0" name="image_file_mandatory"/>
-        <field labelOnTop="0" name="image_file_specific_root_folder"/>
-        <field labelOnTop="0" name="text_file"/>
-        <field labelOnTop="0" name="text_file_mandatory"/>
+        <field labelOnTop="0" name="feature_code"></field>
+        <field labelOnTop="0" name="generic_file"></field>
+        <field labelOnTop="0" name="generic_file_expression_root_folder"></field>
+        <field labelOnTop="0" name="id"></field>
+        <field labelOnTop="0" name="image_file"></field>
+        <field labelOnTop="0" name="image_file_mandatory"></field>
+        <field labelOnTop="0" name="image_file_specific_root_folder"></field>
+        <field labelOnTop="0" name="text_file"></field>
+        <field labelOnTop="0" name="text_file_mandatory"></field>
       </labelOnTop>
-      <reuseLastValue/>
-      <dataDefinedFieldProperties/>
-      <widgets/>
+      <reuseLastValue>
+        <field name="feature_code" reuseLastValue="0"></field>
+        <field name="generic_file" reuseLastValue="0"></field>
+        <field name="generic_file_expression_root_folder" reuseLastValue="0"></field>
+        <field name="id" reuseLastValue="0"></field>
+        <field name="image_file" reuseLastValue="0"></field>
+        <field name="image_file_mandatory" reuseLastValue="0"></field>
+        <field name="image_file_specific_root_folder" reuseLastValue="0"></field>
+        <field name="text_file" reuseLastValue="0"></field>
+        <field name="text_file_mandatory" reuseLastValue="0"></field>
+      </reuseLastValue>
+      <dataDefinedFieldProperties></dataDefinedFieldProperties>
+      <widgets></widgets>
       <previewExpression>"id"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer maxScale="0" symbologyReferenceScale="-1" labelsEnabled="0" refreshOnNotifyMessage="" legendPlaceholderImage="" simplifyLocal="1" autoRefreshEnabled="0" type="vector" autoRefreshTime="0" minScale="100000000" simplifyDrawingTol="1" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" readOnly="0" simplifyAlgorithm="0" wkbType="Point" geometry="Point" simplifyMaxScale="1" simplifyDrawingHints="0" refreshOnNotifyEnabled="0">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Point" hasScaleBasedVisibilityFlag="0" labelsEnabled="0" legendPlaceholderImage="" maxScale="0" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="Point">
       <extent>
         <xmin>8.94556575700502243</xmin>
         <ymin>42.37987578332400318</ymin>
@@ -2050,7 +2125,7 @@ def my_form_open(dialog, layer, feature):
           <email></email>
           <role></role>
         </contact>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
@@ -2067,7 +2142,7 @@ def my_form_open(dialog, layer, feature):
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial crs="EPSG:4326" maxy="0" dimensions="2" miny="0" maxx="0" maxz="0" minx="0" minz="0"/>
+          <spatial crs="EPSG:4326" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
           <temporal>
             <period>
               <start></start>
@@ -2077,262 +2152,262 @@ def my_form_open(dialog, layer, feature):
         </extent>
       </resourceMetadata>
       <provider encoding="">postgres</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
-      <metadataUrls/>
+      <auxiliaryLayer></auxiliaryLayer>
+      <metadataUrls></metadataUrls>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal mode="0" durationUnit="min" endField="" fixedDuration="0" startExpression="" enabled="0" startField="" limitMode="0" durationField="" accumulate="0" endExpression="">
+      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
-      <elevation zoffset="0" zscale="1" extrusionEnabled="0" showMarkerSymbolInSurfacePlots="0" extrusion="0" respectLayerSymbol="1" clamping="Terrain" type="IndividualFeatures" symbology="Line" binding="Centroid">
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
         <data-defined-properties>
           <Option type="Map">
-            <Option value="" name="name" type="QString"/>
-            <Option name="properties"/>
-            <Option value="collection" name="type" type="QString"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </data-defined-properties>
         <profileLineSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="line" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleLine">
+            <layer class="SimpleLine" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="0" name="align_dash_pattern" type="QString"/>
-                <Option value="square" name="capstyle" type="QString"/>
-                <Option value="5;2" name="customdash" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
-                <Option value="MM" name="customdash_unit" type="QString"/>
-                <Option value="0" name="dash_pattern_offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
-                <Option value="0" name="draw_inside_polygon" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="190,207,80,255" name="line_color" type="QString"/>
-                <Option value="solid" name="line_style" type="QString"/>
-                <Option value="0.6" name="line_width" type="QString"/>
-                <Option value="MM" name="line_width_unit" type="QString"/>
-                <Option value="0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="0" name="ring_filter" type="QString"/>
-                <Option value="0" name="trim_distance_end" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
-                <Option value="MM" name="trim_distance_end_unit" type="QString"/>
-                <Option value="0" name="trim_distance_start" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
-                <Option value="MM" name="trim_distance_start_unit" type="QString"/>
-                <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
-                <Option value="0" name="use_custom_dash" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="190,207,80,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileLineSymbol>
         <profileFillSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="fill" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleFill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-                <Option value="190,207,80,255" name="color" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="0,0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="136,148,57,255" name="outline_color" type="QString"/>
-                <Option value="solid" name="outline_style" type="QString"/>
-                <Option value="0.2" name="outline_width" type="QString"/>
-                <Option value="MM" name="outline_width_unit" type="QString"/>
-                <Option value="solid" name="style" type="QString"/>
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="190,207,80,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="136,148,57,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileFillSymbol>
         <profileMarkerSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="marker" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleMarker">
+            <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="0" name="angle" type="QString"/>
-                <Option value="square" name="cap_style" type="QString"/>
-                <Option value="190,207,80,255" name="color" type="QString"/>
-                <Option value="1" name="horizontal_anchor_point" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="diamond" name="name" type="QString"/>
-                <Option value="0,0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="136,148,57,255" name="outline_color" type="QString"/>
-                <Option value="solid" name="outline_style" type="QString"/>
-                <Option value="0.2" name="outline_width" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
-                <Option value="MM" name="outline_width_unit" type="QString"/>
-                <Option value="diameter" name="scale_method" type="QString"/>
-                <Option value="3" name="size" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
-                <Option value="MM" name="size_unit" type="QString"/>
-                <Option value="1" name="vertical_anchor_point" type="QString"/>
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="190,207,80,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="136,148,57,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileMarkerSymbol>
       </elevation>
-      <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="singleSymbol" referencescale="-1">
+      <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
         <symbols>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" frame_rate="10" type="marker" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="0" type="marker">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleMarker">
+            <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="0" name="angle" type="QString"/>
-                <Option value="square" name="cap_style" type="QString"/>
-                <Option value="225,89,137,255" name="color" type="QString"/>
-                <Option value="1" name="horizontal_anchor_point" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="circle" name="name" type="QString"/>
-                <Option value="0,0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="35,35,35,255" name="outline_color" type="QString"/>
-                <Option value="solid" name="outline_style" type="QString"/>
-                <Option value="0" name="outline_width" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
-                <Option value="MM" name="outline_width_unit" type="QString"/>
-                <Option value="diameter" name="scale_method" type="QString"/>
-                <Option value="2" name="size" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
-                <Option value="MM" name="size_unit" type="QString"/>
-                <Option value="1" name="vertical_anchor_point" type="QString"/>
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="225,89,137,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="circle"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="35,35,35,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="2"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
-        <rotation/>
-        <sizescale/>
+        <rotation></rotation>
+        <sizescale></sizescale>
       </renderer-v2>
       <customproperties>
         <Option type="Map">
-          <Option value="0" name="embeddedWidgets/count" type="int"/>
-          <Option name="variableNames"/>
-          <Option name="variableValues"/>
+          <Option name="embeddedWidgets/count" type="int" value="0"></Option>
+          <Option name="variableNames" type="invalid"></Option>
+          <Option name="variableValues" type="invalid"></Option>
         </Option>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
-        <DiagramCategory spacingUnit="MM" backgroundColor="#ffffff" minScaleDenominator="0" backgroundAlpha="255" enabled="0" maxScaleDenominator="1e+08" width="15" sizeScale="3x:0,0,0,0,0,0" rotationOffset="270" penColor="#000000" penAlpha="255" direction="0" sizeType="MM" opacity="1" height="15" spacing="5" diagramOrientation="Up" labelPlacementMethod="XHeight" minimumSize="0" scaleBasedVisibility="0" lineSizeScale="3x:0,0,0,0,0,0" spacingUnitScale="3x:0,0,0,0,0,0" showAxis="1" scaleDependency="Area" barWidth="5" penWidth="0" lineSizeType="MM">
-          <fontProperties underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
-          <attribute color="#000000" field="" label="" colorOpacity="1"/>
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="0" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="1" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="5" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
+          <fontProperties bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></fontProperties>
+          <attribute color="#000000" colorOpacity="1" field="" label=""></attribute>
           <axisSymbol>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="line" is_animated="0">
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
-              <layer locked="0" pass="0" enabled="1" class="SimpleLine">
+              <layer class="SimpleLine" enabled="1" locked="0" pass="0">
                 <Option type="Map">
-                  <Option value="0" name="align_dash_pattern" type="QString"/>
-                  <Option value="square" name="capstyle" type="QString"/>
-                  <Option value="5;2" name="customdash" type="QString"/>
-                  <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
-                  <Option value="MM" name="customdash_unit" type="QString"/>
-                  <Option value="0" name="dash_pattern_offset" type="QString"/>
-                  <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
-                  <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
-                  <Option value="0" name="draw_inside_polygon" type="QString"/>
-                  <Option value="bevel" name="joinstyle" type="QString"/>
-                  <Option value="35,35,35,255" name="line_color" type="QString"/>
-                  <Option value="solid" name="line_style" type="QString"/>
-                  <Option value="0.26" name="line_width" type="QString"/>
-                  <Option value="MM" name="line_width_unit" type="QString"/>
-                  <Option value="0" name="offset" type="QString"/>
-                  <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                  <Option value="MM" name="offset_unit" type="QString"/>
-                  <Option value="0" name="ring_filter" type="QString"/>
-                  <Option value="0" name="trim_distance_end" type="QString"/>
-                  <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
-                  <Option value="MM" name="trim_distance_end_unit" type="QString"/>
-                  <Option value="0" name="trim_distance_start" type="QString"/>
-                  <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
-                  <Option value="MM" name="trim_distance_start_unit" type="QString"/>
-                  <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
-                  <Option value="0" name="use_custom_dash" type="QString"/>
-                  <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
+                  <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                  <Option name="capstyle" type="QString" value="square"></Option>
+                  <Option name="customdash" type="QString" value="5;2"></Option>
+                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="customdash_unit" type="QString" value="MM"></Option>
+                  <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                  <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                  <Option name="joinstyle" type="QString" value="bevel"></Option>
+                  <Option name="line_color" type="QString" value="35,35,35,255"></Option>
+                  <Option name="line_style" type="QString" value="solid"></Option>
+                  <Option name="line_width" type="QString" value="0.26"></Option>
+                  <Option name="line_width_unit" type="QString" value="MM"></Option>
+                  <Option name="offset" type="QString" value="0"></Option>
+                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="offset_unit" type="QString" value="MM"></Option>
+                  <Option name="ring_filter" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end" type="QString" value="0"></Option>
+                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                  <Option name="trim_distance_start" type="QString" value="0"></Option>
+                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                  <Option name="use_custom_dash" type="QString" value="0"></Option>
+                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
                 </Option>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option value="" name="name" type="QString"/>
-                    <Option name="properties"/>
-                    <Option value="collection" name="type" type="QString"/>
+                    <Option name="name" type="QString" value=""></Option>
+                    <Option name="properties"></Option>
+                    <Option name="type" type="QString" value="collection"></Option>
                   </Option>
                 </data_defined_properties>
               </layer>
@@ -2340,28 +2415,28 @@ def my_form_open(dialog, layer, feature):
           </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings linePlacementFlags="18" zIndex="0" priority="0" dist="0" placement="0" obstacle="0" showAll="1">
+      <DiagramLayerSettings dist="0" linePlacementFlags="18" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option value="" name="name" type="QString"/>
-            <Option name="properties"/>
-            <Option value="collection" name="type" type="QString"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
-        <activeChecks/>
-        <checkConfiguration/>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
-      <legend showLabelLegend="0" type="default-vector"/>
-      <referencedLayers/>
+      <legend showLabelLegend="0" type="default-vector"></legend>
+      <referencedLayers></referencedLayers>
       <fieldConfiguration>
         <field configurationFlags="None" name="id">
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="false" name="IsMultiline" type="bool"/>
-                <Option value="false" name="UseHtml" type="bool"/>
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2370,9 +2445,9 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="CheckBox">
             <config>
               <Option type="Map">
-                <Option value="" name="CheckedState" type="QString"/>
-                <Option value="0" name="TextDisplayMethod" type="int"/>
-                <Option value="" name="UncheckedState" type="QString"/>
+                <Option name="CheckedState" type="QString" value=""></Option>
+                <Option name="TextDisplayMethod" type="int" value="0"></Option>
+                <Option name="UncheckedState" type="QString" value=""></Option>
               </Option>
             </config>
           </editWidget>
@@ -2381,9 +2456,9 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="CheckBox">
             <config>
               <Option type="Map">
-                <Option value="" name="CheckedState" type="QString"/>
-                <Option value="0" name="TextDisplayMethod" type="int"/>
-                <Option value="" name="UncheckedState" type="QString"/>
+                <Option name="CheckedState" type="QString" value=""></Option>
+                <Option name="TextDisplayMethod" type="int" value="0"></Option>
+                <Option name="UncheckedState" type="QString" value=""></Option>
               </Option>
             </config>
           </editWidget>
@@ -2394,13 +2469,13 @@ def my_form_open(dialog, layer, feature):
               <Option type="Map">
                 <Option name="map" type="List">
                   <Option type="Map">
-                    <Option value="true" name="One way" type="QString"/>
+                    <Option name="One way" type="QString" value="true"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option value="false" name="Two way" type="QString"/>
+                    <Option name="Two way" type="QString" value="false"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" name="I don't know" type="QString"/>
+                    <Option name="I don't know" type="QString" value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}"></Option>
                   </Option>
                 </Option>
               </Option>
@@ -2413,13 +2488,13 @@ def my_form_open(dialog, layer, feature):
               <Option type="Map">
                 <Option name="map" type="List">
                   <Option type="Map">
-                    <Option value="true" name="One way" type="QString"/>
+                    <Option name="One way" type="QString" value="true"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option value="false" name="Two way" type="QString"/>
+                    <Option name="Two way" type="QString" value="false"></Option>
                   </Option>
                   <Option type="Map">
-                    <Option value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" name="I don't know" type="QString"/>
+                    <Option name="I don't know" type="QString" value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}"></Option>
                   </Option>
                 </Option>
               </Option>
@@ -2428,57 +2503,57 @@ def my_form_open(dialog, layer, feature):
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="id"/>
-        <alias name="" index="1" field="bool_simple_null_cb"/>
-        <alias name="" index="2" field="bool_not_nullable_cb"/>
-        <alias name="" index="3" field="bool_simple_null_vm"/>
-        <alias name="" index="4" field="bool_not_nullable_vm"/>
+        <alias field="id" index="0" name=""></alias>
+        <alias field="bool_simple_null_cb" index="1" name=""></alias>
+        <alias field="bool_not_nullable_cb" index="2" name=""></alias>
+        <alias field="bool_simple_null_vm" index="3" name=""></alias>
+        <alias field="bool_not_nullable_vm" index="4" name=""></alias>
       </aliases>
       <defaults>
-        <default expression="" applyOnUpdate="0" field="id"/>
-        <default expression="" applyOnUpdate="0" field="bool_simple_null_cb"/>
-        <default expression="" applyOnUpdate="0" field="bool_not_nullable_cb"/>
-        <default expression="" applyOnUpdate="0" field="bool_simple_null_vm"/>
-        <default expression="" applyOnUpdate="0" field="bool_not_nullable_vm"/>
+        <default applyOnUpdate="0" expression="" field="id"></default>
+        <default applyOnUpdate="0" expression="" field="bool_simple_null_cb"></default>
+        <default applyOnUpdate="0" expression="" field="bool_not_nullable_cb"></default>
+        <default applyOnUpdate="0" expression="" field="bool_simple_null_vm"></default>
+        <default applyOnUpdate="0" expression="" field="bool_not_nullable_vm"></default>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" exp_strength="0" unique_strength="1" constraints="3" field="id"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="bool_simple_null_cb"/>
-        <constraint notnull_strength="1" exp_strength="0" unique_strength="0" constraints="1" field="bool_not_nullable_cb"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="bool_simple_null_vm"/>
-        <constraint notnull_strength="1" exp_strength="0" unique_strength="0" constraints="1" field="bool_not_nullable_vm"/>
+        <constraint constraints="3" exp_strength="0" field="id" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="bool_simple_null_cb" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="1" exp_strength="0" field="bool_not_nullable_cb" notnull_strength="1" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="bool_simple_null_vm" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="1" exp_strength="0" field="bool_not_nullable_vm" notnull_strength="1" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" desc="" field="id"/>
-        <constraint exp="" desc="" field="bool_simple_null_cb"/>
-        <constraint exp="" desc="" field="bool_not_nullable_cb"/>
-        <constraint exp="" desc="" field="bool_simple_null_vm"/>
-        <constraint exp="" desc="" field="bool_not_nullable_vm"/>
+        <constraint desc="" exp="" field="id"></constraint>
+        <constraint desc="" exp="" field="bool_simple_null_cb"></constraint>
+        <constraint desc="" exp="" field="bool_not_nullable_cb"></constraint>
+        <constraint desc="" exp="" field="bool_simple_null_vm"></constraint>
+        <constraint desc="" exp="" field="bool_not_nullable_vm"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
-      <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column width="-1" hidden="0" name="id" type="field"/>
-          <column width="-1" hidden="0" name="bool_simple_null_cb" type="field"/>
-          <column width="-1" hidden="0" name="bool_not_nullable_cb" type="field"/>
-          <column width="-1" hidden="0" name="bool_simple_null_vm" type="field"/>
-          <column width="-1" hidden="0" name="bool_not_nullable_vm" type="field"/>
-          <column width="-1" hidden="1" type="actions"/>
+          <column hidden="0" name="id" type="field" width="-1"></column>
+          <column hidden="0" name="bool_simple_null_cb" type="field" width="-1"></column>
+          <column hidden="0" name="bool_not_nullable_cb" type="field" width="-1"></column>
+          <column hidden="0" name="bool_simple_null_vm" type="field" width="-1"></column>
+          <column hidden="0" name="bool_not_nullable_vm" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1"></editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -2494,36 +2569,36 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
     geom = feature.geometry()
     control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field editable="1" name="bool_not_nullable_cb"/>
-        <field editable="1" name="bool_not_nullable_vm"/>
-        <field editable="1" name="bool_simple_null_cb"/>
-        <field editable="1" name="bool_simple_null_vm"/>
-        <field editable="0" name="id"/>
+        <field editable="1" name="bool_not_nullable_cb"></field>
+        <field editable="1" name="bool_not_nullable_vm"></field>
+        <field editable="1" name="bool_simple_null_cb"></field>
+        <field editable="1" name="bool_simple_null_vm"></field>
+        <field editable="0" name="id"></field>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="bool_not_nullable_cb"/>
-        <field labelOnTop="0" name="bool_not_nullable_vm"/>
-        <field labelOnTop="0" name="bool_simple_null_cb"/>
-        <field labelOnTop="0" name="bool_simple_null_vm"/>
-        <field labelOnTop="0" name="id"/>
+        <field labelOnTop="0" name="bool_not_nullable_cb"></field>
+        <field labelOnTop="0" name="bool_not_nullable_vm"></field>
+        <field labelOnTop="0" name="bool_simple_null_cb"></field>
+        <field labelOnTop="0" name="bool_simple_null_vm"></field>
+        <field labelOnTop="0" name="id"></field>
       </labelOnTop>
       <reuseLastValue>
-        <field reuseLastValue="0" name="bool_not_nullable_cb"/>
-        <field reuseLastValue="0" name="bool_not_nullable_vm"/>
-        <field reuseLastValue="0" name="bool_simple_null_cb"/>
-        <field reuseLastValue="0" name="bool_simple_null_vm"/>
-        <field reuseLastValue="0" name="id"/>
+        <field name="bool_not_nullable_cb" reuseLastValue="0"></field>
+        <field name="bool_not_nullable_vm" reuseLastValue="0"></field>
+        <field name="bool_simple_null_cb" reuseLastValue="0"></field>
+        <field name="bool_simple_null_vm" reuseLastValue="0"></field>
+        <field name="id" reuseLastValue="0"></field>
       </reuseLastValue>
-      <dataDefinedFieldProperties/>
-      <widgets/>
+      <dataDefinedFieldProperties></dataDefinedFieldProperties>
+      <widgets></widgets>
       <previewExpression>"id"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer styleCategories="AllStyleCategories" autoRefreshEnabled="0" geometry="No geometry" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="0" refreshOnNotifyMessage="" readOnly="0" maxScale="0" minScale="0" autoRefreshTime="0" wkbType="NoGeometry" type="vector" refreshOnNotifyEnabled="0">
+    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="No geometry" hasScaleBasedVisibilityFlag="0" legendPlaceholderImage="" maxScale="0" minScale="0" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" type="vector" wkbType="NoGeometry">
       <id>many_date_formats_1a83b783_8ee0_49a8_bed3_480ecee12fb5</id>
       <datasource>service='lizmapdb' sslmode=disable key='id' checkPrimaryKeyUnicity='1' table="tests_projects"."many_date_formats"</datasource>
       <shortname>many_date_formats</shortname>
@@ -2560,7 +2635,7 @@ def my_form_open(dialog, layer, feature):
           <email></email>
           <role></role>
         </contact>
-        <links/>
+        <links></links>
         <fees></fees>
         <encoding></encoding>
         <crs>
@@ -2577,7 +2652,7 @@ def my_form_open(dialog, layer, feature):
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial crs="" maxy="0" dimensions="2" miny="0" maxx="0" maxz="0" minx="0" minz="0"/>
+          <spatial crs="" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
           <temporal>
             <period>
               <start></start>
@@ -2587,153 +2662,153 @@ def my_form_open(dialog, layer, feature):
         </extent>
       </resourceMetadata>
       <provider encoding="">postgres</provider>
-      <vectorjoins/>
-      <layerDependencies/>
-      <dataDependencies/>
-      <expressionfields/>
+      <vectorjoins></vectorjoins>
+      <layerDependencies></layerDependencies>
+      <dataDependencies></dataDependencies>
+      <expressionfields></expressionfields>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
+        <map-layer-style name="default"></map-layer-style>
       </map-layer-style-manager>
-      <auxiliaryLayer/>
-      <metadataUrls/>
+      <auxiliaryLayer></auxiliaryLayer>
+      <metadataUrls></metadataUrls>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal mode="0" durationUnit="min" endField="" fixedDuration="0" startExpression="" enabled="0" startField="" limitMode="0" durationField="" accumulate="0" endExpression="">
+      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
-      <elevation zoffset="0" zscale="1" extrusionEnabled="0" showMarkerSymbolInSurfacePlots="0" extrusion="0" respectLayerSymbol="1" clamping="Terrain" type="IndividualFeatures" symbology="Line" binding="Centroid">
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
         <data-defined-properties>
           <Option type="Map">
-            <Option value="" name="name" type="QString"/>
-            <Option name="properties"/>
-            <Option value="collection" name="type" type="QString"/>
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
           </Option>
         </data-defined-properties>
         <profileLineSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="line" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleLine">
+            <layer class="SimpleLine" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="0" name="align_dash_pattern" type="QString"/>
-                <Option value="square" name="capstyle" type="QString"/>
-                <Option value="5;2" name="customdash" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
-                <Option value="MM" name="customdash_unit" type="QString"/>
-                <Option value="0" name="dash_pattern_offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
-                <Option value="0" name="draw_inside_polygon" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="229,182,54,255" name="line_color" type="QString"/>
-                <Option value="solid" name="line_style" type="QString"/>
-                <Option value="0.6" name="line_width" type="QString"/>
-                <Option value="MM" name="line_width_unit" type="QString"/>
-                <Option value="0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="0" name="ring_filter" type="QString"/>
-                <Option value="0" name="trim_distance_end" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
-                <Option value="MM" name="trim_distance_end_unit" type="QString"/>
-                <Option value="0" name="trim_distance_start" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
-                <Option value="MM" name="trim_distance_start_unit" type="QString"/>
-                <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
-                <Option value="0" name="use_custom_dash" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="229,182,54,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileLineSymbol>
         <profileFillSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="fill" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleFill">
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-                <Option value="229,182,54,255" name="color" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="0,0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="164,130,39,255" name="outline_color" type="QString"/>
-                <Option value="solid" name="outline_style" type="QString"/>
-                <Option value="0.2" name="outline_width" type="QString"/>
-                <Option value="MM" name="outline_width_unit" type="QString"/>
-                <Option value="solid" name="style" type="QString"/>
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="229,182,54,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="164,130,39,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileFillSymbol>
         <profileMarkerSymbol>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" frame_rate="10" type="marker" is_animated="0">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
             <data_defined_properties>
               <Option type="Map">
-                <Option value="" name="name" type="QString"/>
-                <Option name="properties"/>
-                <Option value="collection" name="type" type="QString"/>
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
               </Option>
             </data_defined_properties>
-            <layer locked="0" pass="0" enabled="1" class="SimpleMarker">
+            <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
               <Option type="Map">
-                <Option value="0" name="angle" type="QString"/>
-                <Option value="square" name="cap_style" type="QString"/>
-                <Option value="229,182,54,255" name="color" type="QString"/>
-                <Option value="1" name="horizontal_anchor_point" type="QString"/>
-                <Option value="bevel" name="joinstyle" type="QString"/>
-                <Option value="diamond" name="name" type="QString"/>
-                <Option value="0,0" name="offset" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-                <Option value="MM" name="offset_unit" type="QString"/>
-                <Option value="164,130,39,255" name="outline_color" type="QString"/>
-                <Option value="solid" name="outline_style" type="QString"/>
-                <Option value="0.2" name="outline_width" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
-                <Option value="MM" name="outline_width_unit" type="QString"/>
-                <Option value="diameter" name="scale_method" type="QString"/>
-                <Option value="3" name="size" type="QString"/>
-                <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
-                <Option value="MM" name="size_unit" type="QString"/>
-                <Option value="1" name="vertical_anchor_point" type="QString"/>
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="229,182,54,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="164,130,39,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" name="name" type="QString"/>
-                  <Option name="properties"/>
-                  <Option value="collection" name="type" type="QString"/>
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -2742,29 +2817,29 @@ def my_form_open(dialog, layer, feature):
       </elevation>
       <customproperties>
         <Option type="Map">
-          <Option value="offline" name="QFieldSync/action" type="QString"/>
-          <Option value="{}" name="QFieldSync/attachment_naming" type="QString"/>
-          <Option value="offline" name="QFieldSync/cloud_action" type="QString"/>
-          <Option value="{}" name="QFieldSync/photo_naming" type="QString"/>
-          <Option value="{}" name="QFieldSync/relationship_maximum_visible" type="QString"/>
-          <Option value="0" name="embeddedWidgets/count" type="int"/>
-          <Option name="variableNames" type="invalid"/>
-          <Option name="variableValues" type="invalid"/>
+          <Option name="QFieldSync/action" type="QString" value="offline"></Option>
+          <Option name="QFieldSync/attachment_naming" type="QString" value="{}"></Option>
+          <Option name="QFieldSync/cloud_action" type="QString" value="offline"></Option>
+          <Option name="QFieldSync/photo_naming" type="QString" value="{}"></Option>
+          <Option name="QFieldSync/relationship_maximum_visible" type="QString" value="{}"></Option>
+          <Option name="embeddedWidgets/count" type="int" value="0"></Option>
+          <Option name="variableNames" type="invalid"></Option>
+          <Option name="variableValues" type="invalid"></Option>
         </Option>
       </customproperties>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
-        <activeChecks/>
-        <checkConfiguration/>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks></activeChecks>
+        <checkConfiguration></checkConfiguration>
       </geometryOptions>
-      <legend showLabelLegend="0" type="default-vector"/>
-      <referencedLayers/>
+      <legend showLabelLegend="0" type="default-vector"></legend>
+      <referencedLayers></referencedLayers>
       <fieldConfiguration>
         <field configurationFlags="None" name="id">
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="false" name="IsMultiline" type="bool"/>
-                <Option value="false" name="UseHtml" type="bool"/>
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2773,11 +2848,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="dd/MM/yyyy" name="display_format" type="QString"/>
-                <Option value="dd/MM/yyyy" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="dd/MM/yyyy"></Option>
+                <Option name="field_format" type="QString" value="dd/MM/yyyy"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2786,11 +2861,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="HH:mm:ss" name="display_format" type="QString"/>
-                <Option value="HH:mm:ss" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="HH:mm:ss"></Option>
+                <Option name="field_format" type="QString" value="HH:mm:ss"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2799,11 +2874,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="dd/MM/yyyy HH:mm:ss" name="display_format" type="QString"/>
-                <Option value="dd/MM/yyyy HH:mm:ss" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="dd/MM/yyyy HH:mm:ss"></Option>
+                <Option name="field_format" type="QString" value="dd/MM/yyyy HH:mm:ss"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2812,11 +2887,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="dd/MM/yyyy" name="display_format" type="QString"/>
-                <Option value="dd/MM/yyyy" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="dd/MM/yyyy"></Option>
+                <Option name="field_format" type="QString" value="dd/MM/yyyy"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2825,11 +2900,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="HH:mm:ss" name="display_format" type="QString"/>
-                <Option value="HH:mm:ss" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="HH:mm:ss"></Option>
+                <Option name="field_format" type="QString" value="HH:mm:ss"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2838,11 +2913,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="dd/MM/yyyy HH:mm:ss" name="display_format" type="QString"/>
-                <Option value="dd/MM/yyyy HH:mm:ss" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="dd/MM/yyyy HH:mm:ss"></Option>
+                <Option name="field_format" type="QString" value="dd/MM/yyyy HH:mm:ss"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2851,11 +2926,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="dd/MM/yyyy" name="display_format" type="QString"/>
-                <Option value="dd/MM/yyyy" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="dd/MM/yyyy"></Option>
+                <Option name="field_format" type="QString" value="dd/MM/yyyy"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2864,11 +2939,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="HH:mm:ss" name="display_format" type="QString"/>
-                <Option value="HH:mm:ss" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="HH:mm:ss"></Option>
+                <Option name="field_format" type="QString" value="HH:mm:ss"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2877,11 +2952,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="dd/MM/yyyy HH:mm:ss" name="display_format" type="QString"/>
-                <Option value="dd/MM/yyyy HH:mm:ss" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="dd/MM/yyyy HH:mm:ss"></Option>
+                <Option name="field_format" type="QString" value="dd/MM/yyyy HH:mm:ss"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2890,11 +2965,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="dd/MM/yyyy" name="display_format" type="QString"/>
-                <Option value="dd/MM/yyyy" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="dd/MM/yyyy"></Option>
+                <Option name="field_format" type="QString" value="dd/MM/yyyy"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2903,11 +2978,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="HH:mm:ss" name="display_format" type="QString"/>
-                <Option value="HH:mm:ss" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="HH:mm:ss"></Option>
+                <Option name="field_format" type="QString" value="HH:mm:ss"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2916,11 +2991,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="dd/MM/yyyy HH:mm:ss" name="display_format" type="QString"/>
-                <Option value="dd/MM/yyyy HH:mm:ss" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="dd/MM/yyyy HH:mm:ss"></Option>
+                <Option name="field_format" type="QString" value="dd/MM/yyyy HH:mm:ss"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2929,11 +3004,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="dd/MM/yyyy" name="display_format" type="QString"/>
-                <Option value="dd/MM/yyyy" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="dd/MM/yyyy"></Option>
+                <Option name="field_format" type="QString" value="dd/MM/yyyy"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2942,11 +3017,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="HH:mm:ss" name="display_format" type="QString"/>
-                <Option value="HH:mm:ss" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="HH:mm:ss"></Option>
+                <Option name="field_format" type="QString" value="HH:mm:ss"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2955,11 +3030,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="dd/MM/yyyy HH:mm:ss" name="display_format" type="QString"/>
-                <Option value="dd/MM/yyyy HH:mm:ss" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="dd/MM/yyyy HH:mm:ss"></Option>
+                <Option name="field_format" type="QString" value="dd/MM/yyyy HH:mm:ss"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2968,11 +3043,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="dd/MM/yyyy" name="display_format" type="QString"/>
-                <Option value="dd/MM/yyyy" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="dd/MM/yyyy"></Option>
+                <Option name="field_format" type="QString" value="dd/MM/yyyy"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2981,11 +3056,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="HH:mm:ss" name="display_format" type="QString"/>
-                <Option value="HH:mm:ss" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="HH:mm:ss"></Option>
+                <Option name="field_format" type="QString" value="HH:mm:ss"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -2994,11 +3069,11 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="dd/MM/yyyy" name="display_format" type="QString"/>
-                <Option value="dd/MM/yyyy" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="dd/MM/yyyy"></Option>
+                <Option name="field_format" type="QString" value="dd/MM/yyyy"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
@@ -3007,143 +3082,143 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="DateTime">
             <config>
               <Option type="Map">
-                <Option value="true" name="allow_null" type="bool"/>
-                <Option value="true" name="calendar_popup" type="bool"/>
-                <Option value="dd/MM/yyyy" name="display_format" type="QString"/>
-                <Option value="dd/MM/yyyy" name="field_format" type="QString"/>
-                <Option value="false" name="field_iso_format" type="bool"/>
+                <Option name="allow_null" type="bool" value="true"></Option>
+                <Option name="calendar_popup" type="bool" value="true"></Option>
+                <Option name="display_format" type="QString" value="dd/MM/yyyy"></Option>
+                <Option name="field_format" type="QString" value="dd/MM/yyyy"></Option>
+                <Option name="field_iso_format" type="bool" value="false"></Option>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="id"/>
-        <alias name="" index="1" field="field_date"/>
-        <alias name="" index="2" field="field_time"/>
-        <alias name="" index="3" field="field_timestamp"/>
-        <alias name="" index="4" field="field_date_auto_cast"/>
-        <alias name="" index="5" field="field_time_auto_cast"/>
-        <alias name="" index="6" field="field_timestamp_auto_cast"/>
-        <alias name="" index="7" field="field_date_auto"/>
-        <alias name="" index="8" field="field_time_auto"/>
-        <alias name="" index="9" field="field_timestamp_auto"/>
-        <alias name="" index="10" field="field_date_expr_now"/>
-        <alias name="" index="11" field="field_time_expr_now"/>
-        <alias name="" index="12" field="field_timestamp_expr_now"/>
-        <alias name="" index="13" field="field_date_expr_now_auto"/>
-        <alias name="" index="14" field="field_time_expr_now_auto"/>
-        <alias name="" index="15" field="field_timestamp_expr_now_auto"/>
-        <alias name="" index="16" field="field_timestamp_date_only"/>
-        <alias name="" index="17" field="field_timestamp_date_only_auto"/>
-        <alias name="" index="18" field="field_timestamp_date_only_expr_now"/>
-        <alias name="" index="19" field="field_timestamp_date_only_expr_now_auto"/>
+        <alias field="id" index="0" name=""></alias>
+        <alias field="field_date" index="1" name=""></alias>
+        <alias field="field_time" index="2" name=""></alias>
+        <alias field="field_timestamp" index="3" name=""></alias>
+        <alias field="field_date_auto_cast" index="4" name=""></alias>
+        <alias field="field_time_auto_cast" index="5" name=""></alias>
+        <alias field="field_timestamp_auto_cast" index="6" name=""></alias>
+        <alias field="field_date_auto" index="7" name=""></alias>
+        <alias field="field_time_auto" index="8" name=""></alias>
+        <alias field="field_timestamp_auto" index="9" name=""></alias>
+        <alias field="field_date_expr_now" index="10" name=""></alias>
+        <alias field="field_time_expr_now" index="11" name=""></alias>
+        <alias field="field_timestamp_expr_now" index="12" name=""></alias>
+        <alias field="field_date_expr_now_auto" index="13" name=""></alias>
+        <alias field="field_time_expr_now_auto" index="14" name=""></alias>
+        <alias field="field_timestamp_expr_now_auto" index="15" name=""></alias>
+        <alias field="field_timestamp_date_only" index="16" name=""></alias>
+        <alias field="field_timestamp_date_only_auto" index="17" name=""></alias>
+        <alias field="field_timestamp_date_only_expr_now" index="18" name=""></alias>
+        <alias field="field_timestamp_date_only_expr_now_auto" index="19" name=""></alias>
       </aliases>
       <defaults>
-        <default expression="" applyOnUpdate="0" field="id"/>
-        <default expression="" applyOnUpdate="0" field="field_date"/>
-        <default expression="" applyOnUpdate="0" field="field_time"/>
-        <default expression="" applyOnUpdate="0" field="field_timestamp"/>
-        <default expression="" applyOnUpdate="0" field="field_date_auto_cast"/>
-        <default expression="" applyOnUpdate="0" field="field_time_auto_cast"/>
-        <default expression="" applyOnUpdate="0" field="field_timestamp_auto_cast"/>
-        <default expression="" applyOnUpdate="0" field="field_date_auto"/>
-        <default expression="" applyOnUpdate="0" field="field_time_auto"/>
-        <default expression="" applyOnUpdate="0" field="field_timestamp_auto"/>
-        <default expression="now()" applyOnUpdate="0" field="field_date_expr_now"/>
-        <default expression="now()" applyOnUpdate="0" field="field_time_expr_now"/>
-        <default expression="now()" applyOnUpdate="0" field="field_timestamp_expr_now"/>
-        <default expression="now()" applyOnUpdate="0" field="field_date_expr_now_auto"/>
-        <default expression="now()" applyOnUpdate="0" field="field_time_expr_now_auto"/>
-        <default expression="now()" applyOnUpdate="0" field="field_timestamp_expr_now_auto"/>
-        <default expression="" applyOnUpdate="0" field="field_timestamp_date_only"/>
-        <default expression="" applyOnUpdate="0" field="field_timestamp_date_only_auto"/>
-        <default expression="now()" applyOnUpdate="0" field="field_timestamp_date_only_expr_now"/>
-        <default expression="now()" applyOnUpdate="0" field="field_timestamp_date_only_expr_now_auto"/>
+        <default applyOnUpdate="0" expression="" field="id"></default>
+        <default applyOnUpdate="0" expression="" field="field_date"></default>
+        <default applyOnUpdate="0" expression="" field="field_time"></default>
+        <default applyOnUpdate="0" expression="" field="field_timestamp"></default>
+        <default applyOnUpdate="0" expression="" field="field_date_auto_cast"></default>
+        <default applyOnUpdate="0" expression="" field="field_time_auto_cast"></default>
+        <default applyOnUpdate="0" expression="" field="field_timestamp_auto_cast"></default>
+        <default applyOnUpdate="0" expression="" field="field_date_auto"></default>
+        <default applyOnUpdate="0" expression="" field="field_time_auto"></default>
+        <default applyOnUpdate="0" expression="" field="field_timestamp_auto"></default>
+        <default applyOnUpdate="0" expression="now()" field="field_date_expr_now"></default>
+        <default applyOnUpdate="0" expression="now()" field="field_time_expr_now"></default>
+        <default applyOnUpdate="0" expression="now()" field="field_timestamp_expr_now"></default>
+        <default applyOnUpdate="0" expression="now()" field="field_date_expr_now_auto"></default>
+        <default applyOnUpdate="0" expression="now()" field="field_time_expr_now_auto"></default>
+        <default applyOnUpdate="0" expression="now()" field="field_timestamp_expr_now_auto"></default>
+        <default applyOnUpdate="0" expression="" field="field_timestamp_date_only"></default>
+        <default applyOnUpdate="0" expression="" field="field_timestamp_date_only_auto"></default>
+        <default applyOnUpdate="0" expression="now()" field="field_timestamp_date_only_expr_now"></default>
+        <default applyOnUpdate="0" expression="now()" field="field_timestamp_date_only_expr_now_auto"></default>
       </defaults>
       <constraints>
-        <constraint notnull_strength="1" exp_strength="0" unique_strength="1" constraints="3" field="id"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_date"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_time"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_timestamp"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_date_auto_cast"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_time_auto_cast"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_timestamp_auto_cast"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_date_auto"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_time_auto"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_timestamp_auto"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_date_expr_now"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_time_expr_now"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_timestamp_expr_now"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_date_expr_now_auto"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_time_expr_now_auto"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_timestamp_expr_now_auto"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_timestamp_date_only"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_timestamp_date_only_auto"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_timestamp_date_only_expr_now"/>
-        <constraint notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0" field="field_timestamp_date_only_expr_now_auto"/>
+        <constraint constraints="3" exp_strength="0" field="id" notnull_strength="1" unique_strength="1"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_date" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_time" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_timestamp" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_date_auto_cast" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_time_auto_cast" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_timestamp_auto_cast" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_date_auto" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_time_auto" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_timestamp_auto" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_date_expr_now" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_time_expr_now" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_timestamp_expr_now" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_date_expr_now_auto" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_time_expr_now_auto" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_timestamp_expr_now_auto" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_timestamp_date_only" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_timestamp_date_only_auto" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_timestamp_date_only_expr_now" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint constraints="0" exp_strength="0" field="field_timestamp_date_only_expr_now_auto" notnull_strength="0" unique_strength="0"></constraint>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" desc="" field="id"/>
-        <constraint exp="" desc="" field="field_date"/>
-        <constraint exp="" desc="" field="field_time"/>
-        <constraint exp="" desc="" field="field_timestamp"/>
-        <constraint exp="" desc="" field="field_date_auto_cast"/>
-        <constraint exp="" desc="" field="field_time_auto_cast"/>
-        <constraint exp="" desc="" field="field_timestamp_auto_cast"/>
-        <constraint exp="" desc="" field="field_date_auto"/>
-        <constraint exp="" desc="" field="field_time_auto"/>
-        <constraint exp="" desc="" field="field_timestamp_auto"/>
-        <constraint exp="" desc="" field="field_date_expr_now"/>
-        <constraint exp="" desc="" field="field_time_expr_now"/>
-        <constraint exp="" desc="" field="field_timestamp_expr_now"/>
-        <constraint exp="" desc="" field="field_date_expr_now_auto"/>
-        <constraint exp="" desc="" field="field_time_expr_now_auto"/>
-        <constraint exp="" desc="" field="field_timestamp_expr_now_auto"/>
-        <constraint exp="" desc="" field="field_timestamp_date_only"/>
-        <constraint exp="" desc="" field="field_timestamp_date_only_auto"/>
-        <constraint exp="" desc="" field="field_timestamp_date_only_expr_now"/>
-        <constraint exp="" desc="" field="field_timestamp_date_only_expr_now_auto"/>
+        <constraint desc="" exp="" field="id"></constraint>
+        <constraint desc="" exp="" field="field_date"></constraint>
+        <constraint desc="" exp="" field="field_time"></constraint>
+        <constraint desc="" exp="" field="field_timestamp"></constraint>
+        <constraint desc="" exp="" field="field_date_auto_cast"></constraint>
+        <constraint desc="" exp="" field="field_time_auto_cast"></constraint>
+        <constraint desc="" exp="" field="field_timestamp_auto_cast"></constraint>
+        <constraint desc="" exp="" field="field_date_auto"></constraint>
+        <constraint desc="" exp="" field="field_time_auto"></constraint>
+        <constraint desc="" exp="" field="field_timestamp_auto"></constraint>
+        <constraint desc="" exp="" field="field_date_expr_now"></constraint>
+        <constraint desc="" exp="" field="field_time_expr_now"></constraint>
+        <constraint desc="" exp="" field="field_timestamp_expr_now"></constraint>
+        <constraint desc="" exp="" field="field_date_expr_now_auto"></constraint>
+        <constraint desc="" exp="" field="field_time_expr_now_auto"></constraint>
+        <constraint desc="" exp="" field="field_timestamp_expr_now_auto"></constraint>
+        <constraint desc="" exp="" field="field_timestamp_date_only"></constraint>
+        <constraint desc="" exp="" field="field_timestamp_date_only_auto"></constraint>
+        <constraint desc="" exp="" field="field_timestamp_date_only_expr_now"></constraint>
+        <constraint desc="" exp="" field="field_timestamp_date_only_expr_now_auto"></constraint>
       </constraintExpressions>
-      <expressionfields/>
+      <expressionfields></expressionfields>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
-      <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column width="-1" hidden="0" name="id" type="field"/>
-          <column width="-1" hidden="0" name="field_date" type="field"/>
-          <column width="-1" hidden="0" name="field_time" type="field"/>
-          <column width="-1" hidden="0" name="field_timestamp" type="field"/>
-          <column width="-1" hidden="0" name="field_date_auto_cast" type="field"/>
-          <column width="-1" hidden="0" name="field_time_auto_cast" type="field"/>
-          <column width="-1" hidden="0" name="field_timestamp_auto_cast" type="field"/>
-          <column width="-1" hidden="0" name="field_date_auto" type="field"/>
-          <column width="-1" hidden="0" name="field_time_auto" type="field"/>
-          <column width="-1" hidden="0" name="field_timestamp_auto" type="field"/>
-          <column width="-1" hidden="0" name="field_date_expr_now" type="field"/>
-          <column width="-1" hidden="0" name="field_time_expr_now" type="field"/>
-          <column width="-1" hidden="0" name="field_timestamp_expr_now" type="field"/>
-          <column width="-1" hidden="0" name="field_date_expr_now_auto" type="field"/>
-          <column width="-1" hidden="0" name="field_time_expr_now_auto" type="field"/>
-          <column width="-1" hidden="0" name="field_timestamp_expr_now_auto" type="field"/>
-          <column width="-1" hidden="0" name="field_timestamp_date_only" type="field"/>
-          <column width="-1" hidden="0" name="field_timestamp_date_only_auto" type="field"/>
-          <column width="-1" hidden="0" name="field_timestamp_date_only_expr_now" type="field"/>
-          <column width="-1" hidden="0" name="field_timestamp_date_only_expr_now_auto" type="field"/>
-          <column width="-1" hidden="1" type="actions"/>
+          <column hidden="0" name="id" type="field" width="-1"></column>
+          <column hidden="0" name="field_date" type="field" width="-1"></column>
+          <column hidden="0" name="field_time" type="field" width="-1"></column>
+          <column hidden="0" name="field_timestamp" type="field" width="-1"></column>
+          <column hidden="0" name="field_date_auto_cast" type="field" width="-1"></column>
+          <column hidden="0" name="field_time_auto_cast" type="field" width="-1"></column>
+          <column hidden="0" name="field_timestamp_auto_cast" type="field" width="-1"></column>
+          <column hidden="0" name="field_date_auto" type="field" width="-1"></column>
+          <column hidden="0" name="field_time_auto" type="field" width="-1"></column>
+          <column hidden="0" name="field_timestamp_auto" type="field" width="-1"></column>
+          <column hidden="0" name="field_date_expr_now" type="field" width="-1"></column>
+          <column hidden="0" name="field_time_expr_now" type="field" width="-1"></column>
+          <column hidden="0" name="field_timestamp_expr_now" type="field" width="-1"></column>
+          <column hidden="0" name="field_date_expr_now_auto" type="field" width="-1"></column>
+          <column hidden="0" name="field_time_expr_now_auto" type="field" width="-1"></column>
+          <column hidden="0" name="field_timestamp_expr_now_auto" type="field" width="-1"></column>
+          <column hidden="0" name="field_timestamp_date_only" type="field" width="-1"></column>
+          <column hidden="0" name="field_timestamp_date_only_auto" type="field" width="-1"></column>
+          <column hidden="0" name="field_timestamp_date_only_expr_now" type="field" width="-1"></column>
+          <column hidden="0" name="field_timestamp_date_only_expr_now_auto" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles/>
-        <fieldstyles/>
+        <rowstyles></rowstyles>
+        <fieldstyles></fieldstyles>
       </conditionalstyles>
-      <storedexpressions/>
+      <storedexpressions></storedexpressions>
       <editform tolerant="1"></editform>
-      <editforminit/>
+      <editforminit></editforminit>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+      <editforminitcode># -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -3159,222 +3234,222 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
     geom = feature.geometry()
     control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
+</editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>tablayout</editorlayout>
       <attributeEditorForm>
-        <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-          <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+        <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
         </labelStyle>
-        <attributeEditorContainer visibilityExpression="" columnCount="1" collapsed="0" showLabel="1" visibilityExpressionEnabled="0" name="Tests" collapsedExpression="" groupBox="0" collapsedExpressionEnabled="0">
-          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-            <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+        <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="1" groupBox="0" name="Tests" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+          <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+            <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
           </labelStyle>
-          <attributeEditorContainer visibilityExpression="" columnCount="1" collapsed="0" showLabel="1" visibilityExpressionEnabled="0" name="Simple" collapsedExpression="" groupBox="1" collapsedExpressionEnabled="0">
-            <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-              <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+          <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="1" groupBox="1" name="Simple" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+            <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+              <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
             </labelStyle>
-            <attributeEditorField showLabel="1" name="field_date" index="1">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="1" name="field_date" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
-            <attributeEditorField showLabel="1" name="field_time" index="2">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="2" name="field_time" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
-            <attributeEditorField showLabel="1" name="field_timestamp" index="3">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="3" name="field_timestamp" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
           </attributeEditorContainer>
-          <attributeEditorContainer visibilityExpression="" columnCount="1" collapsed="0" showLabel="1" visibilityExpressionEnabled="0" name="PG now() with cast" collapsedExpression="" groupBox="1" collapsedExpressionEnabled="0">
-            <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-              <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+          <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="1" groupBox="1" name="PG now() with cast" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+            <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+              <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
             </labelStyle>
-            <attributeEditorField showLabel="1" name="field_date_auto_cast" index="4">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="4" name="field_date_auto_cast" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
-            <attributeEditorField showLabel="1" name="field_time_auto_cast" index="5">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="5" name="field_time_auto_cast" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
-            <attributeEditorField showLabel="1" name="field_timestamp_auto_cast" index="6">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="6" name="field_timestamp_auto_cast" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
           </attributeEditorContainer>
-          <attributeEditorContainer visibilityExpression="" columnCount="1" collapsed="0" showLabel="1" visibilityExpressionEnabled="0" name="PG now() without cast" collapsedExpression="" groupBox="1" collapsedExpressionEnabled="0">
-            <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-              <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+          <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="1" groupBox="1" name="PG now() without cast" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+            <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+              <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
             </labelStyle>
-            <attributeEditorField showLabel="1" name="field_date_auto" index="7">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="7" name="field_date_auto" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
-            <attributeEditorField showLabel="1" name="field_time_auto" index="8">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="8" name="field_time_auto" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
-            <attributeEditorField showLabel="1" name="field_timestamp_auto" index="9">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="9" name="field_timestamp_auto" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
           </attributeEditorContainer>
-          <attributeEditorContainer visibilityExpression="" columnCount="1" collapsed="0" showLabel="1" visibilityExpressionEnabled="0" name="QGIS now()" collapsedExpression="" groupBox="1" collapsedExpressionEnabled="0">
-            <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-              <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+          <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="1" groupBox="1" name="QGIS now()" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+            <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+              <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
             </labelStyle>
-            <attributeEditorField showLabel="1" name="field_date_expr_now" index="10">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="10" name="field_date_expr_now" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
-            <attributeEditorField showLabel="1" name="field_time_expr_now" index="11">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="11" name="field_time_expr_now" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
-            <attributeEditorField showLabel="1" name="field_timestamp_expr_now" index="12">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="12" name="field_timestamp_expr_now" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
           </attributeEditorContainer>
-          <attributeEditorContainer visibilityExpression="" columnCount="1" collapsed="0" showLabel="1" visibilityExpressionEnabled="0" name="PG now() and QGIS now()" collapsedExpression="" groupBox="1" collapsedExpressionEnabled="0">
-            <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-              <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+          <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="1" groupBox="1" name="PG now() and QGIS now()" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+            <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+              <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
             </labelStyle>
-            <attributeEditorField showLabel="1" name="field_date_expr_now_auto" index="13">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="13" name="field_date_expr_now_auto" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
-            <attributeEditorField showLabel="1" name="field_time_expr_now_auto" index="14">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="14" name="field_time_expr_now_auto" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
-            <attributeEditorField showLabel="1" name="field_timestamp_expr_now_auto" index="15">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="15" name="field_timestamp_expr_now_auto" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
           </attributeEditorContainer>
-          <attributeEditorContainer visibilityExpression="" columnCount="1" collapsed="0" showLabel="1" visibilityExpressionEnabled="0" name="Timestamp as date" collapsedExpression="" groupBox="1" collapsedExpressionEnabled="0">
-            <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-              <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+          <attributeEditorContainer collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" columnCount="1" groupBox="1" name="Timestamp as date" showLabel="1" visibilityExpression="" visibilityExpressionEnabled="0">
+            <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+              <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
             </labelStyle>
-            <attributeEditorField showLabel="1" name="field_timestamp_date_only" index="16">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="16" name="field_timestamp_date_only" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
-            <attributeEditorField showLabel="1" name="field_timestamp_date_only_auto" index="17">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="17" name="field_timestamp_date_only_auto" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
-            <attributeEditorField showLabel="1" name="field_timestamp_date_only_expr_now" index="18">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="18" name="field_timestamp_date_only_expr_now" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
-            <attributeEditorField showLabel="1" name="field_timestamp_date_only_expr_now_auto" index="19">
-              <labelStyle overrideLabelColor="0" labelColor="0,0,0,255" overrideLabelFont="0">
-                <labelFont underline="0" italic="0" style="" bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0"/>
+            <attributeEditorField index="19" name="field_timestamp_date_only_expr_now_auto" showLabel="1">
+              <labelStyle labelColor="0,0,0,255" overrideLabelColor="0" overrideLabelFont="0">
+                <labelFont bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></labelFont>
               </labelStyle>
             </attributeEditorField>
           </attributeEditorContainer>
         </attributeEditorContainer>
       </attributeEditorForm>
       <editable>
-        <field editable="1" name="field_date"/>
-        <field editable="1" name="field_date_auto"/>
-        <field editable="1" name="field_date_auto_cast"/>
-        <field editable="1" name="field_date_expr_now"/>
-        <field editable="1" name="field_date_expr_now_auto"/>
-        <field editable="1" name="field_time"/>
-        <field editable="1" name="field_time_auto"/>
-        <field editable="1" name="field_time_auto_cast"/>
-        <field editable="1" name="field_time_expr_now"/>
-        <field editable="1" name="field_time_expr_now_auto"/>
-        <field editable="1" name="field_timestamp"/>
-        <field editable="1" name="field_timestamp_auto"/>
-        <field editable="1" name="field_timestamp_auto_cast"/>
-        <field editable="1" name="field_timestamp_date_only"/>
-        <field editable="1" name="field_timestamp_date_only_auto"/>
-        <field editable="1" name="field_timestamp_date_only_expr_now"/>
-        <field editable="1" name="field_timestamp_date_only_expr_now_auto"/>
-        <field editable="1" name="field_timestamp_expr_now"/>
-        <field editable="1" name="field_timestamp_expr_now_auto"/>
-        <field editable="1" name="id"/>
+        <field editable="1" name="field_date"></field>
+        <field editable="1" name="field_date_auto"></field>
+        <field editable="1" name="field_date_auto_cast"></field>
+        <field editable="1" name="field_date_expr_now"></field>
+        <field editable="1" name="field_date_expr_now_auto"></field>
+        <field editable="1" name="field_time"></field>
+        <field editable="1" name="field_time_auto"></field>
+        <field editable="1" name="field_time_auto_cast"></field>
+        <field editable="1" name="field_time_expr_now"></field>
+        <field editable="1" name="field_time_expr_now_auto"></field>
+        <field editable="1" name="field_timestamp"></field>
+        <field editable="1" name="field_timestamp_auto"></field>
+        <field editable="1" name="field_timestamp_auto_cast"></field>
+        <field editable="1" name="field_timestamp_date_only"></field>
+        <field editable="1" name="field_timestamp_date_only_auto"></field>
+        <field editable="1" name="field_timestamp_date_only_expr_now"></field>
+        <field editable="1" name="field_timestamp_date_only_expr_now_auto"></field>
+        <field editable="1" name="field_timestamp_expr_now"></field>
+        <field editable="1" name="field_timestamp_expr_now_auto"></field>
+        <field editable="1" name="id"></field>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="field_date"/>
-        <field labelOnTop="0" name="field_date_auto"/>
-        <field labelOnTop="0" name="field_date_auto_cast"/>
-        <field labelOnTop="0" name="field_date_expr_now"/>
-        <field labelOnTop="0" name="field_date_expr_now_auto"/>
-        <field labelOnTop="0" name="field_time"/>
-        <field labelOnTop="0" name="field_time_auto"/>
-        <field labelOnTop="0" name="field_time_auto_cast"/>
-        <field labelOnTop="0" name="field_time_expr_now"/>
-        <field labelOnTop="0" name="field_time_expr_now_auto"/>
-        <field labelOnTop="0" name="field_timestamp"/>
-        <field labelOnTop="0" name="field_timestamp_auto"/>
-        <field labelOnTop="0" name="field_timestamp_auto_cast"/>
-        <field labelOnTop="0" name="field_timestamp_date_only"/>
-        <field labelOnTop="0" name="field_timestamp_date_only_auto"/>
-        <field labelOnTop="0" name="field_timestamp_date_only_expr_now"/>
-        <field labelOnTop="0" name="field_timestamp_date_only_expr_now_auto"/>
-        <field labelOnTop="0" name="field_timestamp_expr_now"/>
-        <field labelOnTop="0" name="field_timestamp_expr_now_auto"/>
-        <field labelOnTop="0" name="id"/>
+        <field labelOnTop="0" name="field_date"></field>
+        <field labelOnTop="0" name="field_date_auto"></field>
+        <field labelOnTop="0" name="field_date_auto_cast"></field>
+        <field labelOnTop="0" name="field_date_expr_now"></field>
+        <field labelOnTop="0" name="field_date_expr_now_auto"></field>
+        <field labelOnTop="0" name="field_time"></field>
+        <field labelOnTop="0" name="field_time_auto"></field>
+        <field labelOnTop="0" name="field_time_auto_cast"></field>
+        <field labelOnTop="0" name="field_time_expr_now"></field>
+        <field labelOnTop="0" name="field_time_expr_now_auto"></field>
+        <field labelOnTop="0" name="field_timestamp"></field>
+        <field labelOnTop="0" name="field_timestamp_auto"></field>
+        <field labelOnTop="0" name="field_timestamp_auto_cast"></field>
+        <field labelOnTop="0" name="field_timestamp_date_only"></field>
+        <field labelOnTop="0" name="field_timestamp_date_only_auto"></field>
+        <field labelOnTop="0" name="field_timestamp_date_only_expr_now"></field>
+        <field labelOnTop="0" name="field_timestamp_date_only_expr_now_auto"></field>
+        <field labelOnTop="0" name="field_timestamp_expr_now"></field>
+        <field labelOnTop="0" name="field_timestamp_expr_now_auto"></field>
+        <field labelOnTop="0" name="id"></field>
       </labelOnTop>
       <reuseLastValue>
-        <field reuseLastValue="0" name="field_date"/>
-        <field reuseLastValue="0" name="field_date_auto"/>
-        <field reuseLastValue="0" name="field_date_auto_cast"/>
-        <field reuseLastValue="0" name="field_date_expr_now"/>
-        <field reuseLastValue="0" name="field_date_expr_now_auto"/>
-        <field reuseLastValue="0" name="field_time"/>
-        <field reuseLastValue="0" name="field_time_auto"/>
-        <field reuseLastValue="0" name="field_time_auto_cast"/>
-        <field reuseLastValue="0" name="field_time_expr_now"/>
-        <field reuseLastValue="0" name="field_time_expr_now_auto"/>
-        <field reuseLastValue="0" name="field_timestamp"/>
-        <field reuseLastValue="0" name="field_timestamp_auto"/>
-        <field reuseLastValue="0" name="field_timestamp_auto_cast"/>
-        <field reuseLastValue="0" name="field_timestamp_date_only"/>
-        <field reuseLastValue="0" name="field_timestamp_date_only_auto"/>
-        <field reuseLastValue="0" name="field_timestamp_date_only_expr_now"/>
-        <field reuseLastValue="0" name="field_timestamp_date_only_expr_now_auto"/>
-        <field reuseLastValue="0" name="field_timestamp_expr_now"/>
-        <field reuseLastValue="0" name="field_timestamp_expr_now_auto"/>
-        <field reuseLastValue="0" name="id"/>
+        <field name="field_date" reuseLastValue="0"></field>
+        <field name="field_date_auto" reuseLastValue="0"></field>
+        <field name="field_date_auto_cast" reuseLastValue="0"></field>
+        <field name="field_date_expr_now" reuseLastValue="0"></field>
+        <field name="field_date_expr_now_auto" reuseLastValue="0"></field>
+        <field name="field_time" reuseLastValue="0"></field>
+        <field name="field_time_auto" reuseLastValue="0"></field>
+        <field name="field_time_auto_cast" reuseLastValue="0"></field>
+        <field name="field_time_expr_now" reuseLastValue="0"></field>
+        <field name="field_time_expr_now_auto" reuseLastValue="0"></field>
+        <field name="field_timestamp" reuseLastValue="0"></field>
+        <field name="field_timestamp_auto" reuseLastValue="0"></field>
+        <field name="field_timestamp_auto_cast" reuseLastValue="0"></field>
+        <field name="field_timestamp_date_only" reuseLastValue="0"></field>
+        <field name="field_timestamp_date_only_auto" reuseLastValue="0"></field>
+        <field name="field_timestamp_date_only_expr_now" reuseLastValue="0"></field>
+        <field name="field_timestamp_date_only_expr_now_auto" reuseLastValue="0"></field>
+        <field name="field_timestamp_expr_now" reuseLastValue="0"></field>
+        <field name="field_timestamp_expr_now_auto" reuseLastValue="0"></field>
+        <field name="id" reuseLastValue="0"></field>
       </reuseLastValue>
-      <dataDefinedFieldProperties/>
-      <widgets/>
+      <dataDefinedFieldProperties></dataDefinedFieldProperties>
+      <widgets></widgets>
       <previewExpression>"id"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
   </projectlayers>
   <layerorder>
-    <layer id="many_bool_formats_7aa4cb8a_09ae_4a5b_92e4_189a42ca3a2f"/>
-    <layer id="OpenStreetMap_5d079313_31ef_4014_a205_0a0113ff12e7"/>
+    <layer id="many_bool_formats_7aa4cb8a_09ae_4a5b_92e4_189a42ca3a2f"></layer>
+    <layer id="OpenStreetMap_5d079313_31ef_4014_a205_0a0113ff12e7"></layer>
   </layerorder>
   <properties>
-    <DefaultStyles/>
+    <DefaultStyles></DefaultStyles>
     <Digitizing>
       <AvoidIntersectionsMode type="int">2</AvoidIntersectionsMode>
     </Digitizing>
@@ -3444,12 +3519,12 @@ def my_form_open(dialog, layer, feature):
         <value>lizmap_user_groups</value>
       </variableNames>
       <variableValues type="QStringList">
-        <value>features</value>
+        <value></value>
         <value></value>
         <value></value>
       </variableValues>
     </Variables>
-    <WCSLayers type="QStringList"/>
+    <WCSLayers type="QStringList"></WCSLayers>
     <WCSUrl type="QString"></WCSUrl>
     <WFSLayers type="QStringList">
       <value>data_integers_ca1eb372_c518_4cc2_b2d8_c66d71b908a7</value>
@@ -3468,9 +3543,9 @@ def my_form_open(dialog, layer, feature):
       <many_date_formats_1a83b783_8ee0_49a8_bed3_480ecee12fb5 type="int">8</many_date_formats_1a83b783_8ee0_49a8_bed3_480ecee12fb5>
     </WFSLayersPrecision>
     <WFSTLayers>
-      <Delete type="QStringList"/>
-      <Insert type="QStringList"/>
-      <Update type="QStringList"/>
+      <Delete type="QStringList"></Delete>
+      <Insert type="QStringList"></Insert>
+      <Update type="QStringList"></Update>
     </WFSTLayers>
     <WFSUrl type="QString"></WFSUrl>
     <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
@@ -3505,23 +3580,23 @@ def my_form_open(dialog, layer, feature):
     <WMSUrl type="QString"></WMSUrl>
     <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
     <WMTSGrids>
-      <CRS type="QStringList"/>
-      <Config type="QStringList"/>
+      <CRS type="QStringList"></CRS>
+      <Config type="QStringList"></Config>
     </WMTSGrids>
     <WMTSJpegLayers>
-      <Group type="QStringList"/>
-      <Layer type="QStringList"/>
+      <Group type="QStringList"></Group>
+      <Layer type="QStringList"></Layer>
       <Project type="bool">false</Project>
     </WMTSJpegLayers>
     <WMTSLayers>
-      <Group type="QStringList"/>
-      <Layer type="QStringList"/>
+      <Group type="QStringList"></Group>
+      <Layer type="QStringList"></Layer>
       <Project type="bool">false</Project>
     </WMTSLayers>
     <WMTSMinScale type="int">5000</WMTSMinScale>
     <WMTSPngLayers>
-      <Group type="QStringList"/>
-      <Layer type="QStringList"/>
+      <Group type="QStringList"></Group>
+      <Layer type="QStringList"></Layer>
       <Project type="bool">false</Project>
     </WMTSPngLayers>
     <WMTSUrl type="QString"></WMTSUrl>
@@ -3541,13 +3616,13 @@ def my_form_open(dialog, layer, feature):
   </properties>
   <dataDefinedServerProperties>
     <Option type="Map">
-      <Option value="" name="name" type="QString"/>
-      <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="name" type="QString" value=""></Option>
+      <Option name="properties"></Option>
+      <Option name="type" type="QString" value="collection"></Option>
     </Option>
   </dataDefinedServerProperties>
-  <visibility-presets/>
-  <transformContext/>
+  <visibility-presets></visibility-presets>
+  <transformContext></transformContext>
   <projectMetadata>
     <identifier></identifier>
     <parentidentifier></parentidentifier>
@@ -3564,17 +3639,17 @@ def my_form_open(dialog, layer, feature):
       <email></email>
       <role></role>
     </contact>
-    <links/>
+    <links></links>
     <author>nboisteault</author>
     <creation>2020-12-07T10:34:58</creation>
   </projectMetadata>
-  <Annotations/>
-  <Layouts/>
-  <mapViewDocks3D/>
-  <Bookmarks/>
-  <ProjectViewSettings rotation="0" UseProjectScales="0">
-    <Scales/>
-    <DefaultViewExtent ymin="5001980.53581663593649864" xmin="734622.19786973821464926" xmax="1370343.53331974660977721" ymax="5386685.72563070245087147">
+  <Annotations></Annotations>
+  <Layouts></Layouts>
+  <mapViewDocks3D></mapViewDocks3D>
+  <Bookmarks></Bookmarks>
+  <ProjectViewSettings UseProjectScales="0" rotation="0">
+    <Scales></Scales>
+    <DefaultViewExtent xmax="1287869.03452002303674817" xmin="817096.69666946167126298" ymax="5426349.7634884649887681" ymin="4962316.49795887339860201">
       <spatialrefsys nativeFormat="Wkt">
         <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
         <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
@@ -3588,41 +3663,41 @@ def my_form_open(dialog, layer, feature):
       </spatialrefsys>
     </DefaultViewExtent>
   </ProjectViewSettings>
-  <ProjectStyleSettings DefaultSymbolOpacity="1" projectStyleId="attachment:///vRdVeF_styles.db" RandomizeDefaultSymbolColor="1">
-    <databases/>
+  <ProjectStyleSettings DefaultSymbolOpacity="1" RandomizeDefaultSymbolColor="1" projectStyleId="attachment:///VUvmLo_styles.db">
+    <databases></databases>
   </ProjectStyleSettings>
-  <ProjectTimeSettings frameRate="1" timeStepUnit="h" cumulativeTemporalRange="0" timeStep="1"/>
+  <ProjectTimeSettings cumulativeTemporalRange="0" frameRate="1" timeStep="1" timeStepUnit="h"></ProjectTimeSettings>
   <ElevationProperties>
     <terrainProvider type="flat">
-      <TerrainProvider offset="0" scale="1"/>
+      <TerrainProvider offset="0" scale="1"></TerrainProvider>
     </terrainProvider>
   </ElevationProperties>
-  <ProjectDisplaySettings CoordinateType="MapCrs" CoordinateAxisOrder="Default">
+  <ProjectDisplaySettings CoordinateAxisOrder="Default" CoordinateType="MapCrs">
     <BearingFormat id="bearing">
       <Option type="Map">
-        <Option name="decimal_separator" type="invalid"/>
-        <Option value="6" name="decimals" type="int"/>
-        <Option value="0" name="direction_format" type="int"/>
-        <Option value="0" name="rounding_type" type="int"/>
-        <Option value="false" name="show_plus" type="bool"/>
-        <Option value="true" name="show_thousand_separator" type="bool"/>
-        <Option value="false" name="show_trailing_zeros" type="bool"/>
-        <Option name="thousand_separator" type="invalid"/>
+        <Option name="decimal_separator" type="invalid"></Option>
+        <Option name="decimals" type="int" value="6"></Option>
+        <Option name="direction_format" type="int" value="0"></Option>
+        <Option name="rounding_type" type="int" value="0"></Option>
+        <Option name="show_plus" type="bool" value="false"></Option>
+        <Option name="show_thousand_separator" type="bool" value="true"></Option>
+        <Option name="show_trailing_zeros" type="bool" value="false"></Option>
+        <Option name="thousand_separator" type="invalid"></Option>
       </Option>
     </BearingFormat>
     <GeographicCoordinateFormat id="geographiccoordinate">
       <Option type="Map">
-        <Option value="DecimalDegrees" name="angle_format" type="QString"/>
-        <Option name="decimal_separator" type="invalid"/>
-        <Option value="6" name="decimals" type="int"/>
-        <Option value="0" name="rounding_type" type="int"/>
-        <Option value="false" name="show_leading_degree_zeros" type="bool"/>
-        <Option value="false" name="show_leading_zeros" type="bool"/>
-        <Option value="false" name="show_plus" type="bool"/>
-        <Option value="true" name="show_suffix" type="bool"/>
-        <Option value="true" name="show_thousand_separator" type="bool"/>
-        <Option value="false" name="show_trailing_zeros" type="bool"/>
-        <Option name="thousand_separator" type="invalid"/>
+        <Option name="angle_format" type="QString" value="DecimalDegrees"></Option>
+        <Option name="decimal_separator" type="invalid"></Option>
+        <Option name="decimals" type="int" value="6"></Option>
+        <Option name="rounding_type" type="int" value="0"></Option>
+        <Option name="show_leading_degree_zeros" type="bool" value="false"></Option>
+        <Option name="show_leading_zeros" type="bool" value="false"></Option>
+        <Option name="show_plus" type="bool" value="false"></Option>
+        <Option name="show_suffix" type="bool" value="true"></Option>
+        <Option name="show_thousand_separator" type="bool" value="true"></Option>
+        <Option name="show_trailing_zeros" type="bool" value="false"></Option>
+        <Option name="thousand_separator" type="invalid"></Option>
       </Option>
     </GeographicCoordinateFormat>
     <CoordinateCustomCrs>

--- a/tests/qgis-projects/tests/form_edition_all_field_type.qgs.cfg
+++ b/tests/qgis-projects/tests/form_edition_all_field_type.qgs.cfg
@@ -1,15 +1,13 @@
 {
     "metadata": {
-        "qgis_desktop_version": 32810,
-        "lizmap_plugin_version_str": "3.16.5-alpha",
-        "lizmap_plugin_version": 31605,
-        "lizmap_web_client_target_version": 30700,
-        "lizmap_web_client_target_status": "Dev",
-        "instance_target_url": "https://cookie.org/",
-        "instance_target_repository": "features",
-        "project_valid": true
+        "qgis_desktop_version": 32812,
+        "lizmap_plugin_version_str": "4.0.2-alpha",
+        "lizmap_plugin_version": 40002,
+        "lizmap_web_client_target_version": 30800,
+        "lizmap_web_client_target_status": "Stable",
+        "instance_target_url": "http://lizmap.local:8130/"
     },
-    "warnings": [],
+    "warnings": {},
     "options": {
         "projection": {
             "proj4": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs",
@@ -31,11 +29,13 @@
         ],
         "minScale": 10000,
         "maxScale": 500000,
+        "use_native_zoom_levels": false,
+        "hide_numeric_scale_value": true,
         "initialExtent": [
-            7.340104512217499,
-            40.9297175279041,
-            11.569124376535866,
-            43.48889841252614
+            7.3401,
+            40.9297,
+            11.5691,
+            43.4889
         ],
         "popupLocation": "dock",
         "pointTolerance": 25,
@@ -361,6 +361,7 @@
         },
         "form_edition_upload": {
             "layerId": "form_edition_upload_65de30e9_0bab_44f1_9a3d_b2bf9f47a204",
+            "snap_layers": [],
             "snap_vertices": "False",
             "snap_segments": "False",
             "snap_intersections": "False",


### PR DESCRIPTION
In QGIS editing form configuration, a file-based field (image or generic file) can be set up with an expression to calculate the target directory where the file must be stored. For example:

```sql
-- Here the target directory is calculated based on the value of the field "feature_code" in the form
concat(
	'media/some_target_folder/',
	CASE
		WHEN lower(trim(to_string(current_value('feature_code')))) IN ('', 'null') OR current_value('feature_code') IS NULL 
			THEN 'no_code'
		ELSE trim(to_string(current_value('feature_code')))
	END,
	'/'
)
```

This piece of code adds the same capability in Lizmap Web Client.

Funded by Cartophyl https://www.cartophyl.com/
