### PR TITLE
[Bugfix] Treeview: italic and greyscaled uncheked symbols and their children

### DIFF
--- a/assets/src/components/Treeview.js
+++ b/assets/src/components/Treeview.js
@@ -64,7 +64,7 @@ export default class Treeview extends HTMLElement {
 
         this._symbolTemplate = symbol =>
             html`
-        <li class="symbol${this._isInScale(symbol) ? '' : ' not-in-scale'}">
+        <li class="symbol${this._isInScale(symbol) ? '' : ' not-in-scale'}${symbol.ruleKey && !symbol.checked ? ' not-visible' : ''}">
             ${(symbol.childrenCount)
                 ? html`
                         <div class="expandable ${symbol.expanded ? 'expanded' : ''}" @click=${() => symbol.expanded = !symbol.expanded}></div>`

--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -3014,6 +3014,8 @@ lizmap-treeview label {
 }
 
 lizmap-treeview li.not-visible > div input[type="checkbox"],
+lizmap-treeview li.not-visible > label input[type="checkbox"],
+lizmap-treeview li.not-visible > ul.symbols label input[type="checkbox"],
 lizmap-treeview li.not-in-scale > label input[type="checkbox"],
 lizmap-treeview li.not-in-scale > ul.symbols label input[type="checkbox"] {
   accent-color: #7F7F80;
@@ -3021,6 +3023,7 @@ lizmap-treeview li.not-in-scale > ul.symbols label input[type="checkbox"] {
 
 lizmap-treeview li.not-visible > div label,
 lizmap-treeview li.not-visible > ul.symbols label,
+lizmap-treeview li.not-visible > label,
 lizmap-treeview li.not-in-scale > label,
 lizmap-treeview li.not-in-scale > ul.symbols label {
   font-style: italic;
@@ -3029,6 +3032,7 @@ lizmap-treeview li.not-in-scale > ul.symbols label {
 
 lizmap-treeview li.not-visible > div img,
 lizmap-treeview li.not-visible > ul.symbols img,
+lizmap-treeview li.not-visible > label img,
 lizmap-treeview li.not-in-scale > label img,
 lizmap-treeview li.not-in-scale > ul.symbols img {
   filter: grayscale(1);

--- a/tests/end2end/playwright/legend.spec.js
+++ b/tests/end2end/playwright/legend.spec.js
@@ -70,4 +70,44 @@ test.describe('Legend tests', () => {
         await expect(page.getByTestId('layer_legend_ruled').getByRole('listitem').filter({hasText: '100k +'})).toHaveClass(/not-in-scale/);
         await expect(page.getByTestId('layer_legend_ruled').getByRole('listitem').filter({hasText: '100k -'})).not.toHaveClass(/not-in-scale/);
     });
+
+    test("Layer's rule based symbologie unchecked", async ({ page }) => {
+        // Display layer's rule based legend
+        await page.getByTestId('layer_legend_ruled').locator('.expandable').first().click()
+        await page.getByTestId('layer_legend_ruled').getByRole('listitem').filter({hasText: '100k +'}).locator('.expandable').first().click()
+        await expect(page.getByTestId('layer_legend_ruled').getByRole('listitem').filter({hasText: '100k +'})).not.toHaveClass(/not-visible/);
+
+        await page.getByTestId('layer_legend_ruled').getByLabel('100k +').uncheck();
+        await expect(page.getByTestId('layer_legend_ruled').getByRole('listitem').filter({hasText: '100k +'})).toHaveClass(/not-visible/);
+        await page.getByTestId('layer_legend_ruled').getByLabel('100k +').check();
+        await expect(page.getByTestId('layer_legend_ruled').getByRole('listitem').filter({hasText: '100k +'})).not.toHaveClass(/not-visible/);
+
+        // Check scale and symbology rule in scale
+        await expect(page.locator('#overview-bar .ol-scale-text')).toHaveText('1 : ' + (250000).toLocaleString(locale));
+
+        // Zoom in
+        let getMapRequestPromise = page.waitForRequest(/REQUEST=GetMap/);
+        await page.locator('#navbar button.btn.zoom-in').click();
+        await getMapRequestPromise;
+
+        // Check scale and symbology rule in scale (same)
+        await expect(page.locator('#overview-bar .ol-scale-text')).toHaveText('1 : ' + (100000).toLocaleString(locale));
+
+        // Zoom in
+        getMapRequestPromise = page.waitForRequest(/REQUEST=GetMap/);
+        await page.locator('#navbar button.btn.zoom-in').click();
+        await getMapRequestPromise;
+
+        // Check scale and symbology rule in scale (inverted)
+        await expect(page.locator('#overview-bar .ol-scale-text')).toHaveText('1 : ' + (50000).toLocaleString(locale));
+
+        await page.getByTestId('layer_legend_ruled').getByRole('listitem').filter({hasText: '100k -'}).locator('.expandable').first().click()
+        await expect(page.getByTestId('layer_legend_ruled').getByRole('listitem').filter({hasText: '100k -'})).not.toHaveClass(/not-visible/);
+        await expect(page.getByTestId('layer_legend_ruled').getByRole('listitem').filter({hasText: '100k -'}).getByRole('listitem').filter({hasText: 'category 1'})).not.toHaveClass(/not-visible/);
+
+        await page.getByTestId('layer_legend_ruled').getByLabel('category 1').uncheck();
+        await expect(page.getByTestId('layer_legend_ruled').getByRole('listitem').filter({hasText: '100k -'}).getByRole('listitem').filter({hasText: 'category 1'})).toHaveClass(/not-visible/);
+        await page.getByTestId('layer_legend_ruled').getByRole('listitem').filter({hasText: '100k -'}).getByLabel('category 1').check();
+        await expect(page.getByTestId('layer_legend_ruled').getByRole('listitem').filter({hasText: '100k -'}).getByRole('listitem').filter({hasText: 'category 1'})).not.toHaveClass(/not-visible/);
+    });
 });


### PR DESCRIPTION
![Capture d’écran 2024-05-24 à 13 23 55](https://github.com/3liz/lizmap-web-client/assets/1575538/85a8cdc2-d7d2-43f6-964c-b1601b17ca7f)

![Capture d’écran 2024-05-24 à 13 24 02](https://github.com/3liz/lizmap-web-client/assets/1575538/237ba273-0d16-4f74-8001-b3a21d2250b6)
