### PR TITLE
lizmap-features-table - improve popup table style

### DIFF
--- a/assets/src/components/FeaturesTable.js
+++ b/assets/src/components/FeaturesTable.js
@@ -227,6 +227,12 @@ export default class FeaturesTable extends HTMLElement {
                 this.uniqueField,
                 event.target.parentElement.parentElement.querySelector('div.lizmap-features-table-item-popup'),
                 function(aLayerId, aFeature, aTarget) {
+                    // Add bootstrap classes to the popup tables
+                    const popupTable = aTarget.querySelector('table.lizmapPopupTable');
+                    if (popupTable) {
+                        popupTable.classList.add('table', 'table-condensed', 'table-sm', 'table-bordered', 'table-striped');
+                    }
+                    
                     // Show popup and hide other children
                     const featuresTableDiv = aTarget.parentElement;
                     if (featuresTableDiv) {


### PR DESCRIPTION
Improve the style of `lizmap-features-table` child item tables

Before
![image](https://github.com/user-attachments/assets/72961b2a-7c01-4c20-8e93-8f1741ffeb91)

After
![image](https://github.com/user-attachments/assets/e04013ce-e97a-485c-bc4f-c594b206eb61)


Funded by 3liz
