### PR TITLE
Check QGIS desktop plugin version for edited QGS file

### DIFF
--- a/lizmap/app/system/mainconfig.ini.php
+++ b/lizmap/app/system/mainconfig.ini.php
@@ -36,10 +36,10 @@ lizmapServerPlugin="2.8.4"
 ; Lizmap QGIS desktop plugin required/recommended minimum version for newly or updated project only
 ; This version MUST match at least on https://plugins.qgis.org/plugins/lizmap/#plugin-versions
 ; with the minimum QGIS server version supported above.
-; This is experimental for now.
 ; This value is only forwarded to the plugin thanks to the server metadata. According to the age of the project, it
 ; will be either recommended or required.
 lizmapDesktopPlugin="4.1.8"
+lizmapDesktopPluginDate="2024-01-30"
 
 ; Versions written in QGIS/CFG files, for the GIS administrator
 ; Lizmap CFG files with a lower target version are not displayed in the landing page, but displayed in the administration panel to warn the GIS administrator

--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -341,6 +341,8 @@ Open the project in QGIS desktop with an updated version of the plugin
 project.list.column.target.lizmap.version.label=Target version
 project.list.column.target.lizmap.version.label.longer=Target version of Lizmap Web Client
 project.list.column.lizmap.plugin.version.label=Lizmap plugin
+project.list.column.qgis.desktop.recent.label=This QGIS project has been recently updated in QGIS Desktop, \
+but with a too old Lizmap plugin version. You should upgrade your plugin in the QGIS plugin manager.
 project.list.column.lizmap.warnings.count.label=Warnings
 project.list.column.lizmap.warnings.explanations.label=Check your Lizmap plugin in QGIS Desktop to fix these warnings
 project.list.column.authorized.groups.label=Groups

--- a/lizmap/modules/admin/templates/project_list_zone.tpl
+++ b/lizmap/modules/admin/templates/project_list_zone.tpl
@@ -181,8 +181,14 @@ to view the hidden columns data and when there is no data for these columns -->
                 {assign $title = $title . ' - '}
             {/if}
             {assign $title = $title . @admin.project.list.column.lizmap.plugin.version.label@ . ' ' .  $p['lizmap_plugin_version']}
+            {if $p['lizmap_plugin_update'] }
+                {assign $title = $title . ' ' . @admin.project.list.column.qgis.desktop.recent.label@}
+            {/if}
             <td title="{$title}" class="{$class}">
                 {$p['qgis_version']}
+                {if $p['lizmap_plugin_update'] }
+                    <span class='badge badge-warning'>⚠</span>
+                {/if}
             </td>
 
             <!-- Target version of Lizmap Web Client -->

--- a/lizmap/modules/admin/zones/project_list.zone.php
+++ b/lizmap/modules/admin/zones/project_list.zone.php
@@ -175,6 +175,7 @@ class project_listZone extends jZone
             'lizmap_web_client_target_version' => $projectMetadata->getLizmapWebClientTargetVersion(),
             // convert int to string orderable
             'lizmap_plugin_version' => $this->pluginIntVersionToSortableString($projectMetadata->getLizmapPluginVersion()),
+            'lizmap_plugin_update' => $projectMetadata->updateQgisLizmapPlugin(),
             'file_time' => $projectMetadata->getFileTime(),
             'layer_count' => $projectMetadata->getLayerCount(),
             'acl_groups' => $projectMetadata->getAclGroups(),

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -328,6 +328,16 @@ class Project
     }
 
     /**
+     * Get the last date saved in the QGIS file.
+     *
+     * @return string last saved date time of the file
+     */
+    public function getLastSaveDateTime()
+    {
+        return $this->qgis->getLastSaveDateTime();
+    }
+
+    /**
      * Get the version of the Lizmap plugin
      * used by the project editor on QGIS Desktop.
      * Default to 3.1.8 if the CFG is too old.
@@ -2357,6 +2367,17 @@ class Project
         }
 
         return false;
+    }
+
+    /**
+     * Project needs an update on plugin side.
+     * The check is done only is the QGIS file has been edited recently.
+     *
+     * @return bool true if the plugin needs to be updated
+     */
+    public function updateQgisLizmapPlugin()
+    {
+        return $this->getMetadata()->updateQgisLizmapPlugin();
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -40,6 +40,13 @@ class QgisProject
     protected $qgisProjectVersion;
 
     /**
+     * Last saved date time in the QGIS file.
+     *
+     * @var string
+     */
+    protected $lastSaveDateTime;
+
+    /**
      * @var array contains WMS info
      */
     protected $WMSInformation;
@@ -105,6 +112,7 @@ class QgisProject
         'layers',
         'data',
         'qgisProjectVersion',
+        'lastSaveDateTime',
         'customProjectVariables',
     );
 
