### PR TITLE
[Backport release_3_7] [Bug] Enclose wms/wfs filters in brackets to guarantee filters logic

### DIFF
--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -1258,7 +1258,7 @@ class Project
 
             $filters[$layerName] = array_merge(
                 (array) $loginFilteredConfig,
-                array('filter' => $filter, 'layername' => $lName)
+                array('filter' => '( '.$filter.' )', 'layername' => $lName)
             );
         }
 

--- a/lizmap/modules/lizmap/lib/Request/WFSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WFSRequest.php
@@ -123,13 +123,13 @@ class WFSRequest extends OGCRequest
         // Get client exp_filter parameter
         $clientExpFilter = $this->param('exp_filter', '');
         if (!empty($clientExpFilter)) {
-            $expFilters[] = $clientExpFilter;
+            $expFilters[] = '( '.$clientExpFilter.' )';
         }
 
         // Merge login filter
         $attribute = '';
         foreach ($loginFilters as $typename => $lfilter) {
-            $expFilters[] = $lfilter['filter'];
+            $expFilters[] = '( '.$lfilter['filter'].' )';
             $attribute = $lfilter['filterAttribute'];
         }
 

--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -84,9 +84,9 @@ class WMSRequest extends OGCRequest
                 $lname = trim($b[0]);
                 $lfilter = trim($b[1]);
                 if (array_key_exists($lname, $loginFilters)) {
-                    $loginFilters[$lname]['filter'] .= ' AND '.$lfilter;
+                    $loginFilters[$lname]['filter'] .= ' AND ( '.$lfilter.' )';
                 } else {
-                    $loginFilters[$lname] = array('filter' => $lfilter, 'layername' => $lname);
+                    $loginFilters[$lname] = array('filter' => '( '.$lfilter.' )', 'layername' => $lname);
                 }
             }
         }

--- a/tests/units/classes/Project/ProjectTest.php
+++ b/tests/units/classes/Project/ProjectTest.php
@@ -270,8 +270,9 @@ class ProjectTest extends TestCase
         $aclData2 = array(
             'userIsConnected' => false,
         );
-        $filter1 = '"Group" IN ( \'admin\' , \'groups\' , \'lizmap\' , \'all\' )';
-        $filter2 = '"Group" = \'all\'';
+
+        $filter1 = '( "Group" IN ( \'admin\' , \'groups\' , \'lizmap\' , \'all\' ) )';
+        $filter2 = '( "Group" = \'all\' )';
 
         return array(
             array($aclData1, $filter1),

--- a/tests/units/classes/Request/WFSRequestTest.php
+++ b/tests/units/classes/Request/WFSRequestTest.php
@@ -45,7 +45,7 @@ class WFSRequestTest extends TestCase
             'map' => null,
             'Lizmap_User' => '',
             'Lizmap_User_Groups' => '',
-            'exp_filter' => 'filter AND test',
+            'exp_filter' => '( filter ) AND ( test )',
         );
 
         $params2 = array(
@@ -60,7 +60,7 @@ class WFSRequestTest extends TestCase
             'map' => null,
             'Lizmap_User' => '',
             'Lizmap_User_Groups' => '',
-            'exp_filter' => 'testParam AND filter AND test',
+            'exp_filter' => '( testParam ) AND ( filter ) AND ( test )',
             'propertyname' => 'prop,test attr'
         );
         return array(


### PR DESCRIPTION
Backport #4836
 **Authored by:** @mind84