### PR TITLE
UI: Double clicking on group propagating the checked state

### DIFF
--- a/assets/src/modules/state/LayerTree.js
+++ b/assets/src/modules/state/LayerTree.js
@@ -354,6 +354,26 @@ export class LayerTreeGroupState extends LayerTreeItemState {
     }
 
     /**
+     * Propagate throught tree item the new checked state
+     * @param {boolean} val The new checked state
+     * @returns {boolean} the new checked state
+     */
+    propagateCheckedState(val) {
+        for (const item of this._items) {
+            if (item.type == 'group') {
+                item.propagateCheckedState(val);
+            } else {
+                item.checked = val;
+            }
+            if (item.checked && this.mutuallyExclusive) {
+                break;
+            }
+        }
+        this.checked = val;
+        return this.checked;
+    }
+
+    /**
      * Find layer names
      * @returns {string[]} List of layer names
      */

--- a/assets/src/modules/state/LayerTree.js
+++ b/assets/src/modules/state/LayerTree.js
@@ -355,7 +355,7 @@ export class LayerTreeGroupState extends LayerTreeItemState {
 
     /**
      * Find layer names
-     * @returns {string[]} The layer names of all tree layers
+     * @returns {string[]} List of layer names
      */
     findTreeLayerNames() {
         let names = []
@@ -371,7 +371,7 @@ export class LayerTreeGroupState extends LayerTreeItemState {
 
     /**
      * Find layer items
-     * @returns {LayerTreeLayerState[]} The tree layer states of all tree layers
+     * @returns {LayerTreeLayerState[]}  List of tree layers (not tree groups)
      */
     findTreeLayers() {
         let items = []
@@ -387,7 +387,7 @@ export class LayerTreeGroupState extends LayerTreeItemState {
 
     /**
      * Find layer and group items
-     * @returns {LayerTreeLayerState[]} All tThe tree layer and tree group states
+     * @returns {LayerTreeLayerState[]} List of tree layers and tree groups
      */
     findTreeLayersAndGroups() {
         let items = []

--- a/assets/src/modules/state/MapLayer.js
+++ b/assets/src/modules/state/MapLayer.js
@@ -80,8 +80,9 @@ export class MapItemState extends EventDispatcher {
             layerItemState.addListener(this.dispatch.bind(this), 'layer.filter.token.changed');
         }
     }
+
     /**
-     * Config layers
+     * Map item name
      * @type {string}
      */
     get name() {
@@ -89,7 +90,7 @@ export class MapItemState extends EventDispatcher {
     }
 
     /**
-     * Config layers
+     * Map item type
      * @type {string}
      */
     get type() {
@@ -97,7 +98,7 @@ export class MapItemState extends EventDispatcher {
     }
 
     /**
-     * the layer tree item level
+     * the layer item level
      * @type {number}
      */
     get level() {
@@ -105,7 +106,7 @@ export class MapItemState extends EventDispatcher {
     }
 
     /**
-     * WMS layer name
+     * WMS item name
      * @type {?string}
      */
     get wmsName() {
@@ -113,7 +114,7 @@ export class MapItemState extends EventDispatcher {
     }
 
     /**
-     * WMS layer title
+     * WMS item title
      * @type {string}
      */
     get wmsTitle() {
@@ -121,7 +122,7 @@ export class MapItemState extends EventDispatcher {
     }
 
     /**
-     * WMS layer Geographic Bounding Box
+     * WMS item Geographic Bounding Box
      * @type {?LayerGeographicBoundingBoxConfig}
      */
     get wmsGeographicBoundingBox() {
@@ -129,13 +130,12 @@ export class MapItemState extends EventDispatcher {
     }
 
     /**
-     * WMS layer Bounding Boxes
+     * WMS item Bounding Boxes
      * @type {LayerBoundingBoxConfig[]}
      */
     get wmsBoundingBoxes() {
         return this._layerItemState.wmsBoundingBoxes;
     }
-
 
     /**
      * WMS Minimum scale denominator
@@ -150,7 +150,7 @@ export class MapItemState extends EventDispatcher {
     }
 
     /**
-     * WMS layer maximum scale denominator
+     * WMS Maximum scale denominator
      * If the maximum scale denominator is not defined: -1 is returned
      * If the WMS layer is a group, the maximum scale denominator is the largest of the layers in the group
      * @type {number}
@@ -160,7 +160,7 @@ export class MapItemState extends EventDispatcher {
     }
 
     /**
-     * Layer tree item is checked
+     * Map item is checked
      * @type {boolean}
      */
     get checked() {
@@ -168,7 +168,7 @@ export class MapItemState extends EventDispatcher {
     }
 
     /**
-     * Set layer tree item is checked
+     * Set map item is checked
      * @type {boolean}
      */
     set checked(val) {
@@ -176,7 +176,7 @@ export class MapItemState extends EventDispatcher {
     }
 
     /**
-     * Layer tree item is visible
+     * Map item is visible
      * It depends on the parent visibility
      * @type {boolean}
      */
@@ -185,7 +185,7 @@ export class MapItemState extends EventDispatcher {
     }
 
     /**
-     * Layer tree item opacity
+     * Map item opacity
      * @type {number}
      */
     get opacity() {
@@ -193,7 +193,7 @@ export class MapItemState extends EventDispatcher {
     }
 
     /**
-     * Set layer tree item opacity
+     * Set map item opacity
      * @type {number}
      */
     set opacity(val) {
@@ -210,7 +210,7 @@ export class MapItemState extends EventDispatcher {
 
     /**
      * Lizmap layer item state
-     * @type {?LayerConfig}
+     * @type {?LayerItemState}
      */
     get itemState() {
         return this._layerItemState;
@@ -526,19 +526,19 @@ export class MapLayerState extends MapItemState {
     }
 
     /**
-     * set if the map layer is loaded in a single ImageWMS layer or not
-     * @param {boolean} val
-     */
-    set singleWMSLayer(val){
-        this._singleWMSLayer = val;
-    }
-
-    /**
      * vector layer is loaded in a single layer ImageLayer or not
      * @type {boolean}
      */
     get singleWMSLayer(){
         return this._singleWMSLayer;
+    }
+
+    /**
+     * set if the map layer is loaded in a single ImageWMS layer or not
+     * @type {boolean}
+     */
+    set singleWMSLayer(val){
+        this._singleWMSLayer = val;
     }
 
     /**

--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -3004,6 +3004,7 @@ lizmap-treeview input.rounded-checkbox:checked {
 
 lizmap-treeview .group label {
   font-weight: bold;
+  user-select: none;
 }
 
 lizmap-treeview label {

--- a/tests/end2end/playwright/treeview.spec.js
+++ b/tests/end2end/playwright/treeview.spec.js
@@ -97,6 +97,75 @@ test.describe('Treeview', () => {
     test('displays "title" defined in Lizmap plugin', async ({ page }) => {
         await expect(page.getByTestId('tramway_lines').locator('label')).toHaveText('Tramway lines');
     });
+
+    test('double clicking', async ({ page }) => {
+        // All group1 is checked
+        await expect(page.locator('#node-group1')).toBeChecked();
+        await expect(page.locator('#node-sub-group1')).toBeChecked();
+        await expect(page.locator('#node-subdistricts')).toBeChecked();
+        // Unchecked all group1 by double clicking the label
+        await page.getByText('group1', { exact: true }).dblclick();
+        // All group1 is not checked
+        await expect(page.locator('#node-group1')).not.toBeChecked();
+        await expect(page.locator('#node-sub-group1')).not.toBeChecked();
+        await expect(page.locator('#node-subdistricts')).not.toBeChecked();
+        // Checked all group1 by double clicking the input
+        await page.getByLabel('group1', { exact: true }).dblclick();
+        // All group1 is checked
+        await expect(page.locator('#node-group1')).toBeChecked();
+        await expect(page.locator('#node-sub-group1')).toBeChecked();
+        await expect(page.locator('#node-subdistricts')).toBeChecked();
+
+        // Click to uncheck group1
+        await page.getByLabel('group1', { exact: true }).click();
+        // Only group1 is not checked
+        await expect(page.locator('#node-group1')).not.toBeChecked();
+        await expect(page.locator('#node-sub-group1')).toBeChecked();
+        await expect(page.locator('#node-subdistricts')).toBeChecked();
+
+        // Double clicking sub-group1 does not change the group1 checked state
+        // Because it because unchecked and group1 is already unchecked
+        await page.getByLabel('sub-group1', { exact: true }).dblclick();
+        await expect(page.locator('#node-group1')).not.toBeChecked();
+        await expect(page.locator('#node-sub-group1')).not.toBeChecked();
+        await expect(page.locator('#node-subdistricts')).not.toBeChecked();
+
+        // Double clicking sub-group1 changes the group1 checked state
+        await page.getByLabel('sub-group1', { exact: true }).dblclick();
+        await expect(page.locator('#node-group1')).toBeChecked();
+        await expect(page.locator('#node-sub-group1')).toBeChecked();
+        await expect(page.locator('#node-subdistricts')).toBeChecked();
+
+        // Verify the status of mutually exclusive group
+        await expect(page.getByLabel('group with space in name and shortname defined')).toBeChecked();
+        await expect(page.locator('#node-quartiers')).toBeChecked();
+        await expect(page.locator('#node-shop_bakery_pg')).not.toBeChecked();
+        // Unchecked all mutually exclusive group by double clicking the label
+        await page.getByText('group with space in name and shortname defined').dblclick();
+        await expect(page.getByLabel('group with space in name and shortname defined')).not.toBeChecked();
+        await expect(page.locator('#node-quartiers')).not.toBeChecked();
+        await expect(page.locator('#node-shop_bakery_pg')).not.toBeChecked();
+        // Checked all mutually exclusive group by double clicking the label, only the first child is clicked
+        await page.getByLabel('group with space in name and shortname defined').dblclick();
+        await expect(page.getByLabel('group with space in name and shortname defined')).toBeChecked();
+        await expect(page.locator('#node-quartiers')).toBeChecked();
+        await expect(page.locator('#node-shop_bakery_pg')).not.toBeChecked();
+        // switch visibility in mutually exclusive group
+        await page.locator('#node-shop_bakery_pg').click();
+        await expect(page.getByLabel('group with space in name and shortname defined')).toBeChecked();
+        await expect(page.locator('#node-quartiers')).not.toBeChecked();
+        await expect(page.locator('#node-shop_bakery_pg')).toBeChecked();
+        // Unchecked all mutually exclusive group by double clicking the label
+        await page.getByText('group with space in name and shortname defined').dblclick();
+        await expect(page.getByLabel('group with space in name and shortname defined')).not.toBeChecked();
+        await expect(page.locator('#node-quartiers')).not.toBeChecked();
+        await expect(page.locator('#node-shop_bakery_pg')).not.toBeChecked();
+        // Checked all mutually exclusive group by double clicking the label, only the first child is clicked
+        await page.getByLabel('group with space in name and shortname defined').dblclick();
+        await expect(page.getByLabel('group with space in name and shortname defined')).toBeChecked();
+        await expect(page.locator('#node-quartiers')).toBeChecked();
+        await expect(page.locator('#node-shop_bakery_pg')).not.toBeChecked();
+    });
 });
 
 test.describe('Treeview mocked with "Hide checkboxes for groups" option', () => {


### PR DESCRIPTION
When double clicking on a group label or checkbox, the new checked state of the group will be propagated through the tree to all the children.

With this capability, the user will be able to check all the layers contained in a group whatever the depth.

![lizmap-dblclicking-treeview](https://github.com/3liz/lizmap-web-client/assets/1575538/ee0a6331-c904-4706-abc3-9ed74708ae47)
