### PR TITLE
Cache seed cli accept 0 as argument value

### DIFF
--- a/lizmap/modules/lizmap/lib/Commands/WMTSSeed.php
+++ b/lizmap/modules/lizmap/lib/Commands/WMTSSeed.php
@@ -35,9 +35,9 @@ class WMTSSeed extends \Jelix\Scripts\ModuleCommandAbstract
 
         $fakeServer = new \Jelix\FakeServerConf\ApacheMod(\jApp::wwwPath(), '/index.php');
         $fakeServer->setHttpRequest($req->getServerURI());
-        $tileMatrixMin = $input->getArgument('TileMatrixMin');
-        $tileMatrixMax = $input->getArgument('TileMatrixMax');
-        if (!(filter_var($tileMatrixMin, FILTER_VALIDATE_INT) && filter_var($tileMatrixMax, FILTER_VALIDATE_INT))) {
+        $tileMatrixMin = filter_var($input->getArgument('TileMatrixMin'), FILTER_VALIDATE_INT);
+        $tileMatrixMax = filter_var($input->getArgument('TileMatrixMax'), FILTER_VALIDATE_INT);
+        if (($tileMatrixMin === false) || ($tileMatrixMax === false)) {
             $output->writeln('<error>TileMatrixMin and TileMatrixMax must be of type int</error>');
 
             return 1;

--- a/tests/end2end/cypress/integration/cmdline-wmts-ghaction.js
+++ b/tests/end2end/cypress/integration/cmdline-wmts-ghaction.js
@@ -44,6 +44,16 @@ describe('WMTS command line', function () {
     })
 
     it('wmts:cache:seed --dry-run success', function () {
+        // Get tiles number for zoom level from 0 to 3 (1 for each = 4)
+        cy.exec('./../lizmap-ctl console wmts:cache:seed -v -f --dry-run testsrepository cache Quartiers EPSG:3857 0 3')
+        .its('stdout')
+        .should('contain', 'The TileMatrixSet \'EPSG:3857\'!')
+        .should('contain', '1 tiles to generate for "Quartiers" "EPSG:3857" "0"')
+        .should('contain', '1 tiles to generate for "Quartiers" "EPSG:3857" "1"')
+        .should('contain', '1 tiles to generate for "Quartiers" "EPSG:3857" "2"')
+        .should('contain', '1 tiles to generate for "Quartiers" "EPSG:3857" "3"')
+        .should('contain', '4 tiles to generate for "Quartiers" "EPSG:3857" between "0" and "3"')
+
         // Get tiles number for zoom level 10
         cy.exec('./../lizmap-ctl console wmts:cache:seed -v -f --dry-run testsrepository cache Quartiers EPSG:3857 10 10')
             .its('stdout')


### PR DESCRIPTION
refs #3696 ( https://github.com/3liz/lizmap-web-client/issues/3696#issuecomment-1571809121)

When 0 is used as arg in command line for `tileMatrixMin`/`tileMatrixMax`, the filter_input_var validate as int but returned value (0) is interpreted as false.
I add a strong type comparison 

Funded by 3Liz
