### PR TITLE
Fixing tiles resolutions

### DIFF
--- a/assets/src/modules/config/BaseLayer.js
+++ b/assets/src/modules/config/BaseLayer.js
@@ -367,7 +367,7 @@ const wmtsProperties = {
 }
 
 const wmtsOptionalProperties = {
-    'numZoomLevels': { type: 'number', default: 22 },
+    'numZoomLevels': { type: 'number', default: 19   },
     'key': { type: 'string', nullable: true }
 }
 

--- a/assets/src/modules/config/BaseLayer.js
+++ b/assets/src/modules/config/BaseLayer.js
@@ -716,7 +716,7 @@ const defaultCompleteBaseLayersCfg = {
         "styles": "normal",
         "tileMatrixSet": "PM",
         "crs": "EPSG:3857",
-        "numZoomLevels": 20,
+        "numZoomLevels": 19,
         "attribution": {
             "title": "Institut national de l'information géographique et forestière",
             "url": "https://www.ign.fr/"
@@ -731,7 +731,7 @@ const defaultCompleteBaseLayersCfg = {
         "styles": "normal",
         "tileMatrixSet": "PM",
         "crs": "EPSG:3857",
-        "numZoomLevels": 22,
+        "numZoomLevels": 19,
         "attribution": {
             "title": "Institut national de l'information géographique et forestière",
             "url": "https://www.ign.fr/"
@@ -762,7 +762,7 @@ const defaultCompleteBaseLayersCfg = {
         "styles": "normal",
         "tileMatrixSet": "PM",
         "crs": "EPSG:3857",
-        "numZoomLevels": 20,
+        "numZoomLevels": 19,
         "attribution": {
             "title": "Institut national de l'information géographique et forestière",
             "url": "https://www.ign.fr/"

--- a/tests/js-units/node/config/baselayer.test.js
+++ b/tests/js-units/node/config/baselayer.test.js
@@ -797,7 +797,7 @@ describe('BaseLayersConfig', function () {
         expect(wmtsBl.style).to.be.eq('default')
         expect(wmtsBl.matrixSet).to.be.eq('EPSG:3857')
         expect(wmtsBl.crs).to.be.eq('EPSG:3857')
-        expect(wmtsBl.numZoomLevels).to.be.eq(22)
+        expect(wmtsBl.numZoomLevels).to.be.eq(19)
         expect(wmtsBl.hasLayerConfig).to.be.true
         expect(wmtsBl.layerConfig).to.not.be.null
         expect(wmtsBl.layerConfig.externalWmsToggle).to.be.true

--- a/tests/js-units/node/config/baselayer.test.js
+++ b/tests/js-units/node/config/baselayer.test.js
@@ -300,7 +300,7 @@ describe('BaseLayersConfig', function () {
         expect(ignPhotoBl.style).to.be.eq('normal')
         expect(ignPhotoBl.matrixSet).to.be.eq('PM')
         expect(ignPhotoBl.crs).to.be.eq('EPSG:3857')
-        expect(ignPhotoBl.numZoomLevels).to.be.eq(22)
+        expect(ignPhotoBl.numZoomLevels).to.be.eq(19)
         expect(ignPhotoBl.hasAttribution).to.be.true
         expect(ignPhotoBl.attribution).to.be.instanceOf(AttributionConfig)
         expect(ignPhotoBl.attribution.title).to.be.eq('Institut national de l\'information géographique et forestière')

--- a/tests/js-units/node/state/map.test.js
+++ b/tests/js-units/node/state/map.test.js
@@ -3,7 +3,8 @@ import { expect } from 'chai';
 import { ValidationError, ConversionError } from '../../../../assets/src/modules/Errors.js';
 import EventDispatcher from '../../../../assets/src/utils/EventDispatcher.js';
 import { Extent } from '../../../../assets/src/modules/utils/Extent.js';
-import { MapState } from '../../../../assets/src/modules/state/Map.js';
+import { OptionsConfig } from '../../../../assets/src/modules/config/Options.js';
+import { MapState, buildScales } from '../../../../assets/src/modules/state/Map.js';
 
 describe('MapState', function () {
     it('Valid', function () {
@@ -15,6 +16,9 @@ describe('MapState', function () {
         expect(mapState.projection).to.be.eq('EPSG:3857')
         expect(mapState.center).to.be.an('array').that.have.lengthOf(2).that.deep.equal([0, 0])
         expect(mapState.zoom).to.be.eq(-1)
+        expect(mapState.minZoom).to.be.eq(0)
+        expect(mapState.maxZoom).to.be.eq(-1)
+        expect(mapState.scales).to.be.an('array').that.have.lengthOf(0)
         expect(mapState.size).to.be.an('array').that.have.lengthOf(2).that.deep.equal([0, 0])
         expect(mapState.extent).to.be.instanceOf(Extent).that.have.lengthOf(4).that.deep.equal([0, 0, 0, 0])
         expect(mapState.resolution).to.be.eq(-1)
@@ -352,5 +356,179 @@ describe('MapState', function () {
         } finally {
             expect(mapState.scaleDenominator).to.be.eq(-1)
         }
+    })
+})
+
+describe('buildScales', function () {
+    it('order', function () {
+        const opt = new OptionsConfig({
+            "projection": {
+                "proj4": "+proj=longlat +datum=WGS84 +no_defs",
+                "ref": "EPSG:4326"
+            },
+            "bbox": [
+                "-3.5",
+                "-1.0",
+                "3.5",
+                "1.0"
+            ],
+            "mapScales": [
+                10000,
+                25000,
+                50000,
+                100000,
+                250000,
+                500000
+            ],
+            "minScale": 10000,
+            "maxScale": 500000,
+            "initialExtent": [
+                -3.5,
+                -1.0,
+                3.5,
+                1.0
+            ],
+            "popupLocation": "dock",
+            "pointTolerance": 25,
+            "lineTolerance": 10,
+            "polygonTolerance": 5,
+            "hideProject": "True",
+            "tmTimeFrameSize": 10,
+            "tmTimeFrameType": "seconds",
+            "tmAnimationFrameLength": 1000,
+            "datavizLocation": "dock",
+            "theme": "light",
+            //"wmsMaxHeight": 3000,
+            //"wmsMaxWidth": 3000,
+            //"fixed_scale_overview_map": true,
+            //"use_native_zoom_levels": false,
+            //"hide_numeric_scale_value": false,
+            //"hideGroupCheckbox": false,
+            //"activateFirstMapTheme": false,
+        })
+        // Default value for use_native_zoom_levels
+        expect(opt.use_native_zoom_levels).to.be.eq(false)
+
+        let optScales = Array.from(opt.mapScales);
+        optScales.sort(function(a, b) {
+            return Number(b) - Number(a);
+        });
+        let scales = buildScales(opt);
+        expect(optScales).to.have.length(6);
+        expect(scales).to.have.length(6);
+        expect(scales.at(0)).to.be.eq(optScales.at(0)); // 500000
+        expect(scales.at(-1)).to.be.eq(optScales.at(-1)); // 10000
+    })
+
+    it('use_native_zoom_levels', function () {
+        let opt = new OptionsConfig({
+            "projection": {
+                "proj4": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs",
+                "ref": "EPSG:3857"
+            },
+            "bbox": [
+                "-3.5",
+                "-1.0",
+                "3.5",
+                "1.0"
+            ],
+            "mapScales": [
+                10000,
+                25000,
+                50000,
+                100000,
+                250000,
+                500000
+            ],
+            "minScale": 10000,
+            "maxScale": 500000,
+            "initialExtent": [
+                -3.5,
+                -1.0,
+                3.5,
+                1.0
+            ],
+            "popupLocation": "dock",
+            "pointTolerance": 25,
+            "lineTolerance": 10,
+            "polygonTolerance": 5,
+            "hideProject": "True",
+            "tmTimeFrameSize": 10,
+            "tmTimeFrameType": "seconds",
+            "tmAnimationFrameLength": 1000,
+            "datavizLocation": "dock",
+            "theme": "light",
+            //"wmsMaxHeight": 3000,
+            //"wmsMaxWidth": 3000,
+            //"fixed_scale_overview_map": true,
+            //"use_native_zoom_levels": true,
+            //"hide_numeric_scale_value": false,
+            //"hideGroupCheckbox": false,
+        })
+        // Default value for EPSG:3857 without use_native_zoom_levels defined
+        expect(opt.use_native_zoom_levels).to.be.eq(true)
+
+        let optScales = Array.from(opt.mapScales);
+        optScales.sort(function(a, b) {
+            return Number(b) - Number(a);
+        });
+        let scales = buildScales(opt);
+        expect(optScales).to.have.length(6);
+        expect(scales).to.have.length(5);
+        expect(scales.at(0)).to.be.lessThan(optScales.at(0)); // < 500000
+        expect(Math.round(scales.at(0))).to.be.eq(288896);
+        expect(scales.at(-1)).to.be.greaterThan(optScales.at(-1)); // > 10000
+        expect(Math.round(scales.at(-1))).to.be.eq(18056);
+
+        opt = new OptionsConfig({
+            "projection": {
+                "proj4": "+proj=longlat +datum=WGS84 +no_defs",
+                "ref": "EPSG:4326"
+            },
+            "bbox": [
+                "-3.5",
+                "-1.0",
+                "3.5",
+                "1.0"
+            ],
+            "mapScales": [
+                10000,
+                500000
+            ],
+            "minScale": 10000,
+            "maxScale": 500000,
+            "initialExtent": [
+                -3.5,
+                -1.0,
+                3.5,
+                1.0
+            ],
+            "popupLocation": "dock",
+            "pointTolerance": 25,
+            "lineTolerance": 10,
+            "polygonTolerance": 5,
+            "hideProject": "True",
+            "tmTimeFrameSize": 10,
+            "tmTimeFrameType": "seconds",
+            "tmAnimationFrameLength": 1000,
+            "datavizLocation": "dock",
+            "theme": "light",
+            //"wmsMaxHeight": 3000,
+            //"wmsMaxWidth": 3000,
+            //"fixed_scale_overview_map": true,
+            //"use_native_zoom_levels": true,
+        })
+        // Default value for 2 mapScales without use_native_zoom_levels defined
+        expect(opt.use_native_zoom_levels).to.be.eq(true)
+
+        optScales = Array.from(opt.mapScales);
+        optScales.sort(function(a, b) {
+            return Number(b) - Number(a);
+        });
+        scales = buildScales(opt);
+        expect(optScales).to.have.length(2);
+        expect(scales).to.have.length(6);
+        expect(scales.at(0)).to.be.eq(optScales.at(0)); // 500000
+        expect(scales.at(-1)).to.be.eq(optScales.at(-1)); // 10000
     })
 })


### PR DESCRIPTION
fixes #4332

Currently, if the map allows you to go beyond the min/zoom resolution of a WMTS or XYZ source, Lizmap won't display anything beyond this min/zoom resolution.

OpenLayers is able to do resampling. This can be seen when you zoom in progressively. OpenLayers must be forced to use the max zoom of the grid even when the user goes beyond it.

The solution is described on stackoverflow https://stackoverflow.com/questions/43538345/how-to-force-load-tiles-for-lower-resolution and is based on `TileGrid`'s `getZForResolution` method https://github.com/openlayers/openlayers/blob/main/src/ol/tilegrid/TileGrid.js#L634

```js
  getZForResolution(resolution, opt_direction) {
    const z = linearFindNearest(
      this.resolutions_,
      resolution,
      opt_direction || 0,
    );
    return clamp(z, this.minZoom, this.maxZoom);
  }
```

This method is based on the `this.resolutions_` list of grid resolutions. The index of the resolution closest to that in parameter is then set to the min or max zoom value.

So if `this.resolutions_` contains 24 values but maxZoom is 19, then when the map is at levels 20, 21, 22, 23 and 24, the grid will limit queries to zoom 19.

Funded by FM Projet
