### PR TITLE
Admin - Add missing variable in locale in the project page

### DIFF
--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -344,7 +344,9 @@ project.list.column.target.lizmap.version.label=Target version
 project.list.column.target.lizmap.version.label.longer=Target version of Lizmap Web Client
 project.list.column.lizmap.plugin.version.label=Lizmap plugin
 project.list.column.qgis.desktop.recent.label.html=This QGIS project has been recently updated in QGIS Desktop, \
-but with a too old Lizmap plugin version. You should upgrade your plugin to <strong>%s</strong> in your QGIS plugin manager.
+but with a too old Lizmap plugin version. You should upgrade your plugin in your QGIS plugin manager.
+project.list.column.qgis.desktop.recent.version.label.html=The QGIS project has been recently updated in QGIS Desktop, \
+but with a too old Lizmap plugin version. <strong>Always</strong> install the <strong>latest version available</strong> in your QGIS plugin manager. It must be at least <strong>%s</strong>.
 project.list.column.lizmap.warnings.count.label=Warnings
 project.list.column.lizmap.warnings.explanations.label=Check your Lizmap plugin in QGIS Desktop to fix these warnings
 project.list.column.authorized.groups.label=Groups

--- a/lizmap/modules/admin/templates/project_list_help.tpl
+++ b/lizmap/modules/admin/templates/project_list_help.tpl
@@ -18,19 +18,19 @@
 
             <li>{@admin.project.rules.list.warnings.html@}</li>
             <ul>
+                <li>{@admin.project.list.column.lizmap.plugin.version.label@}</li>
+                <ul class="no_symbol">
+                    <li style="list-style-type: none;">
+                        <span class='badge badge-warning'>⚠</span>
+                        {jlocale "admin.project.list.column.qgis.desktop.recent.version.label.html" , array($lizmapDesktopRecommended)}
+                    </li>
+                </ul>
                 <li>{@admin.project.list.column.qgis.desktop.version.label@}</li>
                 <ul class="rules">
                     <li class="warning">{jlocale "admin.project.rules.list.qgis.version.warning.html",
                         array($serverVersions['qgis_server_version_old'])}</li>
                     <li class="error">{jlocale "admin.project.rules.list.qgis.version.error.html", array(
                         $serverVersions['qgis_server_version_next'])}</li>
-                </ul>
-                <li>{@admin.project.list.column.lizmap.plugin.version.label@}</li>
-                <ul class="no_symbol">
-                    <li style="list-style-type: none;">
-                        <span class='badge badge-warning'>⚠</span>
-                        {jlocale "admin.project.list.column.qgis.desktop.recent.label.html" , array($lizmapDesktopRecommended)}
-                    </li>
                 </ul>
                 <li>{@admin.project.list.column.target.lizmap.version.label.longer@}</li>
                 <ul class="rules">


### PR DESCRIPTION
In the admin project page, a `%s` was missing.