### PR TITLE
remove phpstan ignored errors no more existing [backport 4686]

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -290,12 +290,6 @@ parameters:
 			path: lizmap/modules/lizmap/controllers/edition.classic.php
 
 		-
-			message: "#^Left side of \\|\\| is always false\\.$#"
-			count: 1
-			path: lizmap/modules/lizmap/controllers/edition.classic.php
-
-
-		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 6
 			path: lizmap/modules/lizmap/controllers/edition.classic.php
@@ -324,12 +318,6 @@ parameters:
 			message: "#^Property editionCtrl\\:\\:\\$layerXml is never read, only written\\.$#"
 			count: 1
 			path: lizmap/modules/lizmap/controllers/edition.classic.php
-
-		-
-			message: "#^Right side of \\|\\| is always false\\.$#"
-			count: 1
-			path: lizmap/modules/lizmap/controllers/edition.classic.php
-
 
 		-
 			message: "#^Access to an undefined property jResponse\\:\\:\\$data\\.$#"


### PR DESCRIPTION
Remove phpstan errors from phpstan-basliene.neon that are no more detected since php stan 1.11.10

(backport #4686 )