### PR TITLE
Load custom JS as module

### DIFF
--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -397,6 +397,7 @@ class lizMapCtrl extends jController
             $jsDirArray = array('default', $project);
             foreach ($jsDirArray as $dir) {
                 $jsUrls = array();
+                $mjsUrls = array();
                 $cssUrls = array();
                 $items = array(
                     'media/js/',
@@ -407,7 +408,7 @@ class lizMapCtrl extends jController
                     if (is_dir($jsPathRoot)) {
                         foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($jsPathRoot)) as $filename) {
                             $fileExtension = pathinfo($filename, PATHINFO_EXTENSION);
-                            if ($fileExtension == 'js' || $fileExtension == 'css') {
+                            if ($fileExtension == 'js' || $fileExtension == 'mjs' || $fileExtension == 'css') {
                                 $jsPath = realpath($filename);
                                 $jsRelPath = $item.$dir.str_replace($jsPathRoot, '', $jsPath);
                                 $url = 'view~media:getMedia';
@@ -425,6 +426,8 @@ class lizMapCtrl extends jController
                                 );
                                 if ($fileExtension == 'js') {
                                     $jsUrls[] = $jsUrl;
+                                } elseif ($fileExtension == 'mjs') {
+                                    $mjsUrls[] = $jsUrl;
                                 } else {
                                     $cssUrls[] = $jsUrl;
                                 }
@@ -433,7 +436,7 @@ class lizMapCtrl extends jController
                     }
                 }
 
-                // Add CSS and JS files orderd by name
+                // Add CSS, MJS and JS files ordered by name
                 sort($cssUrls);
                 foreach ($cssUrls as $cssUrl) {
                     $rep->addCSSLink($cssUrl);
@@ -442,6 +445,11 @@ class lizMapCtrl extends jController
                 foreach ($jsUrls as $jsUrl) {
                     // Use addHeadContent and not addJSLink to be sure it will be loaded after minified code
                     $rep->addContent('<script type="text/javascript" src="'.$jsUrl.'" ></script>');
+                }
+                sort($mjsUrls);
+                foreach ($mjsUrls as $mjsUrl) {
+                    // Use addHeadContent and not addJSLink to be sure it will be loaded after minified code
+                    $rep->addContent('<script type="module" src="'.$mjsUrl.'" ></script>');
                 }
             }
         }

--- a/lizmap/modules/view/controllers/media.classic.php
+++ b/lizmap/modules/view/controllers/media.classic.php
@@ -222,6 +222,13 @@ class mediaCtrl extends jController
         ) {
             $mime = jFile::getMimeTypeFromFilename($finalPath);
         }
+
+        // Handle JavaScript modules (.mjs)
+        // as File::getMimeType() returns "text/x-java" for those files
+        if (strtolower($path_parts['extension']) == 'mjs') {
+            $mime = 'application/javascript';
+        }
+
         $rep->mimeType = $mime;
 
         $mimeTextArray = array('text/html', 'text/text');


### PR DESCRIPTION
This allows to load JS files as modules. Files need to have a `mjs` to automatically be loaded in the map this way:

```html
<script type="module" src="/index.php/view/media/getMedia?repository=testsrepository&amp;project=atlas&amp;mtime=1706777478&amp;path=media%2Fjs%2Fatlas%2Fconfetti.mjs"></script>
```

A `confetti.mjs` example file:

```js
import confetti from 'https://cdn.skypack.dev/canvas-confetti';
confetti();
```

Result :)


https://github.com/3liz/lizmap-web-client/assets/2145040/2e717c83-d1da-44ea-bc7c-092b6e248f22

This will help to add OpenLayers part as modules.
Ref: https://github.com/3liz/lizmap-web-client/issues/4091

Funded by 3Liz
