### PR TITLE
JS: using Proj4rs instead of Proj4js

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "ol-wfs-capabilities": "^2.0.0"
+        "ol-wfs-capabilities": "^2.0.0",
+        "proj4rs": "^0.1.5"
       },
       "devDependencies": {
         "dompurify": "^3.1.6",
@@ -18,7 +19,6 @@
         "jsts": "^2.11.0",
         "lit-html": "^3.1.1",
         "ol": "^10.2.1",
-        "proj4": "^2.11.0",
         "shpjs": "^6.1.0",
         "svg-sprite-loader": "^6.0.11",
         "svgo": "^3.2.0",
@@ -4002,6 +4002,11 @@
         "mgrs": "1.0.0",
         "wkt-parser": "^1.3.3"
       }
+    },
+    "node_modules/proj4rs": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/proj4rs/-/proj4rs-0.1.5.tgz",
+      "integrity": "sha512-lenkkbiF4CvoX/KSf1scRhJNdxWsvimR5xz8RnhfKOUM2Rp90WLBwR4FcXpPfa9/uIU2kQgzL10O1RyEupjWEw=="
     },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -16,7 +16,6 @@
     "jsts": "^2.11.0",
     "lit-html": "^3.1.1",
     "ol": "^10.2.1",
-    "proj4": "^2.11.0",
     "shpjs": "^6.1.0",
     "svg-sprite-loader": "^6.0.11",
     "svgo": "^3.2.0",
@@ -28,6 +27,7 @@
   "author": "3Liz",
   "license": "ISC",
   "dependencies": {
-    "ol-wfs-capabilities": "^2.0.0"
+    "ol-wfs-capabilities": "^2.0.0",
+    "proj4rs": "^0.1.5"
   }
 }

--- a/assets/src/index.js
+++ b/assets/src/index.js
@@ -32,7 +32,7 @@ import executeJSFromServer from './modules/ExecuteJSFromServer.js';
 
 import olDep from './dependencies/ol.js';
 import litHTMLDep from './dependencies/lit-html.js';
-import proj4 from 'proj4';
+import {proj4} from 'proj4rs/proj4.js';
 
 lizMap.ol = olDep;
 lizMap.litHTML = litHTMLDep;

--- a/assets/src/modules/Lizmap.js
+++ b/assets/src/modules/Lizmap.js
@@ -33,7 +33,7 @@ import { Extent as olExtent, intersects as olExtentIntersects} from 'ol/extent.j
 import { Projection as olProjection, transform as olTransform, transformExtent as olTransformExtent, get as getProjection, clearAllProjections, addCommon } from 'ol/proj.js';
 import { register } from 'ol/proj/proj4.js';
 
-import proj4 from 'proj4';
+import {proj4} from 'proj4rs/proj4.js';
 import ProxyEvents from './ProxyEvents.js';
 
 /**


### PR DESCRIPTION
Using Rust implementation [Proj4rs](https://www.npmjs.com/package/proj4rs) of the PROJ.4 project instead of the JavaScript implementation [Proj4js](https://www.npmjs.com/package/proj4).

* The aim of Proj4rs is to provide the same functionality as the proj4js library
* The goal of Proj4rs is not to be a replacement of PROJ, but instead being a lightweight implementation of transformations from CRS to CRS that could be used in Rust and WASM environments.
