### PR TITLE
[Bug] Enclose wms/wfs filters in brackets to guarantee filters logic

### DIFF
--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -1364,7 +1364,7 @@ class Project
 
             $filters[$layerName] = array_merge(
                 (array) $loginFilteredConfig,
-                array('filter' => $filter, 'layername' => $lName)
+                array('filter' => '( '.$filter.' )', 'layername' => $lName)
             );
         }
 

--- a/lizmap/modules/lizmap/lib/Request/WFSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WFSRequest.php
@@ -123,13 +123,13 @@ class WFSRequest extends OGCRequest
         // Get client exp_filter parameter
         $clientExpFilter = $this->param('exp_filter', '');
         if (!empty($clientExpFilter)) {
-            $expFilters[] = $clientExpFilter;
+            $expFilters[] = '( '.$clientExpFilter.' )';
         }
 
         // Merge login filter
         $attribute = '';
         foreach ($loginFilters as $typename => $lfilter) {
-            $expFilters[] = $lfilter['filter'];
+            $expFilters[] = '( '.$lfilter['filter'].' )';
             $attribute = $lfilter['filterAttribute'];
         }
 

--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -84,9 +84,9 @@ class WMSRequest extends OGCRequest
                 $lname = trim($b[0]);
                 $lfilter = trim($b[1]);
                 if (array_key_exists($lname, $loginFilters)) {
-                    $loginFilters[$lname]['filter'] .= ' AND '.$lfilter;
+                    $loginFilters[$lname]['filter'] .= ' AND ( '.$lfilter.' )';
                 } else {
-                    $loginFilters[$lname] = array('filter' => $lfilter, 'layername' => $lname);
+                    $loginFilters[$lname] = array('filter' => '( '.$lfilter.' )', 'layername' => $lname);
                 }
             }
         }

--- a/tests/units/classes/Project/ProjectTest.php
+++ b/tests/units/classes/Project/ProjectTest.php
@@ -272,16 +272,16 @@ class ProjectTest extends TestCase
             'userIsConnected' => false,
         );
         //$filter1 = '"descr" IN ( \'admin\' , \'groups\' , \'lizmap\' , \'all\' )';
-        $filter1 = '"descr" = \'admin\' OR "descr" LIKE \'admin,%\' OR "descr" LIKE \'%,admin\' OR "descr" LIKE \'%,admin,%\'';
+        $filter1 = '( "descr" = \'admin\' OR "descr" LIKE \'admin,%\' OR "descr" LIKE \'%,admin\' OR "descr" LIKE \'%,admin,%\'';
         $filter1 .= ' OR ';
         $filter1 .= '"descr" = \'groups\' OR "descr" LIKE \'groups,%\' OR "descr" LIKE \'%,groups\' OR "descr" LIKE \'%,groups,%\'';
         $filter1 .= ' OR ';
         $filter1 .= '"descr" = \'lizmap\' OR "descr" LIKE \'lizmap,%\' OR "descr" LIKE \'%,lizmap\' OR "descr" LIKE \'%,lizmap,%\'';
         $filter1 .= ' OR ';
-        $filter1 .= '"descr" = \'all\' OR "descr" LIKE \'all,%\' OR "descr" LIKE \'%,all\' OR "descr" LIKE \'%,all,%\'';
+        $filter1 .= '"descr" = \'all\' OR "descr" LIKE \'all,%\' OR "descr" LIKE \'%,all\' OR "descr" LIKE \'%,all,%\' )';
 
         //$filter2 = '"Group" = \'all\'';
-        $filter2 = '"descr" = \'all\' OR "descr" LIKE \'all,%\' OR "descr" LIKE \'%,all\' OR "descr" LIKE \'%,all,%\'';
+        $filter2 = '( "descr" = \'all\' OR "descr" LIKE \'all,%\' OR "descr" LIKE \'%,all\' OR "descr" LIKE \'%,all,%\' )';
 
         return array(
             array($aclData1, $filter1),
@@ -338,8 +338,8 @@ class ProjectTest extends TestCase
         $aclData2 = array(
             'userIsConnected' => false,
         );
-        $filter1 = '"descr" = \'admin\' OR "descr" = \'groups\' OR "descr" = \'lizmap\' OR "descr" = \'all\'';
-        $filter2 = '"descr" = \'all\'';
+        $filter1 = '( "descr" = \'admin\' OR "descr" = \'groups\' OR "descr" = \'lizmap\' OR "descr" = \'all\' )';
+        $filter2 = '( "descr" = \'all\' )';
 
         return array(
             array($aclData1, $filter1),

--- a/tests/units/classes/Request/WFSRequestTest.php
+++ b/tests/units/classes/Request/WFSRequestTest.php
@@ -45,7 +45,7 @@ class WFSRequestTest extends TestCase
             'map' => null,
             'Lizmap_User' => '',
             'Lizmap_User_Groups' => '',
-            'exp_filter' => 'filter AND test',
+            'exp_filter' => '( filter ) AND ( test )',
         );
 
         $params2 = array(
@@ -60,7 +60,7 @@ class WFSRequestTest extends TestCase
             'map' => null,
             'Lizmap_User' => '',
             'Lizmap_User_Groups' => '',
-            'exp_filter' => 'testParam AND filter AND test',
+            'exp_filter' => '( testParam ) AND ( filter ) AND ( test )',
             'propertyname' => 'prop,test attr'
         );
         return array(


### PR DESCRIPTION
Currently client filters and login filters are merged 'as is' before system sends WMS/WFS request to the server.

This could lead to unexpected behavior.

Take, for instance, the case where you have set some login filters in a layer and this layer is displayed as child of another one in the feature popup.

Suppose you want to limit the visibility of `child_layer` only to users belonging to `group1` and use a `lizmap_group` column on `child_layer` to achieve this.

So, if a user belonging to `group1` logs into the project and requests a `parent_layer` popup, the desired behavior is:

```
show only children related to the parent
AND
show only children that current user can see according to login filters
```
Current filter is issued like this:
```
"lizmap_group" = 'group1' OR "lizmap_group" = 'all' AND "fid_parent" = '2'
```
The filter concatenation in this case does not produce the desired response because the execution of `OR` and `AND` statements does not respect filters logic. 
This will result in a response containing all child features with `"lizmap_group"='all'` AND all features with `"lizmap_group"='group1'`, regardless of the `parent_layer` record to which they are related. 
In particular cases, this could result in thousands of features, or more, being incorrectly sent for each request.

correct filters should be:
```
( "lizmap_group" = 'group1' OR "lizmap_group" = 'all' ) AND "fid_parent" = '2' 
```

To fix this I simply enclose the filters in parentheses before they are merged. In some cases the result is a bit verbose:

```
( "lizmap_group" = 'group1' OR "lizmap_group" = 'all' ) AND ( "fid_parent" = '2' )
```
but ensures that the feature filter works properly.

Backport to 3.8, if possible.

Funded by Faunalia
