### PR TITLE
FTS: order first by `similarity` then by `item_label`

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapFts.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapFts.class.php
@@ -74,7 +74,7 @@ class lizmapFts
         }
         $sql .= ' )';
         $sql .= '
-        ORDER BY sim DESC
+        ORDER BY sim DESC, item_label
         LIMIT :lim;
         ';
         $this->sql = $sql;


### PR DESCRIPTION
This can be tested with the location_search projet by searching for `a`.

Without this patch:
![image](https://github.com/user-attachments/assets/c9be643a-c47a-49e0-8f46-8e13ff1f223b)


With this patch, three last items are ordered by `item_label` :
![image](https://github.com/user-attachments/assets/8483f7fe-9047-4e65-97ac-f06144c297ad)


Funded By Valabre