### PR TITLE
Tests - Remove docker compose version

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   pgsql:
     image: 3liz/postgis:${LZMPOSTGISVERSION}


### PR DESCRIPTION
We have a warning when launching the stack
