### PR TITLE
hide project description on projets panel

### DIFF
--- a/lizmap/www/themes/default/css/view.css
+++ b/lizmap/www/themes/default/css/view.css
@@ -5,3 +5,6 @@
   color: white;
   background-color: rgba(0, 0, 0, 0.5);
 }
+.tab-pane .liz-project-desc {
+  display: none;
+}


### PR DESCRIPTION
Since https://github.com/3liz/lizmap-web-client/pull/4055 the project description if full css (no more js event to display it). 
The project description is also used in "project panel" (when  enabled) but  the description should not be displayed.

Quick fix add `display:none` in panel

Funded by 3Liz