### PR TITLE
New way to generate JS variables into Lizmap

### DIFF
--- a/lizmap/app/responses/AbstractLizmapHtmlResponse.php
+++ b/lizmap/app/responses/AbstractLizmapHtmlResponse.php
@@ -50,4 +50,21 @@ class AbstractLizmapHtmlResponse extends jResponseHtml
 
         $this->addHeadContent('<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />');
     }
+
+    protected $jsVarData = array();
+
+    public function addJsVariable($name, $value)
+    {
+        $this->jsVarData[$name] = $value;
+    }
+
+    public function addJsVariables(array $variables)
+    {
+        $this->jsVarData = array_merge($this->jsVarData, $variables);
+    }
+
+    protected function doAfterActions()
+    {
+        $this->addHeadContent('<script id="js-vars" type="application/json">'.htmlspecialchars(json_encode($this->jsVarData)).'</script>');
+    }
 }

--- a/lizmap/app/responses/adminHtmlResponse.class.php
+++ b/lizmap/app/responses/adminHtmlResponse.class.php
@@ -48,5 +48,7 @@ class adminHtmlResponse extends AbstractLizmapHtmlResponse
         $this->body->assignIfNone('MAIN', '');
         $this->body->assignIfNone('adminTitle', '');
         $this->body->assign('user', jAuth::getUserSession());
+
+        parent::doAfterActions();
     }
 }

--- a/lizmap/app/responses/adminLoginHtmlResponse.class.php
+++ b/lizmap/app/responses/adminLoginHtmlResponse.class.php
@@ -39,5 +39,7 @@ class adminLoginHtmlResponse extends AbstractLizmapHtmlResponse
         $this->title .= ($this->title != '' ? ' - ' : '').'Administration';
         $this->body->assignIfNone('MAIN', '');
         $this->body->assignIfNone('page_title', jLocale::get('jcommunity~login.login.title'));
+
+        parent::doAfterActions();
     }
 }

--- a/lizmap/app/responses/myHtmlMapResponse.class.php
+++ b/lizmap/app/responses/myHtmlMapResponse.class.php
@@ -48,5 +48,7 @@ class myHtmlMapResponse extends AbstractLizmapHtmlResponse
         $this->body->assignIfNone('user', jAuth::getUserSession());
         $this->body->assignIfNone('auth_url_return', '');
         $this->body->assignIfNone('googleAnalyticsID', '');
+
+        parent::doAfterActions();
     }
 }

--- a/lizmap/app/responses/myHtmlResponse.class.php
+++ b/lizmap/app/responses/myHtmlResponse.class.php
@@ -45,5 +45,7 @@ class myHtmlResponse extends AbstractLizmapHtmlResponse
         $this->body->assignIfNone('auth_url_return', '');
         $this->body->assignIfNone('googleAnalyticsID', '');
         $this->body->assignIfNone('showHomeLink', true);
+
+        parent::doAfterActions();
     }
 }

--- a/lizmap/app/responses/simpleHtmlResponse.class.php
+++ b/lizmap/app/responses/simpleHtmlResponse.class.php
@@ -27,5 +27,7 @@ class simpleHtmlResponse extends AbstractLizmapHtmlResponse
         // main template, the settings of the response etc..
         // $this->bodyTagAttributes = array('onload'=>'init()');
         $this->body->assignIfNone('MAIN', '<p>Pas de contenu</p>');
+
+        parent::doAfterActions();
     }
 }

--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -151,7 +151,7 @@ class lizMapCtrl extends jController
         }
 
         // the html response
-        /** @var jResponseHtml $rep */
+        /** @var AbstractLizmapHtmlResponse $rep */
         $rep = $this->getResponse('htmlmap');
         $rep->addJSLink((jUrl::get('view~translate:index')).'?lang='.jApp::config()->locale, array('defer' => ''));
 
@@ -230,8 +230,9 @@ class lizMapCtrl extends jController
             $lizUrls['resourceUrlReplacement']['webdav'] = 'dav/';
         }
 
-        $rep->addJSCode('var lizUrls = '.json_encode($lizUrls).';');
-        $rep->addJSCode('var lizProj4 = '.json_encode($lproj->getAllProj4()).';');
+        $rep->addJsVariable('lizUrls', $lizUrls);
+        $rep->addJsVariable('lizProj4', $lproj->getAllProj4());
+
         $rep->addStyle('#map', 'background-color:'.$lproj->getCanvasColor().';');
 
         // Get the WMS information
@@ -259,7 +260,7 @@ class lizMapCtrl extends jController
                     )
                 ),
             );
-            $rep->addJSCode('var filterConfigData = '.json_encode($filterConfigData));
+            $rep->addJsVariable('filterConfigData', $filterConfigData);
         }
 
         // Add atlas.js for atlas feature and additionnal CSS for right-dock max-width
@@ -325,7 +326,9 @@ class lizMapCtrl extends jController
                         $rep->addJSLink($js, array('defer' => ''));
                     }
                 }
-                if (array_key_exists('jscode', $addition)) {
+                if (array_key_exists('jsvars', $addition) && is_array($addition['jsvars'])) {
+                    $rep->addJsVariables($addition['jsvars']);
+                } elseif (array_key_exists('jscode', $addition)) {
                     foreach ($addition['jscode'] as $jscode) {
                         $rep->addJSCode($jscode);
                     }


### PR DESCRIPTION
The new `addJsVariable()` method allows to add values for javascript. Values are encoded as JSON into a script element, that should be parsed during the loading of the web page. It will allow to remove most of script elements containing only JS variables.

Funded by 3Liz
