### PR TITLE
[Bugfix] JS State Symbology : checking ruleKey for wmsParameters

### DIFF
--- a/assets/src/modules/state/Symbology.js
+++ b/assets/src/modules/state/Symbology.js
@@ -109,6 +109,20 @@ export class BaseObjectSymbology extends EventDispatcher {
 
         super()
         applyConfig(this, node, requiredProperties, optionalProperties)
+
+        /**
+         * The private symbology type
+         * @type {string}
+         * @private
+         */
+        this._type;
+
+        /**
+         * The private symbology title
+         * @type {string}
+         * @private
+         */
+        this._title;
     }
 
     /**
@@ -157,6 +171,13 @@ export class BaseIconSymbology extends BaseObjectSymbology {
         }
 
         super(node, requiredProperties, optionalProperties)
+
+        /**
+         * The private base64 icon
+         * @type {string}
+         * @private
+         */
+        this._icon;
     }
 
     /**
@@ -195,6 +216,13 @@ export class LayerIconSymbology extends BaseIconSymbology {
         }
 
         super(node, layerIconProperties, {})
+
+        /**
+         * The private layer name
+         * @type {string}
+         * @private
+         */
+        this._name;
     }
 
     /**
@@ -234,6 +262,26 @@ export class SymbolIconSymbology extends BaseIconSymbology {
             node.type = 'icon';
         }
         super(node, symbolIconProperties, symbolIconOptionalProperties)
+
+        /**
+         * The private rule key
+         * @type {string}
+         * @private
+         */
+        this._ruleKey;
+
+        /**
+         * The private is rule checked
+         * @type {boolean}
+         * @private
+         */
+        this._checked;
+
+        /**
+         * The private children rules
+         * @type {BaseIconSymbology[]}
+         * @private
+         */
         this._childrenRules = []
     }
 
@@ -306,8 +354,26 @@ export class SymbolRuleSymbology extends SymbolIconSymbology {
             node.type = 'rule';
         }
         super(node, symbolRuleProperties, symbolRuleOptionalProperties)
+
+        /**
+         * The private parent rule key
+         * @type {string}
+         * @private
+         */
+        this._parentRuleKey;
+
+        /**
+         * The private parent rule
+         * @type {?SymbolRuleSymbology}
+         * @private
+         */
         this._parentRule = null;
-        this._childrenRules = [];
+
+        /**
+         * The private is symbol item expanded ?
+         * @type {boolean}
+         * @private
+         */
         this._expanded = false;
     }
 
@@ -442,11 +508,21 @@ export class BaseSymbolsSymbology extends BaseObjectSymbology {
 
         super(node, requiredProperties, optionalProperties)
 
+        /**
+         * The private children icons
+         * @type {BaseIconSymbology[]}
+         * @private
+         */
         this._icons = [];
         for(const symbol of this._symbols) {
             this._icons.push(new iconClass(symbol));
         }
 
+        /**
+         * The private symbol is expanded ?
+         * @type {boolean}
+         * @private
+         */
         this._expanded = false;
     }
 
