### PR TITLE
UX - Display the path name of the repository in the tooltip

### DIFF
--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -318,6 +318,7 @@ project.rules.list.blocking.description=Some projects are not visible anymore wi
 project.rules.list.blocking.target.html=The project is designed for a Lizmap Web Client version equal or less than <strong>%s</strong>.
 project.rules.list.plugin.warnings.html=The project has <strong>at least one</strong> warning in the QGIS Desktop plugin
 project.list.column.repository.label=Repository
+project.list.column.path.label=Path
 project.list.column.project.label=Project
 project.list.column.inspection.file.time.label=Inspection time
 project.list.column.project.abstract.label=Abstract

--- a/lizmap/modules/admin/templates/project_list_zone.tpl
+++ b/lizmap/modules/admin/templates/project_list_zone.tpl
@@ -78,13 +78,18 @@ to view the hidden columns data and when there is no data for these columns -->
             </td>
 
             <!-- repository -->
-            <td title="{if !empty($mi->title)}{$mi->title|strip_tags|eschtml}{/if}">
+            {* Warning : KEEP the line break after the title to improve the tooltip readability *}
+            <td title="{if !empty($mi->title)}{$mi->title|strip_tags|eschtml}{/if}
+{@admin.project.list.column.path.label@ . ' : ' . $p['folder_repository']}">
+            {* End of warning *}
                 <a target="_blank" href="{$p['url_repository']}">{$mi->id}</a>
             </td>
 
-            <!-- project - KEEP the line break after the title to improve the tooltip readability-->
+            <!-- project -->
+            {* Warning : KEEP the line break after the title to improve the tooltip readability *}
             <td title="{if !empty($p['title'])}{$p['title']|strip_tags|eschtml}{/if}
-            {if !empty($p['abstract'])}{$p['abstract']|strip_tags|eschtml|truncate:150}{/if}">
+{if !empty($p['abstract'])}{$p['abstract']|strip_tags|eschtml|truncate:150}{/if}">
+            {* End of warning *}
             {if $p['needs_update_error']}
                 {*The project cannot be displayed, do not provide a link to open it.*}
                 {$p['id']}

--- a/lizmap/modules/admin/zones/project_list.zone.php
+++ b/lizmap/modules/admin/zones/project_list.zone.php
@@ -149,6 +149,12 @@ class project_listZone extends jZone
      */
     private function getProjectListItem($inspectionDirectoryPath, $projectMetadata)
     {
+        $rootRepositories = lizmap::getServices()->getRootRepositories();
+        $repository = lizmap::getRepository($projectMetadata->getRepository())->getOriginalPath();
+        if ($rootRepositories != '' && strpos($repository, $rootRepositories) === 0) {
+            $repository = basename($repository).'/';
+        }
+
         // Build the project properties table
         $projectItem = array(
             'id' => $projectMetadata->getId(),
@@ -164,6 +170,7 @@ class project_listZone extends jZone
                 'view~default:index',
                 array('repository' => $projectMetadata->getRepository())
             ),
+            'folder_repository' => $repository,
             'cfg_warnings_count' => $projectMetadata->countProjectCfgWarnings(),
             'lizmap_web_client_target_version' => $projectMetadata->getLizmapWebClientTargetVersion(),
             // convert int to string orderable


### PR DESCRIPTION
I don't want the absolute path of the repository, but only the path set in the other admin panel.
~I didn't the find the correct property to use @nworr ?~

Just to be quicker to debug from the QGIS project panel