### PR TITLE
fix opening layer group information window

### DIFF
--- a/assets/src/legacy/switcher-layers-actions.js
+++ b/assets/src/legacy/switcher-layers-actions.js
@@ -149,7 +149,7 @@ var lizLayerActionButtons = function() {
                 }
             }
             // Opacity
-            const currentLayerState = lizMap.mainLizmap.state.rootMapGroup.getMapLayerByName(aName);
+            const currentLayerState = lizMap.mainLizmap.state.rootMapGroup.getMapLayerOrGroupByName(aName);
             if (!currentLayerState.singleWMSLayer) {
                 html+= '        <dt>'+lizDict['layer.metadata.opacity.title']+'</dt>';
                 html+= '<dd>';


### PR DESCRIPTION
Fix to open layer group information window in lizmap web client 3.8.1

Ticket : https://github.com/3liz/lizmap-web-client/issues/4779

Funded by sponsored development