### PR TITLE
JS Digitizing: fixing measure not removed from selection to draw

### DIFF
--- a/assets/src/modules/Digitizing.js
+++ b/assets/src/modules/Digitizing.js
@@ -337,12 +337,20 @@ export default class Digitizing {
     }
 
     set context(aContext) {
+        if (this._context == aContext) {
+            return;
+        }
         if (this.featureDrawn) {
             this._contextFeatures[this._context] = this.featureDrawn;
         } else {
             this._contextFeatures[this._context] = null;
         }
         this._isSaved = false;
+        this._measureTooltips.forEach((measureTooltip) => {
+            mainLizmap.map.removeOverlay(measureTooltip[0]);
+            mainLizmap.map.removeOverlay(measureTooltip[1]);
+            this._measureTooltips.delete(measureTooltip);
+        });
         this._drawLayer.getSource().clear();
         this._context = aContext;
         if (this._contextFeatures[this._context]) {

--- a/tests/end2end/playwright/draw.spec.js
+++ b/tests/end2end/playwright/draw.spec.js
@@ -1,11 +1,12 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+const { gotoMap, reloadMap } = require('./globals')
 
 test.describe('Draw', () => {
 
     test.beforeEach(async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=draw';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         await page.locator('#button-draw').click();
     });
@@ -238,7 +239,7 @@ test.describe('Draw', () => {
         await expect(json_stored).toEqual(the_json);
 
         // Reload
-        await page.reload({ waitUntil: 'networkidle' });
+        await reloadMap(page);
         // Display
         await page.locator('#button-draw').click();
 
@@ -278,11 +279,7 @@ test.describe('Draw', () => {
         await expect(old_stored).toEqual(wkt);
 
         // Reload
-        await page.reload({ waitUntil: 'networkidle' });
-
-        // No error
-        await expect(page.locator('p.error-msg')).toHaveCount(0);
-        await expect(page.locator('#switcher lizmap-treeview ul li')).not.toHaveCount(0);
+        await reloadMap(page);
 
         // The WKT has been drawn
         expect(await page.evaluate(() => lizMap.mainLizmap.digitizing.featureDrawn)).toHaveLength(1);
@@ -327,11 +324,7 @@ test.describe('Draw', () => {
         await expect(old_stored).toEqual(bad_wkt);
 
         // Reload
-        await page.reload({ waitUntil: 'networkidle' });
-
-        // No error
-        await expect(page.locator('p.error-msg')).toHaveCount(0);
-        await expect(page.locator('#switcher lizmap-treeview ul li')).not.toHaveCount(0);
+        await reloadMap(page);
 
         // Not well formed data has been removed
         expect(await page.evaluate(() => localStorage.getItem('testsrepository_draw_drawLayer'))).toBeNull;


### PR DESCRIPTION
If measure is activated in selection tool, the overlay was not removed when you open print or draw.

Funded by Terre de Provence Agglo
