### PR TITLE
Tests - Update redis version from 5 to 7.4

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         aliases:
           - db.lizmap.local
   redis:
-    image: redis:5
+    image: redis:7.4
     container_name: "lizmap${LZMBRANCH}_test_redis"
   openldap:
     build: ./docker-conf/openldap


### PR DESCRIPTION
The latest version of Redis 5 is EOL since April 2020 :/

We need to update a few docker compose file when we find it. I was hesitating to use `latest`.

CC @rldhont @mdouchin @nboisteault @nworr 

@rldhont I haven't tested it, related to our discussion last week, and mainly about environment variables you were talking last week.