### PR TITLE
UX - Rephrase tooltip about CORS settings

### DIFF
--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -152,7 +152,9 @@ form.admin_section.repository.path.help=The directory in which QGIS projects and
 form.admin_section.repository.allowUserDefinedThemes.label=Allow themes/javascript codes for this repository
 form.admin_section.repository.accessControlAllowOrigin.label=List of websites allowed to access the map services (WMS/WMTS/WFS…)
 form.admin_section.repository.accessControlAllowOrigin.help=List of URL separated by a comma, like 'https://domain1.com,https://www.domain2.com'. \
-Path and query parameters will be removed from the URL.
+Path and query parameters will be removed from the URL. \
+This setting will affect CORS headers : Cross Origin Resource Sharing. \
+Read the article on Wikipedia https://wikipedia.org/wiki/Cross-origin_resource_sharing
 form.admin_section.repository.path.invalid=Path not found
 form.admin_section.submit.label=Save
 form.admin_section.data.label=Data config:


### PR DESCRIPTION
Not the best, because the link is neither clickable or selectable.
But at least, the user has a clue what to look for in the internet about this setting.
