### PR TITLE
Fix BS5 badge, use a badge for Lizmap server update instead of adding a new column

### DIFF
--- a/lizmap/modules/admin/controllers/server_information.classic.php
+++ b/lizmap/modules/admin/controllers/server_information.classic.php
@@ -59,16 +59,14 @@ class server_informationCtrl extends jController
             jLog::log($updateQgisServer, 'lizmapadmin');
         }
 
-        $displayPluginActionColumn = false;
         $lizmapQgisServerNeedsUpdate = $server->pluginServerNeedsUpdate(
             $currentLizmapVersion,
             $lizmapPluginMinimumVersionRequired
         );
-        $updateLizmapPlugin = jLocale::get('admin.server.information.plugin.update', array('lizmap_server'));
+        $updateLizmapPlugin = jLocale::get('admin.server.information.plugin.update');
         if (!is_null($currentQgisVersion) && $lizmapQgisServerNeedsUpdate) {
             // lizmap_server is required to use LWC
             jLog::log($updateLizmapPlugin, 'lizmapadmin');
-            $displayPluginActionColumn = true;
         }
 
         // Set the HTML content
@@ -78,7 +76,6 @@ class server_informationCtrl extends jController
             'baseUrlApplication' => \jServer::getServerURI().\jApp::urlBasePath(),
             'qgisServerNeedsUpdate' => $qgisServerNeedsUpdate,
             'updateQgisServer' => $updateQgisServer,
-            'displayPluginActionColumn' => $displayPluginActionColumn,
             'lizmapQgisServerNeedsUpdate' => $lizmapQgisServerNeedsUpdate,
             'lizmapPluginUpdate' => $updateLizmapPlugin,
             'minimumQgisVersion' => $qgisMinimumVersionRequired,

--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -275,7 +275,6 @@ server.information.qgis.plugins=Plugins
 server.information.qgis.plugins.version=Version number
 server.information.qgis.plugin=Plugin
 server.information.qgis.plugin.version=Version
-server.information.qgis.plugin.action=Action
 
 server.information.qgis.test.ok=QGIS Server is correctly installed and returns the expected response for OGC requests.
 server.information.qgis.test.error=QGIS Server is not correctly installed in your server or the URL for OGC requests given in Lizmap configuration is not correct.
@@ -292,7 +291,7 @@ You might need to increase debug level.
 server.information.qgis.error.fetching.information.detail.NO_ACCESS=You don't have access to information about QGIS Server
 server.information.qgis.error.fetching.information.detail.HTTP_ERROR=QGIS Server returns an HTTP error about the Lizmap plugin:
 server.information.qgis.update=QGIS Server needs to be updated at least to version %s for this version of Lizmap Web Client.
-server.information.plugin.update=The %s plugin needs to be updated.
+server.information.plugin.update=The plugin must be updated.
 server.information.qgis.unknown=QGIS server minimum %s and Lizmap QGIS server plugin minimum %s need to be installed and configured correctly. \
 Your QGIS server couldn't be reached correctly with the given URL "%s".
 

--- a/lizmap/modules/admin/templates/maps.tpl
+++ b/lizmap/modules/admin/templates/maps.tpl
@@ -17,7 +17,7 @@
 
             <legend>{$repo->getKey()}
             {if !$repo->hasValidPath() }
-                <span class='badge badge-important'>{@admin~admin.form.admin_section.repository.path.invalid@}</span>
+                <span class='badge bg-warning'>{@admin~admin.form.admin_section.repository.path.invalid@}</span>
             {/if}
             </legend>
             <dl><dt>{@admin~admin.form.admin_section.data.label@}</dt>

--- a/lizmap/modules/admin/templates/server_information.tpl
+++ b/lizmap/modules/admin/templates/server_information.tpl
@@ -141,9 +141,6 @@
         <tr>
             <th style="width:20%;">{@admin.server.information.qgis.plugin@}</th>
             <th style="width:20%;">{@admin.server.information.qgis.plugin.version@}</th>
-            {if $displayPluginActionColumn }
-                <th>{@admin.server.information.qgis.plugin.action@}</th>
-            {/if}
         </tr>
         {foreach $data['qgis_server_info']['plugins'] as $name=>$version}
         <tr>
@@ -164,14 +161,10 @@
                 {else}
                     {$version['version']}
                 {/if}
-            </td>
-            {if $displayPluginActionColumn }
                 {if $name == 'lizmap_server' && $lizmapQgisServerNeedsUpdate}
-                    <td style="background-color:lightcoral;"><strong>{$lizmapPluginUpdate}</strong></td>
-                {else}
-                <td></td>
+                    <span class='badge bg-danger'>{$lizmapPluginUpdate}</span>
                 {/if}
-            {/if}
+            </td>
         </tr>
         {/foreach}
     </table>


### PR DESCRIPTION
* Fix a BS2 badge
* Use a badge instead of adding a new column "Action" in the table.
* Remove the plugin name, it was redundant with the row already

It will be manually backported to 3.8 only.

![image](https://github.com/user-attachments/assets/85ddd38f-f55c-47e4-b375-7e1812a08e05)

