### PR TITLE
fix opening layer group information window

### DIFF
--- a/assets/src/legacy/switcher-layers-actions.js
+++ b/assets/src/legacy/switcher-layers-actions.js
@@ -155,7 +155,7 @@ var lizLayerActionButtons = function() {
                 html+= '<dd>';
                 html+= '<input type="hidden" class="opacityLayer '+isBaselayer+'" value="'+aName+'">';
 
-                const currentOpacity = lizMap.mainLizmap.state.layersAndGroupsCollection.getLayerOrGroupByName(aName).opacity;
+                const currentOpacity = lizMap.mainLizmap.state.layersAndGroupsCollection.getMapLayerOrGroupByName(aName).opacity;
                 var opacities = lizMap.config.options.layersOpacities;
                 if (typeof opacities === 'undefined') {
                     opacities = [0.2, 0.4, 0.6, 0.8, 1];


### PR DESCRIPTION
Fix to open layer group information window in lizmap web client 3.8.1

Ticket : #4779

Funded by sponsored development
