### PR TITLE
Fix Display a warning box when the CFG contains warnings

### DIFF
--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -568,19 +568,20 @@ class lizMapCtrl extends jController
 
         $serverInfoAccess = (\jAcl2::check('lizmap.admin.access') || \jAcl2::check('lizmap.admin.server.information.view'));
         if ($serverInfoAccess && $lproj->projectCountCfgWarnings() >= 1) {
-            $message = htmlspecialchars(jLocale::get('view~default.project.has.warnings'));
-            $messageLink = $message.'<br><a href="'.jUrl::get('admin~qgis_projects:index').'">'.htmlspecialchars(jLocale::get('view~default.project.has.warnings.link')).'</a>';
             $jsWarning = "
                 lizMap.events.on(
                     {
                     'uicreated':function(evt){
-                        lizMap.addMessage('{$messageLink}', 'warning', true).attr('id','lizmap-warning-message');
+                        var message = lizDict['project.has.warnings'];
+                        message += '<br><a href=\"".jUrl::get('admin~qgis_projects:index')."\">';
+                        message += lizDict['project.has.warnings.link'];
+                        message += '</a>'
+                        lizMap.addMessage(message, 'warning', true).attr('id','lizmap-warning-message');
                     }
                 }
             );
             ";
             $rep->addJSCode($jsWarning);
-            \jLog::log($message);
         }
 
         $rep->body->assign($assign);

--- a/lizmap/modules/view/locales/en_US/default.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/default.UTF-8.properties
@@ -18,9 +18,6 @@ project.open.map=Load the map
 project.open.map.metadata=View metadata
 project.close.map.metadata=Close
 project.needs.update=The project needs an update from the GIS administrator. Please contact the GIS administrator to check the QGIS projects panel.
-project.has.warnings=The project has some warnings in the QGIS desktop Lizmap plugin which must be fixed. \
-Only administrators or publishers can see this message.
-project.has.warnings.link=Visit the QGIS project page in the administration panel.
 
 header.connect=Connect
 header.disconnect=Disconnect

--- a/lizmap/modules/view/locales/en_US/dictionnary.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/dictionnary.UTF-8.properties
@@ -1,6 +1,9 @@
 startup.error=An error occurred while loading this map. Some necessary resources may temporarily be unavailable. Please try again later.
 startup.goToProject=Go back to the home page.
 
+project.has.warnings=The project has some warnings in the QGIS desktop Lizmap plugin which must be fixed. Only administrators or publishers can see this message.
+project.has.warnings.link=Visit the QGIS project page in the administration panel.
+
 tree.button.checkbox=Display/Hide
 tree.button.link=Open documentation
 tree.button.removeCache=Remove server's cache for this layer


### PR DESCRIPTION
After #4226 and #4242, the warning message can generate the error `Uncaught SyntaxError: missing ) after argument list`
and `Uncaught ReferenceError: lizUrls is not defined`. These error messages are generated by a quote in the warning message.

To fix it, we use the Lizmap dictionnary which is a JSON version of the Dictionnary local.