### PR TITLE
Raise PHP minimum version to 8.1

### DIFF
--- a/.github/workflows/php-stan.yml
+++ b/.github/workflows/php-stan.yml
@@ -22,8 +22,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - php-version: '7.4'
-          - php-version: '8.0'
           - php-version: '8.1'
           - php-version: '8.2'
           - php-version: '8.3'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - php-version: "7.4"
-            php-unit: "9.6.22"
-          - php-version: "8.0"
-            php-unit: "9.6.22"
           - php-version: "8.1"
             php-unit: "10.5.40"
           - php-version: "8.2"

--- a/CHANGELOG-3.9.md
+++ b/CHANGELOG-3.9.md
@@ -15,6 +15,10 @@ with some extra keywords: backend, tests, test, translation, funders, important
 * **[Golfe du Morbihan Vannes agglomération](https://www.golfedumorbihan-vannesagglomeration.bzh/)**
 * **[VSB Energy](https://www.vsb.energy/)**
 
+### Important
+
+* PHP 8.1 minimum is required
+
 ### Added
 
 * Circular geometry measurement on draw
@@ -33,3 +37,4 @@ with some extra keywords: backend, tests, test, translation, funders, important
 
 * Expose more OpenLayers and lit classes
 * Reduce `mainLizmap` dependencies in all JavaScript code
+* Raise PHP to version 8.1

--- a/lizmap/composer.json
+++ b/lizmap/composer.json
@@ -6,7 +6,7 @@
   "authors": [
   ],
   "require": {
-    "php": ">=7.4",
+    "php": ">=8.1",
     "jelix/jelix": "dev-jelix-1.8.x",
     "jelix/composer-module-setup": "^1.1.0",
     "jelix/jcommunity-module": "^1.4.3",
@@ -24,7 +24,7 @@
       "jelix/composer-module-setup": true
     },
     "platform": {
-      "php": "7.4"
+      "php": "8.1"
     }
   },
   "extra": {

--- a/tests/units/composer.json
+++ b/tests/units/composer.json
@@ -8,7 +8,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3.0",
+        "php": ">=8.1.0",
         "phpunit/phpunit": "^10.5.29",
         "phpstan/phpstan": "1.11.11"
     },


### PR DESCRIPTION
Following the PHP roadmap : https://www.php.net/supported-versions.php

But the issue is about Debian bulleyes, for which it will not be compatible.

~We talked about targeting LWC 3.9 for this change, but I was wondering if we keep this for LWC 3.10 which already include a "breaking" change with the migration from Bootstrap 2 to Bootstrap 5 #4861. (we can check if LWC should switch to 4.0 ?)~

CC @laurentj @mdouchin @mind84 @guenter