### PR TITLE
Fix: `display_when_layer_visible` only useful for layers w/ geometry

### DIFF
--- a/lizmap/www/assets/js/dataviz/dataviz.js
+++ b/lizmap/www/assets/js/dataviz/dataviz.js
@@ -720,6 +720,11 @@ let lizDataviz = function () {
                 // OpenLayers configuration
                 let layerConfig = getLayerConfig[1];
 
+                // Layer needs a geometry to be visible
+                if (layerConfig.geometryType === "none") {
+                    return;
+                }
+
                 // Get the associated layer
                 const layer = lizMap.mainLizmap.state.rootMapGroup.getMapLayerByName(layerConfig.name);
                 if (layer) {


### PR DESCRIPTION
Funded by 3Liz
