### PR TITLE
Use the date stored in the QGS file instead of the file creation date

### DIFF
--- a/lizmap/modules/admin/zones/project_list.zone.php
+++ b/lizmap/modules/admin/zones/project_list.zone.php
@@ -319,6 +319,10 @@ class project_listZone extends jZone
      */
     private function pluginIntVersionToSortableString(string $intVersion): string
     {
+        if ($intVersion == 'master' || $intVersion == 'dev') {
+            return '00.00.00';
+        }
+
         // in some old plugin the version is already human readable
         if (strpos($intVersion, '.') != false) {
             list($majorVersion, $minorVersion, $patchVersion) = explode('.', $intVersion);

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -328,6 +328,16 @@ class Project
     }
 
     /**
+     * Get the last date saved in the QGIS file.
+     *
+     * @return string the last saved date contained in the QGS file
+     */
+    public function getLastSaveDateTime()
+    {
+        return $this->qgis->getLastSaveDateTime();
+    }
+
+    /**
      * Get the version of the Lizmap plugin
      * used by the project editor on QGIS Desktop.
      * Default to 3.1.8 if the CFG is too old.

--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -40,6 +40,13 @@ class QgisProject
     protected $qgisProjectVersion;
 
     /**
+     * Last saved date time in the QGIS file.
+     *
+     * @var string the last saved date contained in the QGS file
+     */
+    protected $lastSaveDateTime;
+
+    /**
      * @var array contains WMS info
      */
     protected $WMSInformation;
@@ -105,6 +112,7 @@ class QgisProject
         'layers',
         'data',
         'qgisProjectVersion',
+        'lastSaveDateTime',
         'customProjectVariables',
     );
 
@@ -223,6 +231,16 @@ class QgisProject
     public function getQgisProjectVersion()
     {
         return $this->qgisProjectVersion;
+    }
+
+    /**
+     * Last saved date time in the QGIS file.
+     *
+     * @return string the last saved date contained in the QGS file
+     */
+    public function getLastSaveDateTime()
+    {
+        return $this->lastSaveDateTime;
     }
 
     public function getWMSInformation()
@@ -1192,6 +1210,7 @@ class QgisProject
 
         // get QGIS project version
         $this->qgisProjectVersion = $this->readQgisProjectVersion($qgsXml);
+        $this->lastSaveDateTime = $this->readLastSaveDateTime($qgs_path);
 
         $this->WMSInformation = $this->readWMSInformation($qgsXml);
         $this->canvasColor = $this->readCanvasColor($qgsXml);
@@ -1280,6 +1299,30 @@ class QgisProject
         }
 
         return (int) $a;
+    }
+
+    /**
+     * Read the last modified date of the QGS file.
+     *
+     * @param string $qgs_path the path to the QGS file
+     *
+     * @return string the last saved date contained in the QGS file
+     */
+    protected function readLastSaveDateTime($qgs_path)
+    {
+        $fp = fopen($qgs_path, 'r');
+        $version = '';
+        for ($i = 0; $i < 5; ++$i) {
+            $line = fgets($fp);
+            if (preg_match('/saveDateTime="(?P<date>[\S]*)"/', $line, $matches)) {
+                $version = $matches['date'];
+
+                break;
+            }
+        }
+        fclose($fp);
+
+        return $version;
     }
 
     /**

--- a/tests/units/classes/Project/QgisProjectTest.php
+++ b/tests/units/classes/Project/QgisProjectTest.php
@@ -234,7 +234,7 @@ class QgisProjectTest extends TestCase
         }
     }
 
-    public function testReadQgisMetadata()
+    public function testReadQgisMetadataFromXml()
     {
         $testQgis = new qgisProjectForTests();
         $xml = simplexml_load_file(__DIR__.'/Ressources/readLayers_316.qgs');
@@ -243,6 +243,17 @@ class QgisProjectTest extends TestCase
         $testQgis = new qgisProjectForTests();
         $xml = simplexml_load_file(__DIR__.'/Ressources/readLayers_310.qgs');
         $this->assertEquals('31004', $testQgis->readQgisVersionForTests($xml));
+    }
+
+    public function testReadQgisMetadataFromLines()
+    {
+        $testQgis = new qgisProjectForTests();
+        $xml_path = __DIR__.'/Ressources/readLayers_316.qgs';
+        $this->assertEquals('2021-06-14T11:50:51', $testQgis->readLastSaveDateTimeForTests($xml_path));
+
+        $testQgis = new qgisProjectForTests();
+        $xml_path = __DIR__.'/Ressources/readLayers_310.qgs';
+        $this->assertEquals('', $testQgis->readLastSaveDateTimeForTests($xml_path));
     }
 
     public function testReadRelations()

--- a/tests/units/testslib/QgisProjectForTests.php
+++ b/tests/units/testslib/QgisProjectForTests.php
@@ -71,6 +71,11 @@ class QgisProjectForTests extends QgisProject
         return $this->readQgisProjectVersion($xml);
     }
 
+    public function readLastSaveDateTimeForTests($file)
+    {
+        return $this->readLastSaveDateTime($file);
+    }
+
     public function readRelationsForTests($xml)
     {
         $this->xml = $xml;


### PR DESCRIPTION
The PR #4287 is not perfect, in case of bulk upload of files.
We can notice on our test server right now. I updated all tests files on the server by doing a "big" copy/paste of all files and now LWC thinks I have touched all QGS files, which is not true.

I assume we should find `saveDateTime` in the first 5 lines of XML.

```xml
<qgis projectname="" saveDateTime="2023-09-07T13:56:00" saveUser="XXXXX" saveUserFull="XXXXXX" version="3.22.16-Białowieża">
```

Backport will be done manually in #4296 and #4297. No backport label on purpose.

Keen to have feedbacks from @mdouchin (and @nworr )