### PR TITLE
Add link to the commit SHA on GitHub if possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ $(DIST): lizmap/www/assets/js/lizmap.js lizmap/vendor
 	cp -aR $(FILES) $(DIST)/
 	sed -i "s/\(<version date=\"\)\([^\"]*\)\(\"\)/\1$(DATE_VERSION)\3/" $(DIST)/lizmap/project.xml
 	sed -i "s/\(<version.*pre\)</\1\.$(COMMIT_NUMBER)</" $(DIST)/lizmap/project.xml
+	sed -i "s@commitSha=@commitSha=$(COMMITID)@g" $(DIST)/lizmap/app/system/mainconfig.ini.php
 	mkdir -p $(DIST)/temp/lizmap/
 	cp -a temp/.htaccess $(DIST)/temp/
 	cp -a temp/lizmap/.empty $(DIST)/temp/lizmap/

--- a/lizmap/app/system/mainconfig.ini.php
+++ b/lizmap/app/system/mainconfig.ini.php
@@ -20,6 +20,9 @@ timeZone="Europe/Paris"
 
 theme=default
 
+; This value will be replaced on CI by the current Git commit SHA value
+; If set, the link is generated in the administration panel
+commitSha=
 
 ; the locales available in the application
 availableLocales="cs_CZ,de_DE,el_GR,en_US,es_ES,eu_ES,fi_FI,fr_FR,gl_ES,hu_HU,it_IT,ja_JP,nl_NL,no_NO,pl_PL,pt_BR,pt_PT,ro_RO,ru_RU,sl_SI,sv_SE,sk_SK,uk_UA"

--- a/lizmap/modules/admin/controllers/server_information.classic.php
+++ b/lizmap/modules/admin/controllers/server_information.classic.php
@@ -83,6 +83,7 @@ class server_informationCtrl extends jController
             'lizmapPluginUpdate' => $updateLizmapPlugin,
             'minimumQgisVersion' => $qgisMinimumVersionRequired,
             'minimumLizmapServer' => $lizmapPluginMinimumVersionRequired,
+            'currentLizmapCommitId' => jApp::config()->commitSha,
         );
         $tpl->assign($assign);
         $rep->body->assign('MAIN', $tpl->fetch('server_information'));

--- a/lizmap/modules/admin/templates/server_information.tpl
+++ b/lizmap/modules/admin/templates/server_information.tpl
@@ -11,7 +11,12 @@
     <table class="table table-striped table-bordered table-server-info table-lizmap-web-client">
         <tr>
             <th>{@admin.server.information.lizmap.info.version@}</th>
-            <td>{$data['info']['version']}</td>
+            <td>
+            {$data['info']['version']}
+            {if $currentLizmapCommitId}
+                - <a href="https://github.com/3liz/lizmap-web-client/commit/{$currentLizmapCommitId}" target="_blank">{$currentLizmapCommitId}</a>
+            {/if}
+            </td>
         </tr>
         <tr>
             <th>{@admin.server.information.lizmap.info.date@}</th>


### PR DESCRIPTION
As a draft for now, I would have prefered to use the `project.xml` file https://github.com/3liz/lizmap-web-client/blob/master/lizmap/project.xml but it's triggering a warning in the Jelix toolbar 

> [Creation of dynamic property Jelix\Core\Infos\AppInfos::$commitId is deprecated](http://lizmap.local:8130/admin.php/admin/server_information#)
> [Creation of dynamic property Jelix\Core\Infos\AppInfos::$commit is deprecated](http://lizmap.local:8130/admin.php/admin/server_information#)

So I used the mainconfig.ini file. But it doesn't seem the perfect place. Anyway, feel free to let me know what you think.


We need to remove one of the "wrong" `sed` before merging

![image](https://github.com/user-attachments/assets/8f41a234-f7d0-4bb8-9df7-6de4bb79cef0)
