### PR TITLE
E2E - Renable some tests due to QGIS 3.34

### DIFF
--- a/tests/end2end/playwright/theme.spec.js
+++ b/tests/end2end/playwright/theme.spec.js
@@ -53,17 +53,14 @@ test.describe('Theme', () => {
 
         // The url has been updated
         const url = new URL(page.url());
-// TODO be fixed QGIS ≥ 3.34, works with QGIS < 3.34
-//        await expect(url.hash).not.toHaveLength(0);
+        await expect(url.hash).not.toHaveLength(0);
         // The decoded hash is
         // #3.730872,43.540386,4.017985,43.679557
         // |Les%20quartiers|style2|1
         // |style2
         // |1
-// TODO be fixed QGIS ≥ 3.34, works with QGIS < 3.34
-//        await expect(url.hash).toMatch(/#3.7308\d+,43.5403\d+,4.0179\d+,43.6795\d+\|/)
-// TODO be fixed QGIS ≥ 3.34, works with QGIS < 3.34
-//        await expect(url.hash).toContain('|Les%20quartiers|style2|1')
+        await expect(url.hash).toMatch(/#3.7308\d+,43.5403\d+,4.0179\d+,43.6795\d+\|/)
+        await expect(url.hash).toContain('|Les%20quartiers|style2|1')
     });
 
     test('must display theme3 when selected', async ({ page }) => {
@@ -98,7 +95,6 @@ test.describe('Theme', () => {
         await page.locator('#theme-selector > ul > li.theme').nth(3).click();
 
         // Baselayer
-// TODO be fixed QGIS ≥ 3.34, works with QGIS < 3.34
-//        await expect(page.locator('lizmap-base-layers select')).toHaveValue('OpenStreetMap');
+        await expect(page.locator('lizmap-base-layers select')).toHaveValue('OpenStreetMap');
     });
 });


### PR DESCRIPTION
<!--
Add the word "fix" in front of "#" if it fixes the ticket
or do nothing to only mention it.

funded by NAME
If funded by someone else than 3Liz, please add label "sponsored development"

Please mention if the PR should be backported and to which versions.

Please add new tests if possible (JS, PHP, End2End…)
-->

Ticket : Follow up from #4367 about re-enabling tests

