### PR TITLE
[Bugfix] Child Attribute table: get parent layer name

### DIFF
--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -1307,15 +1307,18 @@ var lizAttributeTable = function() {
                 if (['#attribute-layer-table-', '#edition-table-'].includes(aTable.replace(cleanName, ''))){
                     isChild = false;
                 }else{
-                    let parentLayerName = '';
+                    let parentLayerCleanName = '';
                     if (aTable.startsWith('#attribute-layer-table-')){
-                        parentLayerName =  aTable.replace('#attribute-layer-table-', '').split('-')[0];
+                        parentLayerCleanName =  aTable.replace('#attribute-layer-table-', '').split('-')[0];
                     } else if (aTable.startsWith('#edition-table-')) {
-                        parentLayerName = aTable.replace('#edition-table-', '').split('-')[0];
+                        parentLayerCleanName = aTable.replace('#edition-table-', '').split('-')[0];
                     }
 
-                    if(parentLayerName){
-                        parentLayerID = config.layers[parentLayerName]['id'];
+                    if(parentLayerCleanName){
+                        const parentLayerName = lizMap.getLayerNameByCleanName(parentLayerCleanName);
+                        if (parentLayerName) {
+                            parentLayerID = config.layers[parentLayerName]['id'];
+                        }
                     }
                 }
 


### PR DESCRIPTION
The table selector uses layer clean name and not the layer name

Funded by Terre de Provence Agglomération