### PR TITLE
Default jForms builder set to HTML Bootstrap

### DIFF
--- a/lizmap/app/system/mainconfig.ini.php
+++ b/lizmap/app/system/mainconfig.ini.php
@@ -121,7 +121,7 @@ urlParamNameLanguage=lang
 useDefaultLanguageBrowser=on
 
 [tplplugins]
-defaultJformsBuilder=html
+defaultJformsBuilder=htmlbootstrap
 
 [responses]
 html=myHtmlResponse


### PR DESCRIPTION
Because of all JavaScripts are `defer` and Lizmap using Bootstrap, the default jForms builder has to be HTML Boostrap.