### PR TITLE
Check plugin version for recently edited QGS file

### DIFF
--- a/lizmap/app/system/mainconfig.ini.php
+++ b/lizmap/app/system/mainconfig.ini.php
@@ -36,10 +36,10 @@ lizmapServerPlugin="2.8.4"
 ; Lizmap QGIS desktop plugin required/recommended minimum version for newly or updated project only
 ; This version MUST match at least on https://plugins.qgis.org/plugins/lizmap/#plugin-versions
 ; with the minimum QGIS server version supported above.
-; This is experimental for now.
 ; This value is only forwarded to the plugin thanks to the server metadata. According to the age of the project, it
 ; will be either recommended or required.
-lizmapDesktopPlugin="4.1.8"
+lizmapDesktopPlugin=40108
+lizmapDesktopPluginDate="2024-01-30"
 
 ; Versions written in QGIS/CFG files, for the GIS administrator
 ; Lizmap CFG files with a lower target version are not displayed in the landing page, but displayed in the administration panel to warn the GIS administrator

--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -341,6 +341,8 @@ Open the project in QGIS desktop with an updated version of the plugin
 project.list.column.target.lizmap.version.label=Target version
 project.list.column.target.lizmap.version.label.longer=Target version of Lizmap Web Client
 project.list.column.lizmap.plugin.version.label=Lizmap plugin
+project.list.column.qgis.desktop.recent.label=This QGIS project has been recently updated in QGIS Desktop, \
+but with a too old Lizmap plugin version. You should upgrade your plugin in the QGIS plugin manager.
 project.list.column.lizmap.warnings.count.label=Warnings
 project.list.column.lizmap.warnings.explanations.label=Check your Lizmap plugin in QGIS Desktop to fix these warnings
 project.list.column.authorized.groups.label=Groups

--- a/lizmap/modules/admin/templates/project_list_zone.tpl
+++ b/lizmap/modules/admin/templates/project_list_zone.tpl
@@ -181,8 +181,14 @@ to view the hidden columns data and when there is no data for these columns -->
                 {assign $title = $title . ' - '}
             {/if}
             {assign $title = $title . @admin.project.list.column.lizmap.plugin.version.label@ . ' ' .  $p['lizmap_plugin_version']}
+            {if $p['lizmap_plugin_update'] }
+                {assign $title = $title . ' ' . @admin.project.list.column.qgis.desktop.recent.label@}
+            {/if}
             <td title="{$title}" class="{$class}">
                 {$p['qgis_version']}
+                {if $p['lizmap_plugin_update'] }
+                    <span class='badge badge-warning'>⚠</span>
+                {/if}
             </td>
 
             <!-- Target version of Lizmap Web Client -->

--- a/lizmap/modules/admin/zones/project_list.zone.php
+++ b/lizmap/modules/admin/zones/project_list.zone.php
@@ -175,6 +175,7 @@ class project_listZone extends jZone
             'lizmap_web_client_target_version' => $projectMetadata->getLizmapWebClientTargetVersion(),
             // convert int to string orderable
             'lizmap_plugin_version' => $this->pluginIntVersionToSortableString($projectMetadata->getLizmapPluginVersion()),
