### PR TITLE
Landing page content for authentified users

### DIFF
--- a/lizmap/modules/admin/controllers/landing_page_content.classic.php
+++ b/lizmap/modules/admin/controllers/landing_page_content.classic.php
@@ -34,23 +34,9 @@ class landing_page_contentCtrl extends jController
             $form = jForms::create('admin~landing_page_content');
         }
 
-        // Get HTML content
-        $TopHTMLContentFile = jApp::varPath('lizmap-theme-config/landing_page_content.html');
-        if (file_exists($TopHTMLContentFile)) {
-            $HTMLContent = jFile::read($TopHTMLContentFile);
-            if ($HTMLContent) {
-                $form->setData('HTMLContent', $HTMLContent);
-            }
-        }
+        $landingContentService = new LizmapAdmin\LandingContent();
 
-        $BottomHTMLContentFile = jApp::varPath('lizmap-theme-config/landing_page_content_bottom.html');
-        if (file_exists($BottomHTMLContentFile)) {
-            $HTMLContent = jFile::read($BottomHTMLContentFile);
-            if ($HTMLContent) {
-                $form->setData('BottomHTMLContent', $HTMLContent);
-            }
-        }
-
+        $landingContentService->initForm($form);
         $tpl = new jTpl();
 
         $tpl->assign('form', $form);
@@ -84,16 +70,11 @@ class landing_page_contentCtrl extends jController
         }
 
         // Save HTML content
