### PR TITLE
JS - Update package.json version

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assets",
-  "version": "1.0.0",
+  "version": "3.8.0",
   "description": "",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Following #4185 it seems that this version should be increased.

I'm still not sure what version we should use. I don't think `3.8` is a valid value, and I would like to keep semver.

But JSDoc will build a different website for each different version. I need to check that.

Maybe only update X.Y.0, whatever the bugfix release number ?