+            'lizmap_plugin_update' => $projectMetadata->qgisLizmapPluginUpdateNeeded(),
             'file_time' => $projectMetadata->getFileTime(),
             'layer_count' => $projectMetadata->getLayerCount(),
             'acl_groups' => $projectMetadata->getAclGroups(),

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -2360,6 +2360,17 @@ class Project
     }
 
     /**
+     * Project needs an update on plugin side.
+     * The check is done only if the QGIS file has been edited recently.
+     *
+     * @return bool true if the plugin needs to be updated
+     */
+    public function qgisLizmapPluginUpdateNeeded()
+    {
+        return $this->getMetadata()->qgisLizmapPluginUpdateNeeded();
+    }
+
+    /**
      * Project warnings in the CFG file.
      *
      * @return null|mixed

--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -567,7 +567,7 @@ class lizMapCtrl extends jController
         }
 
         $serverInfoAccess = (\jAcl2::check('lizmap.admin.access') || \jAcl2::check('lizmap.admin.server.information.view'));
-        if ($serverInfoAccess && $lproj->projectCountCfgWarnings() >= 1) {
+        if ($serverInfoAccess && ($lproj->projectCountCfgWarnings() >= 1 || $lproj->qgisLizmapPluginUpdateNeeded())) {
             $jsWarning = "
                 lizMap.events.on(
                     {

--- a/tests/end2end/cypress/integration/requests-metadata-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-metadata-ghaction.js
@@ -31,7 +31,7 @@ describe('Request JSON metadata', function () {
             expect(response.body.qgis_server_info.plugins.lizmap_server.version).to.match(/(\d+\.\d+|master|dev)/i)
 
             // Desktop plugin
-            expect(response.body.lizmap_desktop_plugin_version).to.match(/(\d+\.\d+|master|dev)/i)
+            expect(response.body.lizmap_desktop_plugin_version).to.match(/(\d{5,6})/i)
 
             // check the repositories
             expect(response.body.repositories.testsrepository.label).to.eq("Tests repository");
@@ -135,7 +135,7 @@ describe('Request JSON metadata', function () {
             expect(response.body.qgis_server_info.py_qgis_server.found).to.eq(true)
 
             // Desktop plugin
-            expect(response.body.lizmap_desktop_plugin_version).to.match(/(\d+\.\d+|master|dev)/i)
+            expect(response.body.lizmap_desktop_plugin_version).to.match(/(\d{5,6})/i)
 
             // check the repositories
             expect(response.body.repositories.testsrepository.label).to.eq("Tests repository");

--- a/tests/units/README.md
+++ b/tests/units/README.md
@@ -1,11 +1,11 @@
 Unit tests for Lizmap
 =====================
 
-A unit tests shoud be added each time you fix a bug or provide a new feature / API.
+A unit tests should be added each time you fix a bug or provide a new feature / API.
 
-- testslib directory: where classes inheriting from Lizmap classes or new classes 
+- `testslib` directory: where classes inheriting from Lizmap classes or new classes 
   for tests are stored.
   No need to do a `require`. These classes are autoloaded, if their name ends
   with `ForTests`.
-- tmp: use this directory to store temporary content for your tests
+- `tmp`: use this directory to store temporary content for your tests
 - Other directories : they contain tests.

--- a/tests/units/classes/Project/QgisProjectTest.php
+++ b/tests/units/classes/Project/QgisProjectTest.php
@@ -234,6 +234,17 @@ class QgisProjectTest extends TestCase
         }
     }
 
+    public function testReadQgisMetadata()
+    {
+        $testQgis = new qgisProjectForTests();
+        $xml = simplexml_load_file(__DIR__.'/Ressources/readLayers_316.qgs');
+        $this->assertEquals('31607', $testQgis->readQgisVersionForTests($xml));
+
+        $testQgis = new qgisProjectForTests();
+        $xml = simplexml_load_file(__DIR__.'/Ressources/readLayers_310.qgs');
+        $this->assertEquals('31004', $testQgis->readQgisVersionForTests($xml));
+    }
+
     public function testReadRelations()
     {
         $expectedRelations = array(

--- a/tests/units/testslib/QgisProjectForTests.php
+++ b/tests/units/testslib/QgisProjectForTests.php
@@ -66,6 +66,11 @@ class QgisProjectForTests extends QgisProject
         return $this->readLayers($xml);
     }
 
+    public function readQgisVersionForTests($xml)
+    {
+        return $this->readQgisProjectVersion($xml);
+    }
+
     public function readRelationsForTests($xml)
     {
         $this->xml = $xml;


### PR DESCRIPTION
Alternative approach for #4269 : not using xpath, but the date in the file metadata.

But for developers, Git is not making dates correct. We can come back later for another approach (reading the first X lines in the QGS file or using xpath carefully like in #4269)

For recently edited QGS file (edited after the release date of  LWC), we check against an hardcoded plugin version.

For now, the warning is only displayed for admin (when connected) on the map, like #4270