### PR TITLE
Tests - Add E2E about iframe in a popup

### DIFF
--- a/tests/end2end/playwright/xss.spec.js
+++ b/tests/end2end/playwright/xss.spec.js
@@ -39,4 +39,10 @@ test.describe('XSS', () => {
 
         expect(dialogOpens).toEqual(0);
     });
+
+    test('Iframe in a popup', async ({ page }) => {
+        const url = '/index.php/view/map/?repository=testsrepository&project=xss&layer=xss_layer&filter=%22id%22%20%3D%20\'2\'&popup=true';
+        await gotoMap(url, page)
+        await expect(page.frameLocator('iframe').locator('#map')).toHaveCount(1);
+    });
 });


### PR DESCRIPTION
Ticket : #4863

Follow up from #4953 

I was hesitating in the selector or what to check exactly @nboisteault 

Funded by Valabre

Just to keep track of previous selector

```
//        await expect(page.locator('.lizmapPopupContent > .lizmapPopupSingleFeature .lizmapPopupDiv iframe:nth-child(1)')).toHaveCount(1);
```