### PR TITLE
Increase `uploadedImageMaxWidthHeight` value for 4K screens

### DIFF
--- a/lizmap/modules/admin/forms/config_services.form.xml
+++ b/lizmap/modules/admin/forms/config_services.form.xml
@@ -164,7 +164,7 @@
     </input>
 
     <!-- uploaded images properties -->
-    <input ref="uploadedImageMaxWidthHeight" type="integer" minvalue="480" maxvalue="3840">
+    <input ref="uploadedImageMaxWidthHeight" type="integer" minvalue="480" maxvalue="4224">
         <label locale="admin~admin.form.admin_services.uploadedImageMaxWidthHeight.label"/>
         <help locale="admin~admin.form.admin_services.uploadedImageMaxWidthHeight.help"/>
     </input>

--- a/lizmap/modules/lizmap/classes/lizmapServices.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapServices.class.php
@@ -207,7 +207,7 @@ class lizmapServices
     // application id for google analytics
     public $googleAnalyticsID = '';
 
-    public $uploadedImageMaxWidthHeight = 1920;
+    public $uploadedImageMaxWidthHeight = 4224;
 
     /**
      * @var bool|int true/1 if metrics should be sent to the metric logger

--- a/tests/units/classes/lizmapServicesTest.php
+++ b/tests/units/classes/lizmapServicesTest.php
@@ -266,11 +266,11 @@ class lizmapServicesTest extends TestCase
         $ini1 = array(
             'appName' => 'Lizmap',
             'adminContactEmail' => 'test.test@test.com',
-            'uploadedImageMaxWidthHeight' => 1920
+            'uploadedImageMaxWidthHeight' => 4224
         );
         $ini1_1 = array(
             'appName' => 'Lizmap',
-            'uploadedImageMaxWidthHeight' => 1920
+            'uploadedImageMaxWidthHeight' => 4224
         );
         $ini2 = array(
             'webmasterName' => 'Adrien',


### PR DESCRIPTION
Many people now have a 4K screen of smartphones w/ big resolution In Lizmap 3.7 the WMS getMap requests has a ratio of 1.1 so we need to set `4224` as the default value.
Many admin don't know `uploadedImageMaxWidthHeight` exists so they don't increase its value, so I prefer to put a high value as default

Funded by 3Liz
