### PR TITLE
check tag with thumbnail class and generate thumbnail

### DIFF
--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -1534,6 +1534,13 @@ var lizAttributeTable = function() {
                                     data.lizSelected = 'a';
                                 }
                             }
+                            ,drawCallback: function (settings) {
+                                // rendering ok, find img with data-attr-thumbnail
+                                const thumbnailColl = document.getElementsByClassName('data-attr-thumbnail');
+                                for(let thumbnail of thumbnailColl) {
+                                    thumbnail.setAttribute('src', lizUrls.media+'?repository='+lizUrls.params.repository+'&project='+lizUrls.params.project+'&path='+thumbnail.dataset.src);
+                                }
+                            }
                             ,dom: myDom
                             ,pageLength: 50
                             ,scrollY: '95%'

--- a/tests/end2end/playwright/attribute-table.spec.js
+++ b/tests/end2end/playwright/attribute-table.spec.js
@@ -1,0 +1,27 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+test.describe('Attribute table', () => {
+    test.beforeEach(async ({ page }) => {
+        const url = '/index.php/view/map/?repository=testsrepository&project=attribute_table';
+        await page.goto(url, { waitUntil: 'networkidle' });
+    });
+
+    test('Thumbnail class generate img with good path', async ({ page }) => {
+        await page.locator('a#button-attributeLayers').click();
+        // display form
+        //await page.locator('#button-edition').click();
+        await page.locator('#attribute-layer-list-table').locator('button[value=Les_quartiers_a_Montpellier]').click();
+        await expect(page.locator('#attribute-layer-table-Les_quartiers_a_Montpellier tbody tr')).toHaveCount(7);
+
+        // mediaFile as stored in data-src attributes
+        const mediaFile = await page.locator('#attribute-layer-table-Les_quartiers_a_Montpellier img.data-attr-thumbnail').first().getAttribute('data-src');
+        // ensure src contain "dynamic" mediaFile
+        await expect(page.locator('#attribute-layer-table-Les_quartiers_a_Montpellier img.data-attr-thumbnail').first()).toHaveAttribute('src', new RegExp(mediaFile));
+        // ensure src contain getMedia and projet URL
+        await expect(page.locator('#attribute-layer-table-Les_quartiers_a_Montpellier img.data-attr-thumbnail').first()).toHaveAttribute('src', /getMedia\?repository=testsrepository&project=attribute_table&/);
+
+
+
+    })
+})


### PR DESCRIPTION
Since inline js is forbidden the [documentation tips to create thumbnail in data table](https://docs.lizmap.com/next/en/publish/lizmap_plugin/attribute_table.html#tips) need to be refactored.

I use a dom class and a data attribute that is used to overwrite the src attribute, once datatable has been rendered.

refs #4396

Funded by 3Liz
