### PR TITLE
Update map.css

### DIFF
--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -3086,7 +3086,7 @@ lizmap-treeview .spinner::after {
 }
 
 lizmap-treeview img.legend{
-  height: 16px;
+  height: 'auto;
   width: 16px;
 }
 


### PR DESCRIPTION
Fix #4036
[Bug]: LWC 3.7.0 and QGIS 3.34 raster - symbology

<!--
Add the word "fix" in front of "#" if it fixes the ticket
or do nothing to only mention it.

funded by NAME
If funded by someone else than 3Liz, please add label "sponsored development"
-->

I don't know why but needs to use 'auto; instead of auto; or 'auto'; but this way works well adapting the png
