### PR TITLE
[Bugfix] Fire treecreated event at proper time

### DIFF
--- a/assets/src/components/Treeview.js
+++ b/assets/src/components/Treeview.js
@@ -198,6 +198,9 @@ export default class Treeview extends HTMLElement {
         mainEventDispatcher.addListener(
             this._onChange, ['resolution.changed']
         );
+
+        // layertree has been created, fire corresponding event
+        mainLizmap.lizmap3.events.triggerEvent('treecreated');
     }
 
     disconnectedCallback() {

--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -3771,11 +3771,6 @@ window.lizMap = function() {
                 // Re-save the config in self
                 self.config = config;
                 self.keyValueConfig = keyValueConfig;
-                /**
-                 * Event when the tree has been created
-                 * @event treecreated
-                 */
-                self.events.triggerEvent("treecreated", self);
 
                 // create the map
                 initProjections(firstLayer);


### PR DESCRIPTION
Starting from versions 3.7 the `treecreated` event is raised before the `lizmap-treeview` component is properly initialized.

To fix that, the `treecreated` event must be fired after `uicreated` event is fired since `Treeview` component is updated in the `uicreated` listener (see [index.js](https://github.com/3liz/lizmap-web-client/blob/05dded203440cfecda5d98a2eb81f6c89a74573c/assets/src/index.js#L41))

This behavior might be confusing, as you might think that the `uicreated` event fires when all UI components are correctly initialized, which is not the case.

As a proposal, it might be useful to reconsider name of the uicreated event (e.g. `uiinitialized` or whatever) and fire the uicreated event when components initialization is completed (see index.js above)

**NOTE:** 
`treecreated` event is fired regardless the `getLegendGraphic` request since for heavy projects this request could take a lot of time.

Ticket : #3965

Funded by Faunalia
