### PR TITLE
FeaturesTable structure & columns improvements 

### DIFF
--- a/assets/src/modules/FeaturesTable.js
+++ b/assets/src/modules/FeaturesTable.js
@@ -38,13 +38,14 @@ export default class FeaturesTable {
      * @param {string|null} filter An QGIS expression filter
      * @param {boolean}     withGeometry If we need to get the geometry
      * @param {string|null} fields List of field names separated by comma
+     * @param {object|array} additionalFields JSON object with the field names and expressions
      *
      * @returns — A Promise that resolves with the result of parsing the response body text as JSON.
      * @throws {ResponseError} In case of invalid content type (not application/json or application/vnd.geo+json) or Invalid JSON
      * @throws {HttpError} In case of not successful response (status not in the range 200 – 299)
      * @throws {NetworkError} In case of catch exceptions
      */
-    getFeatures(layerId, filter = null, withGeometry = false, fields = 'null') {
+    getFeatures(layerId, filter = null, withGeometry = false, fields = 'null', additionalFields = []) {
 
         // Build URL
         const url = `${lizUrls.service.replace('service?','features/displayExpression?')}&`;
@@ -55,7 +56,7 @@ export default class FeaturesTable {
         formData.append('exp_filter', filter);
         formData.append('with_geometry', withGeometry.toString());
         formData.append('fields', fields);
-
+        formData.append('additionalFields',JSON.stringify(additionalFields));
         // Return promise
         return Utils.fetchJSON(url, {
             method: "POST",

--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -3603,43 +3603,50 @@ lizmap-features-table h4 {
 div.lizmap-features-table {
   position: relative;
 }
-div.lizmap-features-table-container {
-  border: 1px solid var(--color-contrasted-elements);
+table.lizmap-features-table-container {
   font-size: 0.9em;
-  margin: 0px 10px 0px 10px;
   position: relative;
   max-height: 30vh;
   overflow: auto;
 }
 
-/* Feature item */
-div.lizmap-features-table-container div.lizmap-features-table-item {
-  padding: 5px;
+/* Decrease the margin of the features table when a popup is displayed underneath (otherwise 20px)  */
+div.lizmap-features-table.popup-displayed table.lizmap-features-table-container {
+  margin-bottom: 5px;
+}
+
+/* Feature item line (tr) */
+table.lizmap-features-table-container tbody tr.lizmap-features-table-item {
   border-top: 1px solid var(--color-contrasted-elements);
   position: relative;
+
+  /* Light gray background for even lines */
+  &:nth-child(even) {
+    background-color: #f9f9f9;
+  }
+
   /* Invert colors on hover & focus */
   &:hover, &:focus, &:active, &.popup-displayed {
       background-color: var(--color-contrasted-elements);
       color: var(--color-contrasted-text);
   }
-  /* Do not render the top border for the first item (parent already has a border) */
-  &:first-child {
-    border-top: none;
-  }
 }
+
 /* Pointer cursor  */
-div.lizmap-features-table-container div.lizmap-features-table-item.has-action {
+table.lizmap-features-table-container tbody tr.lizmap-features-table-item.has-action {
   cursor: pointer;
 }
 
 /* Hide other children of the table if only one child feature is active */
-div.lizmap-features-table.popup-displayed > div.lizmap-features-table-container > div.lizmap-features-table-item:not(.popup-displayed) {
+div.lizmap-features-table.popup-displayed > table.lizmap-features-table-container > tbody > tr.lizmap-features-table-item:not(.popup-displayed) {
     display: none;
 }
+
 /* In this context, display only the active child item */
-div.lizmap-features-table.popup-displayed div.lizmap-features-table-container div.lizmap-features-table-item.popup-displayed {
-  display: block;
+div.lizmap-features-table.popup-displayed > table.lizmap-features-table-container > tbody > tr.lizmap-features-table-item.popup-displayed {
+  display: revert;
 }
+
 /* Toolbar visible when popup is visible */
 div.lizmap-features-table div.lizmap-features-table-toolbar {
   display: none;
@@ -3686,22 +3693,28 @@ div.lizmap-features-table-toolbar button.next-popup {
 
 
 /* Popup div, visible only if popup-dsplayed class is present for it preceeding sibling */
-div.lizmap-features-table div.lizmap-features-table-container + div.lizmap-features-table-item-popup {
+div.lizmap-features-table > table.lizmap-features-table-container + div.lizmap-features-table-item-popup {
   display: none;
   min-height: 200px;
   min-width: 200px;
   overflow: auto;
 }
-div.lizmap-features-table.popup-displayed div.lizmap-features-table-container + div.lizmap-features-table-item-popup {
+div.lizmap-features-table.popup-displayed > table.lizmap-features-table-container + div.lizmap-features-table-item-popup {
   display: block;
 }
 /* Hide title of the popup, since it is already visible above */
-div.lizmap-features-table.popup-displayed div.lizmap-features-table-container + div.lizmap-features-table-item-popup h4.lizmapPopupTitle {
+div.lizmap-features-table.popup-displayed > table.lizmap-features-table-container + div.lizmap-features-table-item-popup h4.lizmapPopupTitle {
   display: none;
 }
 .hide {
   display: none;
 }
+
+/* Remove margin for active item popup lizmapPopupDiv */
+#popupcontent div.lizmap-features-table.popup-displayed > table.lizmap-features-table-container + div.lizmap-features-table-item-popup div.lizmapPopupDiv {
+  margin: 0px !important;
+}
+
 
 
 /* Deactivate the OLD bootstrap-2 modal

--- a/tests/end2end/playwright/lizmap-features-table.spec.js
+++ b/tests/end2end/playwright/lizmap-features-table.spec.js
@@ -34,10 +34,10 @@ test.describe('Display lizmap-features-table component in popup from QGIS toolti
         await expect(lizmapFeaturesTable.locator("h4")).toHaveText("child sub-districts");
 
         // Check items count
-        await expect(lizmapFeaturesTable.locator("div.lizmap-features-table-container div.lizmap-features-table-item")).toHaveCount(10);
+        await expect(lizmapFeaturesTable.locator("table.lizmap-features-table-container tr.lizmap-features-table-item")).toHaveCount(10);
 
         // Get first item and check it
-        let firstItem = lizmapFeaturesTable.locator("div.lizmap-features-table-container div.lizmap-features-table-item").first();
+        let firstItem = lizmapFeaturesTable.locator("table.lizmap-features-table-container tr.lizmap-features-table-item").first();
         await expect(firstItem).toHaveAttribute('data-line-id', '1');
         await expect(firstItem).toHaveAttribute('data-feature-id', '17');
 
@@ -62,6 +62,15 @@ test.describe('Display lizmap-features-table component in popup from QGIS toolti
         await expect(lizmapFeaturesTable.locator('div.lizmap-features-table')).not.toHaveClass(/popup-displayed/);
         await expect(firstItem).not.toHaveClass(/popup-displayed/);
 
+        // Drag and Drop Item
+        await page.locator('.lizmap-features-table-container > tbody > tr:nth-child(2)').dragTo(page.locator('.lizmap-features-table-container > tbody > tr:first-child'));
+
+        await expect(firstItem).toHaveAttribute('data-line-id', '1');
+        await expect(firstItem).toHaveAttribute('data-feature-id', '9');
+
+        let secondItem = lizmapFeaturesTable.locator(".lizmap-features-table-container > tbody > tr:nth-child(2)");
+        await expect(secondItem).toHaveAttribute('data-line-id', '2');
+        await expect(secondItem).toHaveAttribute('data-feature-id', '17');
 
 
         //clear screen


### PR DESCRIPTION
### Added

* Replace the items `<div>` by an HTML `<table>` to prepare the addition of columns
* Allow to add columns from the layer fields : now we can add several columns by adding some `<lizmap-field ... > ... </lizmap-field>` children inside the `<lizmap-features-table>` element
* Add labels of columns in the table
* Add a regular expression verification for the used QGIS expressions in child fields. At present, we only accept expressions requesting fields like `"libsquart"` and not expressions like `rand(10,34)`.
* If fields have the same expression or aliases (except empty ones), only the first one is used.

Example code:

```html
<lizmap-features-table 
	layertitle="child sub-districts" 
	layerid="sousquartiers_24ceec66_e7fe_46a2_b57a_af5c50389649" 
	uniquefield="id" 
	expressionfilter="quartmno = '[% "quartmno" %]'" 
	withgeometry="1" 
	sortingfield="libsquart" 
	sortingorder="asc" 
	draggable="yes"
>
	<lizmap-field 
		data-alias="Name" 
		data-description="Label of sub-district's"
	>"libsquart"</lizmap-field>
	
	<lizmap-field 
		data-alias="Code" 
		data-description="Code of sub-district's name"
	>"squartmno"</lizmap-field>
</lizmap-features-table>
```
How it is rendered (in release_3_9, not in master since bootstrap migration is not finished yet)

![image](https://github.com/user-attachments/assets/12826128-95ee-449b-9698-8821ecb8f2d2)



### Fixed

* Fixed the **end2end playwright test** about FeaturesTable

_Fix version of #4922_ 

Funded by 3liz
