### PR TITLE
[Backport release_3_7] Tests e2e playwright: using gotoMap instead of networkidle

### DIFF
--- a/tests/end2end/playwright/embedded-form.spec.js
+++ b/tests/end2end/playwright/embedded-form.spec.js
@@ -1,10 +1,11 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Edition of an embedded layer', () => {
     test.beforeEach(async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=edition_embed';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
         await page.locator('#dock-close').click();
     });
 

--- a/tests/end2end/playwright/embedded-relation.spec.js
+++ b/tests/end2end/playwright/embedded-relation.spec.js
@@ -1,10 +1,11 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Display embedded relation in popup', () => {
     test.beforeEach(async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=relations_project_embed';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
         await page.locator('#dock-close').click();
     });
 

--- a/tests/end2end/playwright/filter-layer-by-user.spec.js
+++ b/tests/end2end/playwright/filter-layer-by-user.spec.js
@@ -1,11 +1,12 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Filter layer data by user - not connected', () => {
 
     test.beforeEach(async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=filter_layer_by_user';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         // Close dock to access all features on map
         await page.locator('#dock-close').click();
@@ -126,7 +127,7 @@ test.describe('Filter layer data by user - user in group a', () => {
 
     test.beforeEach(async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=filter_layer_by_user';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         // Close dock to access all features on map
         await page.locator('#dock-close').click();
@@ -251,7 +252,7 @@ test.describe('Filter layer data by user - admin', () => {
 
     test.beforeEach(async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=filter_layer_by_user';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         // Close dock to access all features on map
         await page.locator('#dock-close').click();

--- a/tests/end2end/playwright/overview.spec.js
+++ b/tests/end2end/playwright/overview.spec.js
@@ -1,12 +1,13 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Overview', () => {
     test('2154', async ({ page }) => {
         const requestPromise = page.waitForRequest(/GetMap/);
 
         const url = '/index.php/view/map/?repository=testsrepository&project=overview-2154';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         const request = await requestPromise;
         const requestUrl = request.url();
@@ -27,7 +28,7 @@ test.describe('Overview', () => {
         const requestPromise = page.waitForRequest(/GetMap/);
 
         const url = '/index.php/view/map/?repository=testsrepository&project=overview-4326';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         const request = await requestPromise;
         const requestUrl = request.url();
@@ -48,7 +49,7 @@ test.describe('Overview', () => {
         const requestPromise = page.waitForRequest(/GetMap/);
 
         const url = '/index.php/view/map/?repository=testsrepository&project=overview-3857';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         const request = await requestPromise;
         const requestUrl = request.url();

--- a/tests/end2end/playwright/treeview.spec.js
+++ b/tests/end2end/playwright/treeview.spec.js
@@ -1,5 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('Treeview', () => {
 
@@ -109,7 +110,7 @@ test.describe('Treeview mocked with "Hide checkboxes for groups" option', () => 
         });
 
         const url = '/index.php/view/map/?repository=testsrepository&project=treeview';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
 
         await expect(page.locator('lizmap-treeview div.group > input')).toHaveCount(0);
     });

--- a/tests/end2end/playwright/webdav-upload.spec.js
+++ b/tests/end2end/playwright/webdav-upload.spec.js
@@ -1,10 +1,11 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { gotoMap } from './globals';
 
 test.describe('WebDAV Server', () => {
     test.beforeEach(async ({ page }) => {
         const url = '/index.php/view/map/?repository=testsrepository&project=form_upload_webdav';
-        await page.goto(url, { waitUntil: 'networkidle' });
+        await gotoMap(url, page);
         await page.locator('#dock-close').click();
     });
 


### PR DESCRIPTION
Backport https://github.com/3liz/lizmap-web-client/pull/4602
Authored by: @rldhont