### PR TITLE
Tests - Remove warnings from Javascript

### DIFF
--- a/tests/end2end/playwright/filter-layer-by-user.spec.js
+++ b/tests/end2end/playwright/filter-layer-by-user.spec.js
@@ -1,6 +1,10 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
 import { gotoMap } from './globals';
+import { FeatureToolbar } from '../../../assets/src/components/FeatureToolbar.js';
+
+// import Vue from 'vue'
+// Vue.Component('lizmap-feature-toolbar', FeatureToolbar)
 
 test.describe('Filter layer data by user - not connected', () => {
 


### PR DESCRIPTION
In my Javascript IDE, I have plenty of warnings like : 

![image](https://github.com/user-attachments/assets/cb008932-5d8c-4ce6-83a2-d607216503ba)
