### PR TITLE
Force EPSG:3857 if old baselayers in config

### DIFF
--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -640,6 +640,7 @@ window.lizMap = function() {
             Proj4js.defs['EPSG:3857'] = Proj4js.defs['EPSG:900913'];
         }
 
+        // Check config projection
         var proj = config.options.projection;
         if (proj.ref) {
             if ( !(proj.ref in Proj4js.defs) ) {
@@ -648,6 +649,39 @@ window.lizMap = function() {
             // Build proj
             new OpenLayers.Projection(proj.ref);
         } else {
+            proj.ref = 'EPSG:3857';
+            proj.proj4 = Proj4js.defs['EPSG:3857'];
+        }
+
+        // Force projection if config contains old external baselayers
+        // To be removed when baselayers only in the tree
+        if ('osmMapnik' in config.options
+            || 'osmStamenToner' in config.options
+            || 'openTopoMap' in config.options
+            || 'osmCyclemap' in config.options
+            || 'googleStreets' in config.options
+            || 'googleSatellite' in config.options
+            || 'googleHybrid' in config.options
+            || 'googleTerrain' in config.options
+            || 'bingStreets' in config.options
+            || 'bingSatellite' in config.options
+            || 'bingHybrid' in config.options
+            || 'ignTerrain' in config.options
+            || 'ignStreets' in config.options
+            || 'ignSatellite' in config.options
+            || 'ignCadastral' in config.options) {
+            // get projection
+            var projection = new OpenLayers.Projection(proj.ref);
+
+            // get and define the max extent
+            var bbox = config.options.bbox;
+            var initialBbox = config.options.initialExtent;
+            var extent = new OpenLayers.Bounds(Number(bbox[0]),Number(bbox[1]),Number(bbox[2]),Number(bbox[3]));
+            var initialExtent = new OpenLayers.Bounds(Number(initialBbox[0]),Number(initialBbox[1]),Number(initialBbox[2]),Number(initialBbox[3]));
+            extent.transform(projection, 'EPSG:3857');
+            initialExtent.transform(projection, 'EPSG:3857');
+            config.options.bbox = extent.toArray();
+            config.options.initialExtent = initialExtent.toArray();
             proj.ref = 'EPSG:3857';
             proj.proj4 = Proj4js.defs['EPSG:3857'];
         }

--- a/tests/end2end/playwright/overview.spec.ts
+++ b/tests/end2end/playwright/overview.spec.ts
@@ -61,6 +61,6 @@ test.describe('Overview', () => {
         expect(requestUrl).toContain('STYLES=');
         expect(requestUrl).toContain('WIDTH=232');
         expect(requestUrl).toContain('HEIGHT=110');
-        expect(requestUrl).toContain('BBOX=411699.32695692923%2C5396012.897530646%2C450848.73212012084%2C5414575.115495953');
+        expect(requestUrl).toContain('BBOX=411699.3269569552%2C5396012.897530658%2C450848.7321200949%2C5414575.115495941');
     });
 });


### PR DESCRIPTION
To keep the same display as lizmap web client 3.6, if the contains old baselayers, the map will be displayed with EPSG:3857
