### PR TITLE
fix authenticating layers against qGIS auth config

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -282,17 +282,18 @@ class qgisVectorLayer extends qgisMapLayer
                 // when qgis authentication config is used to authenticate a layer against, it requires to have preconfigured jdb::profile to align with the login credentials set in qgis authcfg
                 if (!empty($dtParams->authcfg)) {
                     $jdbParams['authcfg'] = $dtParams->authcfg;
-                    // retrieving user/password from the corresponding jdb::profile in profiles.ini.php. 
+                    // retrieving user/password from the corresponding jdb::profile in profiles.ini.php.
                     $ini = new \Jelix\IniFile\IniModifier(jApp::varConfigPath('profiles.ini.php'));
-					$profiles = $ini->getSectionList();
-					foreach ($profiles as $profile) {
-						if ($profile == 'jdb:'.$dtParams->authcfg) {
-							$options = $ini->getValues($profile);
-							$jdbParams['user'] = $options['user'];
-							$jdbParams['password'] = $options['password'];
-							break;
-						}
-					}
+                    $profiles = $ini->getSectionList();
+                    foreach ($profiles as $profile) {
+                        if ($profile == 'jdb:'.$dtParams->authcfg) {
+                            $options = $ini->getValues($profile);
+                            $jdbParams['user'] = $options['user'];
+                            $jdbParams['password'] = $options['password'];
+
+                            break;
+                        }
+                    }
                 }
             }
             if (!empty($dtParams->schema) && $setSearchPathFromLayer) {

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -284,15 +284,15 @@ class qgisVectorLayer extends qgisMapLayer
                     $jdbParams['authcfg'] = $dtParams->authcfg;
                     // retrieving user/password from the corresponding jdb::profile in profiles.ini.php. 
                     $ini = new \Jelix\IniFile\IniModifier(jApp::varConfigPath('profiles.ini.php'));
-        			$profiles = $ini->getSectionList();
-		            foreach($profiles as $profile) {
-	        			if ($profile == 'jdb:'.$dtParams->authcfg) {
-	        				$options = $ini->getValues($profile);
-			            	$jdbParams['user'] = $options["user"];
-			            	$jdbParams['password'] = $options["password"];
-			            	break;
-	        			}
-	        		}
+					$profiles = $ini->getSectionList();
+					foreach ($profiles as $profile) {
+						if ($profile == 'jdb:'.$dtParams->authcfg) {
+							$options = $ini->getValues($profile);
+							$jdbParams['user'] = $options['user'];
+							$jdbParams['password'] = $options['password'];
+							break;
+						}
+					}
                 }
             }
             if (!empty($dtParams->schema) && $setSearchPathFromLayer) {

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -279,6 +279,21 @@ class qgisVectorLayer extends qgisMapLayer
                 if (!empty($dtParams->sslmode)) {
                     $jdbParams['sslmode'] = $dtParams->sslmode;
                 }
+                // when qgis authentication config is used to authenticate a layer against, it requires to have preconfigured jdb::profile to align with the login credentials set in qgis authcfg
+                if (!empty($dtParams->authcfg)) {
+                    $jdbParams['authcfg'] = $dtParams->authcfg;
+                    // retrieving user/password from the corresponding jdb::profile in profiles.ini.php. 
+                    $ini = new \Jelix\IniFile\IniModifier(jApp::varConfigPath('profiles.ini.php'));
+        			$profiles = $ini->getSectionList();
+		            foreach($profiles as $profile) {
+	        			if ($profile == 'jdb:'.$dtParams->authcfg) {
+	        				$options = $ini->getValues($profile);
+			            	$jdbParams['user'] = $options["user"];
+			            	$jdbParams['password'] = $options["password"];
+			            	break;
+	        			}
+	        		}
+                }
             }
             if (!empty($dtParams->schema) && $setSearchPathFromLayer) {
                 $jdbParams['search_path'] = '"'.$dtParams->schema.'",public';

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -208,7 +208,7 @@ class qgisVectorLayer extends qgisMapLayer
         );
         $parameters = array(
             'dbname', 'service', 'host', 'port', 'user', 'password',
-            'sslmode', 'key', 'estimatedmetadata', 'selectatid',
+            'sslmode', 'authcfg', 'key', 'estimatedmetadata', 'selectatid',
             'srid', 'type', 'checkPrimaryKeyUnicity',
             'table', 'geocol', 'sql', 'schema', 'tablename',
         );

--- a/lizmap/modules/lizmap/classes/qgisVectorLayerDatasource.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayerDatasource.class.php
@@ -22,6 +22,7 @@ class qgisVectorLayerDatasource
         'user' => "user='?([^ ']+)'? ",
         'password' => "password='?([^ ']+)'? ",
         'sslmode' => "sslmode='?([^ ']+)'? ",
+        'authcfg' => "authcfg='?([^ ']+)'? ",
         'key' => "key='?([^ ']+)'? ",
         'estimatedmetadata' => 'estimatedmetadata=([^ ]+) ',
         'selectatid' => 'selectatid=([^ ]+) ',


### PR DESCRIPTION
Fix to authente layers against qGIS auth config when applying a filter in lizmap web client 3.8.1

Ticket : https://github.com/3liz/lizmap-web-client/issues/4470

Funded by sponsored development