### PR TITLE
Headed chrome for Cypress

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -158,6 +158,7 @@ jobs:
         uses: cypress-io/github-action@v6.7.2
         with:
           browser: chrome
+          headed: true
           working-directory: tests/end2end
           spec: cypress/integration/*-ghaction.js
           wait-on: http://localhost:8130


### PR DESCRIPTION
Some tests are failing in headless mode without any reason.
Let's use head mode