### PR TITLE
For admin, check plugin version first, before checking for warnings

### DIFF
--- a/assets/src/modules/ExecuteJSFromServer.js
+++ b/assets/src/modules/ExecuteJSFromServer.js
@@ -1,11 +1,23 @@
 export default function executeJSFromServer() {
     lizMap.events.on({
         uicreated: () => {
-            if (document.body.dataset.lizmapPluginWarningUrl) {
+            if (document.body.dataset.lizmapPluginUpdateWarningUrl) {
+                var message = lizDict['project.plugin.outdated.warning'];
+                message += `<br><a href="${document.body.dataset.lizmapPluginUpdateWarningUrl}">`;
+                message += lizDict['visit.admin.panel.project.page'];
+                message += '</a>';
+                message += '<br>';
+                message += lizDict['project.admin.panel.info'];
+                // The plugin can be easily updated, the popup can not be closed
+                lizMap.addMessage(message, 'warning', false).attr('id', 'lizmap-warning-message');
+            } else if (document.body.dataset.lizmapPluginHasWarningsUrl) {
                 var message = lizDict['project.has.warnings'];
-                message += `<br><a href="${document.body.dataset.lizmapPluginWarningUrl}">`;
-                message += lizDict['project.has.warnings.link'];
-                message += '</a>'
+                message += `<br><a href="${document.body.dataset.lizmapPluginHasWarningsUrl}">`;
+                message += lizDict['visit.admin.panel.project.page'];
+                message += '</a>';
+                message += '<br>';
+                message += lizDict['project.admin.panel.info'];
+                // It can take times to fix these issues, the popup can be closed
                 lizMap.addMessage(message, 'warning', true).attr('id', 'lizmap-warning-message');
             }
 

--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -556,9 +556,12 @@ class lizMapCtrl extends jController
             $assign['googleAnalyticsID'] = $lser->googleAnalyticsID;
         }
 
-        $serverInfoAccess = (\jAcl2::check('lizmap.admin.access') || \jAcl2::check('lizmap.admin.server.information.view'));
-        if ($serverInfoAccess && ($lproj->projectCountCfgWarnings() >= 1 || $lproj->qgisLizmapPluginUpdateNeeded())) {
-            $rep->setBodyAttributes(array('data-lizmap-plugin-warning-url' => jUrl::get('admin~qgis_projects:index')));
+        if (\jAcl2::check('lizmap.admin.access') || \jAcl2::check('lizmap.admin.server.information.view')) {
+            if ($lproj->qgisLizmapPluginUpdateNeeded()) {
+                $rep->setBodyAttributes(array('data-lizmap-plugin-update-warning-url' => jUrl::get('admin~qgis_projects:index')));
+            } elseif ($lproj->projectCountCfgWarnings() >= 1) {
+                $rep->setBodyAttributes(array('data-lizmap-plugin-has-warnings-url' => jUrl::get('admin~qgis_projects:index')));
+            }
         }
 
         $rep->body->assign($assign);

--- a/lizmap/modules/view/locales/en_US/dictionnary.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/dictionnary.UTF-8.properties
@@ -1,8 +1,10 @@
 startup.error=An error occurred while loading this map. Some necessary resources may temporarily be unavailable. Please try again later.
 startup.goToProject=Go back to the home page.
 
-project.has.warnings=The project has some warnings in the QGIS desktop Lizmap plugin which must be fixed. Only administrators or publishers can see this message.
-project.has.warnings.link=Visit the QGIS project page in the administration panel.
+project.has.warnings=The project has some warnings in the QGIS desktop Lizmap plugin which must be fixed.
+project.plugin.outdated.warning=The project has been recently updated in QGIS Desktop, but with an outdated version of the Lizmap plugin. You must upgrade your plugin in QGIS Desktop.
+project.admin.panel.info=Only administrators or publishers can see this message.
+visit.admin.panel.project.page=Visit the QGIS project page in the administration panel.
 
 tree.button.checkbox=Display/Hide
 tree.button.link=Open documentation


### PR DESCRIPTION
It's look more important to me to : 

* first warn the user about outdated plugin version (and given the hardcoded version is at least something like 2 months old)
* then warn the user about warnings in the plugin

An up to date version might give him more updates in the plugin and errors.

I consider the plugin update easy to do, so we can keep the dialog "not closable" ?


I know the backport on 3.6 will fail, but I will propose this small update