-        $fileWriteOK = jFile::write(jApp::varPath('lizmap-theme-config/landing_page_content.html'), $form->getData('HTMLContent'));
-        if (!$fileWriteOK) {
-            $form->setErrorOn('HTMLContent', jLocale::get('admin~admin.landingPageContent.error.save'));
-        }
-        $fileWriteOK2 = jFile::write(jApp::varPath('lizmap-theme-config/landing_page_content_bottom.html'), $form->getData('BottomHTMLContent'));
-        if (!$fileWriteOK2) {
-            $form->setErrorOn('BottomHTMLContent', jLocale::get('admin~admin.landingPageContent.error.save'));
-        }
-        if ($fileWriteOK && $fileWriteOK2) {
+        $landingContentService = new LizmapAdmin\LandingContent();
+        $fileWriteOK = $landingContentService->saveForm($form);
+        if ($fileWriteOK) {
             jMessage::add(jLocale::get('admin~admin.landingPageContent.saved'), 'ok');
+            jForms::destroy('admin~landing_page_content');
         }
 
         return $this->redirect('landing_page_content:index');

--- a/lizmap/modules/admin/forms/landing_page_content.form.xml
+++ b/lizmap/modules/admin/forms/landing_page_content.form.xml
@@ -1,14 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form xmlns="http://jelix.org/ns/forms/1.1">
 
-    <htmleditor ref="HTMLContent" config="ckfullandmedia">
-        <label locale="admin~admin.landingPageContent.top"/>
+ <group ref='top'>
+    <label locale="admin~admin.landingPageContent.group.top"/>
+
+    <htmleditor ref="TopHTMLContent" config="ckfullandmedia">
+        <label locale="admin~admin.landingPageContent.unauthed"/>
     </htmleditor>
+
+    <htmleditor ref="TopHTMLContentForAuth" config="ckfullandmedia">
+        <label locale="admin~admin.landingPageContent.authed"/>
+    </htmleditor>
+
+    <radiobuttons ref="topUnautedContentPosition" required='true'>
+      <label locale="admin~admin.landingPageContent.unauthed.position"/>
+      <item value="before" locale='admin~admin.landingPageContent.unauthed.position.before'></item>
+      <item value="after" locale='admin~admin.landingPageContent.unauthed.position.after'></item>
+      <item value="hide" locale='admin~admin.landingPageContent.unauthed.position.no'></item>
+    </radiobuttons>
+ </group>
+
+ <group ref='bottom'>
+    <label locale="admin~admin.landingPageContent.group.bottom"/>
 
     <htmleditor ref="BottomHTMLContent" config="ckfullandmedia">
-        <label locale="admin~admin.landingPageContent.bottom"/>
+        <label locale="admin~admin.landingPageContent.unauthed"/>
     </htmleditor>
 
+    <htmleditor ref="BottomHTMLContentForAuth" config="ckfullandmedia">
+        <label locale="admin~admin.landingPageContent.authed"/>
+    </htmleditor>
+    <radiobuttons ref="bottomUnautedContentPosition" required='true'>
+      <label locale="admin~admin.landingPageContent.unauthed.position"/>
+      <item value="before" locale='admin~admin.landingPageContent.unauthed.position.before'></item>
+      <item value="after" locale='admin~admin.landingPageContent.unauthed.position.after'></item>
+      <item value="hide" locale='admin~admin.landingPageContent.unauthed.position.no'></item>
+    </radiobuttons>
+ </group>
     <submit ref="_submit">
         <label locale="admin~admin.form.admin_services.submit.label"/>
     </submit>

--- a/lizmap/modules/admin/lib/LandingContent.php
+++ b/lizmap/modules/admin/lib/LandingContent.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace LizmapAdmin;
+
+class LandingContent
+{
+    public const HTMLformCtrls = array(
+        'TopHTMLContent' => 'landing_page_content',
+        'BottomHTMLContent' => 'landing_page_content_bottom',
+        'TopHTMLContentForAuth' => 'authed_landing_page_top_content',
+        'BottomHTMLContentForAuth' => 'authed_landing_page_bottom_content',
+    );
+    public const iniSection = 'landing_page';
+
+    private $iniFile;
+
+    public function __construct()
+    {
+        $file = \jApp::varConfigPath('liveconfig.ini.php');
+        $this->iniFile = new \Jelix\IniFile\IniModifier($file);
+    }
+
+    public function initForm($form)
+    {
+        // HTML editors
+        foreach (self::HTMLformCtrls as $ctrlName => $htmlFileName) {
+            $contentFileName = \jApp::varPath('lizmap-theme-config/'.$htmlFileName.'.html');
+
+            if (file_exists($contentFileName)) {
+                $HTMLContent = \jFile::read($contentFileName);
+                if ($HTMLContent) {
+                    $form->setData($ctrlName, $HTMLContent);
+                }
+            }
+        }
+        // radio buttons
+        $topPosition = $this->iniFile->getValue('top_auth_position', self::iniSection);
+        if (empty($topPosition)) {
+            $topPosition = 'hide';
+        }
+        $form->setData('topUnautedContentPosition', $topPosition);
+        $bottomPosition = $this->iniFile->getValue('bottom_auth_position', self::iniSection);
+        if (empty($bottomPosition)) {
+            $bottomPosition = 'hide';
+        }
+        $form->setData('bottomUnautedContentPosition', $bottomPosition);
+    }
+
+    public function saveForm($form): bool
+    {
+        $ok = true;
+        foreach (self::HTMLformCtrls as $ctrlName => $htmlFileName) {
+            $contentFileName = \jApp::varPath('lizmap-theme-config/'.$htmlFileName.'.html');
+
+            $fileWriteOK = \jFile::write($contentFileName, $form->getData($ctrlName));
+            if (!$fileWriteOK) {
+                $form->setErrorOn($ctrlName, \jLocale::get('admin~admin.landingPageContent.error.save'));
+                $ok = false;
+            }
+        }
+
+        try {
+            $this->iniFile->setValue('top_auth_position', $form->getData('topUnautedContentPosition'), self::iniSection);
+            $this->iniFile->setValue('bottom_auth_position', $form->getData('bottomUnautedContentPosition'), self::iniSection);
+            $this->iniFile->save();
+        } catch (\Exception $e) {
+            $ok = false;
+        }
+
+        return $ok;
+    }
+
+    /**
+     * generic method to get the content for authentified or unauthentified users
+     * regarding the desired position stored using $positionConfig
+     * and using the html identified by $keyForAuth and $keyForUnAuthed.
+     *
+     * @param string $positionConfig the config param name
+     * @param string $keyForAuth     the inner key for the file storing HTML for authentified
+     * @param string $keyForUnauthed the inner key for the file storing HTML for unauthentified
+     *
+     * @return string
+     */
+    private function getContentForView(string $positionConfig, string $keyForAuth, string $keyForUnauthed)
+    {
+        $filePathForAuth = \jApp::varPath('lizmap-theme-config/'.self::HTMLformCtrls[$keyForAuth].'.html');
+        $filePathForUnauth = \jApp::varPath('lizmap-theme-config/'.self::HTMLformCtrls[$keyForUnauthed].'.html');
+        if (\jAuth::isConnected()) {
+            $position = $this->iniFile->getValue($positionConfig, self::iniSection);
+            $files = array();
+
+            switch ($position) {
+                case 'hide':
+                    $files = array($filePathForAuth);
+
+                    break;
+
+                case 'after':
+                    $files = array($filePathForAuth, $filePathForUnauth);
+
+                    break;
+
+                case 'before':
+                    $files = array($filePathForUnauth, $filePathForAuth);
+
+                    break;
+
+            }
+        } else {
+            $files = array($filePathForUnauth);
+        }
+
+        $content = '';
+        foreach ($files as $filePath) {
+            if (file_exists($filePath)) {
+                $content .= \jFile::read($filePath);
+            }
+        }
+
+        return $content;
+    }
+
+    public function getBottomContentForView()
+    {
+        return $this->getContentForView('bottom_auth_position', 'BottomHTMLContentForAuth', 'BottomHTMLContent');
+    }
+
+    public function getTopContentForView()
+    {
+        return $this->getContentForView('top_auth_position', 'TopHTMLContentForAuth', 'TopHTMLContent');
+    }
+}

--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -367,8 +367,15 @@ project.modal.button.close=Close
 project.list.no.hidden.column.content=No extra content for this project in the following hidden table columns
 
 
-landingPageContent.top=Content at the top of the landing page
-landingPageContent.bottom=Content at the bottom of the landing page
+landingPageContent.authed=Content for authenticated users
+landingPageContent.unauthed=Content for unauthenticated users
+landingPageContent.unauthed.position=Add content for unauthenticated user to authenticated users
+landingPageContent.group.top=Top of the landing page
+landingPageContent.group.bottom=Bottom of the landing page
+landingPageContent.unauthed.position.before=Before content for authenticated
+landingPageContent.unauthed.position.after=After content for authenticated
+landingPageContent.unauthed.position.no=No
+
 landingPageContent.error.save=Error while saving the landing page contents
 landingPageContent.error.submit=An error occurred while saving the content. Your session has been terminated, please retry.
 landingPageContent.saved=Content of the landing page has been saved

--- a/lizmap/modules/admin/module.xml
+++ b/lizmap/modules/admin/module.xml
@@ -16,4 +16,7 @@
         <module name="jauthdb_admin"/>
         <module name="jacl2db_admin"/>
     </dependencies>
+    <autoload>
+     <namespacePathMap name="LizmapAdmin" dir="lib"/>
+    </autoload>
 </module>

--- a/lizmap/modules/admin/templates/landing_page_content.tpl
+++ b/lizmap/modules/admin/templates/landing_page_content.tpl
@@ -3,7 +3,7 @@
   <div>
     <h2>{@admin.menu.lizmap.landingPageContent.label@}</h2>
 
-    {form $form, 'admin~landing_page_content:save'}
+    {form $form, 'admin~landing_page_content:save' , array(),  'htmlbootstrap'}
         {formcontrols}
             <h3>{ctrl_label}</h3>
             <div> {ctrl_control} </div>

--- a/lizmap/modules/view/controllers/default.classic.php
+++ b/lizmap/modules/view/controllers/default.classic.php
@@ -131,23 +131,11 @@ class defaultCtrl extends jController
         }
         $rep->body->assign('checkServerInformation', $checkServerInformation);
 
