### PR TITLE
New Lizmap\App\LocalesLoader to load locales for JS

### DIFF
--- a/lizmap/modules/lizmap/lib/App/LocalesBundle.php
+++ b/lizmap/modules/lizmap/lib/App/LocalesBundle.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * locale bundle loader.
+ *
+ * @author    3liz
+ * @copyright 2024 3liz
+ *
+ * @see      https://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+namespace Lizmap\App;
+
+/**
+ * Do not use directly. It will disappear when using futur Jelix versions.
+ *
+ * @internal
+ */
+class LocalesBundle extends \jBundle
+{
+    /**
+     * Get all translations of the bundle.
+     *
+     * @param null|string $charset
+     *
+     * @return array
+     */
+    public function getAllKeys($charset = null)
+    {
+        if ($charset == null) {
+            $charset = \jApp::config()->charset;
+        }
+        if (!in_array($charset, $this->_loadedCharset)) {
+            $this->_loadLocales($charset);
+        }
+
+        return $this->_strings[$charset];
+    }
+}

--- a/lizmap/modules/lizmap/lib/App/LocalesLoader.php
+++ b/lizmap/modules/lizmap/lib/App/LocalesLoader.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * locales loader.
+ *
+ * @author    3liz
+ * @copyright 2024 3liz
+ *
+ * @see      https://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+namespace Lizmap\App;
+
+use jLocale;
+
+/**
+ * Allow to load all locales from a locales file.
+ */
+class LocalesLoader
+{
+    /**
+     * @var LocalesBundle[][]
+     */
+    protected static $bundles = array();
+
+    /**
+     * It returns all translations stored in the file indicated by the given key.
+     *
+     * @param string $key    a locale key. Only module and file prefix filename is required
+     * @param string $locale
+     *
+     * @throws \jExceptionSelector
+     *
+     * @return array all translations
+     */
+    public static function getLocalesFrom($key, $locale = null)
+    {
+        // to be sure we have a valid syntax for the locale selector, we add this string.
+        $key .= '.foo';
+
+        // With Jelix 1.9+
+        if (method_exists('jLocale', 'getBundle')) {
+            return jLocale::getBundle($key, $locale)->getAllKeys();
+        }
+
+        // with Jelix 1.8
+        try {
+            $file = new \jSelectorLoc($key, $locale);
+        } catch (\jExceptionSelector $e) {
+            // the file is not found
+            if ($e->getCode() == 12) {
+                // unknown module..
+                throw $e;
+            }
+
+            throw new \Exception('(212)No locale file found for the given locale key "'.$key
+                .'" in any other default languages');
+        }
+
+        $locale = $file->locale;
+        $keySelector = $file->module.'~'.$file->fileKey;
+
+        if (!isset(self::$bundles[$keySelector][$locale])) {
+            self::$bundles[$keySelector][$locale] = new LocalesBundle($file, $locale);
+        }
+
+        $bundle = self::$bundles[$keySelector][$locale];
+
+        return $bundle->getAllKeys();
+    }
+}

--- a/lizmap/modules/view/controllers/translate.classic.php
+++ b/lizmap/modules/view/controllers/translate.classic.php
@@ -1,4 +1,7 @@
 <?php
+
+use Lizmap\App\LocalesLoader;
+
 /**
  * Service to provide translation dictionnary.
  *
@@ -29,22 +32,10 @@ class translateCtrl extends jController
         $lang = $this->param('lang');
 
         if (!$lang) {
-            $lang = jLocale::getCurrentLang().'_'.jLocale::getCurrentCountry();
+            $lang = jLocale::getCurrentLocale();
         }
 
-        $data = array();
-        $path = jApp::appPath().'modules/view/locales/en_US/dictionnary.UTF-8.properties';
-        if (file_exists($path)) {
-            $lines = file($path);
-            foreach ($lines as $lineNumber => $lineContent) {
-                if (!empty($lineContent) and $lineContent != '\n') {
-                    $exp = explode('=', trim($lineContent));
-                    if (!empty($exp[0])) {
-                        $data[$exp[0]] = jLocale::get('view~dictionnary.'.$exp[0], null, $lang);
-                    }
-                }
-            }
-        }
+        $data = LocalesLoader::getLocalesFrom('view~dictionnary', $lang);
         $rep->content = 'var lizDict = '.json_encode($data).';';
 
         return $rep;
@@ -68,23 +59,10 @@ class translateCtrl extends jController
         $lang = $this->param('lang');
 
         if (!$lang) {
-            $lang = jLocale::getCurrentLang().'_'.jLocale::getCurrentCountry();
+            $lang = jLocale::getCurrentLocale();
         }
 
-        $data = array();
-        $path = jApp::appPath().'modules/view/locales/'.$lang.'/'.$property.'.UTF-8.properties';
-        if (file_exists($path)) {
-            $lines = file($path);
-            foreach ($lines as $lineNumber => $lineContent) {
-                if (!empty($lineContent) and $lineContent != '\n') {
-                    $exp = explode('=', trim($lineContent));
-                    if (!empty($exp[0])) {
-                        $data[$exp[0]] = jLocale::get('view~dictionnary.'.$exp[0], null, $lang);
-                    }
-                }
-            }
-        }
-        $rep->data = $data;
+        $rep->data = LocalesLoader::getLocalesFrom('view~'.$property, $lang);
 
         return $rep;
     }


### PR DESCRIPTION
A new static method LocalesLoader::getLocalesFrom() is provided for Lizmap and modules, when we want to retrieve all translated files of a locales file.

Funded by 3Liz
