### PR TITLE
[Backport release_3_7] [Bugfix] devicePixelRatio is used by OL to defined tile size

### DIFF
--- a/assets/src/modules/BaseLayersMap.js
+++ b/assets/src/modules/BaseLayersMap.js
@@ -73,16 +73,33 @@ export default class BaseLayersMap extends olMap {
             mainLizmap.initialConfig.options.wmsMaxHeight,
         ];
 
-        const customTileGrid = new TileGrid({
-            extent: mainLizmap.lizmap3.map.restrictedExtent.toArray(),
-            resolutions: resolutions,
-            tileSize: this.getSize().map((x, i) => Math.min(Math.ceil(x*this._WMSRatio/2), Math.ceil(wmsMaxSize[i]*this._WMSRatio/2))),
-        });
+        // Get pixel ratio
+        const pixelRatio = this.pixelRatio_;
 
-        const useTileWms = this.getSize().map((x) => Math.ceil(x*this._WMSRatio)).reduce(
-            (r /*accumulator*/, x /*currentValue*/, i /*currentIndex*/) => r || x > wmsMaxSize[i],
+        const useTileWms = this.getSize().reduce(
+            (r /*accumulator*/, x /*currentValue*/, i /*currentIndex*/) => r || Math.ceil(x*this._WMSRatio*pixelRatio) > wmsMaxSize[i],
             false,
         );
+
+        const customTileGrid = useTileWms ? new TileGrid({
+            extent: mainLizmap.lizmap3.map.restrictedExtent.toArray(),
+            resolutions: resolutions,
+            tileSize: this.getSize().map((x, i) => {
+                // Get the min value between the map size and the max size
+                // divided by pixel ratio
+                const vMin = Math.min(
+                    Math.floor(x/pixelRatio),
+                    Math.floor(wmsMaxSize[i]/pixelRatio)
+                );
+                // If the min value with a margin of WMS ratio is less
+                // than max size divided by pixel ratio the keep it
+                if (vMin*this._WMSRatio < wmsMaxSize[i]/pixelRatio) {
+                    return vMin;
+                }
+                // Else get the min value divided by WMS ratio
+                return Math.floor(vMin/this._WMSRatio);
+            })
+        }) : null;
 
         // Mapping between states and OL layers and groups
         this._statesOlLayersandGroupsMap = new Map();
@@ -204,6 +221,8 @@ export default class BaseLayersMap extends olMap {
                                     DPI: 96,
                                     TILED: 'true'
                                 },
+                                wrapX: false, // do not reused across the 180° meridian.
+                                //hidpi: false, pixelRatio is used in useTileWms and customTileGrid definition
                             })
                         });
 
@@ -385,6 +404,8 @@ export default class BaseLayersMap extends olMap {
                                     DPI: 96,
                                     TILED: 'true'
                                 },
+                                wrapX: false, // do not reused across the 180° meridian.
+                                //hidpi: false, pixelRatio is used in useTileWms and customTileGrid definition
                             })
                         });
                     }

