### PR TITLE
Fix: Target "_blank" disapeared on hyperlinks in popups

### DIFF
--- a/assets/src/modules/Popup.js
+++ b/assets/src/modules/Popup.js
@@ -179,6 +179,7 @@ export default class Popup {
 
         wms.getFeatureInfo(wmsParams).then(response => {
             const sanitizedResponse = DOMPurify.sanitize(response, {
+                ADD_ATTR: ['target'],
                 CUSTOM_ELEMENT_HANDLING: {
                     tagNameCheck: /^lizmap-/,
                     attributeNameCheck: /crs|bbox|edition-restricted|layerid|layertitle|uniquefield|expressionfilter|withgeometry|sortingfield|sortingorder|draggable/,


### PR DESCRIPTION
Fix #4728

Funded by 3Liz