### PR TITLE
add deprecatedDeclareFormBeforeControls to builderOptions

### DIFF
--- a/lizmap/plugins/formwidget/htmlbootstrap/htmlbootstrap.formwidget.php
+++ b/lizmap/plugins/formwidget/htmlbootstrap/htmlbootstrap.formwidget.php
@@ -52,6 +52,16 @@ class htmlbootstrapFormWidget extends \jelix\forms\HtmlWidget\RootWidget
      */
     public function outputFooter($builder)
     {
+        // Since jelix 1.8.7, we need to add `deprecatedDeclareFormBeforeControls` builder option
+        // because in the `outputHeader` we defined `jFormsJQ.declareForm(jFormsJQ.tForm);`
+        // and we use `parent::outputFooter($builder);`
+        $builder->setOptions(
+            array(
+                'errorDecorator' => $builder->getOption('errorDecorator'),
+                'modal' => $builder->getOption('modal'),
+                'deprecatedDeclareFormBeforeControls' => true,
+            )
+        );
         if ($builder->getOption('modal')) {
             echo '</div>';
         }


### PR DESCRIPTION
backport https://github.com/3liz/lizmap-web-client/commit/a115c70e2f1149f0a4fd55f89bf20f19dc4bcbcb
on 3.6

 

Funded by 3Liz
