### PR TITLE
Fix JS Dataviz: When dataviz is not available

### DIFF
--- a/lizmap/www/assets/js/dataviz/dataviz.js
+++ b/lizmap/www/assets/js/dataviz/dataviz.js
@@ -121,8 +121,6 @@ let lizDataviz = function () {
             // initialize plot info
             dv.plots[i] = { 'json': null, 'filter': null, 'show_plot': true, 'cache': null, 'data_fetched': false };
             if (!(optionToBoolean(dv.config.layers[i]['only_show_child']))) {
-                let plotContainerId = `dataviz_plot_${i}`;
-
                 // Add plot container
                 addPlotContainer(i);
             }
@@ -143,6 +141,10 @@ let lizDataviz = function () {
             if (!(optionToBoolean(dv.config.layers[i]['only_show_child']))) {
                 // Get the plot data and display it if the container is visible
                 let elem = document.getElementById(plotContainerId);
+                // skip the element if it does not exist
+                if (elem === null) {
+                    continue;
+                }
                 if (isInViewport(elem) || getViewPercentage(elem) > 0) {
                     getPlot(i, null, plotContainerId);
                 }

--- a/tests/end2end/playwright/embed.spec.js
+++ b/tests/end2end/playwright/embed.spec.js
@@ -1,0 +1,10 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+const { gotoMap } = require('./globals')
+
+test.describe('Embed', () => {
+    test('Dataviz does not generate error', async ({ page }) => {
+        const url = '/index.php/view/embed/?repository=testsrepository&project=dataviz';
+        await gotoMap(url, page);
+    })
+})


### PR DESCRIPTION
In embed mode the error is generated because the dataviz elements are not available.
```
TypeError: elem is null
    isInViewport dataviz.js:23
    getPlots dataviz.js:146
    uicreated dataviz.js:774
    triggerEvent OpenLayers.js:246
    init map.js:5034
map.js:5039:28
    init map.js:5039
```
