### PR TITLE
[Bug] Permalink: encode layers style before hash comparison

### DIFF
--- a/assets/src/modules/Permalink.js
+++ b/assets/src/modules/Permalink.js
@@ -294,7 +294,7 @@ export default class Permalink {
         for (const item of mainLizmap.state.rootMapGroup.findMapLayersAndGroups()) {
             if (item.checked){
                 itemsVisibility.push(encodeURIComponent(item.name));
-                itemsStyle.push(item.wmsSelectedStyleName);
+                itemsStyle.push(item.wmsSelectedStyleName ? encodeURIComponent(item.wmsSelectedStyleName) : item.wmsSelectedStyleName);
                 itemsOpacity.push(item.opacity);
             }
         }


### PR DESCRIPTION
Plain comparison between `window.location.hash` and hash stored in `Permalink` `_hash` property 

https://github.com/3liz/lizmap-web-client/blob/7bb076d4811fbf4f60c68213dcc1e95116f00f02/assets/src/modules/Permalink.js#L42C21-L42C55

does not work if a layer style contains spaces or other "special" chars. 

If the hash comparison fails, the hash change could be triggered over and over again. This could also be enforced by the fact that the `extension` permalink parameter is converted in `EPSG:4326` from project CRS and converted again to project CRS to set the map extension. In this conversion process, the original coordinates stored in the permalink may be transformed due to rounding

Backport to 3.8

Funded by Faunalia
