### PR TITLE
Bugfix Permalink: checked groups are not respected when hash is applied

### DIFF
--- a/assets/src/modules/Permalink.js
+++ b/assets/src/modules/Permalink.js
@@ -175,7 +175,10 @@ export default class Permalink {
 
         this._hash = ''+window.location.hash;
 
-        const items = mainLizmap.state.layersAndGroupsCollection.layers.concat(mainLizmap.state.layersAndGroupsCollection.groups);
+        // items are layers then groups from leaf to root
+        const items = mainLizmap.state.layersAndGroupsCollection.layers.concat(
+            mainLizmap.state.layersAndGroupsCollection.groups.reverse() // reverse groups array to get from leaf to root
+        );
 
         const [extent4326, itemsInURL, stylesInURL, opacitiesInURL] = window.location.hash.substring(1).split('|').map(part => part.split(','));
 

--- a/tests/end2end/playwright/permalink.spec.js
+++ b/tests/end2end/playwright/permalink.spec.js
@@ -134,6 +134,25 @@ test.describe('Permalink', () => {
         await page.getByRole('button', { name: 'Close' }).click();
     });
 
+    test('Groups and layers checked: UI according to permalink parameters', async ({ page }) => {
+        const baseUrl = 'http://localhost:8130/index.php/view/map?repository=testsrepository&project=treeview'
+        const bbox = '3.765504,43.559321,3.982897,43.660755'
+        const layers = 'group1,subdistricts,group%20with%20space%20in%20name%20and%20shortname%20defined,quartiers,group%20as%20layer%202'
+        const styles = ',default,,default,'
+        const opacities = '1,1,1,1,1'
+        const url = baseUrl + '#' + bbox + '|' + layers + '|' + styles + '|' + opacities;
+        await gotoMap(url, page);
+
+        // Visibility
+        await expect(page.getByTestId('subdistricts').locator('> div input')).toBeChecked();
+        await expect(page.getByTestId('sub-group1').locator('> div input')).not.toBeChecked();
+        await expect(page.getByTestId('group1').locator('> div input')).toBeChecked();
+
+        await expect(page.getByTestId('group as layer 1').locator('> div input')).not.toBeChecked();
+        await expect(page.getByTestId('group as layer 2').locator('> div input')).toBeChecked();
+        await expect(page.getByTestId('mutually exclusive group with multiple groups as layer').locator('> div input')).not.toBeChecked();
+    });
+
     test('Build permalink, reload and apply one', async ({ page }) => {
         const baseUrl = '/index.php/view/map?repository=testsrepository&project=layer_legends'
         await gotoMap(baseUrl, page);


### PR DESCRIPTION
When a layer is checked, all his parents are checked. So unchecked groups provided by permalink has to be unchecked after the layers and from leaf to root.

![Capture d’écran 2024-09-16 à 14 15 10](https://github.com/user-attachments/assets/b208a889-4d4e-4890-95a8-366fbf6c585d)

Funded by Conseil Départemental du Calvados