@@ -540,6 +616,12 @@ export class LayerSymbolsSymbology extends BaseSymbolsSymbology {
             this._ruleMap = new Map(this._icons.map(i => [i.ruleKey, i]));
             let root = new Map();
             for (const icon of this._icons) {
+                if (icon.parentRuleKey === '') {
+                    // The parentRuleKey could be null
+                    // it is an empty symbol defined in
+                    // JSON GetLegendGraphic
+                    continue;
+                }
                 const parent = this._ruleMap.get(icon.parentRuleKey);
                 if (parent === undefined) {
                     root.set(icon.ruleKey, icon);
@@ -553,8 +635,37 @@ export class LayerSymbolsSymbology extends BaseSymbolsSymbology {
             this._root = root;
         } else {
             super(node, layerSymbolsProperties, {}, SymbolIconSymbology)
+            this._ruleMap = null;
             this._root = null;
         }
+
+        /**
+         * The private layer name
+         * @type {string}
+         * @private
+         */
+        this._name;
+
+        /**
+         * The private children icons
+         * @type {SymbolIconSymbology[]|SymbolRuleSymbology[]}
+         * @private
+         */
+        this._icons;
+
+        /**
+         * The private rule map that contains rule symbology ruleKey:Symbol associations
+         * @type {?Map<string, SymbolRuleSymbology>}
+         * @private
+         */
+        this._ruleMap;
+
+        /**
+         * The private legend root that contains first level rule symbology ruleKey:Symbol associations
+         * @type {?Map<string, SymbolRuleSymbology>}
+         * @private
+         */
+        this._root;
     }
 
     /**
@@ -571,7 +682,7 @@ export class LayerSymbolsSymbology extends BaseSymbolsSymbology {
      */
     get legendOn() {
         for (const symbol of this._icons) {
-            if (symbol.rulekey === '') {
+            if (symbol.ruleKey === '') {
                 return true;
             }
             if (symbol.legendOn) {
@@ -625,7 +736,7 @@ export class LayerSymbolsSymbology extends BaseSymbolsSymbology {
         let keyChecked = [];
         let keyUnchecked = [];
         for (const symbol of this._icons) {
-            if (symbol.rulekey === '') {
+            if (symbol.ruleKey === '') {
                 keyChecked = [];
                 keyUnchecked = [];
                 break;

--- a/tests/js-units/node/state/symbology.test.js
+++ b/tests/js-units/node/state/symbology.test.js
@@ -489,6 +489,9 @@ describe('LayerSymbolsSymbology', function () {
         expect(symbologyChildren[1].legendOn).to.be.true
         expect(symbologyChildren[2].legendOn).to.be.true
         expect(symbology.legendOn).to.be.true
+        // No legend parameter because every legend is ON
+        expect(symbology.wmsParameters('road').LEGEND_ON).to.be.undefined
+        expect(symbology.wmsParameters('road').LEGEND_OFF).to.be.undefined
         expect(symbology.wmsParameters('road')).to.be.an('object').that.be.deep.eq({})
 
         symbologyChildrenFirstChildren[0].checked = false
@@ -585,6 +588,57 @@ describe('LayerSymbolsSymbology', function () {
             "{245c23be-e45f-4f80-9ea4-f1676315f178}",
         ]), symbology.wmsParameters('road').LEGEND_ON)
         .and.to.not.contains("{a9fac601-7bc7-4150-9783-19d7827b2ef8}")
+    })
+
+    it('RuleRenderer mixed', function () {
+        // It is a RuleRenderer with only one rule in the QGIS User interface
+        const symbology = new LayerSymbolsSymbology({
+            "symbols": [
+                {
+                    "icon": "iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAASklEQVQ4jWNgGAWEACM2QWVl5f/4NN29exdDH4YAIUNwGcaCS+GdO3e2YBNXUVHxwSbORIztxIBRgwgDnLGGK3ZwAaolyFFAGAAAD9sQzpjSF7wAAAAASUVORK5CYII=",
+                    "title": "Covoiturage",
+                    "ruleKey": "{8457ada1-6ca6-4fc0-b47b-7597a8084cbf}",
+                    "checked": true,
+                    "parentRuleKey": "{c335718f-d733-41bf-bccd-d85f5f37f135}",
+                    "expression": " \"dess_regul\" = 'st1' "
+                },
+                {
+                    "icon": "iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAADElEQVQImWNgIB0AAAA0AAEjQ4N1AAAAAElFTkSuQmCC",
+                    "title": ""
+                }
+            ],
+            "title": "Arrêts star't",
+            "type": "layer",
+            "name": "arrets_start",
+            "layerName": "Arrêts star't"
+        })
+        expect(symbology).to.be.instanceOf(BaseSymbolsSymbology)
+        expect(symbology).to.be.instanceOf(LayerSymbolsSymbology)
+        expect(symbology.title).to.be.eq('Arrêts star\'t')
+        expect(symbology.name).to.be.eq('arrets_start')
+        expect(symbology.type).to.be.eq('layer')
+        expect(symbology.expanded).to.be.false
+        expect(symbology.legendOn).to.be.true
+        // Only 1 available children like in QGIS User Interface
+        expect(symbology.childrenCount).to.be.eq(1)
+        expect(symbology.children).to.be.an('array').that.have.lengthOf(1)
+        // No legend parameter because every legend is ON or OFF
+        expect(symbology.wmsParameters('arrets_start').LEGEND_ON).to.be.undefined
+        expect(symbology.wmsParameters('arrets_start').LEGEND_OFF).to.be.undefined
+        expect(symbology.wmsParameters('arrets_start')).to.be.an('object').that.be.deep.eq({})
+
+        // We found 2 private icons like in the JSON
+        expect(symbology._icons).to.be.an('array').that.have.lengthOf(2)
+        // The first is the available child
+        expect(symbology._icons[0].ruleKey).to.be.eq('{8457ada1-6ca6-4fc0-b47b-7597a8084cbf}')
+        expect(symbology._icons[0].title).to.be.eq('Covoiturage')
+        expect(symbology._icons[0].parentRuleKey).to.be.eq('{c335718f-d733-41bf-bccd-d85f5f37f135}')
+        expect(symbology._icons[0].parentRule).to.be.null
+        // The second is the unavailable child
+        expect(symbology._icons[1].ruleKey).to.be.eq('')
+        expect(symbology._icons[1].title).to.be.eq('')
+        expect(symbology._icons[1].parentRuleKey).to.be.eq('')
+        expect(symbology._icons[1].parentRule).to.be.null
     })
 
     it('Failing required properties', function () {


### PR DESCRIPTION
Enhancing the docstring of JS State Symbology to correctly checking parameters and avoid some issue. Adding test with a special GetLegendGraphics JSON.

Funded by Keolis Rennes