### PR TITLE
Bugfix selection with measure - overlay is not removed

### DIFF
--- a/assets/src/modules/Digitizing.js
+++ b/assets/src/modules/Digitizing.js
@@ -576,19 +576,7 @@ export default class Digitizing {
                             return false;
                         }
 
-                        const totalOverlay = features[0].getGeometry().get('totalOverlay');
-                        if (totalOverlay) {
-                            this._measureTooltips.forEach((measureTooltip) => {
-                                if(measureTooltip[1] === totalOverlay){
-                                    mainLizmap.map.removeOverlay(measureTooltip[0]);
-                                    mainLizmap.map.removeOverlay(measureTooltip[1]);
-                                    this._measureTooltips.delete(measureTooltip);
-                                    return;
-                                }
-                            });
-                        }
-
-                        this._drawSource.removeFeature(features[0]);
+                        this._eraseFeature(features[0]);
 
                         // Stop erasing mode when no features left
                         if(this._drawSource.getFeatures().length === 0){
@@ -637,6 +625,22 @@ export default class Digitizing {
 
     set angleConstraint(angleConstraint){
         this._angleConstraint = parseInt(angleConstraint)
+    }
+
+    _eraseFeature(feature) {
+        const totalOverlay = feature.getGeometry().get('totalOverlay');
+        if (totalOverlay) {
+            this._measureTooltips.forEach((measureTooltip) => {
+                if(measureTooltip[1] === totalOverlay){
+                    mainLizmap.map.removeOverlay(measureTooltip[0]);
+                    mainLizmap.map.removeOverlay(measureTooltip[1]);
+                    this._measureTooltips.delete(measureTooltip);
+                    return;
+                }
+            });
+        }
+
+        this._drawSource.removeFeature(feature);
     }
 
     _userChangedColor(color) {

--- a/assets/src/modules/SelectionTool.js
+++ b/assets/src/modules/SelectionTool.js
@@ -104,21 +104,9 @@ export default class SelectionTool {
                 if(this.isActive && mainLizmap.digitizing.featureDrawn){
                     // We only handle a single drawn feature currently
                     if (mainLizmap.digitizing.featureDrawn.length > 1){
-                        const lastFeature = mainLizmap.digitizing.featureDrawn[1];
-                        mainLizmap.digitizing.drawLayer.getSource().clear();
-                        mainLizmap.digitizing.drawLayer.getSource().addFeature(lastFeature);
-
+                        // Erase the previous feature
+                        mainLizmap.digitizing._eraseFeature(mainLizmap.digitizing.featureDrawn[0]);
                         mainLizmap.digitizing.saveFeatureDrawn();
-
-                        const oldTooltips = mainLizmap.digitizing._measureTooltips[mainLizmap.digitizing._measureTooltips.length - 2];
-                        if (oldTooltips) {
-                            mainLizmap.map.removeOverlay(oldTooltips[0]);
-                            mainLizmap.map.removeOverlay(oldTooltips[1]);
-                        }
-
-                        // addFeature will provoke a new call of this callack
-                        // so we return to avoid two calls
-                        return;
                     }
 
                     let selectionFeature = mainLizmap.digitizing.featureDrawn[0];


### PR DESCRIPTION
If the measure is activated with selection tool, the measure overlays is not removed when a feature of the digitizing module is removed.

Funded by Terre de Provence Agglomération