### PR TITLE
[Bugfix] Disable High DPI support

### DIFF
--- a/assets/src/modules/map.js
+++ b/assets/src/modules/map.js
@@ -120,6 +120,9 @@ export default class map extends olMap {
             });
         };
 
+        // Disable High DPI for requests
+        this._hidpi = false;
+
         // Ratio between WMS single tiles and map viewport
         this._WMSRatio = 1.1;
 
@@ -129,8 +132,8 @@ export default class map extends olMap {
             mainLizmap.initialConfig.options.wmsMaxHeight,
         ];
 
-        // Get pixel ratio
-        const pixelRatio = this.pixelRatio_;
+        // Get pixel ratio, if High DPI is disabled do not use device pixel ratio
+        const pixelRatio = this._hidpi ? this.pixelRatio_ : 1;
 
         const useTileWms = this.getSize().reduce(
             (r /*accumulator*/, x /*currentValue*/, i /*currentIndex*/) => r || Math.ceil(x*this._WMSRatio*pixelRatio) > wmsMaxSize[i],
@@ -245,6 +248,7 @@ export default class map extends olMap {
                             url: mainLizmap.serviceURL,
                             serverType: 'qgis',
                             ratio: WMSRatio,
+                            hidpi: this._hidpi,
                             params: {
                                 LAYERS: node.wmsName,
                                 FORMAT: node.layerConfig.imageFormat,
@@ -278,7 +282,7 @@ export default class map extends olMap {
                                     TILED: 'true'
                                 },
                                 wrapX: false, // do not reused across the 180° meridian.
-                                //hidpi: false, pixelRatio is used in useTileWms and customTileGrid definition
+                                hidpi: this._hidpi, // pixelRatio is used in useTileWms and customTileGrid definition
                             })
                         });
 
@@ -435,6 +439,7 @@ export default class map extends olMap {
                             projection: qgisProjectProjection,
                             serverType: 'qgis',
                             ratio: this._WMSRatio,
+                            hidpi: this._hidpi,
                             params: {
                                 LAYERS: baseLayerState.itemState.wmsName,
                                 FORMAT: baseLayerState.layerConfig.imageFormat,
@@ -459,7 +464,7 @@ export default class map extends olMap {
                                     TILED: 'true'
                                 },
                                 wrapX: false, // do not reused across the 180° meridian.
-                                //hidpi: false, pixelRatio is used in useTileWms and customTileGrid definition
+                                hidpi: this._hidpi, // pixelRatio is used in useTileWms and customTileGrid definition
                             })
                         });
                     }


### PR DESCRIPTION
OpenLayers supports High DPI rendering. For WMS layers, it requested to the server images with Higher DPI that depends on device pixel ratio. With High DPI enabled, more images are requested and the rendering of QGIS label is too small. We prefer to disble High DPI support.

Funded by Valabre