### PR TITLE
Display a warning box when the CFG contains warnings

### DIFF
--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -316,6 +316,7 @@ project.rules.list.error.memory.html=The project takes more than <strong>%s</str
 project.rules.list.blocking.html=<strong>Blocking</strong>, these projects are not visible anymore :
 project.rules.list.blocking.description=Some projects are not visible anymore without any updates from the GIS administrator.
 project.rules.list.blocking.target.html=The project is designed for a Lizmap Web Client version equal or less than <strong>%s</strong>.
+project.rules.list.plugin.warnings.html=The project has <strong>at least one</strong> warning in the QGIS Desktop plugin
 project.list.column.repository.label=Repository
 project.list.column.project.label=Project
 project.list.column.inspection.file.time.label=Inspection time
@@ -339,6 +340,8 @@ Open the project in QGIS desktop with an updated version of the plugin
 project.list.column.target.lizmap.version.label=Target version
 project.list.column.target.lizmap.version.label.longer=Target version of Lizmap Web Client
 project.list.column.lizmap.plugin.version.label=Lizmap plugin
+project.list.column.lizmap.warnings.count.label=Warnings
+project.list.column.lizmap.warnings.explanations.label=Check your Lizmap plugin in QGIS Desktop to fix these warnings
 project.list.column.authorized.groups.label=Groups
 project.list.column.hidden.project.label=Hidden
 project.list.column.hidden.project.yes.label=Yes

--- a/lizmap/modules/admin/templates/project_list_help.tpl
+++ b/lizmap/modules/admin/templates/project_list_help.tpl
@@ -30,6 +30,12 @@
                     <li class="warning">{jlocale "admin.project.rules.list.target.version.html",
                         array($minimumLizmapTargetVersionRequired)}</li>
                 </ul>
+
+                <li>{@admin.project.list.column.lizmap.warnings.count.label@}</li>
+                <ul class="rules">
+                    <li class="warning">{@admin.project.rules.list.plugin.warnings.html@}</li>
+                </ul>
+
                 <li>{@admin.project.list.column.layers.count.label.longer@}</li>
                 <ul class="rules">
                     <li class="warning">{jlocale "admin.project.rules.list.important.count.layers.html",

--- a/lizmap/modules/admin/templates/project_list_zone.tpl
+++ b/lizmap/modules/admin/templates/project_list_zone.tpl
@@ -43,7 +43,7 @@ to view the hidden columns data and when there is no data for these columns -->
             {/if}
             <th>{@admin.project.list.column.qgis.desktop.version.label@}</th>
             <th>{@admin.project.list.column.target.lizmap.version.label@}</th>
-            <!-- <th class='lizmap_plugin_version'>{@admin.project.list.column.lizmap.plugin.version.label@}</th> -->
+            <th>{@admin.project.list.column.lizmap.warnings.count.label@}</th>
             <th>{@admin.project.list.column.hidden.project.label@}</th>
             <th>{@admin.project.list.column.authorized.groups.label@}</th>
             <th>{@admin.project.list.column.project.file.time.label@}</th>
@@ -79,13 +79,18 @@ to view the hidden columns data and when there is no data for these columns -->
 
             <!-- repository -->
             <td title="{if !empty($mi->title)}{$mi->title|strip_tags|eschtml}{/if}">
-                {$mi->id}
+                <a target="_blank" href="{$p['url_repository']}">{$mi->id}</a>
             </td>
 
             <!-- project - KEEP the line break after the title to improve the tooltip readability-->
             <td title="{if !empty($p['title'])}{$p['title']|strip_tags|eschtml}{/if}
-{if !empty($p['abstract'])}{$p['abstract']|strip_tags|eschtml|truncate:150}{/if}">
+            {if !empty($p['abstract'])}{$p['abstract']|strip_tags|eschtml|truncate:150}{/if}">
+            {if $p['needs_update_error']}
+                {*The project cannot be displayed, do not provide a link to open it.*}
+                {$p['id']}
+            {else}
                 <a target="_blank" href="{$p['url']}">{$p['id']}</a>
+            {/if}
             </td>
 
             <!-- Layer count -->
@@ -155,7 +160,7 @@ to view the hidden columns data and when there is no data for these columns -->
 
         {/if}
 
-            <!-- QGIS project version -->
+            <!-- QGIS desktop version -->
             {assign $class = ''}
             {assign $title = ''}
             {if $serverVersions['qgis_server_version_int'] && $serverVersions['qgis_server_version_int'] - $p['qgis_version_int'] > $oldQgisVersionDiff }
@@ -166,6 +171,11 @@ to view the hidden columns data and when there is no data for these columns -->
                 {assign $class = 'liz-error'}
                 {assign $title = @admin.project.list.column.qgis.desktop.version.above.server@ .' ('.$serverVersions['qgis_server_version'].')'}
             {/if}
+            {if $title != ''}
+                {* Append version of Lizmap plugin for QGIS Desktop in tooltip *}
+                {assign $title = $title . ' - '}
+            {/if}
+            {assign $title = $title . @admin.project.list.column.lizmap.plugin.version.label@ . ' ' .  $p['lizmap_plugin_version']}
             <td title="{$title}" class="{$class}">
                 {$p['qgis_version']}
             </td>
@@ -185,12 +195,16 @@ to view the hidden columns data and when there is no data for these columns -->
                 {$p['lizmap_web_client_target_version_display']}
             </td>
 
-
-            <!-- Version of Lizmap plugin for QGIS Desktop -->
-            <!-- <td>
-                {$p['lizmap_plugin_version']}
-            </td> -->
-
+            <!-- Warnings in CFG file -->
+            {assign $class = ''}
+            {assign $title = ''}
+            {if $p['cfg_warnings_count'] >= 1}
+                {assign $class = 'liz-warning'}
+                {assign $title = @admin.project.list.column.lizmap.warnings.explanations.label@}
+            {/if}
+            <td title="{$title}" class="{$class}">
+            {$p['cfg_warnings_count']}
+            </td>
 
             <!-- Project hidden -->
             <td>

--- a/lizmap/modules/admin/zones/project_list.zone.php
+++ b/lizmap/modules/admin/zones/project_list.zone.php
@@ -160,6 +160,11 @@ class project_listZone extends jZone
                 'view~map:index',
                 array('repository' => $projectMetadata->getRepository(), 'project' => $projectMetadata->getId())
             ),
