### PR TITLE
[Bugfix] Put highlight layer in tools layer group.

### DIFF
--- a/assets/src/modules/map.js
+++ b/assets/src/modules/map.js
@@ -804,7 +804,7 @@ export default class map extends olMap {
                 'stroke-width': styleWidth,
             }
         });
-        this.addLayer(this._highlightLayer);
+        this.addToolLayer(this._highlightLayer);
 
         // Add startup features to map if any
         const startupFeatures = mainLizmap.state.map.startupFeatures;


### PR DESCRIPTION
To keep the highlight layer upper the map layers, it will be added in the tools layer group.

* Fixed #4893 
* Fixed #4961

Funded by 3Liz