### PR TITLE
JS Map State: transform initial extent on projection changes

### DIFF
--- a/assets/src/modules/utils/Extent.js
+++ b/assets/src/modules/utils/Extent.js
@@ -64,6 +64,16 @@ export class Extent extends Array {
     }
 
     /**
+     * @type {number[]}
+     */
+    get center() {
+        return [
+            this.xmin + (this.xmax-this.xmin)/2,
+            this.ymin + (this.ymax-this.ymin)/2
+        ];
+    }
+
+    /**
      * Checks equality with an other extent or array
      * @param {Extent|Array} anOther - An other extent or array with 4 values
      * @returns {boolean} the other extent or array as the same values
@@ -76,4 +86,5 @@ export class Extent extends Array {
             && anOther[2] == this[2]
             && anOther[3] == this[3])
     }
+
 }

--- a/tests/js-units/node/state/map.test.js
+++ b/tests/js-units/node/state/map.test.js
@@ -261,6 +261,165 @@ describe('MapState', function () {
         expect(mapStateChangedEvt).to.be.null // event not dispatch
     })
 
+    it('Transform', function () {
+        let mapState = new MapState();
+        expect(mapState).to.be.instanceOf(MapState)
+        expect(mapState).to.be.instanceOf(EventDispatcher)
+
+        // Update all properties
+        mapState.update({
+            "type": "map.state.changing",
+            "projection": "EPSG:3857",
+            "center": [
+              432082.33132450003,
+              5404877.667855
+            ],
+            "zoom": 4,
+            "size": [
+              1822,
+              634
+            ],
+            "extent": [
+              397265.26494544884,
+              5392762.398873487,
+              466899.3977035512,
+              5416992.936836514
+            ],
+            "resolution": 38.218514137268066,
+            "scaleDenominator": 144447.63855208742,
+            "pointResolution": 27.673393466176645,
+            "pointScaleDenominator": 104592.14407328397
+        });
+
+        let mapStateChangedEvt = null
+
+        mapState.addListener(evt => {
+            mapStateChangedEvt = evt
+        }, 'map.state.changed');
+
+        // update projection
+        mapState.update({
+            "type": "map.state.changing",
+            "projection": "EPSG:4326"
+        });
+
+        expect(mapState.projection).to.be.eq('EPSG:4326')
+        expect(mapState.center).to.be.an('array').that.have.lengthOf(2).that.deep.equal([
+            3.881461622267935,
+            43.60729361373798
+        ])
+        expect(mapState.extent).to.be.instanceOf(Extent).that.have.lengthOf(4).that.deep.equal([
+            3.568694593502878,
+            43.52848921560505,
+            4.194228651032991,
+            43.68609801187091,
+        ])
+
+        expect(mapStateChangedEvt).to.not.be.null // event dispatch
+        expect(mapStateChangedEvt.projection).to.be.eq('EPSG:4326') // the projection has not changed
+        expect(mapStateChangedEvt.center).to.be.an('array').that.have.lengthOf(2).that.deep.equal([
+            3.881461622267935,
+            43.60729361373798
+        ])
+        expect(mapStateChangedEvt.extent).to.be.an('array').that.have.lengthOf(4).that.deep.equal([
+            3.568694593502878,
+            43.52848921560505,
+            4.194228651032991,
+            43.68609801187091,
+        ])
+
+
+        const opt = new OptionsConfig({
+            "projection": {
+                "proj4": "+proj=longlat +datum=WGS84 +no_defs",
+                "ref": "EPSG:4326"
+            },
+            "bbox": [
+                "-3.5",
+                "-1.0",
+                "3.5",
+                "1.0"
+            ],
+            "mapScales": [
+                10000,
+                25000,
+                50000,
+                100000,
+                250000,
+                500000
+            ],
+            "minScale": 10000,
+            "maxScale": 500000,
+            "initialExtent": [
+                -3.5,
+                -1.0,
+                3.5,
+                1.0
+            ],
+            "popupLocation": "dock",
+            "pointTolerance": 25,
+            "lineTolerance": 10,
+            "polygonTolerance": 5,
+            "hideProject": "True",
+            "tmTimeFrameSize": 10,
+            "tmTimeFrameType": "seconds",
+            "tmAnimationFrameLength": 1000,
+            "datavizLocation": "dock",
+            "theme": "light",
+            //"wmsMaxHeight": 3000,
+            //"wmsMaxWidth": 3000,
+            //"fixed_scale_overview_map": true,
+            //"use_native_zoom_levels": false,
+            //"hide_numeric_scale_value": false,
+            //"hideGroupCheckbox": false,
+            //"activateFirstMapTheme": false,
+        })
+        mapState = new MapState(opt);
+
+        // Initial state
+        expect(mapState.projection).to.be.eq('EPSG:4326')
+        expect(mapState.center).to.be.an('array').that.have.lengthOf(2).that.deep.equal([
+            0,
+            0
+        ])
+        expect(mapState.extent).to.be.instanceOf(Extent).that.have.lengthOf(4).that.deep.equal([
+            0,
+            0,
+            0,
+            0
+        ])
+        expect(mapState.initialExtent).to.be.instanceOf(Extent).that.have.lengthOf(4).that.deep.equal([
+            -3.5,
+            -1.0,
+            3.5,
+            1.0
+        ])
+
+        // update projection
+        mapState.update({
+            "type": "map.state.changing",
+            "projection": "EPSG:3857"
+        });
+
+        expect(mapState.projection).to.be.eq('EPSG:3857')
+        expect(mapState.center).to.be.an('array').that.have.lengthOf(2).that.deep.equal([
+            0,
+            0
+        ])
+        expect(mapState.extent).to.be.instanceOf(Extent).that.have.lengthOf(4).that.deep.equal([
+            0,
+            0,
+            0,
+            0
+        ])
+        expect(mapState.initialExtent).to.be.instanceOf(Extent).that.have.lengthOf(4).that.deep.equal([
+            -389618.21777645755,
+            -111325.14286638453,
+            389618.21777645755,
+            111325.14286638486,
+        ])
+    })
+
     it('ConversionError && ValidationError', function () {
         let mapState = new MapState();
         expect(mapState).to.be.instanceOf(MapState)

--- a/tests/js-units/node/utils/extent.test.js
+++ b/tests/js-units/node/utils/extent.test.js
@@ -15,6 +15,7 @@ describe('Extent', function () {
         expect(ext.ymin).to.be.eq(-1)
         expect(ext.xmax).to.be.eq(1)
         expect(ext.ymax).to.be.eq(1)
+        expect(ext.center).to.be.deep.eq([0, 0])
 
         ext = new Extent('-2','-2.0','2','2.0')
         expect(ext.length).to.be.eq(4)
@@ -26,6 +27,7 @@ describe('Extent', function () {
         expect(ext.ymin).to.be.eq(-2)
         expect(ext.xmax).to.be.eq(2)
         expect(ext.ymax).to.be.eq(2)
+        expect(ext.center).to.be.deep.eq([0, 0])
 
         ext = new Extent(...[-1,-1,1,1])
         expect(ext.length).to.be.eq(4)
@@ -37,6 +39,7 @@ describe('Extent', function () {
         expect(ext.ymin).to.be.eq(-1)
         expect(ext.xmax).to.be.eq(1)
         expect(ext.ymax).to.be.eq(1)
+        expect(ext.center).to.be.deep.eq([0, 0])
     })
 
     it('Equals', function () {


### PR DESCRIPTION
If the map projection is not the same as the project projection, the initial extent stored by Map State has to be transform.

This fix the move to bad extent when you click on zoom to initial extent when the map projection is not the same as the project projection. Map projection and project projection could be different if the config still contains external base layers.