### PR TITLE
Remove PHP gettext from composer.json

### DIFF
--- a/lizmap/composer.json
+++ b/lizmap/composer.json
@@ -15,9 +15,6 @@
     "violet/streaming-json-encoder": "^1.1.5",
     "guzzlehttp/guzzle": "^7.7.0"
   },
-  "require-dev": {
-    "gettext/gettext": "^4.6.1"
-  },
   "minimum-stability": "stable",
   "config": {
     "preferred-install": {


### PR DESCRIPTION
Follow up from #4676 

`gettext` is not used in the source code since LWC 3.2
