### PR TITLE
Tests e2e playwright: using gotoMap instead of networkidle

### DIFF
--- a/tests/end2end/playwright/embedded-form.spec.js
+++ b/tests/end2end/playwright/embedded-form.spec.js
@@ -1,10 +1,11 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Edition of an embedded layer', () => {
     test.beforeEach(async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=edition_embed';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
         await page.locator('#dock-close').click();
     });
 

--- a/tests/end2end/playwright/embedded-relation.spec.js
+++ b/tests/end2end/playwright/embedded-relation.spec.js
@@ -1,10 +1,11 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Display embedded relation in popup', () => {
     test.beforeEach(async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=relations_project_embed';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
         await page.locator('#dock-close').click();
     });
 

--- a/tests/end2end/playwright/filter-layer-by-user.spec.js
+++ b/tests/end2end/playwright/filter-layer-by-user.spec.js
@@ -1,11 +1,12 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Filter layer data by user - not connected', () => {
 
     test.beforeEach(async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=filter_layer_by_user';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         // Close dock to access all features on map
         await page.locator('#dock-close').click();
@@ -126,7 +127,7 @@ test.describe('Filter layer data by user - user in group a', () => {
 
     test.beforeEach(async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=filter_layer_by_user';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         // Close dock to access all features on map
         await page.locator('#dock-close').click();
@@ -251,7 +252,7 @@ test.describe('Filter layer data by user - admin', () => {
 
     test.beforeEach(async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=filter_layer_by_user';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         // Close dock to access all features on map
         await page.locator('#dock-close').click();

--- a/tests/end2end/playwright/n_to_m_relations.spec.js
+++ b/tests/end2end/playwright/n_to_m_relations.spec.js
@@ -1,10 +1,11 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('N to M relations', () => {
     test.beforeEach(async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=n_to_m_relations';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
     });
 
     test('Attribute table behavior', async ({ page }) => {

--- a/tests/end2end/playwright/overview.spec.js
+++ b/tests/end2end/playwright/overview.spec.js
@@ -1,12 +1,13 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Overview', () => {
     test('2154', async ({ page }) => {
         const requestPromise = page.waitForRequest(/GetMap/);
 
         const url = '/index.php/view/map/?repository=testsrepository&project=overview-2154';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         const request = await requestPromise;
         const requestUrl = request.url();
@@ -27,7 +28,7 @@ test.describe('Overview', () => {
         const requestPromise = page.waitForRequest(/GetMap/);
 
         const url = '/index.php/view/map/?repository=testsrepository&project=overview-4326';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         const request = await requestPromise;
         const requestUrl = request.url();
@@ -48,7 +49,7 @@ test.describe('Overview', () => {
         const requestPromise = page.waitForRequest(/GetMap/);
 
         const url = '/index.php/view/map/?repository=testsrepository&project=overview-3857';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         const request = await requestPromise;
         const requestUrl = request.url();

--- a/tests/end2end/playwright/singleWMS.spec.js
+++ b/tests/end2end/playwright/singleWMS.spec.js
@@ -1,5 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Single WMS layer', () => {
 
@@ -49,7 +50,7 @@ test.describe('Single WMS layer', () => {
     test('Check opacity', async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=single_wms_image';
 
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         // click on layer tree elements to check opacity
         const lizmapTreeView = page.locator('lizmap-treeview > ul  li');
@@ -93,7 +94,7 @@ test.describe('Single WMS layer', () => {
             request.url().includes('LAYERS=single_wms_baselayer%2Csingle_wms_points%2Csingle_wms_points_group%2Csingle_wms_lines_group%2CGroupAsLayer')
         );
 
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         await page.getByTestId('single_wms_lines').locator('> div input').click();
         const noPointsReq = await getMapNoPointsPromise;
@@ -190,7 +191,7 @@ test.describe('Single WMS layer', () => {
             request.url().includes('LAYERS=single_wms_baselayer%2Csingle_wms_lines%2Csingle_wms_points%2Csingle_wms_points_group%2Csingle_wms_lines_group%2CGroupAsLayer')
         );
 
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         // disable single_wms_lines
         const points = page.getByTestId('single_wms_points')
@@ -212,7 +213,7 @@ test.describe('Single WMS layer', () => {
 
     test('Apply filters on layer, then change layer style', async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=single_wms_image';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         let getFeatureInfoRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeatureInfo') === true);
 
@@ -301,7 +302,7 @@ test.describe('Single WMS layer', () => {
 
     test('Filter on legend, then apply filter', async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=single_wms_image';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         const getLegendFilterPromise = page.waitForRequest(request =>
             request.url().includes('GetMap') &&
@@ -389,7 +390,7 @@ test.describe('Single WMS layer', () => {
 
     test('Switch baselayer', async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=single_wms_image';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         const switchBaseLayersReqPromise = page.waitForRequest(request =>
             request.url().includes('GetMap') &&
@@ -415,7 +416,7 @@ test.describe('Single WMS layer', () => {
 
     test('Edit a layer', async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=single_wms_image';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         await page.locator('#button-edition').click();
         await page.locator('a#edition-draw').click();

--- a/tests/end2end/playwright/snap.spec.js
+++ b/tests/end2end/playwright/snap.spec.js
@@ -1,10 +1,11 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Snap on edition', () => {
     test.beforeEach(async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=form_edition_multilayer_snap';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
     });
 
     test('Snap panel functionalities', async ({ page }) => {

--- a/tests/end2end/playwright/treeview.spec.js
+++ b/tests/end2end/playwright/treeview.spec.js
@@ -1,5 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Treeview', () => {
 
@@ -178,7 +179,7 @@ test.describe('Treeview mocked with "Hide checkboxes for groups" option', () => 
         });
 
         const url = '/index.php/view/map/?repository=testsrepository&project=treeview';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         await expect(page.locator('lizmap-treeview div.group > input')).toHaveCount(0);
     });

--- a/tests/end2end/playwright/webdav-upload.spec.js
+++ b/tests/end2end/playwright/webdav-upload.spec.js
@@ -1,10 +1,11 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('WebDAV Server', () => {
     test.beforeEach(async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=form_upload_webdav';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
         await page.locator('#dock-close').click();
     });
 


### PR DESCRIPTION
Enhancing tests e2e playwright by using gotoMap instead of networkidle
