### PR TITLE
Enable WMTS requests for Lizmap baselayers

### DIFF
--- a/tests/js-units/data/tiled_baselayers-capabilities.json
+++ b/tests/js-units/data/tiled_baselayers-capabilities.json
@@ -1,0 +1,369 @@
+{
+    "version": "1.3.0",
+    "Service": {
+      "Name": "WMS",
+      "Title": "tiled_baselayers",
+      "KeywordList": [
+        "infoMapAccessService"
+      ],
+      "OnlineResource": "http://localhost:8130/index.php/lizmap/service?repository=testsrepository&project=baselayers_tiles",
+      "Fees": "conditions unknown",
+      "AccessConstraints": "None",
+      "MaxWidth": 3000,
+      "MaxHeight": 3000
+    },
+    "Capability": {
+      "Request": {
+        "GetCapabilities": {
+          "Format": [
+            "text/xml"
+          ],
+          "DCPType": [
+            {
+              "HTTP": {
+                "Get": {
+                  "OnlineResource": "http://localhost:8130/index.php/lizmap/service?repository=testsrepository&project=baselayers_tiles&"
+                }
+              }
+            }
+          ]
+        },
+        "GetMap": {
+          "Format": [
+            "image/jpeg",
+            "image/png",
+            "image/png; mode=16bit",
+            "image/png; mode=8bit",
+            "image/png; mode=1bit",
+            "application/dxf"
+          ],
+          "DCPType": [
+            {
+              "HTTP": {
+                "Get": {
+                  "OnlineResource": "http://localhost:8130/index.php/lizmap/service?repository=testsrepository&project=baselayers_tiles&"
+                }
+              }
+            }
+          ]
+        },
+        "GetFeatureInfo": {
+          "Format": [
+            "text/plain",
+            "text/html",
+            "text/xml",
+            "application/vnd.ogc.gml",
+            "application/vnd.ogc.gml/3.1.1",
+            "application/json",
+            "application/geo+json"
+          ],
+          "DCPType": [
+            {
+              "HTTP": {
+                "Get": {
+                  "OnlineResource": "http://localhost:8130/index.php/lizmap/service?repository=testsrepository&project=baselayers_tiles&"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "Exception": [
+        "XML"
+      ],
+      "Layer": {
+        "Name": "tiled_baselayers",
+        "Title": "tiled_baselayers",
+        "KeywordList": [
+          "infoMapAccessService"
+        ],
+        "CRS": [
+          "CRS:84",
+          "EPSG:3857",
+          "EPSG:4326"
+        ],
+        "EX_GeographicBoundingBox": [
+          11.957813,
+          44.31983,
+          12.436779,
+          44.523769
+        ],
+        "BoundingBox": [
+          {
+            "crs": "EPSG:4326",
+            "extent": [
+              44.31983,
+              11.957813,
+              44.523769,
+              12.436779
+            ],
+            "res": [
+              null,
+              null
+            ]
+          },
+          {
+            "crs": "EPSG:3857",
+            "extent": [
+              1331137.665,
+              5515070.854,
+              1384455.827,
+              5546857.617
+            ],
+            "res": [
+              null,
+              null
+            ]
+          }
+        ],
+        "Layer": [
+          {
+            "Name": "baseLayers",
+            "Title": "baseLayers",
+            "CRS": [
+              "CRS:84",
+              "EPSG:3857",
+              "EPSG:4326",
+              "CRS:84",
+              "EPSG:3857",
+              "EPSG:4326"
+            ],
+            "EX_GeographicBoundingBox": [
+              -180,
+              -85.051129,
+              180,
+              85.05113
+            ],
+            "BoundingBox": [
+              {
+                "crs": "EPSG:4326",
+                "extent": [
+                  -85.051129,
+                  -180,
+                  85.05113,
+                  180
+                ],
+                "res": [
+                  null,
+                  null
+                ]
+              },
+              {
+                "crs": "EPSG:3857",
+                "extent": [
+                  -20037508.343,
+                  -20037508.627,
+                  20037508.343,
+                  20037508.627
+                ],
+                "res": [
+                  null,
+                  null
+                ]
+              }
+            ],
+            "Layer": [
+              {
+                "Name": "wms_baselayer",
+                "Title": "wms_baselayer",
+                "CRS": [
+                  "CRS:84",
+                  "EPSG:3857",
+                  "EPSG:4326",
+                  "CRS:84",
+                  "EPSG:3857",
+                  "EPSG:4326"
+                ],
+                "EX_GeographicBoundingBox": [
+                  11.971348,
+                  44.340131,
+                  12.377399,
+                  44.498238
+                ],
+                "BoundingBox": [
+                  {
+                    "crs": "EPSG:4326",
+                    "extent": [
+                      44.340131,
+                      11.971348,
+                      44.498238,
+                      12.377399
+                    ],
+                    "res": [
+                      null,
+                      null
+                    ]
+                  },
+                  {
+                    "crs": "EPSG:3857",
+                    "extent": [
+                      1332644.377,
+                      5518230.089,
+                      1377845.736,
+                      5542872.12
+                    ],
+                    "res": [
+                      null,
+                      null
+                    ]
+                  }
+                ],
+                "Style": [
+                  {
+                    "Name": "default",
+                    "Title": "default",
+                    "LegendURL": [
+                      {
+                        "Format": "image/png",
+                        "OnlineResource": "http://localhost:8130/index.php/lizmap/service?repository=testsrepository&project=baselayers_tiles&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetLegendGraphic&LAYER=wms_baselayer&FORMAT=image/png&STYLE=default&SLD_VERSION=1.1.0",
+                        "size": [
+                          null,
+                          null
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "queryable": true,
+                "opaque": false,
+                "noSubsets": false
+              },
+              {
+                "Name": "tiled_baselayer",
+                "Title": "tiled_baselayer",
+                "CRS": [
+                  "CRS:84",
+                  "EPSG:3857",
+                  "EPSG:4326",
+                  "CRS:84",
+                  "EPSG:3857",
+                  "EPSG:4326"
+                ],
+                "EX_GeographicBoundingBox": [
+                  11.97746,
+                  44.334822,
+                  12.424554,
+                  44.502909
+                ],
+                "BoundingBox": [
+                  {
+                    "crs": "EPSG:4326",
+                    "extent": [
+                      44.334822,
+                      11.97746,
+                      44.502909,
+                      12.424554
+                    ],
+                    "res": [
+                      null,
+                      null
+                    ]
+                  },
+                  {
+                    "crs": "EPSG:3857",
+                    "extent": [
+                      1333324.827,
+                      5517403.827,
+                      1383094.926,
+                      5543601.175
+                    ],
+                    "res": [
+                      null,
+                      null
+                    ]
+                  }
+                ],
+                "Style": [
+                  {
+                    "Name": "default",
+                    "Title": "default",
+                    "LegendURL": [
+                      {
+                        "Format": "image/png",
+                        "OnlineResource": "http://localhost:8130/index.php/lizmap/service?repository=testsrepository&project=baselayers_tiles&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetLegendGraphic&LAYER=tiled_baselayer&FORMAT=image/png&STYLE=default&SLD_VERSION=1.1.0",
+                        "size": [
+                          null,
+                          null
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "queryable": true,
+                "opaque": false,
+                "noSubsets": false
+              },
+              {
+                "Name": "OpenStreetMap",
+                "Title": "OpenStreetMap",
+                "CRS": [
+                  "CRS:84",
+                  "EPSG:3857",
+                  "EPSG:4326",
+                  "CRS:84",
+                  "EPSG:3857",
+                  "EPSG:4326"
+                ],
+                "EX_GeographicBoundingBox": [
+                  -180,
+                  -85.051129,
+                  180,
+                  85.051129
+                ],
+                "BoundingBox": [
+                  {
+                    "crs": "EPSG:4326",
+                    "extent": [
+                      -85.051129,
+                      -180,
+                      85.051129,
+                      180
+                    ],
+                    "res": [
+                      null,
+                      null
+                    ]
+                  },
+                  {
+                    "crs": "EPSG:3857",
+                    "extent": [
+                      -20037508.343,
+                      -20037508.343,
+                      20037508.343,
+                      20037508.343
+                    ],
+                    "res": [
+                      null,
+                      null
+                    ]
+                  }
+                ],
+                "Style": [
+                  {
+                    "Name": "default",
+                    "Title": "default",
+                    "LegendURL": [
+                      {
+                        "Format": "image/png",
+                        "OnlineResource": "http://localhost:8130/index.php/lizmap/service?repository=testsrepository&project=baselayers_tiles&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetLegendGraphic&LAYER=OpenStreetMap&FORMAT=image/png&STYLE=default&SLD_VERSION=1.1.0",
+                        "size": [
+                          null,
+                          null
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "queryable": true,
+                "opaque": false,
+                "noSubsets": false
+              }
+            ],
+            "queryable": true,
+            "opaque": false,
+            "noSubsets": false
+          }
+        ]
+      }
+    }
+  }

--- a/tests/js-units/data/tiled_baselayers-config.json
+++ b/tests/js-units/data/tiled_baselayers-config.json
@@ -1,0 +1,173 @@
+{
+    "metadata": {
+        "qgis_desktop_version": 32815,
+        "lizmap_plugin_version_str": "4.0.1",
+        "lizmap_plugin_version": 40001,
+        "lizmap_web_client_target_version": 30800,
+        "lizmap_web_client_target_status": "Dev",
+        "instance_target_url": "http://localhost:8130/",
+        "instance_target_repository": "intranet"
+    },
+    "warnings": {},
+    "options": {
+        "projection": {
+            "proj4": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs",
+            "ref": "EPSG:3857"
+        },
+        "bbox": [
+            "1331137.66540000005625188",
+            "5515070.85429999977350235",
+            "1384455.82700000004842877",
+            "5546857.61610000021755695"
+        ],
+        "mapScales": [
+            10000,
+            25000,
+            50000,
+            100000,
+            250000,
+            500000
+        ],
+        "minScale": 1,
+        "maxScale": 1000000000,
+        "initialExtent": [
+            1331137.6654,
+            5515070.8543,
+            1384455.827,
+            5546857.6161
+        ],
+        "popupLocation": "dock",
+        "pointTolerance": 25,
+        "lineTolerance": 10,
+        "polygonTolerance": 5,
+        "tmTimeFrameSize": 10,
+        "tmTimeFrameType": "seconds",
+        "tmAnimationFrameLength": 1000,
+        "datavizLocation": "dock",
+        "theme": "dark",
+        "fixed_scale_overview_map": true,
+        "dataviz_drag_drop": []
+    },
+    "layers": {
+        "baseLayers": {
+            "id": "baseLayers",
+            "name": "baseLayers",
+            "type": "group",
+            "title": "baseLayers",
+            "abstract": "",
+            "link": "",
+            "minScale": 1,
+            "maxScale": 1000000000000,
+            "toggled": "True",
+            "popup": "False",
+            "popupSource": "auto",
+            "popupTemplate": "",
+            "popupMaxFeatures": 10,
+            "popupDisplayChildren": "False",
+            "popup_allow_download": true,
+            "legend_image_option": "hide_at_startup",
+            "groupAsLayer": "False",
+            "baseLayer": "False",
+            "displayInLegend": "True",
+            "group_visibility": [],
+            "singleTile": "True",
+            "imageFormat": "image/png",
+            "cached": "False",
+            "clientCacheExpiration": 300
+        },
+        "wms_baselayer": {
+            "id": "wms_baselayer_bb968bb4_8c20_44bc_9fdf_0b61c9ed1e4e",
+            "name": "wms_baselayer",
+            "type": "layer",
+            "geometryType": "polygon",
+            "extent": [
+                11.971348125039231,
+                44.34013155074235,
+                12.377398836894544,
+                44.49823744527483
+            ],
+            "crs": "EPSG:4326",
+            "title": "wms_baselayer",
+            "abstract": "",
+            "link": "",
+            "minScale": 1,
+            "maxScale": 1000000000000,
+            "toggled": "False",
+            "popup": "False",
+            "popupSource": "auto",
+            "popupTemplate": "",
+            "popupMaxFeatures": 10,
+            "popupDisplayChildren": "False",
+            "popup_allow_download": true,
+            "legend_image_option": "hide_at_startup",
+            "groupAsLayer": "False",
+            "baseLayer": "False",
+            "displayInLegend": "True",
+            "group_visibility": [],
+            "singleTile": "True",
+            "imageFormat": "image/png",
+            "cached": "False",
+            "clientCacheExpiration": 300
+        },
+        "tiled_baselayer": {
+            "id": "tiled_baselayer_97a1e74a_5e80_4ac5_a5f3_4ff8cceca2aa",
+            "name": "tiled_baselayer",
+            "type": "layer",
+            "geometryType": "polygon",
+            "extent": [
+                1333324.8279461411,
+                5517403.827637763,
+                1383094.9258853875,
+                5543601.174111643
+            ],
+            "crs": "EPSG:3857",
+            "title": "tiled_baselayer",
+            "abstract": "",
+            "link": "",
+            "minScale": 1,
+            "maxScale": 1000000000000,
+            "toggled": "False",
+            "popup": "False",
+            "popupSource": "auto",
+            "popupTemplate": "",
+            "popupMaxFeatures": 10,
+            "popupDisplayChildren": "False",
+            "popup_allow_download": true,
+            "legend_image_option": "hide_at_startup",
+            "groupAsLayer": "False",
+            "baseLayer": "False",
+            "displayInLegend": "True",
+            "group_visibility": [],
+            "singleTile": "False",
+            "imageFormat": "image/png",
+            "cached": "True",
+            "cacheExpiration": 0,
+            "clientCacheExpiration": 300
+        }
+    },
+    "atlas": {
+        "layers": []
+    },
+    "locateByLayer": {},
+    "attributeLayers": {},
+    "tooltipLayers": {},
+    "editionLayers": {},
+    "layouts": {
+        "config": {
+            "default_popup_print": false
+        },
+        "list": []
+    },
+    "loginFilteredLayers": {},
+    "timemanagerLayers": {},
+    "datavizLayers": {},
+    "filter_by_polygon": {
+        "config": {
+            "polygon_layer_id": "tiled_baselayer_97a1e74a_5e80_4ac5_a5f3_4ff8cceca2aa",
+            "group_field": "id",
+            "filter_by_user": false
+        },
+        "layers": []
+    },
+    "formFilterLayers": {}
+}

--- a/tests/js-units/node/state/baselayer.test.js
+++ b/tests/js-units/node/state/baselayer.test.js
@@ -261,4 +261,33 @@ describe('BaseLayersState', function () {
             ])
     });
 
+    it('Tiled baselayer', function () {
+        const baseLayers = getBaseLayersState('tiled_baselayers')
+        expect(baseLayers.selectedBaseLayerName).to.be.eq('wms_baselayer')
+        expect(baseLayers.selectedBaseLayer).to.not.be.undefined
+        expect(baseLayers.selectedBaseLayer.name).to.be.eq('wms_baselayer')
+        expect(baseLayers.baseLayerNames).to.be.an('array')
+        .that.have.length(2)
+        .that.be.deep.eq([
+            "wms_baselayer",
+            "tiled_baselayer",
+        ])
+
+        expect(baseLayers.baseLayers.map(l => l.type))
+            .to.be.an('array')
+            .that.have.length(2)
+            .that.ordered.members([
+                BaseLayerTypes.Lizmap,
+                BaseLayerTypes.Lizmap,
+        ])
+
+        expect(baseLayers.baseLayers.map(l => l.layerConfig.cached))
+        .to.be.an('array')
+        .that.have.length(2)
+        .that.ordered.members([
+            false,
+            true,
+    ])
+    })
+
 })


### PR DESCRIPTION
Reading the `cached` property on baselayers from Lizmap configuration to enable WMTS on baselayers.

Funded by Faunalia
