### PR TITLE
[Bugfix] Resolutions from OL2 map

### DIFF
--- a/assets/src/modules/map.js
+++ b/assets/src/modules/map.js
@@ -34,10 +34,16 @@ export default class map extends olMap {
     constructor() {
         const qgisProjectProjection = mainLizmap.projection;
         const mapProjection = getProjection(qgisProjectProjection);
+
+        // Get resolutions from OL2 map
         let resolutions = mainLizmap.lizmap3.map.resolutions ? mainLizmap.lizmap3.map.resolutions : mainLizmap.lizmap3.map.baseLayer.resolutions;
         if (resolutions == undefined) {
             resolutions= [mainLizmap.lizmap3.map.resolution];
         }
+        // Remove duplicated values
+        resolutions = [... new Set(resolutions)];
+        // Sorting in descending order
+        resolutions = resolutions.sort((a, b) => a < b);
 
         super({
             controls: [


### PR DESCRIPTION
The resolutions from OL2 map can contain duplicated values. It is needed to remove duplicated values and to be sur they are sorted by descending order.