### PR TITLE
[Bugfix] JS: do not refresh child layer not displayed in map

### DIFF
--- a/assets/src/legacy/edition.js
+++ b/assets/src/legacy/edition.js
@@ -582,14 +582,14 @@ var lizEdition = function() {
                 continue;
 
             var qgisName = childLayerConfig[0];
-            var childLayerConfig = childLayerConfig[1];
+            childLayerConfig = childLayerConfig[1];
 
             if (!('geometryType' in childLayerConfig) || childLayerConfig.geometryType == 'none')
                 continue;
 
             const olLayer = lizMap.mainLizmap.map.getLayerByName(qgisName);
 
-            if (!olLayer.getVisible()) {
+            if (olLayer === undefined || !olLayer.getVisible()) {
                 continue;
             }
 

--- a/assets/src/modules/map.js
+++ b/assets/src/modules/map.js
@@ -719,6 +719,7 @@ export default class map extends olMap {
      * Return overlay layer if `name` matches.
      * `name` is unique for every layers
      * @param name
+     * @returns {Layer|undefined}
      */
     getLayerByName(name){
         return this.overlayLayers.find(
@@ -730,6 +731,7 @@ export default class map extends olMap {
      * Return overlay layer or group if `name` matches.
      * `name` is unique for every layers/groups
      * @param name
+     * @returns {Layer|LayerGroup|undefined}
      */
     getLayerOrGroupByName(name){
         return this.overlayLayersAndGroups.find(


### PR DESCRIPTION
Child layer could be attribute table without display in map.

Funded by Ville d'Avignon