### PR TITLE
[Backport release_3_6] [Bugfix] JS Attribute Table: using wmsName for getFeaturePopupContent

### DIFF
--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -5288,6 +5288,14 @@ window.lizMap = function() {
           qgisName = lizMap.getLayerNameByCleanName(aName);
       }
 
+      var layerConfig = null;
+      if (qgisName in lizMap.config.layers) {
+          layerConfig = lizMap.config.layers[qgisName];
+      }
+
+      if( !layerConfig )
+          return false;
+
       var pkey = null;
       // Get primary key with attributelayer options
       if( (qgisName in lizMap.config.attributeLayers) ){
@@ -5297,7 +5305,6 @@ window.lizMap = function() {
       // Test if primary key is set in the atlas tool
       // Atlas config with one layer (legacy)
       if( !pkey && 'atlasLayer' in lizMap.config.options && 'atlasPrimaryKey' in lizMap.config.options ){
-        var layerConfig = lizMap.config.layers[qgisName];
         if( layerConfig.id == lizMap.config.options['atlasLayer'] && lizMap.config.options['atlasPrimaryKey'] != '' ){
           pkey = lizMap.config.options['atlasPrimaryKey'];
         }
@@ -5305,7 +5312,6 @@ window.lizMap = function() {
 
       // Atlas config with several layers (LWC >= 3.4)
       if (!pkey && 'atlas' in lizMap.config && 'layers' in lizMap.config.atlas && Array.isArray(lizMap.config.atlas['layers']) && lizMap.config.atlas['layers'].length > 0) {
-        const layerConfig = lizMap.config.layers[qgisName];
         for (let index = 0; index < lizMap.config.atlas.layers.length; index++) {
           const layer = lizMap.config.atlas.layers[index];
           if (layerConfig.id === layer.layer){
@@ -5319,7 +5325,9 @@ window.lizMap = function() {
           return false;
 
       var pkVal = feat.properties[pkey];
-      filter = aName + ':"' + pkey + '" = ' + "'" + pkVal + "'" ;
+
+      const wmsName = layerConfig?.shortname || layerConfig?.name || qgisName;
+      filter = wmsName + ':"' + pkey + '" = ' + "'" + pkVal + "'" ;
 
       var crs = 'EPSG:4326';
       if(('crs' in lizMap.config.layers[qgisName]) && lizMap.config.layers[qgisName].crs != ''){
@@ -5327,8 +5335,8 @@ window.lizMap = function() {
       }
 
       var wmsOptions = {
-           'LAYERS': aName
-          ,'QUERY_LAYERS': aName
+           'LAYERS': wmsName
+          ,'QUERY_LAYERS': wmsName
           ,'STYLES': ''
           ,'SERVICE': 'WMS'
           ,'VERSION': '1.3.0'


### PR DESCRIPTION
Backport https://github.com/3liz/lizmap-web-client/pull/4102