@@ -223,6 +231,16 @@ class QgisProject
     public function getQgisProjectVersion()
     {
         return $this->qgisProjectVersion;
+    }
+
+    /**
+     * Last saved date time in the QGIS file.
+     *
+     * @return string
+     */
+    public function getLastSaveDateTime()
+    {
+        return $this->lastSaveDateTime;
     }
 
     public function getWMSInformation()
@@ -1192,6 +1210,7 @@ class QgisProject
 
         // get QGIS project version
         $this->qgisProjectVersion = $this->readQgisProjectVersion($qgsXml);
+        $this->lastSaveDateTime = $this->readLastSaveDateTime($qgsXml);
 
         $this->WMSInformation = $this->readWMSInformation($qgsXml);
         $this->canvasColor = $this->readCanvasColor($qgsXml);
@@ -1257,6 +1276,21 @@ class QgisProject
             'WMSContactPerson' => $WMSContactPerson,
             'WMSContactPhone' => $WMSContactPhone,
         );
+    }
+
+    /**
+     * Read  the last modified date of the QGS file.
+     *
+     * @param \SimpleXMLElement $xml
+     *
+     * @return string
+     */
+    protected function readLastSaveDateTime($xml)
+    {
+        $qgisRoot = $xml->xpath('//qgis');
+        $qgisRootZero = $qgisRoot[0];
+
+        return (string) $qgisRootZero->attributes()->saveDateTime;
     }
 
     /**

--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -567,7 +567,7 @@ class lizMapCtrl extends jController
         }
 
         $serverInfoAccess = (\jAcl2::check('lizmap.admin.access') || \jAcl2::check('lizmap.admin.server.information.view'));
-        if ($serverInfoAccess && $lproj->projectCountCfgWarnings() >= 1) {
+        if ($serverInfoAccess && ($lproj->projectCountCfgWarnings() >= 1 || $lproj->updateQgisLizmapPlugin())) {
             $jsWarning = "
                 lizMap.events.on(
                     {

--- a/tests/units/README.md
+++ b/tests/units/README.md
@@ -1,11 +1,11 @@
 Unit tests for Lizmap
 =====================
 
-A unit tests shoud be added each time you fix a bug or provide a new feature / API.
+A unit tests should be added each time you fix a bug or provide a new feature / API.
 
-- testslib directory: where classes inheriting from Lizmap classes or new classes 
+- `testslib` directory: where classes inheriting from Lizmap classes or new classes 
   for tests are stored.
   No need to do a `require`. These classes are autoloaded, if their name ends
   with `ForTests`.
-- tmp: use this directory to store temporary content for your tests
+- `tmp`: use this directory to store temporary content for your tests
 - Other directories : they contain tests.

--- a/tests/units/classes/Project/QgisProjectTest.php
+++ b/tests/units/classes/Project/QgisProjectTest.php
@@ -234,6 +234,19 @@ class QgisProjectTest extends TestCase
         }
     }
 
+    public function testReadQgisMetadata()
+    {
+        $testQgis = new qgisProjectForTests();
+        $xml = simplexml_load_file(__DIR__.'/Ressources/readLayers_316.qgs');
+        $this->assertEquals('31607', $testQgis->readQgisVersionForTests($xml));
+        $this->assertEquals('2021-06-14T11:50:51', $testQgis->readLastSaveDateTimeForTests($xml));
+
+        $testQgis = new qgisProjectForTests();
+        $xml = simplexml_load_file(__DIR__.'/Ressources/readLayers_310.qgs');
+        $this->assertEquals('31004', $testQgis->readQgisVersionForTests($xml));
+        $this->assertEquals('', $testQgis->readLastSaveDateTimeForTests($xml));
+    }
+
     public function testReadRelations()
     {
         $expectedRelations = array(

--- a/tests/units/testslib/QgisProjectForTests.php
+++ b/tests/units/testslib/QgisProjectForTests.php
@@ -66,6 +66,16 @@ class QgisProjectForTests extends QgisProject
         return $this->readLayers($xml);
     }
 
+    public function readQgisVersionForTests($xml)
+    {
+        return $this->readQgisProjectVersion($xml);
+    }
+
+    public function readLastSaveDateTimeForTests($xml)
+    {
+        return $this->readLastSaveDateTime($xml);
+    }
+
     public function readRelationsForTests($xml)
     {
         $this->xml = $xml;


### PR DESCRIPTION
* For **edited** QGS file recently, we check if the plugin was up to date (less than a 2 months for instance)

This is to avoid a situation I got recently with QGIS Desktop 3.34 but a plugin from end of 2022.

To be discussed and polished

Funded by 3Liz
