### PR TITLE
Fix phpstan error detected sinc phpstan 1.11

### DIFF
--- a/lizmap/modules/dataviz/classes/datavizPlot.class.php
+++ b/lizmap/modules/dataviz/classes/datavizPlot.class.php
@@ -474,7 +474,7 @@ class datavizPlot
                 $matches = array();
                 $preg = preg_match_all('#"\b[^\s]+\b"#', $exp_filter, $matches);
                 $pp = '';
-                if (count($matches) > 0 and count($matches[0]) > 0) {
+                if ($preg != false && count($matches[0]) > 0) {
                     foreach ($matches[0] as $m) {
                         $pp .= ','.trim($m, '"');
                     }

--- a/lizmap/modules/lizmap/classes/qgisExpressionUtils.class.php
+++ b/lizmap/modules/lizmap/classes/qgisExpressionUtils.class.php
@@ -21,8 +21,8 @@ class qgisExpressionUtils
         if ($exp === null || trim($exp) === '') {
             return array();
         }
-        preg_match_all('/"([^"]+)"/', $exp, $matches);
-        if (count($matches) < 2) {
+        $preg = preg_match_all('/"([^"]+)"/', $exp, $matches);
+        if ($preg == false) {
             return array();
         }
 
@@ -59,8 +59,8 @@ class qgisExpressionUtils
      */
     public static function getCurrentValueCriteriaFromExpression($exp)
     {
-        preg_match_all('/\\bcurrent_value\\(\\s*\'([^)]*)\'\\s*\\)/', $exp, $matches);
-        if (count($matches) == 2) {
+        $preg = preg_match_all('/\\bcurrent_value\\(\\s*\'([^)]*)\'\\s*\\)/', $exp, $matches);
+        if ($preg !== false) {
             return array_values(array_unique($matches[1]));
         }
 

--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -169,10 +169,8 @@ class WMSRequest extends OGCRequest
             if (!preg_match('@Service>.*?Max'.$d.'.*?</Service@si', $data)) {
                 $matches = array();
                 if (preg_match('@Service>(.*?)</Service@si', $data, $matches)) {
-                    if (count($matches) > 1) {
-                        $sUpdate = $matches[1].'<Max'.$d.'>3000</Max'.$d.">\n ";
-                        $data = str_replace($matches[1], $sUpdate, $data);
-                    }
+                    $sUpdate = $matches[1].'<Max'.$d.'>3000</Max'.$d.">\n ";
+                    $data = str_replace($matches[1], $sUpdate, $data);
                 }
             }
         }

--- a/tests/units/composer.json
+++ b/tests/units/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=7.3.0",
         "phpunit/phpunit": "^9.5.7",
-        "phpstan/phpstan": "1.11.*"
+        "phpstan/phpstan": "^1.10.1"
     },
     "autoload": {
         "classmap": ["../../lizmap/modules/lizmap/classes/" ],


### PR DESCRIPTION
The 1.12  version of phpstan improve `preg_match  / preg_match_all` detection, some new errors appears.
Since preg_match_all always fill `$matches` with 2 item, phpstan consider `count($matches)  ` comparison  useless.
 
Refactoring use return value from preg_match_all instead of `count($matches) `