### PR TITLE
 Fix: Add project-background-color even if the default_background_color_index is not defined

### DIFF
--- a/tests/js-units/node/config/baselayer.test.js
+++ b/tests/js-units/node/config/baselayer.test.js
@@ -910,6 +910,28 @@ describe('BaseLayersConfig', function () {
                 "WMS single internal",
                 "WMS grouped external",
             ]);
+
+        const baseLayersWithoutOptions = new BaseLayersConfig({}, {}, layers, blGroup)
+        expect(baseLayersWithoutOptions.baseLayerNames)
+            .to.have.length(11) // still 11
+            .that.be.deep.eq([
+                //"=== TMS ===",
+                "Stamen Watercolor",
+                "OSM TMS internal",
+                "OSM TMS external",
+                //"=== GROUPS ===",
+                "project-background-color",
+                //"empty group",
+                "group with many layers and shortname",
+                "group with sub",
+                //"=== LOCAL LAYERS ===",
+                "local vector layer",
+                "local raster layer",
+                //"=== WM[T]S are on demo.lizmap.com ===",
+                "WMTS single external",
+                "WMS single internal",
+                "WMS grouped external",
+            ]);
     })
 
     it('startupBaseLayer', function () {

--- a/tests/js-units/node/config/baselayer.test.js
+++ b/tests/js-units/node/config/baselayer.test.js
@@ -678,6 +678,7 @@ describe('BaseLayersConfig', function () {
         expect(blGroup.name).to.be.eq('baselayers')
         expect(blGroup.type).to.be.eq('group')
         expect(blGroup.level).to.be.eq(1)
+        expect(blGroup.childrenCount).to.be.eq(16)
 
         const baseLayers = new BaseLayersConfig({}, {}, layers, blGroup)
         expect(baseLayers.baseLayerNames)
@@ -835,6 +836,80 @@ describe('BaseLayersConfig', function () {
             "styles": "d%C3%A9faut",
             "url": "https://demo.lizmap.com/lizmap/index.php/lizmap/service?repository=miscellaneous&project=flatgeobuf&VERSION=1.3.0"
         })
+    })
+
+    it('default_background_color_index', function () {
+        const capabilities = JSON.parse(readFileSync('./data/backgrounds-capabilities.json', 'utf8'));
+        expect(capabilities).to.not.be.undefined
+        expect(capabilities.Capability).to.not.be.undefined
+        const config = JSON.parse(readFileSync('./data/backgrounds-config.json', 'utf8'));
+        expect(config).to.not.be.undefined
+
+        const layers = new LayersConfig(config.layers);
+
+        // Removed empty groups from capabilities like with QGIS Server 3.34
+        for(const wmsCapaLayer of capabilities.Capability.Layer.Layer) {
+            if (!wmsCapaLayer.hasOwnProperty('Layer') || wmsCapaLayer.Layer.length === 0) {
+                continue;
+            }
+            if (wmsCapaLayer.Name != 'baselayers') {
+                continue;
+            }
+            wmsCapaLayer.Layer = wmsCapaLayer.Layer.filter((baseLayer) => {
+                const cfg = layers.getLayerConfigByWmsName(baseLayer.Name);
+                if (cfg == null) {
+                    return false;
+                }
+                if (cfg.type != 'group') {
+                    return true;
+                }
+                if (!baseLayer.hasOwnProperty('Layer') || baseLayer.Layer.length === 0) {
+                    return false;
+                }
+                return true;
+            });
+        }
+
+        const root = buildLayerTreeConfig(capabilities.Capability.Layer, layers);
+
+        expect(root).to.be.instanceOf(LayerTreeGroupConfig)
+        expect(root.name).to.be.eq('root')
+        expect(root.type).to.be.eq('group')
+        expect(root.level).to.be.eq(0)
+        expect(root.childrenCount).to.be.eq(3)
+
+        const blGroup = root.children[2];
+        expect(blGroup).to.be.instanceOf(LayerTreeGroupConfig)
+        expect(blGroup.name).to.be.eq('baselayers')
+        expect(blGroup.type).to.be.eq('group')
+        expect(blGroup.level).to.be.eq(1)
+        expect(blGroup.childrenCount).to.be.eq(10) // was 16
+
+        const options = {
+            default_background_color_index: 3,
+        };
+
+        const baseLayers = new BaseLayersConfig({}, options, layers, blGroup)
+        expect(baseLayers.baseLayerNames)
+            .to.have.length(11) // still 11
+            .that.be.deep.eq([
+                //"=== TMS ===",
+                "Stamen Watercolor",
+                "OSM TMS internal",
+                "OSM TMS external",
+                //"=== GROUPS ===",
+                "project-background-color",
+                //"empty group",
+                "group with many layers and shortname",
+                "group with sub",
+                //"=== LOCAL LAYERS ===",
+                "local vector layer",
+                "local raster layer",
+                //"=== WM[T]S are on demo.lizmap.com ===",
+                "WMTS single external",
+                "WMS single internal",
+                "WMS grouped external",
+            ]);
     })
 
     it('startupBaseLayer', function () {


### PR DESCRIPTION
Since QGIS Server 3.34, empty groups are not available in WMS GetCapabilities. project-background-color is an empty group placed in baselayers group to provide no baselayer in Lizmap Web Client User Interface.
Since Lizmap Desktop Plugin 4.3.0, an option default_background_color_index provides the index to add project-background-color in the list of baselayers.

If the configuration has not been updated, but the QGIS Server has been, Lizmap Web CLient will not provide a no baselayer to the user.
This changes wil provide a no baselayer capability, if the project-background-color is found in the Lizmap config at the right place.

Funded by 3liz