### PR TITLE
[Bugfix] Too many embedded layers cause php to hit max_execution_time 

### DIFF
--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -581,15 +581,28 @@ class QgisProject
      *
      * @deprecated
      *
-     * @param mixed $layerId
+     * @param mixed      $layerId
+     * @param null|array $embeddedRelationsProjects reference to associative array path(key) - QgisProject instance (value)
      *
      * @return \SimpleXMLElement[]
      */
-    public function getXmlLayer($layerId)
+    public function getXmlLayer($layerId, &$embeddedRelationsProjects = null)
     {
         $layer = $this->getLayerDefinition($layerId);
         if ($layer && array_key_exists('embedded', $layer) && $layer['embedded'] == 1) {
-            $qgsProj = new QgisProject(realpath(dirname($this->path).DIRECTORY_SEPARATOR.$layer['projectPath']), $this->services, $this->appContext);
+            // avoid reloading the same qgis project multiple times while reading relations by checking embeddedRelationsProjects param
+            // If this array is null or does not contains the corresponding qgis project, then the function if forced to load a new qgis project
+            if ($embeddedRelationsProjects && array_key_exists($layer['projectPath'], $embeddedRelationsProjects)) {
+                // use QgisProject instance already created
+                $qgsProj = $embeddedRelationsProjects[$layer['projectPath']];
+            } else {
+                // create new QgisProject instance
+                $qgsProj = new QgisProject(realpath(dirname($this->path).DIRECTORY_SEPARATOR.$layer['projectPath']), $this->services, $this->appContext);
+                // update the array, if exists
+                if ($embeddedRelationsProjects) {
+                    $embeddedRelationsProjects[$layer['projectPath']] = $qgsProj;
+                }
+            }
 
             return $qgsProj->getXml()->xpath("//maplayer[id='{$layerId}']");
         }
@@ -1336,11 +1349,15 @@ class QgisProject
         $pivotGather = array();
         $pivot = array();
         if ($xmlRelations) {
+            // Store qgisProjects references in a key=>value array and pass it by reference along the methods that loads and validates relations.
+            // This avoid to reload the same QgisProject instance multiple times, if there are many "embedded relations" referencing the same (embedded) qgis project
+            $embeddedRelationsProjects = array();
+
             /** @var \SimpleXMLElement $relation */
             foreach ($xmlRelations[0] as $relation) {
                 $relationObj = $relation->attributes();
 
-                $relationField = $this->readRelationField($relation);
+                $relationField = $this->readRelationField($relation, $embeddedRelationsProjects);
                 if ($relationField === null) {
                     // no corresponding layer
                     continue;
@@ -1384,12 +1401,13 @@ class QgisProject
 
     /**
      * @param \SimpleXMLElement $relationXml
+     * @param null|array        $embeddedRelationsProjects
      */
-    protected function readRelationField($relationXml)
+    protected function readRelationField($relationXml, &$embeddedRelationsProjects = null)
     {
         $referencedLayerId = $relationXml->attributes()->referencedLayer;
 
-        $_referencedLayerXml = $this->getXmlLayer($referencedLayerId);
+        $_referencedLayerXml = $this->getXmlLayer($referencedLayerId, $embeddedRelationsProjects);
         if (count($_referencedLayerXml) == 0) {
             return null;
         }


### PR DESCRIPTION
There are cases where a project might embed several layers from another project. 

In this scenario Lizmap [loads](https://github.com/3liz/lizmap-web-client/blob/1b302d40f667706f05f4f4b0e8882720a779449f/lizmap/modules/lizmap/lib/Project/QgisProject.php#L1494) the same project (embedded project) multiple times for each of these layers and this behavior could cause php to hit `max_execution_time` if there are many embedded layers.

To fix that I've grouped the embedded layers and load the related QGIS embedded project once.

**Test note**
I haven't add php unit tests since seems to me that the current tests already covers this changes. Of course, if you think that more tests are needed, I'll add them.

Funded by Faunalia
