### PR TITLE
Improve user/group filter to allow multiple users/groups

### DIFF
--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -1223,10 +1223,19 @@ class Project
      * Get login filters, get expressions for layers based on login filtered
      * config.
      *
+     * NOTE: We could delegate this completely to the lizmap_server plugin
+     * for all requests. The only request needed to have the SQL filter
+     * is the WFS GetFeature request, if the layer is a PostgreSQL layer.
+     * It this particular case, we could use a similar approach
+     * that the one use with qgisVectorLayer::requestPolygonFilter
+     * which calls the server plugin with SERVICE=Lizmap&REQUEST=GetSubsetString
+     *
      * @param string[] $layers  : layers' name list
      * @param bool     $edition : get login filters for edition
      *
-     * @return array
+     * @return array Array containing layers names as key and filter configuration
+     *               and SQL filters as values. Array might be empty if no filter
+     *               is configured for the layer.
      */
     public function getLoginFilters($layers, $edition = false)
     {
@@ -1258,22 +1267,64 @@ class Project
             // attribute to filter
             $attribute = $loginFilteredConfig->filterAttribute;
 
+            // Quoted attribute with double-quotes
+            $cnx = $this->appContext->getDbConnection();
+            $quotedField = $cnx->encloseName($attribute);
+
             // default no user connected
-            $filter = "\"{$attribute}\" = 'all'";
+            $filter = "{$quotedField} = 'all' OR {$quotedField} LIKE 'all,%' OR {$quotedField} LIKE '%,all' OR {$quotedField} LIKE '%,all,%'";
 
             // A user is connected
             if ($this->appContext->userIsConnected()) {
+                // Get the user
                 $user = $this->appContext->getUserSession();
                 $login = $user->login;
+
+                // List of values for expression
+                $values = array();
                 if (property_exists($loginFilteredConfig, 'filterPrivate')
                     && $this->optionToBoolean($loginFilteredConfig->filterPrivate)
                 ) {
-                    $filter = "\"{$attribute}\" IN ( '".$login."' , 'all' )";
+                    // If filter is private use user_login
+                    $values[] = $login;
                 } else {
+                    // Else use user groups
                     $userGroups = $this->appContext->aclUserPublicGroupsId();
-                    $flatGroups = implode("' , '", $userGroups);
-                    $filter = "\"{$attribute}\" IN ( '".$flatGroups."' , 'all' )";
+                    $values = $userGroups;
                 }
+
+                // Add all to values
+                $values[] = 'all';
+                $allValuesFilters = array();
+
+                // For each value (group, all, login, etc.), create a filter
+                // combining all the possibility: equality & LIKE
+                foreach ($values as $value) {
+                    $valueFilters = array();
+                    // Quote the value with single quotes
+                    $quotedValue = $cnx->quote($value);
+
+                    // equality
+                    $valueFilters[] = "{$quotedField} = {$quotedValue}";
+
+                    // begins with value & comma
+                    $quotedLikeValue = $cnx->quote("{$value},%");
+                    $valueFilters[] = "{$quotedField} LIKE {$quotedLikeValue}";
+
+                    // ends with comma & value
+                    $quotedLikeValue = $cnx->quote("%,{$value}");
+                    $valueFilters[] = "{$quotedField} LIKE {$quotedLikeValue}";
+
+                    // value between two commas
+                    $quotedLikeValue = $cnx->quote("%,{$value},%");
+                    $valueFilters[] = "{$quotedField} LIKE {$quotedLikeValue}";
+
+                    // Build the filter for this value
+                    $allValuesFilters[] = implode(' OR ', $valueFilters);
+                }
+
+                // Build filter for all values
+                $filter = implode(' OR ', $allValuesFilters);
             }
 
             $filters[$layerName] = array_merge(

--- a/lizmap/modules/lizmap/lib/Request/WFSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WFSRequest.php
@@ -643,13 +643,13 @@ class WFSRequest extends OGCRequest
             if (strpos($validFilter, '$id') !== false) {
                 $key = $this->datasource->key;
                 if (count(explode(',', $key)) == 1) {
-                    return ' AND '.str_replace('$id ', $cnx->encloseName($key).' ', $validFilter);
+                    return ' AND ( '.str_replace('$id ', $cnx->encloseName($key).' ', $validFilter).' ) ';
                 }
 
                 return false;
             }
 
-            return ' AND '.$validFilter;
+            return ' AND ( '.$validFilter.' ) ';
         }
 
         return '';

--- a/tests/end2end/cypress/integration/requests-metadata-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-metadata-ghaction.js
@@ -41,6 +41,7 @@ describe('Request JSON metadata', function () {
                     "__anonymous",
                     "admins",
                     "group_a",
+                    "group_b",
                     "publishers"
                 ].sort()
             );
@@ -49,6 +50,7 @@ describe('Request JSON metadata', function () {
                     "__anonymous",
                     "admins",
                     "group_a",
+                    "group_b",
                     "publishers"
                 ].sort()
             );
@@ -71,6 +73,9 @@ describe('Request JSON metadata', function () {
                     },
                     "group_a": {
                         "label": "group_a"
+                    },
+                    "group_b": {
+                        "label": "group_b"
                     },
                     "intranet": {
                         "label": "Intranet demos group"
@@ -145,6 +150,7 @@ describe('Request JSON metadata', function () {
                     "__anonymous",
                     "admins",
                     "group_a",
+                    "group_b",
                     "publishers"
                 ].sort()
             );
@@ -153,6 +159,7 @@ describe('Request JSON metadata', function () {
                     "__anonymous",
                     "admins",
                     "group_a",
+                    "group_b",
                     "publishers"
                 ].sort()
             );
@@ -166,6 +173,9 @@ describe('Request JSON metadata', function () {
                     },
                     "group_a": {
                         "label": "group_a"
+                    },
+                    "group_b": {
+                        "label": "group_b"
                     },
                     "intranet": {
                         "label": "Intranet demos group"

--- a/tests/end2end/playwright/filter-layer-by-user.spec.js
+++ b/tests/end2end/playwright/filter-layer-by-user.spec.js
@@ -27,7 +27,7 @@ test.describe('Filter layer data by user - not connected', () => {
     test('WMS GetFeatureInfo JSON', async ({ page }) => {
 
         const getFeatureInfo = await page.evaluate(async () => {
-            return await fetch("/index.php/lizmap/service?repository=testsrepository&project=filter_layer_by_user&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&CRS=EPSG%3A2154&INFO_FORMAT=application%2Fjson&QUERY_LAYERS=green_filter_layer_by_user_edition_only%2Cblue_filter_layer_by_user%2Cred_layer_with_no_filter&LAYERS=green_filter_layer_by_user_edition_only%2Cblue_filter_layer_by_user%2Cred_layer_with_no_filter&STYLE=default%2Cdefault%2Cdefault&BBOX=-310600.3821764754%2C726545.2026738503%2C364617.6349262256%2C1244071.2377259205&FEATURE_COUNT=10&FILTER=green_filter_layer_by_user_edition_only:\"gid\" > 0")
+            return await fetch("/index.php/lizmap/service?repository=testsrepository&project=filter_layer_by_user&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&CRS=EPSG%3A2154&INFO_FORMAT=application%2Fjson&QUERY_LAYERS=green_filter_layer_by_user_edition_only%2Cblue_filter_layer_by_user%2Cred_layer_with_no_filter&LAYERS=green_filter_layer_by_user_edition_only%2Cblue_filter_layer_by_user%2Cred_layer_with_no_filter&STYLE=default%2Cdefault%2Cdefault&FEATURE_COUNT=10&FILTER=green_filter_layer_by_user_edition_only:\"gid\" > 0")
                 .then(r => r.ok ? r.json() : Promise.reject(r))
         })
 
@@ -165,7 +165,7 @@ test.describe('Filter layer data by user - user in group a', () => {
     test('WMS GetFeatureInfo JSON', async ({ page }) => {
 
         const getFeatureInfo = await page.evaluate(async () => {
-            return await fetch("/index.php/lizmap/service?repository=testsrepository&project=filter_layer_by_user&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&CRS=EPSG%3A2154&INFO_FORMAT=application%2Fjson&QUERY_LAYERS=green_filter_layer_by_user_edition_only%2Cblue_filter_layer_by_user%2Cred_layer_with_no_filter&LAYERS=green_filter_layer_by_user_edition_only%2Cblue_filter_layer_by_user%2Cred_layer_with_no_filter&STYLE=default%2Cdefault%2Cdefault&BBOX=-310600.3821764754%2C726545.2026738503%2C364617.6349262256%2C1244071.2377259205&FEATURE_COUNT=10&FILTER=green_filter_layer_by_user_edition_only:\"gid\" > 0")
+            return await fetch("/index.php/lizmap/service?repository=testsrepository&project=filter_layer_by_user&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&CRS=EPSG%3A2154&INFO_FORMAT=application%2Fjson&QUERY_LAYERS=green_filter_layer_by_user_edition_only%2Cblue_filter_layer_by_user%2Cred_layer_with_no_filter&LAYERS=green_filter_layer_by_user_edition_only%2Cblue_filter_layer_by_user%2Cred_layer_with_no_filter&STYLE=default%2Cdefault%2Cdefault&FEATURE_COUNT=10&FILTER=green_filter_layer_by_user_edition_only:\"gid\" > 0")
                 .then(r => r.ok ? r.json() : Promise.reject(r))
         })
 
@@ -307,7 +307,7 @@ test.describe('Filter layer data by user - admin', () => {
     test('WMS GetFeatureInfo JSON', async ({ page }) => {
 
         const getFeatureInfo = await page.evaluate(async () => {
-            return await fetch("/index.php/lizmap/service?repository=testsrepository&project=filter_layer_by_user&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&CRS=EPSG%3A2154&INFO_FORMAT=application%2Fjson&QUERY_LAYERS=green_filter_layer_by_user_edition_only%2Cblue_filter_layer_by_user%2Cred_layer_with_no_filter&LAYERS=green_filter_layer_by_user_edition_only%2Cblue_filter_layer_by_user%2Cred_layer_with_no_filter&STYLE=default%2Cdefault%2Cdefault&BBOX=-310600.3821764754%2C726545.2026738503%2C364617.6349262256%2C1244071.2377259205&FEATURE_COUNT=10&FILTER=green_filter_layer_by_user_edition_only:\"gid\" > 0")
+            return await fetch("/index.php/lizmap/service?repository=testsrepository&project=filter_layer_by_user&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&CRS=EPSG%3A2154&INFO_FORMAT=application%2Fjson&QUERY_LAYERS=green_filter_layer_by_user_edition_only%2Cblue_filter_layer_by_user%2Cred_layer_with_no_filter&LAYERS=green_filter_layer_by_user_edition_only%2Cblue_filter_layer_by_user%2Cred_layer_with_no_filter&STYLE=default%2Cdefault%2Cdefault&FEATURE_COUNT=10&FILTER=green_filter_layer_by_user_edition_only:\"gid\" > 0")
                 .then(r => r.ok ? r.json() : Promise.reject(r))
         })
 

--- a/tests/end2end/playwright/filter-layer-by-user.spec.js
+++ b/tests/end2end/playwright/filter-layer-by-user.spec.js
@@ -12,17 +12,34 @@ test.describe('Filter layer data by user - not connected', () => {
         await page.locator('#dock-close').click();
     });
 
-    test('GetMap', async ({ page }) => {
-        // Hide all elements but #newOlMap and its children
-        await page.$eval("*", el => el.style.visibility = 'hidden');
-        await page.$eval("#newOlMap, #newOlMap *", el => el.style.visibility = 'visible');
+    // DISABLED BECAUSE IT IS NOT RELIABLE, MAINTAINABLE AND CAUSES HEADACHE ;-)
+    // Instead, we use a WMS GetFeatureInfo in JSON format below
+    // test('GetMap', async ({ page }) => {
+    //     // Hide all elements but #newOlMap and its children
+    //     await page.$eval("*", el => el.style.visibility = 'hidden');
+    //     await page.$eval("#newOlMap, #newOlMap *", el => el.style.visibility = 'visible');
 
-        expect(await page.locator('#newOlMap').screenshot()).toMatchSnapshot('map_not_connected.png', {
-            maxDiffPixels: 500
-        });
+    //     expect(await page.locator('#newOlMap').screenshot()).toMatchSnapshot('map_not_connected.png', {
+    //         maxDiffPixels: 500
+    //     });
+    // });
+
+    test('WMS GetFeatureInfo JSON', async ({ page }) => {
+
+        const getFeatureInfo = await page.evaluate(async () => {
+            return await fetch("/index.php/lizmap/service?repository=testsrepository&project=filter_layer_by_user&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&CRS=EPSG%3A2154&INFO_FORMAT=application%2Fjson&QUERY_LAYERS=green_filter_layer_by_user_edition_only%2Cblue_filter_layer_by_user%2Cred_layer_with_no_filter&LAYERS=green_filter_layer_by_user_edition_only%2Cblue_filter_layer_by_user%2Cred_layer_with_no_filter&STYLE=default%2Cdefault%2Cdefault&BBOX=-310600.3821764754%2C726545.2026738503%2C364617.6349262256%2C1244071.2377259205&FEATURE_COUNT=10&FILTER=green_filter_layer_by_user_edition_only:\"gid\" > 0")
+                .then(r => r.ok ? r.json() : Promise.reject(r))
+        })
+
+        // check features
+        expect(getFeatureInfo.features).toHaveLength(4)
+        // check a specific feature
+        const feature = getFeatureInfo.features[0]
+        expect(feature.id).not.toBeUndefined()
+
     });
 
-    test('Popup', async ({ page }) => {
+    test('Popup with map click', async ({ page }) => {
         let getFeatureInfoRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeatureInfo') === true);
 
         // blue_filter_layer_by_user
@@ -133,17 +150,34 @@ test.describe('Filter layer data by user - user in group a', () => {
         await page.locator('#dock-close').click();
     });
 
-    test('GetMap', async ({ page }) => {
-        // Hide all elements but #newOlMap and its children
-        await page.$eval("*", el => el.style.visibility = 'hidden');
-        await page.$eval("#newOlMap, #newOlMap *", el => el.style.visibility = 'visible');
+    // DISABLED BECAUSE IT IS NOT RELIABLE, MAINTAINABLE AND CAUSES HEADACHE ;-)
+    // Instead, we use a WMS GetFeatureInfo in JSON format below
+    // test('GetMap', async ({ page }) => {
+    //     // Hide all elements but #newOlMap and its children
+    //     await page.$eval("*", el => el.style.visibility = 'hidden');
+    //     await page.$eval("#newOlMap, #newOlMap *", el => el.style.visibility = 'visible');
 
-        expect(await page.locator('#newOlMap').screenshot()).toMatchSnapshot('map_connected_as_user_in_group_a.png', {
-            maxDiffPixels: 500
-        });
+    //     expect(await page.locator('#newOlMap').screenshot()).toMatchSnapshot('map_connected_as_user_in_group_a.png', {
+    //         maxDiffPixels: 500
+    //     });
+    // });
+
+    test('WMS GetFeatureInfo JSON', async ({ page }) => {
+
+        const getFeatureInfo = await page.evaluate(async () => {
+            return await fetch("/index.php/lizmap/service?repository=testsrepository&project=filter_layer_by_user&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&CRS=EPSG%3A2154&INFO_FORMAT=application%2Fjson&QUERY_LAYERS=green_filter_layer_by_user_edition_only%2Cblue_filter_layer_by_user%2Cred_layer_with_no_filter&LAYERS=green_filter_layer_by_user_edition_only%2Cblue_filter_layer_by_user%2Cred_layer_with_no_filter&STYLE=default%2Cdefault%2Cdefault&BBOX=-310600.3821764754%2C726545.2026738503%2C364617.6349262256%2C1244071.2377259205&FEATURE_COUNT=10&FILTER=green_filter_layer_by_user_edition_only:\"gid\" > 0")
+                .then(r => r.ok ? r.json() : Promise.reject(r))
+        })
+
+        // check features
+        expect(getFeatureInfo.features).toHaveLength(5)
+        // check a specific feature
+        const feature = getFeatureInfo.features[0]
+        expect(feature.id).not.toBeUndefined()
+
     });
 
-    test('Popup', async ({ page }) => {
+    test('Popup with map click', async ({ page }) => {
         let getFeatureInfoRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeatureInfo') === true);
 
         // blue_filter_layer_by_user
@@ -258,17 +292,34 @@ test.describe('Filter layer data by user - admin', () => {
         await page.locator('#dock-close').click();
     });
 
-    test('GetMap', async ({ page }) => {
-        // Hide all elements but #newOlMap and its children
-        await page.$eval("*", el => el.style.visibility = 'hidden');
-        await page.$eval("#newOlMap, #newOlMap *", el => el.style.visibility = 'visible');
+    // DISABLED BECAUSE IT IS NOT RELIABLE, MAINTAINABLE AND CAUSES HEADACHE ;-)
+    // Instead, we use a WMS GetFeatureInfo in JSON format below
+    // test('GetMap', async ({ page }) => {
+    //     // Hide all elements but #newOlMap and its children
+    //     await page.$eval("*", el => el.style.visibility = 'hidden');
+    //     await page.$eval("#newOlMap, #newOlMap *", el => el.style.visibility = 'visible');
 
-        expect(await page.locator('#newOlMap').screenshot()).toMatchSnapshot('map_connected_as_admin.png', {
-            maxDiffPixels: 500
-        });
+    //     expect(await page.locator('#newOlMap').screenshot()).toMatchSnapshot('map_connected_as_admin.png', {
+    //         maxDiffPixels: 500
+    //     });
+    // });
+
+    test('WMS GetFeatureInfo JSON', async ({ page }) => {
+
+        const getFeatureInfo = await page.evaluate(async () => {
+            return await fetch("/index.php/lizmap/service?repository=testsrepository&project=filter_layer_by_user&SERVICE=WMS&REQUEST=GetFeatureInfo&VERSION=1.3.0&CRS=EPSG%3A2154&INFO_FORMAT=application%2Fjson&QUERY_LAYERS=green_filter_layer_by_user_edition_only%2Cblue_filter_layer_by_user%2Cred_layer_with_no_filter&LAYERS=green_filter_layer_by_user_edition_only%2Cblue_filter_layer_by_user%2Cred_layer_with_no_filter&STYLE=default%2Cdefault%2Cdefault&BBOX=-310600.3821764754%2C726545.2026738503%2C364617.6349262256%2C1244071.2377259205&FEATURE_COUNT=10&FILTER=green_filter_layer_by_user_edition_only:\"gid\" > 0")
+                .then(r => r.ok ? r.json() : Promise.reject(r))
+        })
+
+        // check features
+        expect(getFeatureInfo.features).toHaveLength(7)
+        // check a specific feature
+        const feature = getFeatureInfo.features[0]
+        expect(feature.id).not.toBeUndefined()
+
     });
 
-    test('Popup', async ({ page }) => {
+    test('Popup with map click', async ({ page }) => {
         let getFeatureInfoRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeatureInfo') === true);
 
         // blue_filter_layer_by_user

--- a/tests/end2end/playwright/maps-management.spec.js
+++ b/tests/end2end/playwright/maps-management.spec.js
@@ -36,45 +36,54 @@ test.describe('Maps management', () => {
 
         // Check default rights on repository
         // anonymous, admins and users can view
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.repositories\\.view_0"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.repositories\\.view_1"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.repositories\\.view_2"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.repositories\\.view_3"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.repositories\\.view_4"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.repositories\\.view_5"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.repositories\\.view_6"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.repositories.view[]"][value="__anonymous"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.repositories.view[]"][value="admins"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.repositories.view[]"][value="group_a"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.repositories.view[]"][value="group_b"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.repositories.view[]"][value="intranet"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.repositories.view[]"][value="lizadmins"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.repositories.view[]"][value="publishers"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.repositories.view[]"][value="users"]')).toBeChecked();
+
         // admins and users can display get capabilities links
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.displayGetCapabilitiesLinks_0"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.displayGetCapabilitiesLinks_1"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.displayGetCapabilitiesLinks_2"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.displayGetCapabilitiesLinks_3"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.displayGetCapabilitiesLinks_4"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.displayGetCapabilitiesLinks_5"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.displayGetCapabilitiesLinks_6"]')).toBeChecked();
-        // admins and users can use edition
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.edition\\.use_0"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.edition\\.use_1"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.edition\\.use_2"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.edition\\.use_3"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.edition\\.use_4"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.edition\\.use_5"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.edition\\.use_6"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.displayGetCapabilitiesLinks[]"][value="__anonymous"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.displayGetCapabilitiesLinks[]"][value="admins"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.displayGetCapabilitiesLinks[]"][value="group_a"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.displayGetCapabilitiesLinks[]"][value="group_b"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.displayGetCapabilitiesLinks[]"][value="intranet"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.displayGetCapabilitiesLinks[]"][value="lizadmins"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.displayGetCapabilitiesLinks[]"][value="publishers"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.displayGetCapabilitiesLinks[]"][value="users"]')).toBeChecked();
+
+        // admins can use edition
+        await expect(page.locator('input[name="lizmap.tools.edition.use[]"][value="__anonymous"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.edition.use[]"][value="admins"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.edition.use[]"][value="group_a"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.edition.use[]"][value="group_b"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.edition.use[]"][value="intranet"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.edition.use[]"][value="lizadmins"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.edition.use[]"][value="publishers"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.edition.use[]"][value="users"]')).not.toBeChecked();
+
         // admins and users can export layers
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.layer\\.export_0"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.layer\\.export_1"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.layer\\.export_2"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.layer\\.export_3"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.layer\\.export_4"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.layer\\.export_5"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.layer\\.export_6"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.layer.export[]"][value="__anonymous"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.layer.export[]"][value="admins"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.layer.export[]"][value="group_a"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.layer.export[]"][value="group_b"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.layer.export[]"][value="intranet"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.layer.export[]"][value="lizadmins"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.layer.export[]"][value="publishers"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.layer.export[]"][value="users"]')).toBeChecked();
+
         // no users override login filtered layers
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.loginFilteredLayers\\.override_0"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.loginFilteredLayers\\.override_1"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.loginFilteredLayers\\.override_2"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.loginFilteredLayers\\.override_3"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.loginFilteredLayers\\.override_4"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.loginFilteredLayers\\.override_5"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.loginFilteredLayers\\.override_6"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.loginFilteredLayers.override[]"][value="__anonymous"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.loginFilteredLayers.override[]"][value="admins"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.loginFilteredLayers.override[]"][value="group_a"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.loginFilteredLayers.override[]"][value="group_b"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.loginFilteredLayers.override[]"][value="intranet"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.loginFilteredLayers.override[]"][value="lizadmins"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.loginFilteredLayers.override[]"][value="publishers"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.loginFilteredLayers.override[]"][value="users"]')).not.toBeChecked();
 
         // Select a path to create a new repository
         await page.locator('[id=jforms_admin_config_section_path]').selectOption('/srv/lzm/tests/qgis-projects/ProJets 1982*!/');
@@ -132,46 +141,55 @@ test.describe('Maps management', () => {
         await expect(page.locator('[id=jforms_admin_config_section_accessControlAllowOrigin]')).toHaveValue('http://othersite.local:8130');
 
         // Check default rights on repository
-        // anonymous, admins, group_a and publishers can view
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.repositories\\.view_0"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.repositories\\.view_1"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.repositories\\.view_2"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.repositories\\.view_3"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.repositories\\.view_4"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.repositories\\.view_5"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.repositories\\.view_6"]')).not.toBeChecked();
-        // anonymous, admins, group_a and publishers can display get capabilities links
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.displayGetCapabilitiesLinks_0"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.displayGetCapabilitiesLinks_1"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.displayGetCapabilitiesLinks_2"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.displayGetCapabilitiesLinks_3"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.displayGetCapabilitiesLinks_4"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.displayGetCapabilitiesLinks_5"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.displayGetCapabilitiesLinks_6"]')).not.toBeChecked();
-        // anonymous, admins, group_a and publishers can use edition
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.edition\\.use_0"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.edition\\.use_1"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.edition\\.use_2"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.edition\\.use_3"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.edition\\.use_4"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.edition\\.use_5"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.edition\\.use_6"]')).not.toBeChecked();
-        // anonymous, admins, group_a and publishers can export layers
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.layer\\.export_0"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.layer\\.export_1"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.layer\\.export_2"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.layer\\.export_3"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.layer\\.export_4"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.layer\\.export_5"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.layer\\.export_6"]')).not.toBeChecked();
+        // anonymous, admins, group_a, group_b and publishers can view
+        await expect(page.locator('input[name="lizmap.repositories.view[]"][value="__anonymous"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.repositories.view[]"][value="admins"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.repositories.view[]"][value="group_a"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.repositories.view[]"][value="group_b"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.repositories.view[]"][value="intranet"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.repositories.view[]"][value="lizadmins"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.repositories.view[]"][value="publishers"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.repositories.view[]"][value="users"]')).not.toBeChecked();
+
+        // anonymous, admins, group_a, group_b and publishers can display get capabilities links
+        await expect(page.locator('input[name="lizmap.tools.displayGetCapabilitiesLinks[]"][value="__anonymous"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.displayGetCapabilitiesLinks[]"][value="admins"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.displayGetCapabilitiesLinks[]"][value="group_a"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.displayGetCapabilitiesLinks[]"][value="group_b"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.displayGetCapabilitiesLinks[]"][value="intranet"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.displayGetCapabilitiesLinks[]"][value="lizadmins"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.displayGetCapabilitiesLinks[]"][value="publishers"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.displayGetCapabilitiesLinks[]"][value="users"]')).not.toBeChecked();
+
+        // anonymous, admins, group_a, group_b and publishers can use edition
+        await expect(page.locator('input[name="lizmap.tools.edition.use[]"][value="__anonymous"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.edition.use[]"][value="admins"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.edition.use[]"][value="group_a"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.edition.use[]"][value="group_b"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.edition.use[]"][value="intranet"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.edition.use[]"][value="lizadmins"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.edition.use[]"][value="publishers"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.edition.use[]"][value="users"]')).not.toBeChecked();
+
+        // anonymous, admins, group_a, group_b and publishers can export layers
+        await expect(page.locator('input[name="lizmap.tools.layer.export[]"][value="__anonymous"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.layer.export[]"][value="admins"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.layer.export[]"][value="group_a"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.layer.export[]"][value="group_b"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.layer.export[]"][value="intranet"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.layer.export[]"][value="lizadmins"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.layer.export[]"][value="publishers"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.layer.export[]"][value="users"]')).not.toBeChecked();
+
         // admins and publishers override login filtered layers
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.loginFilteredLayers\\.override_0"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.loginFilteredLayers\\.override_1"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.loginFilteredLayers\\.override_2"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.loginFilteredLayers\\.override_3"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.loginFilteredLayers\\.override_4"]')).not.toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.loginFilteredLayers\\.override_5"]')).toBeChecked();
-        await expect(page.locator('[id="jforms_admin_config_section_lizmap\\.tools\\.loginFilteredLayers\\.override_6"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.loginFilteredLayers.override[]"][value="__anonymous"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.loginFilteredLayers.override[]"][value="admins"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.loginFilteredLayers.override[]"][value="group_a"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.loginFilteredLayers.override[]"][value="group_b"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.loginFilteredLayers.override[]"][value="intranet"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.loginFilteredLayers.override[]"][value="lizadmins"]')).not.toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.loginFilteredLayers.override[]"][value="publishers"]')).toBeChecked();
+        await expect(page.locator('input[name="lizmap.tools.loginFilteredLayers.override[]"][value="users"]')).not.toBeChecked();
 
         await page.getByRole('link', { name: 'Back' }).click();
         // Check URL

--- a/tests/qgis-projects/tests/filter_layer_by_user.qgs
+++ b/tests/qgis-projects/tests/filter_layer_by_user.qgs
@@ -1,11 +1,10 @@
-<qgis projectname="" saveDateTime="2023-07-03T13:53:49" saveUser="nboisteault" saveUserFull="nboisteault" version="3.22.16-Białowieża">
+<qgis projectname="" saveDateTime="2024-06-27T12:06:36" saveUser="nboisteault" saveUserFull="nboisteault" version="3.28.15-Firenze">
   <homePath path=""></homePath>
   <title></title>
-  <autotransaction active="0"></autotransaction>
-  <evaluateDefaultValues active="0"></evaluateDefaultValues>
-  <trust active="0"></trust>
+  <transaction mode="Disabled"></transaction>
+  <projectFlags set="TrustStoredLayerStatistics"></projectFlags>
   <projectCrs>
-    <spatialrefsys>
+    <spatialrefsys nativeFormat="Wkt">
       <wkt>PROJCRS["RGF93 v1 / Lambert-93",BASEGEOGCRS["RGF93 v1",DATUM["Reseau Geodesique Francais 1993 v1",ELLIPSOID["GRS 1980",6378137,298.257222101,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4171]],CONVERSION["Lambert-93",METHOD["Lambert Conic Conformal (2SP)",ID["EPSG",9802]],PARAMETER["Latitude of false origin",46.5,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8821]],PARAMETER["Longitude of false origin",3,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8822]],PARAMETER["Latitude of 1st standard parallel",49,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8823]],PARAMETER["Latitude of 2nd standard parallel",44,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8824]],PARAMETER["Easting at false origin",700000,LENGTHUNIT["metre",1],ID["EPSG",8826]],PARAMETER["Northing at false origin",6600000,LENGTHUNIT["metre",1],ID["EPSG",8827]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Engineering survey, topographic mapping."],AREA["France - onshore and offshore, mainland and Corsica."],BBOX[41.15,-9.86,51.56,10.38]],ID["EPSG",2154]]</wkt>
       <proj4>+proj=lcc +lat_0=46.5 +lon_0=3 +lat_1=49 +lat_2=44 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
       <srsid>145</srsid>
@@ -45,8 +44,8 @@
   <snapping-settings enabled="0" intersection-snapping="0" maxScale="0" minScale="0" mode="2" scaleDependencyMode="0" self-snapping="0" tolerance="12" type="1" unit="1">
     <individual-layer-settings>
       <layer-setting enabled="0" id="filter_layer_by_user_8bd3128f_2cad_4121_b5f9_0b6f6118e2f0" maxScale="0" minScale="0" tolerance="12" type="1" units="1"></layer-setting>
-      <layer-setting enabled="0" id="filter_layer_by_user_edition_only_7bc0e81c_2860_4d6b_8b20_ad6c7b76e42f" maxScale="0" minScale="0" tolerance="12" type="1" units="1"></layer-setting>
       <layer-setting enabled="0" id="layer_with_no_filter_89c540b5_0c19_4805_b505_78770286189f" maxScale="0" minScale="0" tolerance="12" type="1" units="1"></layer-setting>
+      <layer-setting enabled="0" id="filter_layer_by_user_edition_only_7bc0e81c_2860_4d6b_8b20_ad6c7b76e42f" maxScale="0" minScale="0" tolerance="12" type="1" units="1"></layer-setting>
     </individual-layer-settings>
   </snapping-settings>
   <relations></relations>
@@ -61,7 +60,7 @@
     </extent>
     <rotation>0</rotation>
     <destinationsrs>
-      <spatialrefsys>
+      <spatialrefsys nativeFormat="Wkt">
         <wkt>PROJCRS["RGF93 v1 / Lambert-93",BASEGEOGCRS["RGF93 v1",DATUM["Reseau Geodesique Francais 1993 v1",ELLIPSOID["GRS 1980",6378137,298.257222101,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4171]],CONVERSION["Lambert-93",METHOD["Lambert Conic Conformal (2SP)",ID["EPSG",9802]],PARAMETER["Latitude of false origin",46.5,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8821]],PARAMETER["Longitude of false origin",3,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8822]],PARAMETER["Latitude of 1st standard parallel",49,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8823]],PARAMETER["Latitude of 2nd standard parallel",44,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8824]],PARAMETER["Easting at false origin",700000,LENGTHUNIT["metre",1],ID["EPSG",8826]],PARAMETER["Northing at false origin",6600000,LENGTHUNIT["metre",1],ID["EPSG",8827]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Engineering survey, topographic mapping."],AREA["France - onshore and offshore, mainland and Corsica."],BBOX[41.15,-9.86,51.56,10.38]],ID["EPSG",2154]]</wkt>
         <proj4>+proj=lcc +lat_0=46.5 +lon_0=3 +lat_1=49 +lat_2=44 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
         <srsid>145</srsid>
@@ -95,7 +94,6 @@
     </legendlayer>
   </legend>
   <mapViewDocks></mapViewDocks>
-  <mapViewDocks3D></mapViewDocks3D>
   <main-annotation-layer autoRefreshEnabled="0" autoRefreshTime="0" legendPlaceholderImage="" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" type="annotation">
     <id>Annotations_1b82beaa_5a0a_445e_b2ad_d7288106e20f</id>
     <datasource></datasource>
@@ -104,7 +102,7 @@
     </keywordList>
     <layername></layername>
     <srs>
-      <spatialrefsys>
+      <spatialrefsys nativeFormat="Wkt">
         <wkt></wkt>
         <proj4></proj4>
         <srsid>0</srsid>
@@ -127,7 +125,7 @@
       <fees></fees>
       <encoding></encoding>
       <crs>
-        <spatialrefsys>
+        <spatialrefsys nativeFormat="Wkt">
           <wkt></wkt>
           <proj4></proj4>
           <srsid>0</srsid>
@@ -168,7 +166,7 @@
       </keywordList>
       <layername>blue_filter_layer_by_user</layername>
       <srs>
-        <spatialrefsys>
+        <spatialrefsys nativeFormat="Wkt">
           <wkt>PROJCRS["RGF93 v1 / Lambert-93",BASEGEOGCRS["RGF93 v1",DATUM["Reseau Geodesique Francais 1993 v1",ELLIPSOID["GRS 1980",6378137,298.257222101,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4171]],CONVERSION["Lambert-93",METHOD["Lambert Conic Conformal (2SP)",ID["EPSG",9802]],PARAMETER["Latitude of false origin",46.5,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8821]],PARAMETER["Longitude of false origin",3,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8822]],PARAMETER["Latitude of 1st standard parallel",49,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8823]],PARAMETER["Latitude of 2nd standard parallel",44,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8824]],PARAMETER["Easting at false origin",700000,LENGTHUNIT["metre",1],ID["EPSG",8826]],PARAMETER["Northing at false origin",6600000,LENGTHUNIT["metre",1],ID["EPSG",8827]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Engineering survey, topographic mapping."],AREA["France - onshore and offshore, mainland and Corsica."],BBOX[41.15,-9.86,51.56,10.38]],ID["EPSG",2154]]</wkt>
           <proj4>+proj=lcc +lat_0=46.5 +lon_0=3 +lat_1=49 +lat_2=44 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>145</srsid>
@@ -200,7 +198,7 @@
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt>PROJCRS["RGF93 v1 / Lambert-93",BASEGEOGCRS["RGF93 v1",DATUM["Reseau Geodesique Francais 1993 v1",ELLIPSOID["GRS 1980",6378137,298.257222101,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4171]],CONVERSION["Lambert-93",METHOD["Lambert Conic Conformal (2SP)",ID["EPSG",9802]],PARAMETER["Latitude of false origin",46.5,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8821]],PARAMETER["Longitude of false origin",3,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8822]],PARAMETER["Latitude of 1st standard parallel",49,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8823]],PARAMETER["Latitude of 2nd standard parallel",44,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8824]],PARAMETER["Easting at false origin",700000,LENGTHUNIT["metre",1],ID["EPSG",8826]],PARAMETER["Northing at false origin",6600000,LENGTHUNIT["metre",1],ID["EPSG",8827]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Engineering survey, topographic mapping."],AREA["France - onshore and offshore, mainland and Corsica."],BBOX[41.15,-9.86,51.56,10.38]],ID["EPSG",2154]]</wkt>
             <proj4>+proj=lcc +lat_0=46.5 +lon_0=3 +lat_1=49 +lat_2=44 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
             <srsid>145</srsid>
@@ -244,9 +242,141 @@
           <end></end>
         </fixedRange>
       </temporal>
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="133,182,111,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="133,182,111,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="95,130,79,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="133,182,111,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="95,130,79,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
       <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
         <symbols>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="marker">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="0" type="marker">
             <data_defined_properties>
               <Option type="Map">
                 <Option name="name" type="QString" value=""></Option>
@@ -276,25 +406,6 @@
                 <Option name="size_unit" type="QString" value="MM"></Option>
                 <Option name="vertical_anchor_point" type="QString" value="1"></Option>
               </Option>
-              <prop k="angle" v="0"></prop>
-              <prop k="cap_style" v="square"></prop>
-              <prop k="color" v="72,123,182,255"></prop>
-              <prop k="horizontal_anchor_point" v="1"></prop>
-              <prop k="joinstyle" v="bevel"></prop>
-              <prop k="name" v="circle"></prop>
-              <prop k="offset" v="0,0"></prop>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="offset_unit" v="MM"></prop>
-              <prop k="outline_color" v="50,87,128,255"></prop>
-              <prop k="outline_style" v="solid"></prop>
-              <prop k="outline_width" v="0.4"></prop>
-              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="outline_width_unit" v="MM"></prop>
-              <prop k="scale_method" v="diameter"></prop>
-              <prop k="size" v="4"></prop>
-              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="size_unit" v="MM"></prop>
-              <prop k="vertical_anchor_point" v="1"></prop>
               <data_defined_properties>
                 <Option type="Map">
                   <Option name="name" type="QString" value=""></Option>
@@ -310,12 +421,12 @@
       </renderer-v2>
       <labeling type="simple">
         <settings calloutType="simple">
-          <text-style allowHtml="0" blendMode="0" capitalization="0" fieldName="user" fontFamily="Ubuntu" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="10" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" isExpression="0" legendString="Aa" multilineHeight="1" namedStyle="Regular" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal" useSubstitutions="0">
+          <text-style allowHtml="0" blendMode="0" capitalization="0" fieldName="user" fontFamily="Ubuntu" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="10" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" forcedBold="0" forcedItalic="0" isExpression="0" legendString="Aa" multilineHeight="1" multilineHeightUnit="Percentage" namedStyle="Regular" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal" useSubstitutions="0">
             <families></families>
             <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
             <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="0" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
             <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
-              <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="markerSymbol" type="marker">
+              <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="markerSymbol" type="marker">
                 <data_defined_properties>
                   <Option type="Map">
                     <Option name="name" type="QString" value=""></Option>
@@ -345,25 +456,6 @@
                     <Option name="size_unit" type="QString" value="MM"></Option>
                     <Option name="vertical_anchor_point" type="QString" value="1"></Option>
                   </Option>
-                  <prop k="angle" v="0"></prop>
-                  <prop k="cap_style" v="square"></prop>
-                  <prop k="color" v="231,113,72,255"></prop>
-                  <prop k="horizontal_anchor_point" v="1"></prop>
-                  <prop k="joinstyle" v="bevel"></prop>
-                  <prop k="name" v="circle"></prop>
-                  <prop k="offset" v="0,0"></prop>
-                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                  <prop k="offset_unit" v="MM"></prop>
-                  <prop k="outline_color" v="35,35,35,255"></prop>
-                  <prop k="outline_style" v="solid"></prop>
-                  <prop k="outline_width" v="0"></prop>
-                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                  <prop k="outline_width_unit" v="MM"></prop>
-                  <prop k="scale_method" v="diameter"></prop>
-                  <prop k="size" v="2"></prop>
-                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                  <prop k="size_unit" v="MM"></prop>
-                  <prop k="vertical_anchor_point" v="1"></prop>
                   <data_defined_properties>
                     <Option type="Map">
                       <Option name="name" type="QString" value=""></Option>
@@ -373,7 +465,7 @@
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="fillSymbol" type="fill">
+              <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="fillSymbol" type="fill">
                 <data_defined_properties>
                   <Option type="Map">
                     <Option name="name" type="QString" value=""></Option>
@@ -395,17 +487,6 @@
                     <Option name="outline_width_unit" type="QString" value="MM"></Option>
                     <Option name="style" type="QString" value="solid"></Option>
                   </Option>
-                  <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                  <prop k="color" v="255,255,255,255"></prop>
-                  <prop k="joinstyle" v="bevel"></prop>
-                  <prop k="offset" v="0,0"></prop>
-                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                  <prop k="offset_unit" v="MM"></prop>
-                  <prop k="outline_color" v="128,128,128,255"></prop>
-                  <prop k="outline_style" v="no"></prop>
-                  <prop k="outline_width" v="0"></prop>
-                  <prop k="outline_width_unit" v="MM"></prop>
-                  <prop k="style" v="solid"></prop>
                   <data_defined_properties>
                     <Option type="Map">
                       <Option name="name" type="QString" value=""></Option>
@@ -427,8 +508,8 @@
             <substitutions></substitutions>
           </text-style>
           <text-format addDirectionSymbol="0" autoWrapLength="0" decimals="3" formatNumbers="0" leftDirectionSymbol="&lt;" multilineAlign="3" placeDirectionSymbol="0" plussign="0" reverseDirectionSymbol="0" rightDirectionSymbol=">" useMaxLineLengthForAutoWrap="1" wrapChar=""></text-format>
-          <placement centroidInside="0" centroidWhole="0" dist="0" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="PointGeometry" lineAnchorClipping="0" lineAnchorPercent="0.5" lineAnchorType="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" offsetType="0" offsetUnits="MM" overrunDistance="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" placement="0" placementFlags="10" polygonPlacementFlags="2" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" preserveRotation="1" priority="5" quadOffset="4" repeatDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" rotationAngle="0" rotationUnit="AngleDegrees" xOffset="0" yOffset="0"></placement>
-          <rendering displayAll="0" drawLabels="1" fontLimitPixelSize="0" fontMaxPixelSize="10000" fontMinPixelSize="3" labelPerPart="0" limitNumLabels="0" maxNumLabels="2000" mergeLines="0" minFeatureSize="0" obstacle="1" obstacleFactor="1" obstacleType="0" scaleMax="0" scaleMin="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" zIndex="0"></rendering>
+          <placement allowDegraded="0" centroidInside="0" centroidWhole="0" dist="0" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="PointGeometry" lineAnchorClipping="0" lineAnchorPercent="0.5" lineAnchorTextPoint="CenterOfText" lineAnchorType="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" offsetType="0" offsetUnits="MM" overlapHandling="PreventOverlap" overrunDistance="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" placement="0" placementFlags="10" polygonPlacementFlags="2" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" preserveRotation="1" priority="5" quadOffset="4" repeatDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" rotationAngle="0" rotationUnit="AngleDegrees" xOffset="0" yOffset="0"></placement>
+          <rendering drawLabels="1" fontLimitPixelSize="0" fontMaxPixelSize="10000" fontMinPixelSize="3" labelPerPart="0" limitNumLabels="0" maxNumLabels="2000" mergeLines="0" minFeatureSize="0" obstacle="1" obstacleFactor="1" obstacleType="0" scaleMax="0" scaleMin="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" zIndex="0"></rendering>
           <dd_properties>
             <Option type="Map">
               <Option name="name" type="QString" value=""></Option>
@@ -448,7 +529,7 @@
               <Option name="drawToAllParts" type="bool" value="false"></Option>
               <Option name="enabled" type="QString" value="0"></Option>
               <Option name="labelAnchorPoint" type="QString" value="point_on_exterior"></Option>
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; clip_to_extent=&quot;1&quot; alpha=&quot;1&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; enabled=&quot;1&quot; pass=&quot;0&quot; locked=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/>&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/>&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/>&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/>&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/>&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;/Option>&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"></Option>
+              <Option name="lineSymbol" type="QString" value="&lt;symbol alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; type=&quot;line&quot; force_rhr=&quot;0&quot; name=&quot;symbol&quot; frame_rate=&quot;10&quot; is_animated=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer enabled=&quot;1&quot; pass=&quot;0&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"></Option>
               <Option name="minLength" type="double" value="0"></Option>
               <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
               <Option name="minLengthUnit" type="QString" value="MM"></Option>
@@ -464,7 +545,9 @@
       </labeling>
       <customproperties>
         <Option type="Map">
-          <Option name="dualview/previewExpressions" type="QString" value="&quot;gid&quot;"></Option>
+          <Option name="dualview/previewExpressions" type="List">
+            <Option type="QString" value="&quot;gid&quot;"></Option>
+          </Option>
           <Option name="embeddedWidgets/count" type="QString" value="0"></Option>
           <Option name="variableNames" type="invalid"></Option>
           <Option name="variableValues" type="invalid"></Option>
@@ -475,10 +558,10 @@
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
         <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
-          <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+          <fontProperties bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></fontProperties>
           <attribute color="#000000" colorOpacity="1" field="" label=""></attribute>
           <axisSymbol>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="line">
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
               <data_defined_properties>
                 <Option type="Map">
                   <Option name="name" type="QString" value=""></Option>
@@ -516,33 +599,6 @@
                   <Option name="use_custom_dash" type="QString" value="0"></Option>
                   <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
                 </Option>
-                <prop k="align_dash_pattern" v="0"></prop>
-                <prop k="capstyle" v="square"></prop>
-                <prop k="customdash" v="5;2"></prop>
-                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="customdash_unit" v="MM"></prop>
-                <prop k="dash_pattern_offset" v="0"></prop>
-                <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="dash_pattern_offset_unit" v="MM"></prop>
-                <prop k="draw_inside_polygon" v="0"></prop>
-                <prop k="joinstyle" v="bevel"></prop>
-                <prop k="line_color" v="35,35,35,255"></prop>
-                <prop k="line_style" v="solid"></prop>
-                <prop k="line_width" v="0.26"></prop>
-                <prop k="line_width_unit" v="MM"></prop>
-                <prop k="offset" v="0"></prop>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="offset_unit" v="MM"></prop>
-                <prop k="ring_filter" v="0"></prop>
-                <prop k="trim_distance_end" v="0"></prop>
-                <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="trim_distance_end_unit" v="MM"></prop>
-                <prop k="trim_distance_start" v="0"></prop>
-                <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="trim_distance_start_unit" v="MM"></prop>
-                <prop k="tweak_dash_pattern_on_corners" v="0"></prop>
-                <prop k="use_custom_dash" v="0"></prop>
-                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
                 <data_defined_properties>
                   <Option type="Map">
                     <Option name="name" type="QString" value=""></Option>
@@ -620,7 +676,7 @@
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
           <column hidden="0" name="gid" type="field" width="-1"></column>
-          <column hidden="0" name="user" type="field" width="-1"></column>
+          <column hidden="0" name="user" type="field" width="444"></column>
           <column hidden="0" name="group" type="field" width="-1"></column>
           <column hidden="1" type="actions" width="-1"></column>
         </columns>
@@ -663,7 +719,11 @@ def my_form_open(dialog, layer, feature):
         <field labelOnTop="0" name="group"></field>
         <field labelOnTop="0" name="user"></field>
       </labelOnTop>
-      <reuseLastValue></reuseLastValue>
+      <reuseLastValue>
+        <field name="gid" reuseLastValue="0"></field>
+        <field name="group" reuseLastValue="0"></field>
+        <field name="user" reuseLastValue="0"></field>
+      </reuseLastValue>
       <dataDefinedFieldProperties></dataDefinedFieldProperties>
       <widgets></widgets>
       <previewExpression>"gid"</previewExpression>
@@ -690,7 +750,7 @@ def my_form_open(dialog, layer, feature):
       </keywordList>
       <layername>green_filter_layer_by_user_edition_only</layername>
       <srs>
-        <spatialrefsys>
+        <spatialrefsys nativeFormat="Wkt">
           <wkt>PROJCRS["RGF93 v1 / Lambert-93",BASEGEOGCRS["RGF93 v1",DATUM["Reseau Geodesique Francais 1993 v1",ELLIPSOID["GRS 1980",6378137,298.257222101,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4171]],CONVERSION["Lambert-93",METHOD["Lambert Conic Conformal (2SP)",ID["EPSG",9802]],PARAMETER["Latitude of false origin",46.5,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8821]],PARAMETER["Longitude of false origin",3,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8822]],PARAMETER["Latitude of 1st standard parallel",49,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8823]],PARAMETER["Latitude of 2nd standard parallel",44,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8824]],PARAMETER["Easting at false origin",700000,LENGTHUNIT["metre",1],ID["EPSG",8826]],PARAMETER["Northing at false origin",6600000,LENGTHUNIT["metre",1],ID["EPSG",8827]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Engineering survey, topographic mapping."],AREA["France - onshore and offshore, mainland and Corsica."],BBOX[41.15,-9.86,51.56,10.38]],ID["EPSG",2154]]</wkt>
           <proj4>+proj=lcc +lat_0=46.5 +lon_0=3 +lat_1=49 +lat_2=44 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>145</srsid>
@@ -722,7 +782,7 @@ def my_form_open(dialog, layer, feature):
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt>PROJCRS["RGF93 v1 / Lambert-93",BASEGEOGCRS["RGF93 v1",DATUM["Reseau Geodesique Francais 1993 v1",ELLIPSOID["GRS 1980",6378137,298.257222101,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4171]],CONVERSION["Lambert-93",METHOD["Lambert Conic Conformal (2SP)",ID["EPSG",9802]],PARAMETER["Latitude of false origin",46.5,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8821]],PARAMETER["Longitude of false origin",3,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8822]],PARAMETER["Latitude of 1st standard parallel",49,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8823]],PARAMETER["Latitude of 2nd standard parallel",44,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8824]],PARAMETER["Easting at false origin",700000,LENGTHUNIT["metre",1],ID["EPSG",8826]],PARAMETER["Northing at false origin",6600000,LENGTHUNIT["metre",1],ID["EPSG",8827]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Engineering survey, topographic mapping."],AREA["France - onshore and offshore, mainland and Corsica."],BBOX[41.15,-9.86,51.56,10.38]],ID["EPSG",2154]]</wkt>
             <proj4>+proj=lcc +lat_0=46.5 +lon_0=3 +lat_1=49 +lat_2=44 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
             <srsid>145</srsid>
@@ -766,9 +826,141 @@ def my_form_open(dialog, layer, feature):
           <end></end>
         </fixedRange>
       </temporal>
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="125,139,143,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="125,139,143,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="89,99,102,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="125,139,143,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="89,99,102,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
       <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
         <symbols>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="marker">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="0" type="marker">
             <data_defined_properties>
               <Option type="Map">
                 <Option name="name" type="QString" value=""></Option>
@@ -798,25 +990,6 @@ def my_form_open(dialog, layer, feature):
                 <Option name="size_unit" type="QString" value="MM"></Option>
                 <Option name="vertical_anchor_point" type="QString" value="1"></Option>
               </Option>
-              <prop k="angle" v="0"></prop>
-              <prop k="cap_style" v="square"></prop>
-              <prop k="color" v="84,176,74,255"></prop>
-              <prop k="horizontal_anchor_point" v="1"></prop>
-              <prop k="joinstyle" v="bevel"></prop>
-              <prop k="name" v="circle"></prop>
-              <prop k="offset" v="0,0"></prop>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="offset_unit" v="MM"></prop>
-              <prop k="outline_color" v="61,128,53,255"></prop>
-              <prop k="outline_style" v="solid"></prop>
-              <prop k="outline_width" v="0.4"></prop>
-              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="outline_width_unit" v="MM"></prop>
-              <prop k="scale_method" v="diameter"></prop>
-              <prop k="size" v="4"></prop>
-              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="size_unit" v="MM"></prop>
-              <prop k="vertical_anchor_point" v="1"></prop>
               <data_defined_properties>
                 <Option type="Map">
                   <Option name="name" type="QString" value=""></Option>
@@ -832,12 +1005,12 @@ def my_form_open(dialog, layer, feature):
       </renderer-v2>
       <labeling type="simple">
         <settings calloutType="simple">
-          <text-style allowHtml="0" blendMode="0" capitalization="0" fieldName="user" fontFamily="Ubuntu" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="10" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" isExpression="0" legendString="Aa" multilineHeight="1" namedStyle="Regular" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal" useSubstitutions="0">
+          <text-style allowHtml="0" blendMode="0" capitalization="0" fieldName="user" fontFamily="Ubuntu" fontItalic="0" fontKerning="1" fontLetterSpacing="0" fontSize="10" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontStrikeout="0" fontUnderline="0" fontWeight="50" fontWordSpacing="0" forcedBold="0" forcedItalic="0" isExpression="0" legendString="Aa" multilineHeight="1" multilineHeightUnit="Percentage" namedStyle="Regular" previewBkgrdColor="255,255,255,255" textColor="0,0,0,255" textOpacity="1" textOrientation="horizontal" useSubstitutions="0">
             <families></families>
             <text-buffer bufferBlendMode="0" bufferColor="255,255,255,255" bufferDraw="0" bufferJoinStyle="128" bufferNoFill="1" bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM"></text-buffer>
             <text-mask maskEnabled="0" maskJoinStyle="128" maskOpacity="1" maskSize="0" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSizeUnits="MM" maskType="0" maskedSymbolLayers=""></text-mask>
             <background shapeBlendMode="0" shapeBorderColor="128,128,128,255" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeDraw="0" shapeFillColor="255,255,255,255" shapeJoinStyle="64" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetX="0" shapeOffsetY="0" shapeOpacity="1" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="MM" shapeRadiiX="0" shapeRadiiY="0" shapeRotation="0" shapeRotationType="0" shapeSVGFile="" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeSizeUnit="MM" shapeSizeX="0" shapeSizeY="0" shapeType="0">
-              <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="markerSymbol" type="marker">
+              <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="markerSymbol" type="marker">
                 <data_defined_properties>
                   <Option type="Map">
                     <Option name="name" type="QString" value=""></Option>
@@ -867,25 +1040,6 @@ def my_form_open(dialog, layer, feature):
                     <Option name="size_unit" type="QString" value="MM"></Option>
                     <Option name="vertical_anchor_point" type="QString" value="1"></Option>
                   </Option>
-                  <prop k="angle" v="0"></prop>
-                  <prop k="cap_style" v="square"></prop>
-                  <prop k="color" v="229,182,54,255"></prop>
-                  <prop k="horizontal_anchor_point" v="1"></prop>
-                  <prop k="joinstyle" v="bevel"></prop>
-                  <prop k="name" v="circle"></prop>
-                  <prop k="offset" v="0,0"></prop>
-                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                  <prop k="offset_unit" v="MM"></prop>
-                  <prop k="outline_color" v="35,35,35,255"></prop>
-                  <prop k="outline_style" v="solid"></prop>
-                  <prop k="outline_width" v="0"></prop>
-                  <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                  <prop k="outline_width_unit" v="MM"></prop>
-                  <prop k="scale_method" v="diameter"></prop>
-                  <prop k="size" v="2"></prop>
-                  <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                  <prop k="size_unit" v="MM"></prop>
-                  <prop k="vertical_anchor_point" v="1"></prop>
                   <data_defined_properties>
                     <Option type="Map">
                       <Option name="name" type="QString" value=""></Option>
@@ -895,7 +1049,7 @@ def my_form_open(dialog, layer, feature):
                   </data_defined_properties>
                 </layer>
               </symbol>
-              <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="fillSymbol" type="fill">
+              <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="fillSymbol" type="fill">
                 <data_defined_properties>
                   <Option type="Map">
                     <Option name="name" type="QString" value=""></Option>
@@ -917,17 +1071,6 @@ def my_form_open(dialog, layer, feature):
                     <Option name="outline_width_unit" type="QString" value="MM"></Option>
                     <Option name="style" type="QString" value="solid"></Option>
                   </Option>
-                  <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                  <prop k="color" v="255,255,255,255"></prop>
-                  <prop k="joinstyle" v="bevel"></prop>
-                  <prop k="offset" v="0,0"></prop>
-                  <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                  <prop k="offset_unit" v="MM"></prop>
-                  <prop k="outline_color" v="128,128,128,255"></prop>
-                  <prop k="outline_style" v="no"></prop>
-                  <prop k="outline_width" v="0"></prop>
-                  <prop k="outline_width_unit" v="MM"></prop>
-                  <prop k="style" v="solid"></prop>
                   <data_defined_properties>
                     <Option type="Map">
                       <Option name="name" type="QString" value=""></Option>
@@ -949,8 +1092,8 @@ def my_form_open(dialog, layer, feature):
             <substitutions></substitutions>
           </text-style>
           <text-format addDirectionSymbol="0" autoWrapLength="0" decimals="3" formatNumbers="0" leftDirectionSymbol="&lt;" multilineAlign="3" placeDirectionSymbol="0" plussign="0" reverseDirectionSymbol="0" rightDirectionSymbol=">" useMaxLineLengthForAutoWrap="1" wrapChar=""></text-format>
-          <placement centroidInside="0" centroidWhole="0" dist="0" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="PointGeometry" lineAnchorClipping="0" lineAnchorPercent="0.5" lineAnchorType="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" offsetType="0" offsetUnits="MM" overrunDistance="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" placement="0" placementFlags="10" polygonPlacementFlags="2" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" preserveRotation="1" priority="5" quadOffset="4" repeatDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" rotationAngle="0" rotationUnit="AngleDegrees" xOffset="0" yOffset="0"></placement>
-          <rendering displayAll="0" drawLabels="1" fontLimitPixelSize="0" fontMaxPixelSize="10000" fontMinPixelSize="3" labelPerPart="0" limitNumLabels="0" maxNumLabels="2000" mergeLines="0" minFeatureSize="0" obstacle="1" obstacleFactor="1" obstacleType="0" scaleMax="0" scaleMin="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" zIndex="0"></rendering>
+          <placement allowDegraded="0" centroidInside="0" centroidWhole="0" dist="0" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" fitInPolygonOnly="0" geometryGenerator="" geometryGeneratorEnabled="0" geometryGeneratorType="PointGeometry" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" layerType="PointGeometry" lineAnchorClipping="0" lineAnchorPercent="0.5" lineAnchorTextPoint="CenterOfText" lineAnchorType="0" maxCurvedCharAngleIn="25" maxCurvedCharAngleOut="-25" offsetType="0" offsetUnits="MM" overlapHandling="PreventOverlap" overrunDistance="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" overrunDistanceUnit="MM" placement="0" placementFlags="10" polygonPlacementFlags="2" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" preserveRotation="1" priority="5" quadOffset="4" repeatDistance="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceUnits="MM" rotationAngle="0" rotationUnit="AngleDegrees" xOffset="0" yOffset="0"></placement>
+          <rendering drawLabels="1" fontLimitPixelSize="0" fontMaxPixelSize="10000" fontMinPixelSize="3" labelPerPart="0" limitNumLabels="0" maxNumLabels="2000" mergeLines="0" minFeatureSize="0" obstacle="1" obstacleFactor="1" obstacleType="0" scaleMax="0" scaleMin="0" scaleVisibility="0" unplacedVisibility="0" upsidedownLabels="0" zIndex="0"></rendering>
           <dd_properties>
             <Option type="Map">
               <Option name="name" type="QString" value=""></Option>
@@ -970,7 +1113,7 @@ def my_form_open(dialog, layer, feature):
               <Option name="drawToAllParts" type="bool" value="false"></Option>
               <Option name="enabled" type="QString" value="0"></Option>
               <Option name="labelAnchorPoint" type="QString" value="point_on_exterior"></Option>
-              <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; clip_to_extent=&quot;1&quot; alpha=&quot;1&quot; type=&quot;line&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; enabled=&quot;1&quot; pass=&quot;0&quot; locked=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/>&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/>&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255&quot;/>&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/>&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/>&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;/Option>&lt;prop v=&quot;0&quot; k=&quot;align_dash_pattern&quot;/>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;dash_pattern_offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;dash_pattern_offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;trim_distance_end&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_end_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;trim_distance_start&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;trim_distance_start_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"></Option>
+              <Option name="lineSymbol" type="QString" value="&lt;symbol alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; type=&quot;line&quot; force_rhr=&quot;0&quot; name=&quot;symbol&quot; frame_rate=&quot;10&quot; is_animated=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer enabled=&quot;1&quot; pass=&quot;0&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"></Option>
               <Option name="minLength" type="double" value="0"></Option>
               <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"></Option>
               <Option name="minLengthUnit" type="QString" value="MM"></Option>
@@ -986,6 +1129,9 @@ def my_form_open(dialog, layer, feature):
       </labeling>
       <customproperties>
         <Option type="Map">
+          <Option name="dualview/previewExpressions" type="List">
+            <Option type="QString" value="&quot;gid&quot;"></Option>
+          </Option>
           <Option name="embeddedWidgets/count" type="QString" value="0"></Option>
           <Option name="variableNames" type="invalid"></Option>
           <Option name="variableValues" type="invalid"></Option>
@@ -996,10 +1142,10 @@ def my_form_open(dialog, layer, feature):
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
         <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="1" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="0" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="0" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
-          <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
+          <fontProperties bold="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" italic="0" strikethrough="0" style="" underline="0"></fontProperties>
           <attribute color="#000000" colorOpacity="1" field="" label=""></attribute>
           <axisSymbol>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="line">
+            <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
               <data_defined_properties>
                 <Option type="Map">
                   <Option name="name" type="QString" value=""></Option>
@@ -1037,33 +1183,6 @@ def my_form_open(dialog, layer, feature):
                   <Option name="use_custom_dash" type="QString" value="0"></Option>
                   <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
                 </Option>
-                <prop k="align_dash_pattern" v="0"></prop>
-                <prop k="capstyle" v="square"></prop>
-                <prop k="customdash" v="5;2"></prop>
-                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="customdash_unit" v="MM"></prop>
-                <prop k="dash_pattern_offset" v="0"></prop>
-                <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="dash_pattern_offset_unit" v="MM"></prop>
-                <prop k="draw_inside_polygon" v="0"></prop>
-                <prop k="joinstyle" v="bevel"></prop>
-                <prop k="line_color" v="35,35,35,255"></prop>
-                <prop k="line_style" v="solid"></prop>
-                <prop k="line_width" v="0.26"></prop>
-                <prop k="line_width_unit" v="MM"></prop>
-                <prop k="offset" v="0"></prop>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="offset_unit" v="MM"></prop>
-                <prop k="ring_filter" v="0"></prop>
-                <prop k="trim_distance_end" v="0"></prop>
-                <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="trim_distance_end_unit" v="MM"></prop>
-                <prop k="trim_distance_start" v="0"></prop>
-                <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="trim_distance_start_unit" v="MM"></prop>
-                <prop k="tweak_dash_pattern_on_corners" v="0"></prop>
-                <prop k="use_custom_dash" v="0"></prop>
-                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
                 <data_defined_properties>
                   <Option type="Map">
                     <Option name="name" type="QString" value=""></Option>
@@ -1141,7 +1260,7 @@ def my_form_open(dialog, layer, feature):
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
           <column hidden="0" name="gid" type="field" width="-1"></column>
-          <column hidden="0" name="user" type="field" width="-1"></column>
+          <column hidden="0" name="user" type="field" width="279"></column>
           <column hidden="0" name="group" type="field" width="-1"></column>
           <column hidden="1" type="actions" width="-1"></column>
         </columns>
@@ -1211,7 +1330,7 @@ def my_form_open(dialog, layer, feature):
       </keywordList>
       <layername>red_layer_with_no_filter</layername>
       <srs>
-        <spatialrefsys>
+        <spatialrefsys nativeFormat="Wkt">
           <wkt>PROJCRS["RGF93 v1 / Lambert-93",BASEGEOGCRS["RGF93 v1",DATUM["Reseau Geodesique Francais 1993 v1",ELLIPSOID["GRS 1980",6378137,298.257222101,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4171]],CONVERSION["Lambert-93",METHOD["Lambert Conic Conformal (2SP)",ID["EPSG",9802]],PARAMETER["Latitude of false origin",46.5,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8821]],PARAMETER["Longitude of false origin",3,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8822]],PARAMETER["Latitude of 1st standard parallel",49,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8823]],PARAMETER["Latitude of 2nd standard parallel",44,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8824]],PARAMETER["Easting at false origin",700000,LENGTHUNIT["metre",1],ID["EPSG",8826]],PARAMETER["Northing at false origin",6600000,LENGTHUNIT["metre",1],ID["EPSG",8827]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Engineering survey, topographic mapping."],AREA["France - onshore and offshore, mainland and Corsica."],BBOX[41.15,-9.86,51.56,10.38]],ID["EPSG",2154]]</wkt>
           <proj4>+proj=lcc +lat_0=46.5 +lon_0=3 +lat_1=49 +lat_2=44 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>145</srsid>
@@ -1234,7 +1353,7 @@ def my_form_open(dialog, layer, feature):
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt>PROJCRS["RGF93 v1 / Lambert-93",BASEGEOGCRS["RGF93 v1",DATUM["Reseau Geodesique Francais 1993 v1",ELLIPSOID["GRS 1980",6378137,298.257222101,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4171]],CONVERSION["Lambert-93",METHOD["Lambert Conic Conformal (2SP)",ID["EPSG",9802]],PARAMETER["Latitude of false origin",46.5,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8821]],PARAMETER["Longitude of false origin",3,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8822]],PARAMETER["Latitude of 1st standard parallel",49,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8823]],PARAMETER["Latitude of 2nd standard parallel",44,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8824]],PARAMETER["Easting at false origin",700000,LENGTHUNIT["metre",1],ID["EPSG",8826]],PARAMETER["Northing at false origin",6600000,LENGTHUNIT["metre",1],ID["EPSG",8827]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Engineering survey, topographic mapping."],AREA["France - onshore and offshore, mainland and Corsica."],BBOX[41.15,-9.86,51.56,10.38]],ID["EPSG",2154]]</wkt>
             <proj4>+proj=lcc +lat_0=46.5 +lon_0=3 +lat_1=49 +lat_2=44 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
             <srsid>145</srsid>
@@ -1270,9 +1389,141 @@ def my_form_open(dialog, layer, feature):
           <end></end>
         </fixedRange>
       </temporal>
+      <elevation binding="Centroid" clamping="Terrain" extrusion="0" extrusionEnabled="0" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0" symbology="Line" type="IndividualFeatures" zoffset="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""></Option>
+            <Option name="properties"></Option>
+            <Option name="type" type="QString" value="collection"></Option>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="line">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"></Option>
+                <Option name="capstyle" type="QString" value="square"></Option>
+                <Option name="customdash" type="QString" value="5;2"></Option>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="customdash_unit" type="QString" value="MM"></Option>
+                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
+                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="line_color" type="QString" value="145,82,45,255"></Option>
+                <Option name="line_style" type="QString" value="solid"></Option>
+                <Option name="line_width" type="QString" value="0.6"></Option>
+                <Option name="line_width_unit" type="QString" value="MM"></Option>
+                <Option name="offset" type="QString" value="0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="ring_filter" type="QString" value="0"></Option>
+                <Option name="trim_distance_end" type="QString" value="0"></Option>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
+                <Option name="trim_distance_start" type="QString" value="0"></Option>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
+                <Option name="use_custom_dash" type="QString" value="0"></Option>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="fill">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="color" type="QString" value="145,82,45,255"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="104,59,32,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="style" type="QString" value="solid"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="" type="marker">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""></Option>
+                <Option name="properties"></Option>
+                <Option name="type" type="QString" value="collection"></Option>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="angle" type="QString" value="0"></Option>
+                <Option name="cap_style" type="QString" value="square"></Option>
+                <Option name="color" type="QString" value="145,82,45,255"></Option>
+                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
+                <Option name="joinstyle" type="QString" value="bevel"></Option>
+                <Option name="name" type="QString" value="diamond"></Option>
+                <Option name="offset" type="QString" value="0,0"></Option>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="offset_unit" type="QString" value="MM"></Option>
+                <Option name="outline_color" type="QString" value="104,59,32,255"></Option>
+                <Option name="outline_style" type="QString" value="solid"></Option>
+                <Option name="outline_width" type="QString" value="0.2"></Option>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="outline_width_unit" type="QString" value="MM"></Option>
+                <Option name="scale_method" type="QString" value="diameter"></Option>
+                <Option name="size" type="QString" value="3"></Option>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="size_unit" type="QString" value="MM"></Option>
+                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
       <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
         <symbols>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="marker">
+          <symbol alpha="1" clip_to_extent="1" force_rhr="0" frame_rate="10" is_animated="0" name="0" type="marker">
             <data_defined_properties>
               <Option type="Map">
                 <Option name="name" type="QString" value=""></Option>
@@ -1302,25 +1553,6 @@ def my_form_open(dialog, layer, feature):
                 <Option name="size_unit" type="QString" value="MM"></Option>
                 <Option name="vertical_anchor_point" type="QString" value="1"></Option>
               </Option>
-              <prop k="angle" v="0"></prop>
-              <prop k="cap_style" v="square"></prop>
-              <prop k="color" v="219,30,42,255"></prop>
-              <prop k="horizontal_anchor_point" v="1"></prop>
-              <prop k="joinstyle" v="bevel"></prop>
-              <prop k="name" v="circle"></prop>
-              <prop k="offset" v="0,0"></prop>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="offset_unit" v="MM"></prop>
-              <prop k="outline_color" v="128,17,25,255"></prop>
-              <prop k="outline_style" v="solid"></prop>
-              <prop k="outline_width" v="0.4"></prop>
-              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="outline_width_unit" v="MM"></prop>
-              <prop k="scale_method" v="diameter"></prop>
-              <prop k="size" v="4"></prop>
-              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="size_unit" v="MM"></prop>
-              <prop k="vertical_anchor_point" v="1"></prop>
               <data_defined_properties>
                 <Option type="Map">
                   <Option name="name" type="QString" value=""></Option>
@@ -1335,7 +1567,11 @@ def my_form_open(dialog, layer, feature):
         <sizescale></sizescale>
       </renderer-v2>
       <customproperties>
-        <Option></Option>
+        <Option type="Map">
+          <Option name="dualview/previewExpressions" type="List">
+            <Option type="QString" value="&quot;gid&quot;"></Option>
+          </Option>
+        </Option>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
@@ -1374,7 +1610,10 @@ def my_form_open(dialog, layer, feature):
         <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
-        <columns></columns>
+        <columns>
+          <column hidden="0" name="gid" type="field" width="-1"></column>
+          <column hidden="1" type="actions" width="-1"></column>
+        </columns>
       </attributetableconfig>
       <conditionalstyles>
         <rowstyles></rowstyles>
@@ -1393,7 +1632,7 @@ def my_form_open(dialog, layer, feature):
       <reuseLastValue></reuseLastValue>
       <dataDefinedFieldProperties></dataDefinedFieldProperties>
       <widgets></widgets>
-      <previewExpression></previewExpression>
+      <previewExpression>"gid"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
   </projectlayers>
@@ -1403,14 +1642,7 @@ def my_form_open(dialog, layer, feature):
     <layer id="layer_with_no_filter_89c540b5_0c19_4805_b505_78770286189f"></layer>
   </layerorder>
   <properties>
-    <DefaultStyles>
-      <ColorRamp type="QString"></ColorRamp>
-      <Fill type="QString"></Fill>
-      <Line type="QString"></Line>
-      <Marker type="QString"></Marker>
-      <Opacity type="double">1</Opacity>
-      <RandomColors type="bool">true</RandomColors>
-    </DefaultStyles>
+    <DefaultStyles></DefaultStyles>
     <Digitizing>
       <AvoidIntersectionsMode type="int">2</AvoidIntersectionsMode>
     </Digitizing>
@@ -1470,7 +1702,7 @@ def my_form_open(dialog, layer, feature):
         <value>lizmap_user_groups</value>
       </variableNames>
       <variableValues type="QStringList">
-        <value>intranet</value>
+        <value>testsrepository</value>
         <value></value>
         <value></value>
       </variableValues>
@@ -1558,7 +1790,7 @@ def my_form_open(dialog, layer, feature):
   <transformContext>
     <srcDest allowFallback="1" coordinateOp="">
       <src>
-        <spatialrefsys>
+        <spatialrefsys nativeFormat="Wkt">
           <wkt>PROJCRS["RGF93 v1 / Lambert-93",BASEGEOGCRS["RGF93 v1",DATUM["Reseau Geodesique Francais 1993 v1",ELLIPSOID["GRS 1980",6378137,298.257222101,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4171]],CONVERSION["Lambert-93",METHOD["Lambert Conic Conformal (2SP)",ID["EPSG",9802]],PARAMETER["Latitude of false origin",46.5,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8821]],PARAMETER["Longitude of false origin",3,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8822]],PARAMETER["Latitude of 1st standard parallel",49,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8823]],PARAMETER["Latitude of 2nd standard parallel",44,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8824]],PARAMETER["Easting at false origin",700000,LENGTHUNIT["metre",1],ID["EPSG",8826]],PARAMETER["Northing at false origin",6600000,LENGTHUNIT["metre",1],ID["EPSG",8827]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Engineering survey, topographic mapping."],AREA["France - onshore and offshore, mainland and Corsica."],BBOX[41.15,-9.86,51.56,10.38]],ID["EPSG",2154]]</wkt>
           <proj4>+proj=lcc +lat_0=46.5 +lon_0=3 +lat_1=49 +lat_2=44 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>145</srsid>
@@ -1571,7 +1803,7 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </src>
       <dest>
-        <spatialrefsys>
+        <spatialrefsys nativeFormat="Wkt">
           <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
           <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
           <srsid>3452</srsid>
@@ -1607,11 +1839,12 @@ def my_form_open(dialog, layer, feature):
   </projectMetadata>
   <Annotations></Annotations>
   <Layouts></Layouts>
+  <mapViewDocks3D></mapViewDocks3D>
   <Bookmarks></Bookmarks>
   <ProjectViewSettings UseProjectScales="0" rotation="0">
     <Scales></Scales>
-    <DefaultViewExtent xmax="611430.73520733194891363" xmin="-494971.69091073388699442" ymax="1329107.51270445785485208" ymin="698659.04196717543527484">
-      <spatialrefsys>
+    <DefaultViewExtent xmax="623944.44455094973091036" xmin="-507485.40025435166899115" ymax="1329107.51270445785485208" ymin="698659.04196717543527484">
+      <spatialrefsys nativeFormat="Wkt">
         <wkt>PROJCRS["RGF93 v1 / Lambert-93",BASEGEOGCRS["RGF93 v1",DATUM["Reseau Geodesique Francais 1993 v1",ELLIPSOID["GRS 1980",6378137,298.257222101,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4171]],CONVERSION["Lambert-93",METHOD["Lambert Conic Conformal (2SP)",ID["EPSG",9802]],PARAMETER["Latitude of false origin",46.5,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8821]],PARAMETER["Longitude of false origin",3,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8822]],PARAMETER["Latitude of 1st standard parallel",49,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8823]],PARAMETER["Latitude of 2nd standard parallel",44,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8824]],PARAMETER["Easting at false origin",700000,LENGTHUNIT["metre",1],ID["EPSG",8826]],PARAMETER["Northing at false origin",6600000,LENGTHUNIT["metre",1],ID["EPSG",8827]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Engineering survey, topographic mapping."],AREA["France - onshore and offshore, mainland and Corsica."],BBOX[41.15,-9.86,51.56,10.38]],ID["EPSG",2154]]</wkt>
         <proj4>+proj=lcc +lat_0=46.5 +lon_0=3 +lat_1=49 +lat_2=44 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
         <srsid>145</srsid>
@@ -1624,19 +1857,55 @@ def my_form_open(dialog, layer, feature):
       </spatialrefsys>
     </DefaultViewExtent>
   </ProjectViewSettings>
+  <ProjectStyleSettings DefaultSymbolOpacity="1" RandomizeDefaultSymbolColor="1" projectStyleId="attachment:///nkDNiW_styles.db">
+    <databases></databases>
+  </ProjectStyleSettings>
   <ProjectTimeSettings cumulativeTemporalRange="0" frameRate="1" timeStep="1" timeStepUnit="h"></ProjectTimeSettings>
-  <ProjectDisplaySettings>
+  <ElevationProperties>
+    <terrainProvider type="flat">
+      <TerrainProvider offset="0" scale="1"></TerrainProvider>
+    </terrainProvider>
+  </ElevationProperties>
+  <ProjectDisplaySettings CoordinateAxisOrder="Default" CoordinateType="MapCrs">
     <BearingFormat id="bearing">
       <Option type="Map">
-        <Option name="decimal_separator" type="QChar" value=""></Option>
+        <Option name="decimal_separator" type="invalid"></Option>
         <Option name="decimals" type="int" value="6"></Option>
         <Option name="direction_format" type="int" value="0"></Option>
         <Option name="rounding_type" type="int" value="0"></Option>
         <Option name="show_plus" type="bool" value="false"></Option>
         <Option name="show_thousand_separator" type="bool" value="true"></Option>
         <Option name="show_trailing_zeros" type="bool" value="false"></Option>
-        <Option name="thousand_separator" type="QChar" value=""></Option>
+        <Option name="thousand_separator" type="invalid"></Option>
       </Option>
     </BearingFormat>
+    <GeographicCoordinateFormat id="geographiccoordinate">
+      <Option type="Map">
+        <Option name="angle_format" type="QString" value="DecimalDegrees"></Option>
+        <Option name="decimal_separator" type="invalid"></Option>
+        <Option name="decimals" type="int" value="6"></Option>
+        <Option name="rounding_type" type="int" value="0"></Option>
+        <Option name="show_leading_degree_zeros" type="bool" value="false"></Option>
+        <Option name="show_leading_zeros" type="bool" value="false"></Option>
+        <Option name="show_plus" type="bool" value="false"></Option>
+        <Option name="show_suffix" type="bool" value="true"></Option>
+        <Option name="show_thousand_separator" type="bool" value="true"></Option>
+        <Option name="show_trailing_zeros" type="bool" value="false"></Option>
+        <Option name="thousand_separator" type="invalid"></Option>
+      </Option>
+    </GeographicCoordinateFormat>
+    <CoordinateCustomCrs>
+      <spatialrefsys nativeFormat="Wkt">
+        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+        <srsid>3452</srsid>
+        <srid>4326</srid>
+        <authid>EPSG:4326</authid>
+        <description>WGS 84</description>
+        <projectionacronym>longlat</projectionacronym>
+        <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+        <geographicflag>true</geographicflag>
+      </spatialrefsys>
+    </CoordinateCustomCrs>
   </ProjectDisplaySettings>
 </qgis>

--- a/tests/qgis-projects/tests/filter_layer_by_user.qgs.cfg
+++ b/tests/qgis-projects/tests/filter_layer_by_user.qgs.cfg
@@ -1,15 +1,17 @@
 {
     "metadata": {
-        "qgis_desktop_version": 32216,
-        "lizmap_plugin_version_str": "3.14.3-alpha",
-        "lizmap_plugin_version": 31403,
-        "lizmap_web_client_target_version": 30700,
+        "qgis_desktop_version": 32815,
+        "lizmap_plugin_version_str": "4.3.18-alpha",
+        "lizmap_plugin_version": 40318,
+        "lizmap_web_client_target_version": 30900,
         "lizmap_web_client_target_status": "Dev",
         "instance_target_url": "http://localhost:8130/",
-        "instance_target_repository": "intranet",
-        "project_valid": true
+        "instance_target_repository": "testsrepository"
     },
-    "warnings": [],
+    "warnings": {},
+    "debug": {
+        "total_time": 0.379
+    },
     "options": {
         "projection": {
             "proj4": "+proj=lcc +lat_0=46.5 +lon_0=3 +lat_1=49 +lat_2=44 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs",
@@ -33,11 +35,13 @@
         ],
         "minScale": 10000,
         "maxScale": 2000000,
+        "use_native_zoom_levels": false,
+        "hide_numeric_scale_value": false,
         "initialExtent": [
-            -492657.5601093583,
-            698659.0419671754,
-            609116.6044059563,
-            1329107.5127044579
+            -492657.5601,
+            698659.042,
+            609116.6044,
+            1329107.5127
         ],
         "popupLocation": "dock",
         "pointTolerance": 25,

--- a/tests/qgis-projects/tests/set_tests_respository_rights.sql
+++ b/tests/qgis-projects/tests/set_tests_respository_rights.sql
@@ -5,6 +5,8 @@ INSERT INTO lizmap.jacl2_group(
 	id_aclgrp, name, grouptype, ownerlogin)
 	VALUES ('group_a', 'group_a', 0, null),
     ('__priv_user_in_group_a', 'user_in_group_a', 2, 'user_in_group_a'),
+	('group_b', 'group_b', 0, null),
+    ('__priv_user_in_group_b', 'user_in_group_b', 2, 'user_in_group_b'),
     ('__priv_publisher', 'publisher', 2, 'publisher')
     ON CONFLICT DO NOTHING
     ;
@@ -14,6 +16,7 @@ INSERT INTO lizmap.jlx_user(
 	usr_login, usr_email, usr_password, status, create_date)
 	VALUES
 	('user_in_group_a', 'user_in_group_a@nomail.nomail', '$2y$10$d2KZfxeYJP0l3YbNyDMZYe2vGSA3JWa8kFJSdecmSEIqInjnunTJ.', 1, NOW()),
+	('user_in_group_b', 'user_in_group_b@nomail.nomail', '$2y$10$d2KZfxeYJP0l3YbNyDMZYe2vGSA3JWa8kFJSdecmSEIqInjnunTJ.', 1, NOW()),
 	('publisher', 'publisher@nomail.nomail', '$2y$10$d2KZfxeYJP0l3YbNyDMZYe2vGSA3JWa8kFJSdecmSEIqInjnunTJ.', 1, NOW())
 	ON CONFLICT DO NOTHING
 	;
@@ -24,6 +27,9 @@ INSERT INTO lizmap.jacl2_user_group(
 	VALUES ('user_in_group_a', 'group_a'),
 	('user_in_group_a', '__priv_user_in_group_a'),
 	('user_in_group_a', 'users'),
+	('user_in_group_b', 'group_b'),
+	('user_in_group_b', '__priv_user_in_group_b'),
+	('user_in_group_b', 'users'),
 	('publisher', '__priv_publisher'),
 	('publisher', 'users'),
 	('publisher', 'publishers')
@@ -54,6 +60,11 @@ VALUES
 ('lizmap.repositories.view', 'group_a', 'testsrepository', 0),
 ('lizmap.tools.displayGetCapabilitiesLinks', 'group_a', 'testsrepository', 0),
 ('lizmap.tools.edition.use', 'group_a', 'testsrepository', 0),
-('lizmap.tools.layer.export', 'group_a', 'testsrepository', 0)
+('lizmap.tools.layer.export', 'group_a', 'testsrepository', 0),
+-- ...for users in group_b group
+('lizmap.repositories.view', 'group_b', 'testsrepository', 0),
+('lizmap.tools.displayGetCapabilitiesLinks', 'group_b', 'testsrepository', 0),
+('lizmap.tools.edition.use', 'group_b', 'testsrepository', 0),
+('lizmap.tools.layer.export', 'group_b', 'testsrepository', 0)
 ON CONFLICT DO NOTHING
 ;

--- a/tests/qgis-projects/tests/tests_dataset.sql
+++ b/tests/qgis-projects/tests/tests_dataset.sql
@@ -3,7 +3,7 @@
 --
 
 -- Dumped from database version 14.11 (Debian 14.11-1.pgdg110+2)
--- Dumped by pg_dump version 14.11 (Ubuntu 14.11-0ubuntu0.22.04.1)
+-- Dumped by pg_dump version 14.12 (Ubuntu 14.12-0ubuntu0.22.04.1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -402,6 +402,38 @@ CREATE SEQUENCE tests_projects.dnd_popup_id_seq
 --
 
 ALTER SEQUENCE tests_projects.dnd_popup_id_seq OWNED BY tests_projects.dnd_popup.id;
+
+
+--
+-- Name: double_geom; Type: TABLE; Schema: tests_projects; Owner: -
+--
+
+CREATE TABLE tests_projects.double_geom (
+    id integer NOT NULL,
+    title text,
+    geom public.geometry(Polygon,4326),
+    geom_d public.geometry(Polygon,4326)
+);
+
+
+--
+-- Name: double_geom_id_seq; Type: SEQUENCE; Schema: tests_projects; Owner: -
+--
+
+CREATE SEQUENCE tests_projects.double_geom_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: double_geom_id_seq; Type: SEQUENCE OWNED BY; Schema: tests_projects; Owner: -
+--
+
+ALTER SEQUENCE tests_projects.double_geom_id_seq OWNED BY tests_projects.double_geom.id;
 
 
 --
@@ -2319,6 +2351,39 @@ ALTER SEQUENCE tests_projects.tramway_stops_id_stop_seq OWNED BY tests_projects.
 
 
 --
+-- Name: triple_geom; Type: TABLE; Schema: tests_projects; Owner: -
+--
+
+CREATE TABLE tests_projects.triple_geom (
+    id integer NOT NULL,
+    title text,
+    geom public.geometry(Point,4326),
+    geom_l public.geometry(LineString,4326),
+    geom_p public.geometry(Polygon,4326)
+);
+
+
+--
+-- Name: triple_geom_id_seq; Type: SEQUENCE; Schema: tests_projects; Owner: -
+--
+
+CREATE SEQUENCE tests_projects.triple_geom_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: triple_geom_id_seq; Type: SEQUENCE OWNED BY; Schema: tests_projects; Owner: -
+--
+
+ALTER SEQUENCE tests_projects.triple_geom_id_seq OWNED BY tests_projects.triple_geom.id;
+
+
+--
 -- Name: xss; Type: TABLE; Schema: tests_projects; Owner: -
 --
 
@@ -2347,69 +2412,6 @@ CREATE SEQUENCE tests_projects.xss_id_seq
 --
 
 ALTER SEQUENCE tests_projects.xss_id_seq OWNED BY tests_projects.xss.id;
-
---
--- Name: double_geom; Type: TABLE; Schema: tests_projects; Owner: -
---
-
-CREATE TABLE tests_projects.double_geom (
-    id integer NOT NULL,
-    title text,
-    geom public.geometry(Polygon,4326),
-    geom_d public.geometry(Polygon,4326)
-);
-
---
--- Name: double_geom; Type: SEQUENCE; Schema: tests_projects; Owner: -
---
-
-CREATE SEQUENCE tests_projects.double_geom_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: double_geom_id_seq; Type: SEQUENCE OWNED BY; Schema: tests_projects; Owner: -
---
-
-ALTER SEQUENCE tests_projects.double_geom_id_seq OWNED BY tests_projects.double_geom.id;
-
-
---
--- Name: triple_geom; Type: TABLE; Schema: tests_projects; Owner: -
---
-
-CREATE TABLE tests_projects.triple_geom (
-    id integer NOT NULL,
-    title text,
-    geom public.geometry(Point,4326),
-    geom_l public.geometry(LineString,4326),
-    geom_p public.geometry(Polygon,4326)
-
-);
-
---
--- Name: triple_geom Type: SEQUENCE; Schema: tests_projects; Owner: -
---
-
-CREATE SEQUENCE tests_projects.triple_geom_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: triple_geom_id_seq; Type: SEQUENCE OWNED BY; Schema: tests_projects; Owner: -
---
-
-ALTER SEQUENCE tests_projects.triple_geom_id_seq OWNED BY tests_projects.triple_geom.id;
 
 
 --
@@ -2487,6 +2489,13 @@ ALTER TABLE ONLY tests_projects.dnd_form_geom ALTER COLUMN id SET DEFAULT nextva
 --
 
 ALTER TABLE ONLY tests_projects.dnd_popup ALTER COLUMN id SET DEFAULT nextval('tests_projects.dnd_popup_id_seq'::regclass);
+
+
+--
+-- Name: double_geom id; Type: DEFAULT; Schema: tests_projects; Owner: -
+--
+
+ALTER TABLE ONLY tests_projects.double_geom ALTER COLUMN id SET DEFAULT nextval('tests_projects.double_geom_id_seq'::regclass);
 
 
 --
@@ -2903,22 +2912,18 @@ ALTER TABLE ONLY tests_projects.tramway_stops ALTER COLUMN id_stop SET DEFAULT n
 
 
 --
+-- Name: triple_geom id; Type: DEFAULT; Schema: tests_projects; Owner: -
+--
+
+ALTER TABLE ONLY tests_projects.triple_geom ALTER COLUMN id SET DEFAULT nextval('tests_projects.triple_geom_id_seq'::regclass);
+
+
+--
 -- Name: xss id; Type: DEFAULT; Schema: tests_projects; Owner: -
 --
 
 ALTER TABLE ONLY tests_projects.xss ALTER COLUMN id SET DEFAULT nextval('tests_projects.xss_id_seq'::regclass);
 
---
--- Name: double_geom id; Type: DEFAULT; Schema: tests_projects; Owner: -
---
-
-ALTER TABLE ONLY tests_projects.double_geom ALTER COLUMN id SET DEFAULT nextval('tests_projects.double_geom_id_seq'::regclass);
-
---
--- Name: triple_geom id; Type: DEFAULT; Schema: tests_projects; Owner: -
---
-
-ALTER TABLE ONLY tests_projects.triple_geom ALTER COLUMN id SET DEFAULT nextval('tests_projects.triple_geom_id_seq'::regclass);
 
 --
 -- Data for Name: attribute_table; Type: TABLE DATA; Schema: tests_projects; Owner: -
@@ -3066,6 +3071,15 @@ COPY tests_projects.dnd_popup (id, field_tab1, field_tab2, geom) FROM stdin;
 
 
 --
+-- Data for Name: double_geom; Type: TABLE DATA; Schema: tests_projects; Owner: -
+--
+
+COPY tests_projects.double_geom (id, title, geom, geom_d) FROM stdin;
+1	F2	0103000020E610000001000000060000005520F9393F8E0E4043232852C1CD454091126D1728C40E4049F9C8EAF5CB454015E1134ED2540E40190EB02B2ECC454015E1134ED2540E40190EB02B2ECC454089C25720B0490E402CE5037573CE45405520F9393F8E0E4043232852C1CD4540	0103000020E61000000100000007000000879AE9F0C7BA0E4030327583F7D1454067325F7DA79E0E404EB50AFEA5D04540FA7B2DC3A5AF0E40CC0ED2F6E3CE45408E34CC0DD0C10E40F5B479184BCF45408E34CC0DD0C10E40F5B479184BCF4540BC614BB6D4EA0E40BE84EFBB22D04540879AE9F0C7BA0E4030327583F7D14540
+\.
+
+
+--
 -- Data for Name: edition_layer_embed_child; Type: TABLE DATA; Schema: tests_projects; Owner: -
 --
 
@@ -3119,8 +3133,8 @@ COPY tests_projects.end2end_form_edition_geom (id, value, geom) FROM stdin;
 
 COPY tests_projects.filter_layer_by_user (gid, "user", "group", geom) FROM stdin;
 1	admin	\N	01010000206A08000000E08B6EAA0E744090DC4977C6372F41
-2	user_in_group_a	\N	01010000206A08000084D3086E0FDFF3404A2C05E482472F41
 3	\N	\N	01010000206A08000028B76AD632CBE540B5C59180B9102E41
+2	user_in_group_a,user_in_group_b	\N	01010000206A08000084D3086E0FDFF3404A2C05E482472F41
 \.
 
 
@@ -3731,25 +3745,20 @@ COPY tests_projects.tramway_stops (id_stop, geom) FROM stdin;
 
 
 --
+-- Data for Name: triple_geom; Type: TABLE DATA; Schema: tests_projects; Owner: -
+--
+
+COPY tests_projects.triple_geom (id, title, geom, geom_l, geom_p) FROM stdin;
+1	P2	0101000020E61000009BAFF31C24420F40B0F20C103ECD4540	0102000020E610000003000000F831609D15230F40B6C8ADA872CB45400D2267EAD5350F40CA0ED2F6E3CE4540CD98B4D8D86F0F40013F5C530CCE4540	0103000020E610000001000000040000008CEAFEE73F350F40CE5B430568D2454027CEAF4A464D0F40F4234A1D77D045405E04E2147F7E0F402E327583F7D145408CEAFEE73F350F40CE5B430568D24540
+\.
+
+
+--
 -- Data for Name: xss; Type: TABLE DATA; Schema: tests_projects; Owner: -
 --
 
 COPY tests_projects.xss (id, geom, description) FROM stdin;
 1	01010000206A0800000D9D9921FD822741B3C56B7B4DF45741	<script>alert('XSS')</script>
-\.
-
---
--- Data for Name: double_geom; Type: TABLE DATA; Schema: tests_projects; Owner: -
---
-COPY tests_projects.double_geom (id, title, geom, geom_d) FROM stdin;
-1	F2	010300000001000000060000005520F9393F8E0E4043232852C1CD454091126D1728C40E4049F9C8EAF5CB454015E1134ED2540E40190EB02B2ECC454015E1134ED2540E40190EB02B2ECC454089C25720B0490E402CE5037573CE45405520F9393F8E0E4043232852C1CD4540	01030000000100000007000000879AE9F0C7BA0E4030327583F7D1454067325F7DA79E0E404EB50AFEA5D04540FA7B2DC3A5AF0E40CC0ED2F6E3CE45408E34CC0DD0C10E40F5B479184BCF45408E34CC0DD0C10E40F5B479184BCF4540BC614BB6D4EA0E40BE84EFBB22D04540879AE9F0C7BA0E4030327583F7D14540
-\.
-
---
--- Data for Name: triple_geom; Type: TABLE DATA; Schema: tests_projects; Owner: -
---
-COPY tests_projects.triple_geom (id, title, geom, geom_l, geom_p) FROM stdin;
-1	P2	01010000009BAFF31C24420F40B0F20C103ECD4540	010200000003000000F831609D15230F40B6C8ADA872CB45400D2267EAD5350F40CA0ED2F6E3CE4540CD98B4D8D86F0F40013F5C530CCE4540	010300000001000000040000008CEAFEE73F350F40CE5B430568D2454027CEAF4A464D0F40F4234A1D77D045405E04E2147F7E0F402E327583F7D145408CEAFEE73F350F40CE5B430568D24540
 \.
 
 
@@ -3828,6 +3837,13 @@ SELECT pg_catalog.setval('tests_projects.dnd_form_id_seq', 1, true);
 --
 
 SELECT pg_catalog.setval('tests_projects.dnd_popup_id_seq', 2, true);
+
+
+--
+-- Name: double_geom_id_seq; Type: SEQUENCE SET; Schema: tests_projects; Owner: -
+--
+
+SELECT pg_catalog.setval('tests_projects.double_geom_id_seq', 1, true);
 
 
 --
@@ -4258,23 +4274,17 @@ SELECT pg_catalog.setval('tests_projects.tramway_stops_id_stop_seq', 5, true);
 
 
 --
--- Name: xss_id_seq; Type: SEQUENCE SET; Schema: tests_projects; Owner: -
---
-
-SELECT pg_catalog.setval('tests_projects.xss_id_seq', 1, true);
-
---
--- Name: double_geom_id_seq; Type: SEQUENCE SET; Schema: tests_projects; Owner: -
---
-
-SELECT pg_catalog.setval('tests_projects.double_geom_id_seq', 1, true);
-
---
 -- Name: triple_geom_id_seq; Type: SEQUENCE SET; Schema: tests_projects; Owner: -
 --
 
 SELECT pg_catalog.setval('tests_projects.triple_geom_id_seq', 1, true);
 
+
+--
+-- Name: xss_id_seq; Type: SEQUENCE SET; Schema: tests_projects; Owner: -
+--
+
+SELECT pg_catalog.setval('tests_projects.xss_id_seq', 1, true);
 
 
 --
@@ -4363,6 +4373,14 @@ ALTER TABLE ONLY tests_projects.dnd_form
 
 ALTER TABLE ONLY tests_projects.dnd_popup
     ADD CONSTRAINT dnd_popup_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: double_geom double_geom_pkey; Type: CONSTRAINT; Schema: tests_projects; Owner: -
+--
+
+ALTER TABLE ONLY tests_projects.double_geom
+    ADD CONSTRAINT double_geom_pkey PRIMARY KEY (id);
 
 
 --
@@ -4878,27 +4896,19 @@ ALTER TABLE ONLY tests_projects.tramway_stops
 
 
 --
+-- Name: triple_geom triple_pkey; Type: CONSTRAINT; Schema: tests_projects; Owner: -
+--
+
+ALTER TABLE ONLY tests_projects.triple_geom
+    ADD CONSTRAINT triple_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: xss xss_pkey; Type: CONSTRAINT; Schema: tests_projects; Owner: -
 --
 
 ALTER TABLE ONLY tests_projects.xss
     ADD CONSTRAINT xss_pkey PRIMARY KEY (id);
-
-
---
--- Name: double_geom double_geom_pkey; Type: CONSTRAINT; Schema: tests_projects; Owner: -
---
-
-ALTER TABLE ONLY tests_projects.double_geom
-    ADD CONSTRAINT double_geom_pkey PRIMARY KEY (id);
-
-
---
--- Name: triple_geom triple_geom_pkey; Type: CONSTRAINT; Schema: tests_projects; Owner: -
---
-
-ALTER TABLE ONLY tests_projects.triple_geom
-    ADD CONSTRAINT triple_pkey PRIMARY KEY (id);
 
 
 --
@@ -4976,3 +4986,4 @@ ALTER TABLE ONLY tests_projects.tramway_pivot
 --
 -- PostgreSQL database dump complete
 --
+

--- a/tests/units/classes/Project/ProjectTest.php
+++ b/tests/units/classes/Project/ProjectTest.php
@@ -270,8 +270,17 @@ class ProjectTest extends TestCase
         $aclData2 = array(
             'userIsConnected' => false,
         );
-        $filter1 = '"Group" IN ( \'admin\' , \'groups\' , \'lizmap\' , \'all\' )';
-        $filter2 = '"Group" = \'all\'';
+        //$filter1 = '"Group" IN ( \'admin\' , \'groups\' , \'lizmap\' , \'all\' )';
+        $filter1 = '"Group" = \'admin\' OR "Group" LIKE \'admin,%\' OR "Group" LIKE \'%,admin\' OR "Group" LIKE \'%,admin,%\'';
+        $filter1 .= ' OR ';
+        $filter1 .= '"Group" = \'groups\' OR "Group" LIKE \'groups,%\' OR "Group" LIKE \'%,groups\' OR "Group" LIKE \'%,groups,%\'';
+        $filter1 .= ' OR ';
+        $filter1 .= '"Group" = \'lizmap\' OR "Group" LIKE \'lizmap,%\' OR "Group" LIKE \'%,lizmap\' OR "Group" LIKE \'%,lizmap,%\'';
+        $filter1 .= ' OR ';
+        $filter1 .= '"Group" = \'all\' OR "Group" LIKE \'all,%\' OR "Group" LIKE \'%,all\' OR "Group" LIKE \'%,all,%\'';
+
+        //$filter2 = '"Group" = \'all\'';
+        $filter2 = '"Group" = \'all\' OR "Group" LIKE \'all,%\' OR "Group" LIKE \'%,all\' OR "Group" LIKE \'%,all,%\'';
 
         return array(
             array($aclData1, $filter1),

--- a/tests/units/classes/Project/Ressources/edition_embed_parent_filtered.qgs.cfg
+++ b/tests/units/classes/Project/Ressources/edition_embed_parent_filtered.qgs.cfg
@@ -1,27 +1,24 @@
 {
     "metadata": {
         "qgis_desktop_version": 32815,
-        "lizmap_plugin_version_str": "4.3.18-alpha",
-        "lizmap_plugin_version": 40318,
-        "lizmap_web_client_target_version": 30900,
+        "lizmap_plugin_version_str": "4.1.8",
+        "lizmap_plugin_version": 40108,
+        "lizmap_web_client_target_version": 30800,
         "lizmap_web_client_target_status": "Dev",
         "instance_target_url": "http://localhost:8130/",
-        "instance_target_repository": "testsrepository"
+        "instance_target_repository": "intranet"
     },
     "warnings": {},
-    "debug": {
-        "total_time": 0.379
-    },
     "options": {
         "projection": {
-            "proj4": "+proj=lcc +lat_0=46.5 +lon_0=3 +lat_1=49 +lat_2=44 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs",
-            "ref": "EPSG:2154"
+            "proj4": "+proj=longlat +datum=WGS84 +no_defs",
+            "ref": "EPSG:4326"
         },
         "bbox": [
-            "-390939.83559743227669969",
-            "601473.29528003837913275",
-            "710834.32891788182314485",
-            "1231921.76601732056587934"
+            "3.72495035999999979",
+            "43.54176487699999853",
+            "4.03651796000000029",
+            "43.68444261700000197"
         ],
         "mapScales": [
             10000,
@@ -29,19 +26,17 @@
             50000,
             100000,
             250000,
-            500000,
-            1000000,
-            2000000
+            500000
         ],
-        "minScale": 10000,
-        "maxScale": 2000000,
+        "minScale": 1,
+        "maxScale": 1000000000,
         "use_native_zoom_levels": false,
         "hide_numeric_scale_value": false,
         "initialExtent": [
-            -492657.5601,
-            698659.042,
-            609116.6044,
-            1329107.5127
+            3.72495036,
+            43.541764877,
+            4.03651796,
+            43.684442617
         ],
         "popupLocation": "dock",
         "pointTolerance": 25,
@@ -51,31 +46,31 @@
         "tmTimeFrameType": "seconds",
         "tmAnimationFrameLength": 1000,
         "datavizLocation": "dock",
-        "theme": "light",
+        "theme": "dark",
         "fixed_scale_overview_map": true,
         "dataviz_drag_drop": []
     },
     "layers": {
-        "red_layer_with_no_filter": {
-            "id": "layer_with_no_filter_89c540b5_0c19_4805_b505_78770286189f",
-            "name": "red_layer_with_no_filter",
+        "edition_layer_embed_point": {
+            "id": "edition_layer_embed_point_7794e305_0e9b_40d0_bf0b_2494790d4eb3",
+            "name": "edition_layer_embed_point",
             "type": "layer",
             "geometryType": "point",
             "extent": [
-                44130.035582289565,
-                1103012.1745566626,
-                44130.035582289565,
-                1103012.1745566626
+                3.859641575782584,
+                43.61140074084927,
+                3.887664580431485,
+                43.63103265725464
             ],
-            "crs": "EPSG:2154",
-            "title": "red_layer_with_no_filter",
+            "crs": "EPSG:4326",
+            "title": "Embedded Point",
             "abstract": "",
             "link": "",
             "minScale": 1,
             "maxScale": 1000000000000,
             "toggled": "True",
             "popup": "True",
-            "popupSource": "auto",
+            "popupSource": "form",
             "popupTemplate": "",
             "popupMaxFeatures": 10,
             "popupDisplayChildren": "False",
@@ -86,23 +81,23 @@
             "displayInLegend": "True",
             "group_visibility": [],
             "singleTile": "True",
-            "imageFormat": "image/png; mode=8bit",
+            "imageFormat": "image/png",
             "cached": "False",
             "clientCacheExpiration": 300
         },
-        "blue_filter_layer_by_user": {
-            "id": "filter_layer_by_user_8bd3128f_2cad_4121_b5f9_0b6f6118e2f0",
-            "name": "blue_filter_layer_by_user",
+        "edition_layer_embed_line": {
+            "id": "edition_layer_embed_line_e74301b9_95ae_4b72_81cc_71fafb80082f",
+            "name": "edition_layer_embed_line",
             "type": "layer",
-            "geometryType": "point",
+            "geometryType": "line",
             "extent": [
-                320.9166093314998,
-                985180.7511121543,
-                81392.9643638861,
-                1024961.4453519669
+                3.827400054304815,
+                43.58412355578639,
+                3.916290230341653,
+                43.62405315475053
             ],
-            "crs": "EPSG:2154",
-            "title": "blue_filter_layer_by_user",
+            "crs": "EPSG:4326",
+            "title": "Embedded Line",
             "abstract": "",
             "link": "",
             "minScale": 1,
@@ -120,29 +115,29 @@
             "displayInLegend": "True",
             "group_visibility": [],
             "singleTile": "True",
-            "imageFormat": "image/png; mode=8bit",
+            "imageFormat": "image/png",
             "cached": "False",
             "clientCacheExpiration": 300
         },
-        "green_filter_layer_by_user_edition_only": {
-            "id": "filter_layer_by_user_edition_only_7bc0e81c_2860_4d6b_8b20_ad6c7b76e42f",
-            "name": "green_filter_layer_by_user_edition_only",
+        "edition_layer_embed_child": {
+            "id": "edition_layer_embed_child_d87f81cd_26d2_4c40_820d_676ba03ff6ab",
+            "name": "edition_layer_embed_child",
             "type": "layer",
-            "geometryType": "point",
+            "geometryType": "none",
             "extent": [
-                12909.743900411398,
-                907885.3515449236,
-                65531.04197712544,
-                941875.1852308394
+                1.7976931348623157e+308,
+                1.7976931348623157e+308,
+                -1.7976931348623157e+308,
+                -1.7976931348623157e+308
             ],
-            "crs": "EPSG:2154",
-            "title": "green_filter_layer_by_user_edition_only",
+            "crs": "",
+            "title": "Relation_table_id",
             "abstract": "",
             "link": "",
             "minScale": 1,
             "maxScale": 1000000000000,
-            "toggled": "True",
-            "popup": "True",
+            "toggled": "False",
+            "popup": "False",
             "popupSource": "auto",
             "popupTemplate": "",
             "popupMaxFeatures": 10,
@@ -154,7 +149,7 @@
             "displayInLegend": "True",
             "group_visibility": [],
             "singleTile": "True",
-            "imageFormat": "image/png; mode=8bit",
+            "imageFormat": "image/png",
             "cached": "False",
             "clientCacheExpiration": 300
         }
@@ -163,11 +158,39 @@
         "layers": []
     },
     "locateByLayer": {},
-    "attributeLayers": {},
+    "attributeLayers": {
+        "edition_layer_embed_line": {
+            "layerId": "edition_layer_embed_line_e74301b9_95ae_4b72_81cc_71fafb80082f",
+            "primaryKey": "id",
+            "pivot": "False",
+            "hideAsChild": "False",
+            "hideLayer": "False",
+            "custom_config": "False",
+            "order": 0
+        },
+        "edition_layer_embed_child": {
+            "layerId": "edition_layer_embed_child_d87f81cd_26d2_4c40_820d_676ba03ff6ab",
+            "primaryKey": "id",
+            "pivot": "False",
+            "hideAsChild": "False",
+            "hideLayer": "False",
+            "custom_config": "False",
+            "order": 1
+        },
+        "edition_layer_embed_point": {
+            "layerId": "edition_layer_embed_point_7794e305_0e9b_40d0_bf0b_2494790d4eb3",
+            "primaryKey": "id",
+            "pivot": "False",
+            "hideAsChild": "False",
+            "hideLayer": "False",
+            "custom_config": "False",
+            "order": 2
+        }
+    },
     "tooltipLayers": {},
     "editionLayers": {
-        "blue_filter_layer_by_user": {
-            "layerId": "filter_layer_by_user_8bd3128f_2cad_4121_b5f9_0b6f6118e2f0",
+        "edition_layer_embed_line": {
+            "layerId": "edition_layer_embed_line_e74301b9_95ae_4b72_81cc_71fafb80082f",
             "snap_vertices": "False",
             "snap_segments": "False",
             "snap_intersections": "False",
@@ -182,11 +205,11 @@
                 "modifyGeometry": "True",
                 "deleteFeature": "True"
             },
-            "geometryType": "point",
+            "geometryType": "line",
             "order": 0
         },
-        "green_filter_layer_by_user_edition_only": {
-            "layerId": "filter_layer_by_user_edition_only_7bc0e81c_2860_4d6b_8b20_ad6c7b76e42f",
+        "edition_layer_embed_point": {
+            "layerId": "edition_layer_embed_point_7794e305_0e9b_40d0_bf0b_2494790d4eb3",
             "snap_vertices": "False",
             "snap_segments": "False",
             "snap_intersections": "False",
@@ -204,8 +227,9 @@
             "geometryType": "point",
             "order": 1
         },
-        "red_layer_with_no_filter": {
-            "layerId": "layer_with_no_filter_89c540b5_0c19_4805_b505_78770286189f",
+        "edition_layer_embed_child": {
+            "layerId": "edition_layer_embed_child_d87f81cd_26d2_4c40_820d_676ba03ff6ab",
+            "snap_layers": [],
             "snap_vertices": "False",
             "snap_segments": "False",
             "snap_intersections": "False",
@@ -217,10 +241,10 @@
                 "createFeature": "True",
                 "allow_without_geom": "False",
                 "modifyAttribute": "True",
-                "modifyGeometry": "True",
+                "modifyGeometry": "False",
                 "deleteFeature": "True"
             },
-            "geometryType": "point",
+            "geometryType": "none",
             "order": 2
         }
     },
@@ -230,25 +254,24 @@
         },
         "list": []
     },
+    "loginFilteredLayers": {},
+    "timemanagerLayers": {},
     "loginFilteredLayers": {
-        "blue_filter_layer_by_user": {
-            "layerId": "filter_layer_by_user_8bd3128f_2cad_4121_b5f9_0b6f6118e2f0",
-            "filterAttribute": "user",
-            "filterPrivate": "True",
-            "edition_only": "False",
+        "edition_layer_embed_point": {
+            "layerId": "edition_layer_embed_point_7794e305_0e9b_40d0_bf0b_2494790d4eb3",
+            "filterAttribute": "descr",
+            "filterPrivate": "False",
             "allow_multiple_acl_values": true,
             "order": 0
         },
-        "green_filter_layer_by_user_edition_only": {
-            "layerId": "filter_layer_by_user_edition_only_7bc0e81c_2860_4d6b_8b20_ad6c7b76e42f",
-            "filterAttribute": "user",
-            "filterPrivate": "True",
-            "edition_only": "True",
-            "allow_multiple_acl_values": true,
-            "order": 1
+        "edition_layer_embed_line": {
+            "layerId": "edition_layer_embed_line_e74301b9_95ae_4b72_81cc_71fafb80082f",
+            "filterAttribute": "descr",
+            "filterPrivate": "False",
+            "allow_multiple_acl_values": false,
+            "order": 0
         }
     },
-    "timemanagerLayers": {},
     "datavizLayers": {},
     "filter_by_polygon": {
         "config": {

--- a/tests/units/classes/Request/WFSRequestTest.php
+++ b/tests/units/classes/Request/WFSRequestTest.php
@@ -138,9 +138,9 @@ class WFSRequestTest extends TestCase
             'geometryname' => 'none'
         );
         return array(
-            array($paramsComplete, $wfsFields, array('prop', 'name', 'key', 'geom', 'test'), ' SELECT prop, name, key, geom, test, geocol AS geosource FROM table'),
-            array($paramsGeom, $wfsFields, array('prop', 'name', 'notProp', 'key', 'geom', 'test'), ' SELECT prop, name, notProp, key, geom, test, geocol AS geosource FROM table'),
-            array($paramsProp, $wfsFields, array('prop', 'name', 'key', 'geom', 'test'), ' SELECT prop, name, key, geom, test FROM table'),
+            array($paramsComplete, $wfsFields, array('"prop"', '"name"', '"key"', '"geom"', '"test"'), ' SELECT "prop", "name", "key", "geom", "test", "geocol" AS "geosource" FROM table'),
+            array($paramsGeom, $wfsFields, array('"prop"', '"name"', '"notProp"', '"key"', '"geom"', '"test"'), ' SELECT "prop", "name", "notProp", "key", "geom", "test", "geocol" AS "geosource" FROM table'),
+            array($paramsProp, $wfsFields, array('"prop"', '"name"', '"key"', '"geom"', '"test"'), ' SELECT "prop", "name", "key", "geom", "test" FROM table'),
         );
     }
 
@@ -191,8 +191,8 @@ class WFSRequestTest extends TestCase
         return array(
             array(array(), '', ''),
             array(array('exp_filter' => 'select'), '', false),
-            array(array('exp_filter' => 'filter for test'), '', ' AND filter for test'),
-            array(array('exp_filter' => 'filter for test with $id = 5'), 'key', ' AND filter for test with key = 5'),
+            array(array('exp_filter' => 'filter for test'), '', ' AND ( filter for test ) '),
+            array(array('exp_filter' => 'filter for test with $id = 5'), 'key', ' AND ( filter for test with "key" = 5 ) '),
             array(array('exp_filter' => 'filter for test with $id = 5'), 'key,otherKey', false),
         );
     }
@@ -213,9 +213,9 @@ class WFSRequestTest extends TestCase
     {
         return array(
             array('', '', '', ''),
-            array('type', 'type.test@@55', 'key,otherKey', ' AND (key = "test" AND otherKey = 55)'),
-            array('type', 'type.test@@55,you shall not pass,type.name@@42', 'key,otherKey', ' AND (key = "test" AND otherKey = 55) OR (key = "name" AND otherKey = 42)'),
-            array('', 'type.test@@55', 'key,otherKey', ' AND (key = "test" AND otherKey = 55)'),
+            array('type', 'type.test@@55', 'key,otherKey', ' AND ("key" = \'test\' AND "otherKey" = 55)'),
+            array('type', 'type.test@@55,you shall not pass,type.name@@42', 'key,otherKey', ' AND ("key" = \'test\' AND "otherKey" = 55) OR ("key" = \'name\' AND "otherKey" = 42)'),
+            array('', 'type.test@@55', 'key,otherKey', ' AND ("key" = \'test\' AND "otherKey" = 55)'),
         );
     }
 
@@ -240,7 +240,7 @@ class WFSRequestTest extends TestCase
             array(array(), array(), ''),
             array(array('sortby' => ''), array(), ''),
             array(array('sortby' => 'id a,test d,wfs a'), array(), ''),
-            array(array('sortby' => 'id a,test d,wfs a'), array('test', 'field', 'wfs'), ' ORDER BY test DESC, wfs ASC'),
+            array(array('sortby' => 'id a,test d,wfs a'), array('test', 'field', 'wfs'), ' ORDER BY "test" DESC, "wfs" ASC'),
         );
     }
 

--- a/tests/units/testslib/ContextForTests.php
+++ b/tests/units/testslib/ContextForTests.php
@@ -181,6 +181,7 @@ class ContextForTests implements AppContextInterface
 
     public function getDbConnection($profile = '')
     {
+        return new jDbConnectionForTests();
     }
 
     public function getLocale($key, $variables = array())

--- a/tests/units/testslib/jDbConnectionForTests.php
+++ b/tests/units/testslib/jDbConnectionForTests.php
@@ -4,11 +4,11 @@ class jDbConnectionForTests
 {
     public function encloseName($name)
     {
-        return $name;
+        return '"'.$name.'"';
     }
 
     public function quote($name)
     {
-        return '"'.$name.'"';
+        return "'".str_replace("'", "\\'", $name)."'";
     }
 }


### PR DESCRIPTION
Lizmap Web Client allows **filtering the content of vector layers** depending on the authenticated user. Before version 3.8, for the attribute filter, every layer to filter must have a field which value must be **only one group identifier (or one user login)**, such as:

|id | name  | filter_field |
|----|----------|--------------|
| 1  | one    | group_a  |
| 2  | two    | group_b  |
| 3  | three | group_b  |
| 4  | four   | all             |

This modification allows using **a list of groups (or a list of users) separated with a comma** (with no spaces) inside the field used as the source of filtering. This will ease showing some features for more than one group (or user). For example, the filtered layer could contain:

|id | name  | filter_field              |
|----|----------|---------------------------|
| 1  | one    | group_a,group_b  |
| 2  | two    | group_b                  |
| 3  | three | group_b,all             |
| 4  | four   | all                             |

We focus on keeping the filter sent to the layer provider **as standard as possible**, to be able to be directly used by PostgreSQL and **avoid evaluating a complex expression** on all features.

This new feature is only available:

* for **PostgreSQL layers**
* if the map editor has chosen to **allow multiple values** in the filter field (this can be configured in Lizmap desktop plugin)

These safeguards allow Lizmap default behaviour to not change between version 3.7 and 3.8.  The map editor will decide to manually activate this new feature. It is safer, as a specific index must be added to have good performance with the new multiple value search.

The filter is built this way:

* we explode the list of groups and use `LIKE` statements combining all possibilities. For example, the above example will lead to a filter like this if the authenticated user is in the group `group_a`:
   ```sql
   "filter_field" = 'group_a' OR "filter_field" LIKE 'group_a,%' OR "filter_field" LIKE '%,group_a' OR "filter_field" LIKE '%,group_a,%'
   OR
   "filter_field" = 'all' OR "filter_field" LIKE 'all,%' OR "filter_field" LIKE '%,all' OR "filter_field" LIKE '%,all,%'
   ```
* **no space** must be used between the group (or user) names and commas.

On big datasets, a proper `GIN` index using the extension `pg_trgm` is **highly recommended**.

```sql
CREATE EXTENSION IF NOT EXISTS pg_trgm;
CREATE INDEX ON some_schema.some_table USING GIN (filter_field gin_trgm_ops);
```

Linked to https://github.com/3liz/qgis-lizmap-server-plugin/pull/86

Funded by: Conseil Départemental du Calvados https://www.calvados.fr/