### PR TITLE
fix(css): hide only adjacent non-popup-displayed table items

### DIFF
--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -3632,9 +3632,9 @@ div.lizmap-features-table-container div.lizmap-features-table-item.has-action {
   cursor: pointer;
 }
 
-/* Hide other children if only one child feature is active */
-div.lizmap-features-table.popup-displayed div.lizmap-features-table-container div.lizmap-features-table-item {
-  display: none;
+/* Hide other children of the table if only one child feature is active */
+div.lizmap-features-table.popup-displayed > div.lizmap-features-table-container > div.lizmap-features-table-item:not(.popup-displayed) {
+    display: none;
 }
 /* In this context, display only the active child item */
 div.lizmap-features-table.popup-displayed div.lizmap-features-table-container div.lizmap-features-table-item.popup-displayed {


### PR DESCRIPTION
https://github.com/3liz/lizmap-web-client/issues/5023#issuecomment-2508151247

<!--
Add the word "fix" in front of "#" if it fixes the ticket
or do nothing to only mention it.

funded by NAME
If funded by someone else than 3Liz, please add label "sponsored development"

Please mention if the PR should be backported and to which versions.

Please add new tests if possible (JS, PHP, End2End…)
-->

Ticket : fix #5023

Funded by Erwan Vinot
