### PR TITLE
[Bugfix] Use external WMS when activated

### DIFF
--- a/assets/src/modules/map.js
+++ b/assets/src/modules/map.js
@@ -229,19 +229,20 @@ export default class map extends olMap {
                         node.singleWMSLayer = true;
                         return
                     } else {
+                        const itemState = node.itemState;
                         if (this._useTileWms) {
                             layer = new TileLayer({
                                 // extent: extent,
                                 minResolution: minResolution,
                                 maxResolution: maxResolution,
                                 source: new TileWMS({
-                                    url: mainLizmap.serviceURL,
+                                    url: itemState.externalWmsToggle ? itemState.externalAccess.url : mainLizmap.serviceURL,
                                     serverType: 'qgis',
                                     tileGrid: this._customTileGrid,
                                     params: {
-                                        LAYERS: node.wmsName,
-                                        FORMAT: node.layerConfig.imageFormat,
-                                        STYLES: node.wmsSelectedStyleName,
+                                        LAYERS: itemState.externalWmsToggle ? itemState.externalAccess.layers : node.wmsName,
+                                        FORMAT: itemState.externalWmsToggle ? itemState.externalAccess.format : node.layerConfig.imageFormat,
+                                        STYLES: itemState.externalWmsToggle ? itemState.externalAccess.styles : node.wmsSelectedStyleName,
                                         DPI: 96,
                                         TILED: 'true'
                                     },
@@ -262,14 +263,14 @@ export default class map extends olMap {
                                 minResolution: minResolution,
                                 maxResolution: maxResolution,
                                 source: new ImageWMS({
-                                    url: mainLizmap.serviceURL,
+                                    url: itemState.externalWmsToggle ? itemState.externalAccess.url : mainLizmap.serviceURL,
                                     serverType: 'qgis',
                                     ratio: WMSRatio,
                                     hidpi: this._hidpi,
                                     params: {
-                                        LAYERS: node.wmsName,
-                                        FORMAT: node.layerConfig.imageFormat,
-                                        STYLES: node.wmsSelectedStyleName,
+                                        LAYERS: itemState.externalWmsToggle ? itemState.externalAccess.layers : node.wmsName,
+                                        FORMAT: itemState.externalWmsToggle ? itemState.externalAccess.format : node.layerConfig.imageFormat,
+                                        STYLES: itemState.externalWmsToggle ? itemState.externalAccess.styles : node.wmsSelectedStyleName,
                                         DPI: 96
                                     },
                                 })

--- a/tests/end2end/cypress/integration/external_wms_layer-ghaction.js
+++ b/tests/end2end/cypress/integration/external_wms_layer-ghaction.js
@@ -23,7 +23,7 @@
 
 describe('External WMS layers', function () {
 
-    it('should get correct mime type in response', function () {
+    it('should get correct mime type in response and not localhost', function () {
         // Increasing the timeout because the external server seems too slow to respond on time
         defaultCommandTimeout: 10000
 
@@ -48,7 +48,8 @@ describe('External WMS layers', function () {
         cy.get('#node-png').click()
         cy.wait('@getMap').then((interception) => {
             expect(interception.response.headers['content-type'], 'expect mime type to be image/png').to.equal('image/png')
-            console.log(interception.response)
+            expect(interception.request.headers['host'], 'expect not localhost').to.not.equal(undefined)
+            expect(interception.request.headers['host'], 'expect not localhost').to.not.equal('localhost')
         })
         cy.get('#node-png').click()
 
@@ -59,6 +60,8 @@ describe('External WMS layers', function () {
         cy.get('#node-jpeg').click()
         cy.wait('@getMap').then((interception) => {
             expect(interception.response.headers['content-type'], 'expect mime type to be image/jpeg').to.equal('image/jpeg')
+            expect(interception.request.headers['host'], 'expect not localhost').to.not.equal(undefined)
+            expect(interception.request.headers['host'], 'expect not localhost').to.not.equal('localhost')
         })
         cy.get('#node-jpeg').click()
 


### PR DESCRIPTION
With the transition to OpenLayers 8+, Lizmap loose the use of external WMS.

Thanks to @guenterw to provide projects in different lizmap version.

Fixes #4379 
Fix #4318