-        // Add custom HTML content at top of page
-        $HTMLContentFile = jApp::varPath('lizmap-theme-config/landing_page_content.html');
-        if (file_exists($HTMLContentFile)) {
-            $HTMLContent = jFile::read($HTMLContentFile);
-            if ($HTMLContent) {
-                $rep->body->assign('landing_page_content', $HTMLContent);
-            }
-        }
+        $landingContentService = new LizmapAdmin\LandingContent();
 
-        // Add custom HTML content at bottom of page
-        $HTMLContentFile = jApp::varPath('lizmap-theme-config/landing_page_content_bottom.html');
-        if (file_exists($HTMLContentFile)) {
-            $HTMLContent = jFile::read($HTMLContentFile);
-            if ($HTMLContent) {
-                $rep->body->assign('landing_page_content_bottom', $HTMLContent);
-            }
-        }
+        // Add custom HTML content at top of page
+        $rep->body->assign('landing_page_content_bottom', $landingContentService->getBottomContentForView());
+        $rep->body->assign('landing_page_content', $landingContentService->getTopContentForView());
 
         // Hide header if parameter h=0
         $h = $this->intParam('h', 1);

--- a/tests/end2end/playwright/landing_page_config.spec.ts
+++ b/tests/end2end/playwright/landing_page_config.spec.ts
@@ -1,0 +1,68 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+test.describe('Landing page content', () => {
+
+  test('Fill form & check content', async ({ browser }) => {
+
+    const adminContext = await browser.newContext({ storageState: 'playwright/.auth/admin.json' });
+    const page = await adminContext.newPage();
+    // unanthenticated context
+    const userContext = await browser.newContext();
+    const userPage = await userContext.newPage();
+
+    // Go to Landing Page admin
+    await page.goto('admin.php');
+    await page.getByRole('link', { name: 'Landing page content' }).click();
+    // set top content
+    // NOTE : use .ck-content to get the CKEditor
+    await page.getByRole('group', { name: 'Top of the landing page' }).locator('.ck-content').first().fill('Top for unauth 2nd');
+    await page.getByRole('group', { name: 'Top of the landing page' }).locator('.ck-content').last().fill('Top for auth 1st');
+    await page.getByRole('group', { name: 'Top of the landing page' }).getByLabel('After content for authenticated').check();
+
+    // set bottom content
+    await page.getByRole('group', { name: 'Bottom of the landing page' }).locator('.ck-content').first().fill('Bottom for unauth 1st');
+    await page.getByRole('group', { name: 'Bottom of the landing page' }).locator('.ck-content').last().fill('Bottom for auth 2nd');
+    await page.getByRole('group', { name: 'Bottom of the landing page' }).getByLabel('Before content for authenticated').check();
+
+    // save form and ensure, it's ok
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.locator('#admin-message div p')).toHaveText('Content of the landing page has been saved');
+
+    // Go to Landing page
+    await page.goto('index.php');
+    // check text order
+    await expect(page.locator('#landingPageContent')).toHaveText('Top for auth 1st Top for unauth 2nd');
+    await expect(page.locator('#landingPageContentBottom')).toHaveText('Bottom for unauth 1st Bottom for auth 2nd');
+
+    // check unauthenticated
+    await userPage.goto('http://localhost:8130/index.php');
+
+    await expect(userPage.locator('#landingPageContent')).toHaveText('Top for unauth 2nd');
+    await expect(userPage.locator('#landingPageContentBottom')).toHaveText('Bottom for unauth 1st');
+
+    // now, we'll disable content for unauthenticated in authed context
+    await page.goto('admin.php');
+    await page.getByRole('link', { name: 'Landing page content' }).click();
+    await page.getByRole('group', { name: 'Top of the landing page' }).locator('.ck-content').last().fill('Top only');
+    await page.getByRole('group', { name: 'Bottom of the landing page' }).locator('.ck-content').last().fill('Bottom only');
+    await page.getByRole('group', { name: 'Top of the landing page' }).locator('.ck-content').first().fill('Top unauth only');
+    await page.getByRole('group', { name: 'Bottom of the landing page' }).locator('.ck-content').first().fill('Bottom unauth only');
+
+    await page.getByRole('group', { name: 'Top of the landing page' }).getByLabel('No').check();
+    await page.getByRole('group', { name: 'Bottom of the landing page' }).getByLabel('No').check();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.locator('#admin-message div p')).toHaveText('Content of the landing page has been saved');
+
+    // go to landing page ...
+    await page.goto('index.php');
+    await expect(page.locator('#landingPageContent')).toHaveText('Top only');
+    await expect(page.locator('#landingPageContentBottom')).toHaveText('Bottom only');
+
+    // check unauthed
+    await userPage.goto('http://localhost:8130/index.php');
+    await expect(userPage.locator('#landingPageContent')).toHaveText('Top unauth only');
+    await expect(userPage.locator('#landingPageContentBottom')).toHaveText('Bottom unauth only');
+
+  });
+});


### PR DESCRIPTION
the administrator can now define content at the top and bottom of the landing page that will only be displayed to authenticated users, with an option to display unauthenticated content or not 

 
![image](https://github.com/3liz/lizmap-web-client/assets/43475951/bc4669ce-4ad6-46c6-861c-83935478c943)


Ticket : # 

Funded by JPEE
