### PR TITLE
Tests e2e playwright: replace require par import ... from

### DIFF
--- a/tests/end2end/playwright/attribute-table.spec.js
+++ b/tests/end2end/playwright/attribute-table.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-const { gotoMap } = require('./globals')
+import { gotoMap } from './globals';
 
 test.describe('Attribute table', () => {
     test.beforeEach(async ({ page }) => {

--- a/tests/end2end/playwright/attributions.spec.js
+++ b/tests/end2end/playwright/attributions.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
-const { test, expect } = require('@playwright/test');
-const { gotoMap } = require('./globals')
+import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Attributions', () => {
 

--- a/tests/end2end/playwright/axis_orientation.spec.js
+++ b/tests/end2end/playwright/axis_orientation.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
-const { test, expect } = require('@playwright/test');
-const { gotoMap } = require('./globals')
+import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Axis Orientation', () => {
 

--- a/tests/end2end/playwright/base-layers.spec.js
+++ b/tests/end2end/playwright/base-layers.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
-const { test, expect } = require('@playwright/test');
-const { gotoMap } = require('./globals')
+import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Base layers', () => {
 

--- a/tests/end2end/playwright/custom-javascript-api.spec.js
+++ b/tests/end2end/playwright/custom-javascript-api.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-const { gotoMap } = require('./globals')
+import { gotoMap } from './globals';
 
 test.describe('Maps management', () => {
 

--- a/tests/end2end/playwright/display_in_layer_tree.spec.js
+++ b/tests/end2end/playwright/display_in_layer_tree.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
-const { test, expect } = require('@playwright/test');
-const { gotoMap } = require('./globals')
+import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Display in layer tree', () => {
 

--- a/tests/end2end/playwright/edition-form.spec.js
+++ b/tests/end2end/playwright/edition-form.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-const { gotoMap } = require('./globals')
+import { gotoMap } from './globals';
 
 test.describe('Edition Form Validation', () => {
 

--- a/tests/end2end/playwright/embed.spec.js
+++ b/tests/end2end/playwright/embed.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
-const { test, expect } = require('@playwright/test');
-const { gotoMap } = require('./globals')
+import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Embed', () => {
     test('Dataviz does not generate error', async ({ page }) => {

--- a/tests/end2end/playwright/error-occurred.spec.js
+++ b/tests/end2end/playwright/error-occurred.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-const { gotoMap } = require('./globals')
+import { gotoMap } from './globals';
 
 export async function goBackHomeAfterError(page) {
     await page.getByRole('link', { name: 'Go back to the home page.' }).click();

--- a/tests/end2end/playwright/exposed_dependencies.spec.js
+++ b/tests/end2end/playwright/exposed_dependencies.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-const { gotoMap } = require('./globals')
+import { gotoMap } from './globals';
 
 test.describe('Exposed dependencies', () => {
     test('Dependencies are accessible', async ({ page }) => {

--- a/tests/end2end/playwright/form_relational_value.spec.js
+++ b/tests/end2end/playwright/form_relational_value.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-const { gotoMap } = require('./globals')
+import { gotoMap } from './globals';
 
 test.describe('Form relational values', () => {
 

--- a/tests/end2end/playwright/google-basemap.spec.js
+++ b/tests/end2end/playwright/google-basemap.spec.js
@@ -1,6 +1,6 @@
 
-const { test, expect } = require('@playwright/test');
-const { gotoMap } = require('./globals');
+import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';;
 
 test.describe('Google Maps Baselayers', () => {
     test('Load map with no API Key', async ({ page }) => {

--- a/tests/end2end/playwright/legend.spec.js
+++ b/tests/end2end/playwright/legend.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-const { gotoMap } = require('./globals')
+import { gotoMap } from './globals';
 
 test.describe('Legend tests', () => {
 

--- a/tests/end2end/playwright/permalink.spec.js
+++ b/tests/end2end/playwright/permalink.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-const { gotoMap, reloadMap } = require('./globals')
+import { gotoMap, reloadMap } from './globals';
 
 test.describe('Permalink', () => {
 

--- a/tests/end2end/playwright/popup.spec.js
+++ b/tests/end2end/playwright/popup.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
-const { test, expect } = require('@playwright/test');
-const { gotoMap } = require('./globals')
+import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Dataviz in popup', () => {
     test('Check lizmap feature toolbar', async ({ page }) => {
@@ -378,4 +378,3 @@ test.describe('Popup max features', () => {
         await expect(page.locator('.lizmapPopupSingleFeature')).toHaveCount(15);
     });
 });
-

--- a/tests/end2end/playwright/print.spec.js
+++ b/tests/end2end/playwright/print.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-const { gotoMap } = require('./globals')
+import { gotoMap } from './globals';
 
 test.describe('Print', () => {
 

--- a/tests/end2end/playwright/print_in_project_projection.spec.js
+++ b/tests/end2end/playwright/print_in_project_projection.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
-const { test, expect } = require('@playwright/test');
-const { gotoMap } = require('./globals');
+import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';;
 
 test.describe('Print in project projection', () => {
 

--- a/tests/end2end/playwright/project_load_warning.spec.js
+++ b/tests/end2end/playwright/project_load_warning.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-const { gotoMap } = require('./globals')
+import { gotoMap } from './globals';
 
 test.describe('Project warnings in CFG as admin', () => {
     test.use({ storageState: 'playwright/.auth/admin.json' });

--- a/tests/end2end/playwright/qgis-request.spec.js
+++ b/tests/end2end/playwright/qgis-request.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
-const { test, expect } = require('@playwright/test');
-const { gotoMap } = require('./globals')
+import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('QGIS Requests', () => {
     test('WMS Get Legend Graphic JSON', async ({ page }) => {

--- a/tests/end2end/playwright/startup.spec.js
+++ b/tests/end2end/playwright/startup.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-const { gotoMap } = require('./globals')
+import { gotoMap } from './globals';
 
 test.describe('Startup', () => {
 

--- a/tests/end2end/playwright/theme.spec.js
+++ b/tests/end2end/playwright/theme.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-const { gotoMap } = require('./globals')
+import { gotoMap } from './globals';
 
 test.describe('Theme', () => {
     test.beforeEach(async ({ page }) => {

--- a/tests/end2end/playwright/timemanage.spec.js
+++ b/tests/end2end/playwright/timemanage.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
-const { test, expect } = require('@playwright/test');
-const { gotoMap } = require('./globals')
+import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Time Manager', () => {
 

--- a/tests/end2end/playwright/viewport.spec.js
+++ b/tests/end2end/playwright/viewport.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-const { gotoMap } = require('./globals')
+import { gotoMap } from './globals';
 
 test.describe('Viewport devicePixelRatio 1', () => {
     test('Greater than WMS max size', async ({ page }) => {

--- a/tests/end2end/playwright/wmts.spec.js
+++ b/tests/end2end/playwright/wmts.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-const { gotoMap } = require('./globals')
+import { gotoMap } from './globals';
 
 test.describe('WMTS', () => {
     test('Check GetCapabilities', async ({ page }) => {

--- a/tests/end2end/playwright/xss.spec.js
+++ b/tests/end2end/playwright/xss.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-const { gotoMap } = require('./globals')
+import { gotoMap } from './globals';
 
 test.describe('XSS', () => {
     // Test that flawed data are sanitized before being displayed


### PR DESCRIPTION
To homogenize tests e2e playwright `require` is replaced by `import ... from`