+            'url_repository' => jUrl::get(
+                'view~default:index',
+                array('repository' => $projectMetadata->getRepository())
+            ),
+            'cfg_warnings_count' => $projectMetadata->countProjectCfgWarnings(),
             'lizmap_web_client_target_version' => $projectMetadata->getLizmapWebClientTargetVersion(),
             // convert int to string orderable
             'lizmap_plugin_version' => $this->pluginIntVersionToSortableString($projectMetadata->getLizmapPluginVersion()),

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -2360,6 +2360,16 @@ class Project
     }
 
     /**
+     * Project warnings.
+     *
+     * @return null|object
+     */
+    public function getProjectCfgWarnings()
+    {
+        return $this->cfg->getProjectCfgWarnings();
+    }
+
+    /**
      * Check acl rights on the project.
      *
      * @return bool true if the current user as rights on the project

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -2360,13 +2360,34 @@ class Project
     }
 
     /**
-     * Project warnings.
+     * Project warnings in the CFG file.
      *
-     * @return null|object
+     * @return null|mixed
      */
     public function getProjectCfgWarnings()
     {
+        // Before plugin 4.0.0, it was a array of errors :
+        // e.g ["ogc_not_valid", "invalid_field_type"] → 2
+        // Starting from 4.0.0, it's an object : with properties for each error type having value as error count :
+        // e.g  {"ogc_not_valid": 1, "invalid_field_type": 3} → 4
         return $this->cfg->getProjectCfgWarnings();
+    }
+
+    /**
+     * Project warnings counts in the CFG file.
+     *
+     * @see getProjectCfgWarnings() for data structure
+     *
+     * @return int
+     */
+    public function projectCountCfgWarnings()
+    {
+        $warnings = $this->getProjectCfgWarnings();
+        if (is_array($warnings)) {
+            return count($warnings);
+        }
+
+        return array_sum((array) $warnings);
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
@@ -74,7 +74,7 @@ class ProjectConfig
     protected $metadata;
 
     /**
-     * @var object
+     * @var mixed
      */
     protected $warnings;
 

--- a/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
@@ -74,6 +74,11 @@ class ProjectConfig
     protected $metadata;
 
     /**
+     * @var object
+     */
+    protected $warnings;
+
+    /**
      * @var mixed
      */
     protected $options;
@@ -93,6 +98,7 @@ class ProjectConfig
         'filter_by_polygon',
         'datavizLayers',
         'metadata',
+        'warnings',
     );
 
     /**
@@ -468,6 +474,17 @@ class ProjectConfig
     public function getTooltipLayers()
     {
         return $this->tooltipLayers;
+    }
+
+    /**
+     * Get warnings from the CFG files
+     * If the CFG file has been made with at least with 4.0.0 version.
+     *
+     * @return null|object
+     */
+    public function getProjectCfgWarnings()
+    {
+        return $this->warnings;
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/Project/ProjectMetadata.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectMetadata.php
@@ -45,6 +45,7 @@ class ProjectMetadata
             'lizmapWebClientTargetVersion' => $project->getLizmapWebCLientTargetVersion(),
             'needsUpdateError' => $project->needsUpdateError(),
             'needsUpdateWarning' => $project->needsUpdateWarning(),
+            'projectCountCfgWarnings' => $project->projectCountCfgWarnings(),
             'layerCount' => $project->getLayerCount(),
             'fileTime' => $project->getFileTime(),
             'aclGroups' => '',
@@ -228,6 +229,16 @@ class ProjectMetadata
     public function needsUpdateWarning()
     {
         return $this->data['needsUpdateWarning'];
+    }
+
+    /**
+     * Returns the count of warnings in the CFG file.
+     *
+     * @return int
+     */
+    public function countProjectCfgWarnings()
+    {
+        return $this->data['projectCountCfgWarnings'];
     }
 
     /**

--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -567,13 +567,14 @@ class lizMapCtrl extends jController
         }
 
         $serverInfoAccess = (\jAcl2::check('lizmap.admin.access') || \jAcl2::check('lizmap.admin.server.information.view'));
-        if ($serverInfoAccess && count((array) $lproj->getProjectCfgWarnings()) >= 1) {
+        if ($serverInfoAccess && $lproj->projectCountCfgWarnings() >= 1) {
             $message = jLocale::get('view~default.project.has.warnings');
+            $messageLink = $message.'<br><a href="'.jUrl::get('admin~qgis_projects:index').'">'.jLocale::get('view~default.project.has.warnings.link').'</a>';
             $jsWarning = "
                 lizMap.events.on(
                     {
                     'uicreated':function(evt){
-                        lizMap.addMessage('${message}', 'warning', false).attr('id','lizmap-warning-message');
+                        lizMap.addMessage('{$messageLink}', 'warning', true).attr('id','lizmap-warning-message');
                     }
                 }
             );

--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -566,6 +566,22 @@ class lizMapCtrl extends jController
             $assign['googleAnalyticsID'] = $lser->googleAnalyticsID;
         }
 
+        $serverInfoAccess = (\jAcl2::check('lizmap.admin.access') || \jAcl2::check('lizmap.admin.server.information.view'));
+        if ($serverInfoAccess && count((array) $lproj->getProjectCfgWarnings()) >= 1) {
+            $message = jLocale::get('view~default.project.has.warnings');
+            $jsWarning = "
+                lizMap.events.on(
+                    {
+                    'uicreated':function(evt){
+                        lizMap.addMessage('${message}', 'warning', false).attr('id','lizmap-warning-message');
+                    }
+                }
+            );
+            ";
+            $rep->addJSCode($jsWarning);
+            \jLog::log($message);
+        }
+
         $rep->body->assign($assign);
 
         // Log

--- a/lizmap/modules/view/locales/en_US/default.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/default.UTF-8.properties
@@ -18,6 +18,8 @@ project.open.map=Load the map
 project.open.map.metadata=View metadata
 project.close.map.metadata=Close
 project.needs.update=The project needs an update from the GIS administrator. Please contact the GIS administrator to check the QGIS projects panel.
+project.has.warnings=The project has some warnings in the QGIS desktop Lizmap plugin which must be fixed. \
+<br/>Only administrators or publishers can see this message.
 
 header.connect=Connect
 header.disconnect=Disconnect

--- a/lizmap/modules/view/locales/en_US/default.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/default.UTF-8.properties
@@ -20,6 +20,7 @@ project.close.map.metadata=Close
 project.needs.update=The project needs an update from the GIS administrator. Please contact the GIS administrator to check the QGIS projects panel.
 project.has.warnings=The project has some warnings in the QGIS desktop Lizmap plugin which must be fixed. \
 <br/>Only administrators or publishers can see this message.
+project.has.warnings.link=Visit the QGIS project page in the administration panel.
 
 header.connect=Connect
 header.disconnect=Disconnect

--- a/tests/units/classes/Project/ProjectConfigTest.php
+++ b/tests/units/classes/Project/ProjectConfigTest.php
@@ -22,6 +22,7 @@ class projectConfigTest extends TestCase
         $expected->filter_by_polygon = new stdClass();
         $expected->metadata = new stdClass();
         $expected->layouts = new stdClass();
+        $expected->warnings = new stdClass();
         return array(
             array($json, $expected),
         );
@@ -44,7 +45,7 @@ class projectConfigTest extends TestCase
         $file = __DIR__.'/Ressources/events.qgs.cfg';
         $data = json_decode(file_get_contents($file));
         $cachedProperties = array('layersOrder', 'locateByLayer', 'formFilterLayers', 'editionLayers',
-            'attributeLayers', 'options', 'layers', 'metadata');
+            'attributeLayers', 'options', 'layers', 'metadata', 'warnings');
         $testCfg = new Project\ProjectConfig($data);
         foreach ($cachedProperties as $prop) {
             if (property_exists($data, $prop)) {


### PR DESCRIPTION
![image](https://github.com/3liz/lizmap-web-client/assets/1609292/9bc0e371-a747-427b-903c-d523db69202a)

![image](https://github.com/3liz/lizmap-web-client/assets/1609292/dcff8bda-a882-4ce5-a4cd-a873e53b2f5d)

_Since the screenshot, it's now possible to close the dialog warning on the map_

Maybe it would be nice to cross info with "Administration panel → QGIS projects" ?

Funded by 3Liz
