### PR TITLE
Editing - Allow the authenticated user to save form if loginFilteredOverride is True

### DIFF
--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -725,6 +725,12 @@ class QgisForm implements QgisFormControlsInterface
                     continue;
                 }
                 if ($fieldName === $expByUserLoginKey) {
+                    // Do not check if the authenticated user has "loginFilterOverride"
+                    if ($this->loginFilteredOverride) {
+                        continue;
+                    }
+
+                    // If not, set an error
                     $loginFilterConfig = $project->getLoginFilteredConfig($this->layer->getName());
                     $form->setErrorOn($loginFilterConfig->filterAttribute, \jLocale::get('view~edition.message.error.feature.editable'));
 


### PR DESCRIPTION
This prevent the message "Feature not editable" for this case

* the filter by login is based on an attribute and on the user name (login), not on groups
* the authenticated user has the right `loginFilteredOverride` which means he can view and edit any filtered feature

Funded by PNR Haut-Jura https://www.parc-haut-jura.fr/
