### PR TITLE
JS Web Component Digitizing: define attributes to config the element

### DIFF
--- a/assets/src/components/Digitizing.js
+++ b/assets/src/components/Digitizing.js
@@ -7,7 +7,7 @@
  */
 
 import { mainLizmap, mainEventDispatcher } from '../modules/Globals.js';
-import { DigitizingAvailableTools } from '../modules/Digitizing.js'
+import { DigitizingAvailableTools, DigitizingTools } from '../modules/Digitizing.js'
 import { html, render } from 'lit-html';
 
 import '../images/svg/point.svg';
@@ -16,6 +16,7 @@ import '../images/svg/polygon.svg';
 import '../images/svg/box.svg';
 import '../images/svg/circle.svg';
 import '../images/svg/freehand.svg';
+import '../images/svg/text.svg';
 
 import '../images/svg/pencil.svg';
 import '../images/svg/edit.svg';
@@ -35,12 +36,25 @@ export default class Digitizing extends HTMLElement {
     constructor() {
         super();
         this._toolSelected = DigitizingAvailableTools[0];
+        this._availableTools = DigitizingAvailableTools.slice(1);
     }
 
     connectedCallback() {
 
+        if (this.hasAttribute('available-tools')) {
+            const attrAvailableTools = this.getAttribute('available-tools')
+                .split(',')
+                .map((item) => item.trim())
+                .filter((item) => this._availableTools.includes(item));
+            if (attrAvailableTools.length > 0) {
+                this._availableTools = attrAvailableTools;
+            }
+        }
         if (this.hasAttribute('selected-tool')) {
-            this._toolSelected = this.getAttribute('selected-tool');
+            const attrToolSelected = this.getAttribute('selected-tool');
+            if (this._availableTools.includes(attrToolSelected)) {
+                this._toolSelected = attrToolSelected;
+            }
         }
 
         const mainTemplate = () => html`
@@ -51,60 +65,74 @@ export default class Digitizing extends HTMLElement {
                         <use xlink:href="#pencil"></use>
                     </svg>
                     <!-- Display selected tool -->
-                    <svg class="digitizing-selected-tool ${this.toolSelected === 'point' ? '' : 'hidden'}">
+                    <svg class="digitizing-selected-tool ${this.toolSelected === DigitizingTools.Point ? '' : 'hidden'}">
                         <use xlink:href="#point"></use>
                     </svg>
-                    <svg class="digitizing-selected-tool ${this.toolSelected === 'line' ? '' : 'hidden'}">
+                    <svg class="digitizing-selected-tool ${this.toolSelected === DigitizingTools.Line ? '' : 'hidden'}">
                         <use xlink:href="#line"></use>
                     </svg>
-                    <svg class="digitizing-selected-tool ${this.toolSelected === 'polygon' ? '' : 'hidden'}">
+                    <svg class="digitizing-selected-tool ${this.toolSelected === DigitizingTools.Polygon ? '' : 'hidden'}">
                         <use xlink:href="#polygon"></use>
                     </svg>
-                    <svg class="digitizing-selected-tool ${this.toolSelected === 'box' ? '' : 'hidden'}">
+                    <svg class="digitizing-selected-tool ${this.toolSelected === DigitizingTools.Box ? '' : 'hidden'}">
                         <use xlink:href="#box"></use>
                     </svg>
-                    <svg class="digitizing-selected-tool ${this.toolSelected === 'circle' ? '' : 'hidden'}">
+                    <svg class="digitizing-selected-tool ${this.toolSelected === DigitizingTools.Circle ? '' : 'hidden'}">
                         <use xlink:href="#circle"></use>
                     </svg>
-                    <svg class="digitizing-selected-tool ${this.toolSelected === 'freehand' ? '' : 'hidden'}">
+                    <svg class="digitizing-selected-tool ${this.toolSelected === DigitizingTools.Freehand ? '' : 'hidden'}">
                         <use xlink:href="#freehand"></use>
+                    </svg>
+                    <svg class="digitizing-selected-tool ${this.toolSelected === DigitizingTools.Text ? '' : 'hidden'}">
+                        <use xlink:href="#text"></use>
                     </svg>
                 </a>
                 <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
                     <span class="caret"></span>
                 </a>
                 <ul class="dropdown-menu">
-                    <li class="digitizing-point btn ${this.toolSelected === 'point' ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = 'point'} data-original-title="${lizDict['digitizing.toolbar.point']}">
+                    ${this._availableTools.includes(DigitizingTools.Point) ? html`
+                    <li class="digitizing-${DigitizingTools.Point} btn ${this.toolSelected === DigitizingTools.Point ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = DigitizingTools.Point} data-original-title="${lizDict['digitizing.toolbar.'+DigitizingTools.Point]}">
                         <svg>
                             <use xlink:href="#point"></use>
                         </svg>
-                    </li>
-                    <li class="digitizing-line btn ${this.toolSelected === 'line' ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = 'line'} data-original-title="${lizDict['digitizing.toolbar.line']}">
+                    </li>` : ''}
+                    ${this._availableTools.includes(DigitizingTools.Line) ? html`
+                    <li class="digitizing-${DigitizingTools.Line} btn ${this.toolSelected === DigitizingTools.Line ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = DigitizingTools.Line} data-original-title="${lizDict['digitizing.toolbar.'+DigitizingTools.Line]}">
                         <svg>
                             <use xlink:href="#line"></use>
                         </svg>
-                    </li>
-                    <li class="digitizing-polygon btn ${this.toolSelected === 'polygon' ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = 'polygon'} data-original-title="${lizDict['digitizing.toolbar.polygon']}">
+                    </li>` : ''}
+                    ${this._availableTools.includes(DigitizingTools.Polygon) ? html`
+                    <li class="digitizing-${DigitizingTools.Polygon} btn ${this.toolSelected === DigitizingTools.Polygon ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = DigitizingTools.Polygon} data-original-title="${lizDict['digitizing.toolbar.'+DigitizingTools.Polygon]}">
                         <svg>
                             <use xlink:href="#polygon"></use>
                         </svg>
-                    </li>
-                    <li class="digitizing-box btn ${this.toolSelected === 'box' ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = 'box'} data-original-title="${lizDict['digitizing.toolbar.box']}">
+                    </li>` : ''}
+                    ${this._availableTools.includes(DigitizingTools.Box) ? html`
+                    <li class="digitizing-${DigitizingTools.Box} btn ${this.toolSelected === DigitizingTools.Box ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = DigitizingTools.Box} data-original-title="${lizDict['digitizing.toolbar.'+DigitizingTools.Box]}">
                         <svg>
                             <use xlink:href="#box"></use>
                         </svg>
-                    </li>
-                    <li class="digitizing-circle btn ${this.toolSelected === 'circle' ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = 'circle'} data-original-title="${lizDict['digitizing.toolbar.circle']}">
+                    </li>` : ''}
+                    ${this._availableTools.includes(DigitizingTools.Circle) ? html`
+                    <li class="digitizing-${DigitizingTools.Circle} btn ${this.toolSelected === DigitizingTools.Circle ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = DigitizingTools.Circle} data-original-title="${lizDict['digitizing.toolbar.'+DigitizingTools.Circle]}">
                         <svg>
                             <use xlink:href="#circle"></use>
                         </svg>
-                    </li>
-                    <li class="digitizing-freehand btn ${this.toolSelected === 'freehand' ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = 'freehand'} data-original-title="${lizDict['digitizing.toolbar.freehand']}">
+                    </li>` : ''}
+                    ${this._availableTools.includes(DigitizingTools.Freehand) ? html`
+                    <li class="digitizing-${DigitizingTools.Freehand} btn ${this.toolSelected === DigitizingTools.Freehand ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = DigitizingTools.Freehand} data-original-title="${lizDict['digitizing.toolbar.'+DigitizingTools.Freehand]}">
                         <svg>
                             <use xlink:href="#freehand"></use>
                         </svg>
-                    </li>
-                    <li class="digitizing-text btn ${this.toolSelected === 'text' ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = 'text'} data-original-title="${lizDict['digitizing.toolbar.text']}">Abc</li>
+                    </li>` : ''}
+                    ${this._availableTools.includes(DigitizingTools.Text) ? html`
+                    <li class="digitizing-${DigitizingTools.Text} btn ${this.toolSelected === DigitizingTools.Text ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = DigitizingTools.Text} data-original-title="${lizDict['digitizing.toolbar.'+DigitizingTools.Text]}">
+                        <svg>
+                            <use xlink:href="#text"></use>
+                        </svg>
+                    </li>` : ''}
                 </ul>
             </div>
             <input type="color" class="digitizing-color btn" .value="${mainLizmap.digitizing.drawColor}" @input=${(event) => mainLizmap.digitizing._userChangedColor(event.target.value)} data-original-title="${lizDict['digitizing.toolbar.color']}">
@@ -304,6 +332,17 @@ export default class Digitizing extends HTMLElement {
     }
 
     /**
+     * The available tools
+     * The element attribute: available-tools
+     * All or part of DigitizingAvailableTools except deactivate
+     * @see DigitizingAvailableTools
+     * @type {string}
+     */
+    get availableTools() {
+        return this._availableTools;
+    }
+
+    /**
      * The selected tool
      * The element attribute: selected-tool
      * @type {string}
@@ -318,7 +357,7 @@ export default class Digitizing extends HTMLElement {
      * @param {string} tool - switch new OL map on top of OL2 one
      */
     set toolSelected(tool) {
-        if (DigitizingAvailableTools.includes(tool)) {
+        if (this._availableTools.includes(tool)) {
             this._toolSelected = tool;
             mainLizmap.digitizing.toolSelected = tool;
         }

--- a/assets/src/components/Digitizing.js
+++ b/assets/src/components/Digitizing.js
@@ -7,6 +7,7 @@
  */
 
 import { mainLizmap, mainEventDispatcher } from '../modules/Globals.js';
+import { DigitizingAvailableTools } from '../modules/Digitizing.js'
 import { html, render } from 'lit-html';
 
 import '../images/svg/point.svg';
@@ -33,34 +34,39 @@ import '../images/svg/file-upload.svg';
 export default class Digitizing extends HTMLElement {
     constructor() {
         super();
+        this._toolSelected = DigitizingAvailableTools[0];
     }
 
     connectedCallback() {
 
+        if (this.hasAttribute('selected-tool')) {
+            this._toolSelected = this.getAttribute('selected-tool');
+        }
+
         const mainTemplate = () => html`
         <div class="digitizing">
             <div class="digitizing-buttons btn-group" data-original-title="${lizDict['digitizing.toolbar.drawTools']}">
-                <a class="btn dropdown-toggle ${this.deactivate ? '' : 'active btn-primary'}" @click=${(event) => { if(mainLizmap.digitizing.toolSelected !== 'deactivate') {mainLizmap.digitizing.toolSelected = 'deactivate'; event.stopPropagation();}}} data-toggle="dropdown" href="#">
+                <a class="btn dropdown-toggle ${this.deactivate ? '' : 'active btn-primary'}" @click=${(event) => {this.toggleToolSelected(event)}} data-toggle="dropdown" href="#">
                     <svg>
                         <use xlink:href="#pencil"></use>
                     </svg>
                     <!-- Display selected tool -->
-                    <svg class="digitizing-selected-tool ${mainLizmap.digitizing.toolSelected === 'point' ? '' : 'hidden'}">
+                    <svg class="digitizing-selected-tool ${this.toolSelected === 'point' ? '' : 'hidden'}">
                         <use xlink:href="#point"></use>
                     </svg>
-                    <svg class="digitizing-selected-tool ${mainLizmap.digitizing.toolSelected === 'line' ? '' : 'hidden'}">
+                    <svg class="digitizing-selected-tool ${this.toolSelected === 'line' ? '' : 'hidden'}">
                         <use xlink:href="#line"></use>
                     </svg>
-                    <svg class="digitizing-selected-tool ${mainLizmap.digitizing.toolSelected === 'polygon' ? '' : 'hidden'}">
+                    <svg class="digitizing-selected-tool ${this.toolSelected === 'polygon' ? '' : 'hidden'}">
                         <use xlink:href="#polygon"></use>
                     </svg>
-                    <svg class="digitizing-selected-tool ${mainLizmap.digitizing.toolSelected === 'box' ? '' : 'hidden'}">
+                    <svg class="digitizing-selected-tool ${this.toolSelected === 'box' ? '' : 'hidden'}">
                         <use xlink:href="#box"></use>
                     </svg>
-                    <svg class="digitizing-selected-tool ${mainLizmap.digitizing.toolSelected === 'circle' ? '' : 'hidden'}">
+                    <svg class="digitizing-selected-tool ${this.toolSelected === 'circle' ? '' : 'hidden'}">
                         <use xlink:href="#circle"></use>
                     </svg>
-                    <svg class="digitizing-selected-tool ${mainLizmap.digitizing.toolSelected === 'freehand' ? '' : 'hidden'}">
+                    <svg class="digitizing-selected-tool ${this.toolSelected === 'freehand' ? '' : 'hidden'}">
                         <use xlink:href="#freehand"></use>
                     </svg>
                 </a>
@@ -68,37 +74,37 @@ export default class Digitizing extends HTMLElement {
                     <span class="caret"></span>
                 </a>
                 <ul class="dropdown-menu">
-                    <li class="digitizing-point btn ${mainLizmap.digitizing.toolSelected === 'point' ? 'active btn-primary' : ''}" @click=${() => mainLizmap.digitizing.toolSelected = 'point'} data-original-title="${lizDict['digitizing.toolbar.point']}">
+                    <li class="digitizing-point btn ${this.toolSelected === 'point' ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = 'point'} data-original-title="${lizDict['digitizing.toolbar.point']}">
                         <svg>
                             <use xlink:href="#point"></use>
                         </svg>
                     </li>
-                    <li class="digitizing-line btn ${mainLizmap.digitizing.toolSelected === 'line' ? 'active btn-primary' : ''}" @click=${() => mainLizmap.digitizing.toolSelected = 'line'} data-original-title="${lizDict['digitizing.toolbar.line']}">
+                    <li class="digitizing-line btn ${this.toolSelected === 'line' ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = 'line'} data-original-title="${lizDict['digitizing.toolbar.line']}">
                         <svg>
                             <use xlink:href="#line"></use>
                         </svg>
                     </li>
-                    <li class="digitizing-polygon btn ${mainLizmap.digitizing.toolSelected === 'polygon' ? 'active btn-primary' : ''}" @click=${() => mainLizmap.digitizing.toolSelected = 'polygon'} data-original-title="${lizDict['digitizing.toolbar.polygon']}">
+                    <li class="digitizing-polygon btn ${this.toolSelected === 'polygon' ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = 'polygon'} data-original-title="${lizDict['digitizing.toolbar.polygon']}">
                         <svg>
                             <use xlink:href="#polygon"></use>
                         </svg>
                     </li>
-                    <li class="digitizing-box btn ${mainLizmap.digitizing.toolSelected === 'box' ? 'active btn-primary' : ''}" @click=${() => mainLizmap.digitizing.toolSelected = 'box'} data-original-title="${lizDict['digitizing.toolbar.box']}">
+                    <li class="digitizing-box btn ${this.toolSelected === 'box' ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = 'box'} data-original-title="${lizDict['digitizing.toolbar.box']}">
                         <svg>
                             <use xlink:href="#box"></use>
                         </svg>
                     </li>
-                    <li class="digitizing-circle btn ${mainLizmap.digitizing.toolSelected === 'circle' ? 'active btn-primary' : ''}" @click=${() => mainLizmap.digitizing.toolSelected = 'circle'} data-original-title="${lizDict['digitizing.toolbar.circle']}">
+                    <li class="digitizing-circle btn ${this.toolSelected === 'circle' ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = 'circle'} data-original-title="${lizDict['digitizing.toolbar.circle']}">
                         <svg>
                             <use xlink:href="#circle"></use>
                         </svg>
                     </li>
-                    <li class="digitizing-freehand btn ${mainLizmap.digitizing.toolSelected === 'freehand' ? 'active btn-primary' : ''}" @click=${() => mainLizmap.digitizing.toolSelected = 'freehand'} data-original-title="${lizDict['digitizing.toolbar.freehand']}">
+                    <li class="digitizing-freehand btn ${this.toolSelected === 'freehand' ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = 'freehand'} data-original-title="${lizDict['digitizing.toolbar.freehand']}">
                         <svg>
                             <use xlink:href="#freehand"></use>
                         </svg>
                     </li>
-                    <li class="digitizing-text btn ${mainLizmap.digitizing.toolSelected === 'text' ? 'active btn-primary' : ''}" @click=${() => mainLizmap.digitizing.toolSelected = 'text'} data-original-title="${lizDict['digitizing.toolbar.text']}">Abc</li>
+                    <li class="digitizing-text btn ${this.toolSelected === 'text' ? 'active btn-primary' : ''}" @click=${() => this.toolSelected = 'text'} data-original-title="${lizDict['digitizing.toolbar.text']}">Abc</li>
                 </ul>
             </div>
             <input type="color" class="digitizing-color btn" .value="${mainLizmap.digitizing.drawColor}" @input=${(event) => mainLizmap.digitizing._userChangedColor(event.target.value)} data-original-title="${lizDict['digitizing.toolbar.color']}">
@@ -295,6 +301,39 @@ export default class Digitizing extends HTMLElement {
      */
     get importExportAvailable() {
         return this.hasAttribute('import-export');
+    }
+
+    /**
+     * The selected tool
+     * The element attribute: selected-tool
+     * @type {string}
+     */
+    get toolSelected() {
+        return this._toolSelected;
+    }
+
+    /**
+     * Setting the selected
+     * @see DigitizingAvailableTools
+     * @param {string} tool - switch new OL map on top of OL2 one
+     */
+    set toolSelected(tool) {
+        if (DigitizingAvailableTools.includes(tool)) {
+            this._toolSelected = tool;
+            mainLizmap.digitizing.toolSelected = tool;
+        }
+    }
+
+    /**
+     * Toggle selected tool
+     * @param {MouseEvent} event - The click event on the button
+     */
+    toggleToolSelected(event) {
+        if (this.toolSelected === DigitizingAvailableTools[0]) {
+            return;
+        }
+        mainLizmap.digitizing.toolSelected = (mainLizmap.digitizing.toolSelected !== DigitizingAvailableTools[0]) ? DigitizingAvailableTools[0] : this.toolSelected;
+        event.stopPropagation();
     }
 
     eraseAll() {

--- a/assets/src/components/Digitizing.js
+++ b/assets/src/components/Digitizing.js
@@ -40,7 +40,7 @@ export default class Digitizing extends HTMLElement {
         const mainTemplate = () => html`
         <div class="digitizing">
             <div class="digitizing-buttons btn-group" data-original-title="${lizDict['digitizing.toolbar.drawTools']}">
-                <a class="btn dropdown-toggle ${mainLizmap.digitizing.toolSelected !== 'deactivate' ? 'active btn-primary' : ''}" @click=${(event) => { if(mainLizmap.digitizing.toolSelected !== 'deactivate') {mainLizmap.digitizing.toolSelected = 'deactivate'; event.stopPropagation();}}} data-toggle="dropdown" href="#">
+                <a class="btn dropdown-toggle ${this.deactivate ? '' : 'active btn-primary'}" @click=${(event) => { if(mainLizmap.digitizing.toolSelected !== 'deactivate') {mainLizmap.digitizing.toolSelected = 'deactivate'; event.stopPropagation();}}} data-toggle="dropdown" href="#">
                     <svg>
                         <use xlink:href="#pencil"></use>
                     </svg>
@@ -220,13 +220,54 @@ export default class Digitizing extends HTMLElement {
 
         mainEventDispatcher.addListener(
             () => {
-                render(mainTemplate(), this);
+                if (!this.disabled) {
+                    render(mainTemplate(), this);
+                }
             },
             ['digitizing.featureDrawn', 'digitizing.visibility', 'digitizing.toolSelected', 'digitizing.editionBegins', 'digitizing.editionEnds', 'digitizing.erasingBegins', 'digitizing.erasingEnds', 'digitizing.erase', 'digitizing.erase.all', 'digitizing.drawColor', 'digitizing.save', 'digitizing.measure', 'digitizing.editedFeatureText', 'digitizing.editedFeatureRotation', 'digitizing.editedFeatureScale']
         );
     }
 
     disconnectedCallback() {
+    }
+
+    /**
+     * Digitizing context
+     * The element attribute: context
+     * @type {string}
+     */
+    get context() {
+        if (this.hasAttribute('context')) {
+            return this.getAttribute('context');
+        }
+        return 'draw';
+    }
+
+    /**
+     * The element is deactivated
+     * if the element is disabled
+     * or if the tool is deactivated
+     * @type {boolean}
+     */
+    get deactivate() {
+        if (mainLizmap.digitizing.context !== this.context) {
+            return true;
+        }
+        if (mainLizmap.digitizing.toolSelected === 'deactivate') {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * The element is disabled if the context is not the same as the module
+     * @type {boolean}
+     */
+    get disabled() {
+        if (mainLizmap.digitizing.context !== this.context) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/assets/src/components/Digitizing.js
+++ b/assets/src/components/Digitizing.js
@@ -28,9 +28,20 @@ import '../images/svg/file-download.svg';
 import '../images/svg/file-upload.svg';
 
 /**
+ * Digitizing element
+ * Provides user interface for digitizing shapes and text
+ * Attributes:
+ *  context - The digitizing context to linked element to Digitizing module context
+ *  selected-tool - Start selected drawing tools one of DigitizingAvailableTools or available-tools
+ *  available-tools - List of available drawing tools based on DigitizingAvailableTools
+ *  save - Enable save capability
+ *  measure - Enable measure capability
+ *  import-export - Enable import / export capabilities
  * @class
  * @name Digitizing
  * @augments HTMLElement
+ * @example
+ * <lizmap-digitizing context="draw" selected-tool="box" available-tools="point,line,polygon,box,freehand" save import-export measure></lizmap-digitizing>
  */
 export default class Digitizing extends HTMLElement {
     constructor() {

--- a/assets/src/components/Digitizing.js
+++ b/assets/src/components/Digitizing.js
@@ -120,7 +120,7 @@ export default class Digitizing extends HTMLElement {
             <button type="button" class="digitizing-toggle-visibility btn" ?disabled=${!mainLizmap.digitizing.featureDrawn} @click=${() => mainLizmap.digitizing.toggleVisibility()} data-original-title="${lizDict['tree.button.checkbox']}">
                 <i class="icon-eye-${mainLizmap.digitizing.visibility ? 'open' : 'close'}"></i>
             </button>
-            <button type="button" class="digitizing-toggle-measure btn ${mainLizmap.digitizing.hasMeasureVisible ? 'active btn-primary' : ''} ${this.hasAttribute('measure') ? '' : 'hide'}" @click=${() => mainLizmap.digitizing.toggleMeasure()} data-original-title="${lizDict['digitizing.toolbar.measure']}">
+            <button type="button" class="digitizing-toggle-measure btn ${mainLizmap.digitizing.hasMeasureVisible ? 'active btn-primary' : ''} ${this.measureAvailable ? '' : 'hide'}" @click=${() => mainLizmap.digitizing.toggleMeasure()} data-original-title="${lizDict['digitizing.toolbar.measure']}">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                     <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
                     <path d="M17 3l4 4l-14 14l-4 -4z"></path>
@@ -130,12 +130,12 @@ export default class Digitizing extends HTMLElement {
                     <path d="M7 16l-1.5 -1.5"></path>
                 </svg>
             </button>
-            <button type="button" class="digitizing-save btn ${mainLizmap.digitizing.isSaved ? 'active btn-primary' : ''} ${this.hasAttribute('save') ? '' : 'hide'}" @click=${()=> this.toggleSave()} data-original-title="${lizDict['digitizing.toolbar.save']}">
+            <button type="button" class="digitizing-save btn ${mainLizmap.digitizing.isSaved ? 'active btn-primary' : ''} ${this.saveAvailable ? '' : 'hide'}" @click=${()=> this.toggleSave()} data-original-title="${lizDict['digitizing.toolbar.save']}">
                 <svg>
                     <use xlink:href="#save" />
                 </svg>
             </button>
-            <div class="digitizing-import-export ${this.hasAttribute('import-export') ? '' : 'hide'}">
+            <div class="digitizing-import-export ${this.importExportAvailable ? '' : 'hide'}">
                 <div class="btn-group digitizing-export">
                     <button class="btn dropdown-toggle" ?disabled=${!mainLizmap.digitizing.featureDrawn} data-toggle="dropdown" data-original-title="${lizDict['attributeLayers.toolbar.btn.data.export.title']}">
                         <svg>
@@ -227,6 +227,33 @@ export default class Digitizing extends HTMLElement {
     }
 
     disconnectedCallback() {
+    }
+
+    /**
+     * Measure is available
+     * The element has attribute: measure
+     * @type {boolean}
+     */
+    get measureAvailable() {
+        return this.hasAttribute('measure');
+    }
+
+    /**
+     * Save is available
+     * The element has attribute: save
+     * @type {boolean}
+     */
+    get saveAvailable() {
+        return this.hasAttribute('save');
+    }
+
+    /**
+     * Import/export is available
+     * The element has attribute: import-export
+     * @type {boolean}
+     */
+    get importExportAvailable() {
+        return this.hasAttribute('import-export');
     }
 
     eraseAll() {

--- a/assets/src/components/SelectionTool.js
+++ b/assets/src/components/SelectionTool.js
@@ -43,7 +43,7 @@ export default class SelectionTool extends HTMLElement {
                         </optgroup>
                     </select>
                 </div>
-                <lizmap-digitizing context="selectiontool" import-export></lizmap-digitizing>
+                <lizmap-digitizing context="selectiontool" selected-tool="box" import-export></lizmap-digitizing>
                 <div class="selectiontool-buffer">
                     <label><span>${lizDict['selectiontool.toolbar.buffer']}</span>
                         <div class="input-append">

--- a/assets/src/components/SelectionTool.js
+++ b/assets/src/components/SelectionTool.js
@@ -43,7 +43,7 @@ export default class SelectionTool extends HTMLElement {
                         </optgroup>
                     </select>
                 </div>
-                <lizmap-digitizing import-export></lizmap-digitizing>
+                <lizmap-digitizing context="selectiontool" import-export></lizmap-digitizing>
                 <div class="selectiontool-buffer">
                     <label><span>${lizDict['selectiontool.toolbar.buffer']}</span>
                         <div class="input-append">

--- a/assets/src/components/SelectionTool.js
+++ b/assets/src/components/SelectionTool.js
@@ -43,7 +43,7 @@ export default class SelectionTool extends HTMLElement {
                         </optgroup>
                     </select>
                 </div>
-                <lizmap-digitizing context="selectiontool" selected-tool="box" import-export></lizmap-digitizing>
+                <lizmap-digitizing context="selectiontool" selected-tool="box" available-tools="point,line,polygon,box,freehand" import-export></lizmap-digitizing>
                 <div class="selectiontool-buffer">
                     <label><span>${lizDict['selectiontool.toolbar.buffer']}</span>
                         <div class="input-append">

--- a/assets/src/images/svg/text.svg
+++ b/assets/src/images/svg/text.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg10"
+   version="1.1"
+   width="24"
+   height="24"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs14" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:125%;font-family:FontAwesome;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:currentColor;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="2.3229163"
+     y="15.976575"
+     id="text5085"><tspan
+       id="tspan5083"
+       x="2.3229163"
+       y="15.976575">Abc</tspan></text>
+</svg>

--- a/assets/src/modules/Digitizing.js
+++ b/assets/src/modules/Digitizing.js
@@ -6,6 +6,7 @@
  */
 import { mainLizmap, mainEventDispatcher } from '../modules/Globals.js';
 import { deepFreeze } from './config/Tools.js';
+import { createEnum } from './utils/Enums.js';
 import Utils from '../modules/Utils.js';
 
 import GeoJSON from 'ol/format/GeoJSON.js';
@@ -37,6 +38,17 @@ import { transform } from 'ol/proj.js';
  * @constant {Array<string>}
  */
 export const DigitizingAvailableTools = deepFreeze(['deactivate', 'point', 'line', 'polygon', 'box', 'circle', 'freehand', 'text']);
+
+export const DigitizingTools = createEnum({
+    'Deactivate': 'deactivate',
+    'Point': 'point',
+    'Line': 'line',
+    'Polygon': 'polygon',
+    'Box': 'box',
+    'Circle': 'circle',
+    'Freehand': 'freehand',
+    'Text': 'text'
+});
 
 /**
  * @class

--- a/assets/src/modules/Digitizing.js
+++ b/assets/src/modules/Digitizing.js
@@ -5,6 +5,7 @@
  * @license MPL-2.0
  */
 import { mainLizmap, mainEventDispatcher } from '../modules/Globals.js';
+import { deepFreeze } from './config/Tools.js';
 import Utils from '../modules/Utils.js';
 
 import GeoJSON from 'ol/format/GeoJSON.js';
@@ -31,10 +32,17 @@ import { unByKey } from 'ol/Observable.js';
 import { transform } from 'ol/proj.js';
 
 /**
+ * List of digitizing available tools
+ * @name DigitizingAvailableTools
+ * @constant {Array<string>}
+ */
+export const DigitizingAvailableTools = deepFreeze(['deactivate', 'point', 'line', 'polygon', 'box', 'circle', 'freehand', 'text']);
+
+/**
  * @class
  * @name Digitizing
  */
-export default class Digitizing {
+export class Digitizing {
 
     constructor() {
 
@@ -42,7 +50,7 @@ export default class Digitizing {
         this._context = 'draw';
         this._contextFeatures = {};
 
-        this._tools = ['deactivate', 'point', 'line', 'polygon', 'box', 'circle', 'freehand', 'text'];
+        this._tools = DigitizingAvailableTools;
         this._toolSelected = this._tools[0];
 
         this._repoAndProjectString = globalThis['lizUrls'].params.repository + '_' + globalThis['lizUrls'].params.project;

--- a/assets/src/modules/Lizmap.js
+++ b/assets/src/modules/Lizmap.js
@@ -11,7 +11,7 @@ import Edition from './Edition.js';
 import Geolocation from './Geolocation.js';
 import GeolocationSurvey from './GeolocationSurvey.js';
 import SelectionTool from './SelectionTool.js';
-import Digitizing from './Digitizing.js';
+import { Digitizing } from './Digitizing.js';
 import Snapping from './Snapping.js';
 import Layers from './Layers.js';
 import WFS from './WFS.js';

--- a/lizmap/modules/view/templates/map_draw.tpl
+++ b/lizmap/modules/view/templates/map_draw.tpl
@@ -11,6 +11,6 @@
     </h3>
 
     <div class="menu-content">
-        <lizmap-digitizing save import-export measure></lizmap-digitizing>
+        <lizmap-digitizing context="draw" save import-export measure></lizmap-digitizing>
     </div>
 </div>

--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -2495,10 +2495,6 @@ lizmap-mouse-position > div.coords-unit > select{
   vertical-align: text-bottom;
 }
 
-#selectiontool .digitizing-circle, #selectiontool .digitizing-text{
-  display: none;
-}
-
 lizmap-selection-invert svg {
   width: 14px;
   height: 14px;

--- a/tests/end2end/cypress/integration/selectionTool-ghaction.js
+++ b/tests/end2end/cypress/integration/selectionTool-ghaction.js
@@ -57,7 +57,7 @@ describe('Selection tool', function () {
         cy.get('#button-selectiontool').click()
 
         // Activate polygon tool
-        cy.get('#selectiontool .digitizing-buttons .dropdown-toggle').first().click()
+        cy.get('#selectiontool .digitizing-buttons .dropdown-toggle').eq(1).click()
         cy.get('#selectiontool .digitizing-polygon').click()
 
         // Select single layer and intersects geom operator
@@ -101,7 +101,7 @@ describe('Selection tool', function () {
         cy.get('#button-selectiontool').click()
 
         // Activate polygon tool
-        cy.get('#selectiontool .digitizing-buttons .dropdown-toggle').first().click()
+        cy.get('#selectiontool .digitizing-buttons .dropdown-toggle').eq(1).click()
         cy.get('#selectiontool .digitizing-line').click()
 
         // Select single layer and intersects geom operator
@@ -144,7 +144,7 @@ describe('Selection tool', function () {
         cy.get('#button-selectiontool').click()
 
         // Activate polygon tool
-        cy.get('#selectiontool .digitizing-buttons .dropdown-toggle').first().click()
+        cy.get('#selectiontool .digitizing-buttons .dropdown-toggle').eq(1).click()
         cy.get('#selectiontool .digitizing-point').click()
 
         // Select single layer and intersects geom operator
@@ -194,7 +194,7 @@ describe('Selection tool connected as user a', function () {
         cy.get('#button-selectiontool').click()
 
         // Activate polygon tool
-        cy.get('#selectiontool .digitizing-buttons .dropdown-toggle').first().click()
+        cy.get('#selectiontool .digitizing-buttons .dropdown-toggle').eq(1).click()
         cy.get('#selectiontool .digitizing-polygon').click()
 
         // Select single layer and intersects geom operator
@@ -243,7 +243,7 @@ describe('Selection tool connected as admin', function () {
         cy.get('#button-selectiontool').click()
 
         // Activate polygon tool
-        cy.get('#selectiontool .digitizing-buttons .dropdown-toggle').first().click()
+        cy.get('#selectiontool .digitizing-buttons .dropdown-toggle').eq(1).click()
         cy.get('#selectiontool .digitizing-polygon').click()
 
         // Select single layer and intersects geom operator


### PR DESCRIPTION
Digitizing element provides user interface for digitizing shapes and text

The available Attributes are:
 *  context - The digitizing context to linked element to Digitizing module context
 *  selected-tool - Start selected drawing tools one of DigitizingAvailableTools or available-tools
 *  available-tools - List of available drawing tools based on DigitizingAvailableTools
 *  save - Enable save capability
 *  measure - Enable measure capability
 *  import-export - Enable import / export capabilities

 By default
```html
<lizmap-digitizing context="draw" save import-export measure></lizmap-digitizing>
```

For selection tool
```html
<lizmap-digitizing context="selectiontool" selected-tool="box" available-tools="point,line,polygon,box,freehand" import-export></lizmap-digitizing>
```

For editing polygon, it could be used like that
```html
<lizmap-digitizing context="editing" selected-tool="polygon" available-tools="polygon"></lizmap-digitizing>
```