--- a/tests/end2end/playwright/viewport.spec.js
+++ b/tests/end2end/playwright/viewport.spec.js
@@ -1,0 +1,131 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Viewport devicePixelRatio 1', () => {
+    test('Greater than WMS max size', async ({ page }) => {
+        // world-3857 project with permalink to do not activate layers
+        const url = '/index.php/view/map/?repository=testsrepository&project=world-3857#-522.0703124273273,-89.68790709387876,522.0703124273273,89.68790709387875||';
+
+        // Overwrite WMS Max Size
+        let requests = [];
+        await page.route('**/service/getProjectConfig*', async route => {
+            const request = route.request();
+            requests.push(request.url());
+            if (request.url().includes('getProjectConfig')) {
+                const response = await route.fetch();
+                const json = await response.json();
+                expect(json.options.wmsMaxWidth).toBe('3000');
+                expect(json.options.wmsMaxHeight).toBe('3000');
+                json.options.wmsMaxWidth = 950; // just lower than 870*1.1 == 957
+                json.options.wmsMaxHeight = 950; // same
+                expect(json.options.wmsMaxWidth).toBe(950);
+                expect(json.options.wmsMaxHeight).toBe(950);
+                await route.fulfill({ response, json });
+            }
+        });
+
+        // Go to the map
+        await page.goto(url, { waitUntil: 'load' });
+        // Check that the get project config has been catched
+        expect(requests).toHaveLength(1);
+
+        // Wait to let the JS build classes
+        await page.waitForTimeout(1000);
+
+        // Check that the WMS Max Size has been well overwrite
+        expect(await page.evaluate(() => lizMap.mainLizmap.initialConfig.options.wmsMaxHeight)).toBe(950);
+        expect(await page.evaluate(() => window.devicePixelRatio)).toBe(1);
+        expect(await page.evaluate(() => lizMap.mainLizmap.map.getSize())).toStrictEqual([870,575]);
+        await page.unroute('**/service/getProjectConfig*')
+
+        // Catch GetMaps request;
+        let GetMaps = [];
+        await page.route('**/service*', async route => {
+            const request = route.request();
+            if (request.url().includes('GetMap')) {
+                GetMaps.push(request.url());
+            }
+        }, {times: 4});
+
+        // Activate world layer
+        await page.getByLabel('world').check();
+
+        // Wait for requests fetched
+        await page.waitForTimeout(1000);
+
+        // Check GetMap requests
+        expect(GetMaps).toHaveLength(4);
+        for(const GetMap of GetMaps) {
+            expect(GetMap).toContain('&WIDTH=790&')
+            expect(GetMap).toContain('&HEIGHT=575&')
+            expect(GetMap).toContain('&DPI=96&')
+        }
+
+        await page.unroute('**/service*')
+    })
+})
+
+test.describe('Viewport devicePixelRatio 2', () => {
+    test.use({
+        deviceScaleFactor: 2,
+    });
+    test('Greater than WMS max size', async ({ page }) => {
+        // world-3857 project with permalink to do not activate layers
+        const url = '/index.php/view/map/?repository=testsrepository&project=world-3857#-522.0703124273273,-89.68790709387876,522.0703124273273,89.68790709387875||';
+
+        // Overwrite WMS Max Size
+        let requests = [];
+        await page.route('**/service/getProjectConfig*', async route => {
+            const request = route.request();
+            requests.push(request.url());
+            if (request.url().includes('getProjectConfig')) {
+                const response = await route.fetch();
+                const json = await response.json();
+                expect(json.options.wmsMaxWidth).toBe('3000');
+                expect(json.options.wmsMaxHeight).toBe('3000');
+                json.options.wmsMaxWidth = 1900; // just lower than 870*1.1*2 == 1914
+                json.options.wmsMaxHeight = 1900; // same
+                expect(json.options.wmsMaxWidth).toBe(1900);
+                expect(json.options.wmsMaxHeight).toBe(1900);
+                await route.fulfill({ response, json });
+            }
+        });
+
+        // Go to the map
+        await page.goto(url, { waitUntil: 'load' });
+        // Check that the get project config has been catched
+        expect(requests).toHaveLength(1);
+
+        // Wait to let the JS build classes
+        await page.waitForTimeout(1000);
+
+        // Check that the WMS Max Size has been well overwrite
+        expect(await page.evaluate(() => lizMap.mainLizmap.initialConfig.options.wmsMaxHeight)).toBe(1900);
+        expect(await page.evaluate(() => window.devicePixelRatio)).toBe(2);
+        expect(await page.evaluate(() => lizMap.mainLizmap.map.getSize())).toStrictEqual([870,620]);
+        await page.unroute('**/service/getProjectConfig*')
+
+        // Catch GetMaps request;
+        let GetMaps = [];
+        await page.route('**/service*', async route => {
+            const request = route.request();
+            if (request.url().includes('GetMap')) {
+                GetMaps.push(request.url());
+            }
+        }, {times: 4});
+
+        // Activate world layer
+        await page.getByLabel('world').check();
+
+        // Wait for requests fetched
+        await page.waitForTimeout(1000);
+
+        // Check GetMap requests
+        expect(GetMaps).toHaveLength(4);
+        for(const GetMap of GetMaps) {
+            expect(GetMap).toContain('&WIDTH=870&')
+            expect(GetMap).toContain('&HEIGHT=620&')
+            expect(GetMap).toContain('&DPI=180&')
+        }
+        await page.unroute('**/service*')
+    })
+})


### PR DESCRIPTION
Backport https://github.com/3liz/lizmap-web-client/pull/4167
Authored by: @rldhont 