### PR TITLE
[Bugfix] <lizmap-features-table>: lower case sortingOrder and draggable attribute values

### DIFF
--- a/assets/src/components/FeaturesTable.js
+++ b/assets/src/components/FeaturesTable.js
@@ -53,14 +53,14 @@ export default class FeaturesTable extends HTMLElement {
         // Sorting attribute and direction
         this.sortingField = this.getAttribute('sortingField');
         const sortingOrder = this.getAttribute('sortingOrder');
-        this.sortingOrder = (sortingOrder !== null && ['asc', 'desc'].includes(sortingOrder)) ? sortingOrder : 'asc';
+        this.sortingOrder = (sortingOrder !== null && ['asc', 'desc'].includes(sortingOrder.toLowerCase())) ? sortingOrder : 'asc';
 
         // open popup ?
         this.openPopup = (this.layerConfig && this.layerConfig.popup);
 
         // Add drag&drop capability ?
         const draggable = this.getAttribute('draggable');
-        this.itemsDraggable = (draggable !== null && ['yes', 'no'].includes(draggable)) ? draggable : 'no';
+        this.itemsDraggable = (draggable !== null && ['yes', 'no'].includes(draggable.toLowerCase())) ? draggable : 'no';
 
         // Features
         this.features = [];


### PR DESCRIPTION
The sortingOrder and draggable attribute values has not to be case sensitive.

Funded Haute-Saone Numérique
