### PR TITLE
PHP: Using getXml instead of direct acces to xml protected attribute

### DIFF
--- a/lizmap/modules/lizmap/lib/Project/ProjectCache.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectCache.php
@@ -90,6 +90,7 @@ class ProjectCache
         try {
             $data = $this->appContext->getCache($this->fileKey, $this->profile);
             if ($data === false
+                || is_null($data)
                 || $data['qgsmtime'] < $this->qgsMtime
                 || $data['qgscfgmtime'] < $this->qgsCfgMtime
                 || !isset($data['format_version'])

--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -629,7 +629,7 @@ class QgisProject
      */
     public function xpathQuery($query)
     {
-        $ret = $this->xml->xpath($query);
+        $ret = $this->getXml()->xpath($query);
         if ($ret && is_array($ret)) {
             return $ret;
         }
@@ -683,7 +683,7 @@ class QgisProject
      */
     protected function getXml()
     {
-        if ($this->xml) {
+        if ($this->xml !== null) {
             return $this->xml;
         }
         $qgs_path = $this->path;
@@ -699,6 +699,7 @@ class QgisProject
 
             throw new \Exception('The QGIS project '.basename($qgs_path).' has invalid content!');
         }
+
         $this->xml = $xml;
 
         return $xml;
@@ -749,7 +750,7 @@ class QgisProject
     {
         // get restricted composers
         $rComposers = array();
-        $restrictedComposers = $this->xml->xpath('//properties/WMSRestrictedComposers/value');
+        $restrictedComposers = $this->getXml()->xpath('//properties/WMSRestrictedComposers/value');
         if ($restrictedComposers && is_array($restrictedComposers)) {
             foreach ($restrictedComposers as $restrictedComposer) {
                 $rComposers[] = (string) $restrictedComposer;
@@ -758,7 +759,7 @@ class QgisProject
 
         $printTemplates = array();
         // get layout qgs project version >= 3
-        $layouts = $this->xml->xpath('//Layout');
+        $layouts = $this->getXml()->xpath('//Layout');
         if ($layouts && is_array($layouts)) {
             foreach ($layouts as $layout) {
                 // test restriction
@@ -874,7 +875,7 @@ class QgisProject
         }
         // update locateByLayer with alias and filter information
         foreach ($locateByLayer as $k => $v) {
-            $xmlLayer = $this->getXmlLayer2($this->xml, $v->layerId);
+            $xmlLayer = $this->getXmlLayer2($this->getXml(), $v->layerId);
             if (is_null($xmlLayer)) {
                 continue;
             }
@@ -935,7 +936,7 @@ class QgisProject
             if ($qgisProject) {
                 $xml = $qgisProject->getXml();
             } else {
-                $xml = $this->xml;
+                $xml = $this->getXml();
             }
 
             // Read layer property from QGIS project XML
@@ -964,7 +965,7 @@ class QgisProject
             if ($qgisProject) {
                 $xml = $qgisProject->getXml();
             } else {
-                $xml = $this->xml;
+                $xml = $this->getXml();
             }
 
             $layerXml = $this->getXmlLayer2($xml, $obj->layerId);
@@ -1029,7 +1030,7 @@ class QgisProject
         // Get QGIS form fields configurations for each layer
         $layersLabeledFieldsConfig = array();
         foreach ($layerIds as $layerId) {
-            $layerXml = $this->getXmlLayer2($this->xml, $layerId);
+            $layerXml = $this->getXmlLayer2($this->getXml(), $layerId);
             if (is_null($layerXml)) {
                 continue;
             }
@@ -1095,7 +1096,7 @@ class QgisProject
             }
 
             // Read layer property from QGIS project XML
-            $layerXml = $this->getXmlLayer2($this->xml, $obj->layerId);
+            $layerXml = $this->getXmlLayer2($this->getXml(), $obj->layerId);
             if (is_null($layerXml)) {
                 continue;
             }
@@ -1122,7 +1123,7 @@ class QgisProject
     {
         $layersOrder = array();
         if ($this->qgisProjectVersion >= 30000) { // For QGIS >=3.0, custom-order is in layer-tree-group
-            $customOrder = $this->xml->xpath('layer-tree-group/custom-order');
+            $customOrder = $this->getXml()->xpath('layer-tree-group/custom-order');
             if (count($customOrder) == 0) {
                 return $layersOrder;
             }
@@ -1142,7 +1143,7 @@ class QgisProject
                 return $layersOrder;
             }
         } elseif ($this->qgisProjectVersion >= 20400) { // For QGIS >=2.4, new item layer-tree-canvas
-            $customOrder = $this->xml->xpath('//layer-tree-canvas/custom-order');
+            $customOrder = $this->getXml()->xpath('//layer-tree-canvas/custom-order');
             if (count($customOrder) == 0) {
                 return $layersOrder;
             }
@@ -1159,7 +1160,7 @@ class QgisProject
                     ++$lo;
                 }
             } else {
-                $items = $this->xml->xpath('layer-tree-group//layer-tree-layer');
+                $items = $this->getXml()->xpath('layer-tree-group//layer-tree-layer');
                 $lo = 0;
                 foreach ($items as $layerTree) {
                     // Get layer name from config instead of XML for possible embedded layers
@@ -1171,14 +1172,14 @@ class QgisProject
                 }
             }
         } else {
-            $legend = $this->xml->xpath('//legend');
+            $legend = $this->getXml()->xpath('//legend');
             if (count($legend) == 0) {
                 return $layersOrder;
             }
             $legendZero = $legend[0];
             $updateDrawingOrder = (string) $legendZero->attributes()->updateDrawingOrder;
             if ($updateDrawingOrder == 'false') {
-                $layers = $this->xml->xpath('//legendlayer');
+                $layers = $this->getXml()->xpath('//legendlayer');
                 foreach ($layers as $layer) {
                     if ($layer->attributes()->drawingOrder && intval($layer->attributes()->drawingOrder) >= 0) {
                         $layersOrder[(string) $layer->attributes()->name] = (int) $layer->attributes()->drawingOrder;

--- a/tests/units/classes/Project/ProjectTest.php
+++ b/tests/units/classes/Project/ProjectTest.php
@@ -16,7 +16,8 @@ class ProjectTest extends TestCase
             'layers' => array(),
         );
         $qgis_default = new QgisProjectForTests($data);
-        $qgis_default->setXml(new SimpleXMLElement('<root></root>'));
+        $qgis_default->setXmlForTest(new SimpleXMLElement('<root></root>'));
+        $this->assertNotNull($qgis_default->getXmlForTest());
         $rep = new Project\Repository('key', array(), null, null, null);
         $proj = new ProjectForTests();
         $cfg = json_decode(file_get_contents(__DIR__.'/Ressources/readProject.qgs.cfg'));

--- a/tests/units/classes/Project/QgisProjectTest.php
+++ b/tests/units/classes/Project/QgisProjectTest.php
@@ -395,7 +395,7 @@ class QgisProjectTest extends TestCase
         $expectedLayer->montpellier_events->opacity = (float) 0.85;
         $cfg = new Project\ProjectConfig((object) array('layers' => $json->layers));
         $testProj = new qgisProjectForTests();
-        $testProj->setXml(simplexml_load_file(__DIR__.'/Ressources/opacity.qgs'));
+        $testProj->setXmlForTest(simplexml_load_file(__DIR__.'/Ressources/opacity.qgs'));
         $testProj->setLayerOpacityForTest($cfg);
         $this->assertEquals($expectedLayer, $cfg->getLayers());
     }
@@ -477,7 +477,7 @@ class QgisProjectTest extends TestCase
         $file = __DIR__.'/Ressources/'.$fileName.'.qgs';
         $eLayers = json_decode(file_get_contents($file.'.cfg'))->editionLayers;
         $testProj = new qgisProjectForTests();
-        $testProj->setXml(simplexml_load_file($file));
+        $testProj->setXmlForTest(simplexml_load_file($file));
         $testProj->readEditionLayersForTest($eLayers);
         $this->assertEquals($expectedELayer, $eLayers);
     }
@@ -690,7 +690,7 @@ class QgisProjectTest extends TestCase
         $aLayer = json_decode(file_get_contents($file.'.cfg'))->attributeLayers;
         $xml = simplexml_load_string($table);
         $testProj = new qgisProjectForTests();
-        $testProj->setXml(simplexml_load_file($file));
+        $testProj->setXmlForTest(simplexml_load_file($file));
         $testProj->readAttributeLayersForTest($aLayer);
         $xml = json_decode(str_replace('@', '', json_encode($xml)));
         $this->assertEquals($xml, $aLayer->montpellier_events->attributetableconfig);
@@ -724,7 +724,7 @@ class QgisProjectTest extends TestCase
             ),
         );
         $testProj = new qgisProjectForTests();
-        $testProj->setXml(simplexml_load_file($file));
+        $testProj->setXmlForTest(simplexml_load_file($file));
         $cfg = new Project\ProjectConfig((object) array('layers' => (object) $layers));
         $testProj->setShortNamesForTest($cfg);
         $layer = $cfg->getLayers();

--- a/tests/units/testslib/QgisProjectForTests.php
+++ b/tests/units/testslib/QgisProjectForTests.php
@@ -92,11 +92,15 @@ class QgisProjectForTests extends QgisProject
         return $this->setLayerOpacity($cfg);
     }
 
-    public function setXml($xml)
+    public function getXmlForTest()
+    {
+        return $this->getXml();
+    }
+
+    public function setXmlForTest($xml)
     {
         $this->xml = $xml;
     }
-
 
     public function setPath($path)
     {


### PR DESCRIPTION
Updating PHP QgisProject class to easily remove access to XML QGIS Project.