### PR TITLE
[Feature] Circular geometry measurement on draw

### DIFF
--- a/assets/src/modules/Digitizing.js
+++ b/assets/src/modules/Digitizing.js
@@ -480,13 +480,7 @@ export class Digitizing {
                     geom.set('totalOverlay', Array.from(this._measureTooltips).pop()[1], true);
                     geom.on('change', (e) => {
                         const geom = e.target;
-                        if (geom instanceof Polygon) {
-                            this._updateTotalMeasureTooltip(geom.getCoordinates()[0], geom, 'Polygon', geom.get('totalOverlay'));
-                        } else if (geom instanceof LineString) {
-                            this._updateTotalMeasureTooltip(geom.getCoordinates(), geom, 'Linestring', geom.get('totalOverlay'));
-                        } else if ( geom instanceof CircleGeom) {
-                            this._updateTotalMeasureTooltip([geom.getFirstCoordinate(), geom.getLastCoordinate()], geom, 'Circle', geom.get('totalOverlay'));
-                        }
+                        this._setTooltipContentByGeom(geom);
                     });
 
                     this._constraintLayer.setVisible(false);
@@ -900,6 +894,43 @@ export class Digitizing {
     }
 
     /**
+     * Initializes measure tooltip and change event on a feature loaded from local storage.
+     * @param {Geometry} geom The geometry.
+     */
+    _initMeasureTooltipOnLoadedFeatures(geom){
+        // create overlays
+        this.createMeasureTooltips();
+
+        geom.set('totalOverlay', Array.from(this._measureTooltips).pop()[1], true);
+        // calculate measures
+        this._setTooltipContentByGeom(geom);
+        geom.on('change', (e) => {
+            const geom = e.target;
+            this._setTooltipContentByGeom(geom);
+        });
+        // make measure tooltip static and hidden
+        this._totalMeasureTooltipElement.className = 'ol-tooltip ol-tooltip-static';
+        this._totalMeasureTooltipElement.classList.toggle('hide', !this._hasMeasureVisible);
+
+        // reset measureTooltip element
+        this._totalMeasureTooltipElement = null;
+    }
+
+    /**
+     * Calculates measuements for a specific geometry.
+     * @param {Geometry} geom The geometry.
+     */
+    _setTooltipContentByGeom(geom){
+        if (geom instanceof Polygon) {
+            this._updateTotalMeasureTooltip(geom.getCoordinates()[0], geom, 'Polygon', geom.get('totalOverlay'));
+        } else if (geom instanceof LineString) {
+            this._updateTotalMeasureTooltip(geom.getCoordinates(), geom, 'Linestring', geom.get('totalOverlay'));
+        } else if ( geom instanceof CircleGeom) {
+            this._updateTotalMeasureTooltip([geom.getFirstCoordinate(), geom.getLastCoordinate()], geom, 'Circle', geom.get('totalOverlay'));
+        }
+    }
+
+    /**
      * Creates measure tooltips
      */
     createMeasureTooltips() {
@@ -1114,6 +1145,8 @@ export class Digitizing {
 
                     if(loadedGeom){
                         const loadedFeature = new Feature(loadedGeom);
+                        // init measure tooltip
+                        this._initMeasureTooltipOnLoadedFeatures(loadedFeature.getGeometry());
                         loadedFeature.set('color', feature.color);
                         loadedFeatures.push(loadedFeature);
                     }
@@ -1128,6 +1161,8 @@ export class Digitizing {
                     console.log(loadedFeatures.length+' features read from WKT!');
                     // set color
                     for(const loadedFeature of loadedFeatures){
+                        // init measure tooltip
+                        this._initMeasureTooltipOnLoadedFeatures(loadedFeature.getGeometry());
                         loadedFeature.set('color', this._drawColor);
                     }
                     // No features read from localStorage so remove the data

--- a/tests/end2end/playwright/draw.spec.js
+++ b/tests/end2end/playwright/draw.spec.js
@@ -281,6 +281,26 @@ test.describe('Draw', () => {
         expect(await page.evaluate(() => lizMap.mainLizmap.digitizing.featureDrawn)).toBeNull();
     });
 
+    test('Circular geometry measure', async ({ page }) => {
+        await page.locator('#draw button.dropdown-toggle:nth-child(2)').click();
+        await page.locator('.digitizing-circle > svg').click();
+        await page.locator('#newOlMap').click({
+            position: {
+                x: 450,
+                y: 75
+            }
+        });
+        await page.locator('#newOlMap').click({
+            position: {
+                x: 480,
+                y: 115
+            }
+        });
+        await page.locator('#draw button.digitizing-toggle-measure').click();
+        await expect(page.locator('.ol-tooltip.ol-tooltip-static')).toBeVisible();
+        await expect(page.locator('.ol-tooltip.ol-tooltip-static')).toHaveText('3.3 km34.27 km2');
+    })
+
     test('From local storage', async ({ page }) => {
         const the_json = '[{"type":"Polygon","color":"#000000","coords":[[[764321.0416656,6290805.935670358],[767628.3399468632,6290805.935670358],[767628.3399468632,6295105.423436],[764321.0416656,6295105.423436],[764321.0416656,6290805.935670358],[764321.0416656,6290805.935670358]]]}]';
         await page.evaluate(token => localStorage.setItem('testsrepository_draw_draw_drawLayer', token), the_json);
@@ -312,6 +332,13 @@ test.describe('Draw', () => {
         await expect(drawn[0][3]).toHaveLength(2);
         await expect(drawn[0][4]).toHaveLength(2);
         await expect(drawn[0][5]).toHaveLength(2);
+
+        // check measure initialization
+        await page.locator('#draw button.digitizing-toggle-measure').click();
+        await expect(page.locator('.ol-tooltip.ol-tooltip-static')).toBeVisible();
+        await expect(page.locator('.ol-tooltip.ol-tooltip-static')).toHaveText('15.2 km14.19 km2');
+        // hide measure
+        await page.locator('#draw button.digitizing-toggle-measure').click();
 
         // Hide all elements but #map, #newOlMap and their children
         await page.$eval("*", el => el.style.visibility = 'hidden');


### PR DESCRIPTION
**ADDED FEATURES:**
 
- Add measure tooltip on circles with radius and area measurement
- Initialize measure tooltips on features loaded from `local storage`

**NOTES:**

- Circles area is calculated using the `fromCirlce` method of Openlayers Polygon [class](https://openlayers.org/en/latest/apidoc/module-ol_geom_Polygon.html).
There is another (more verbose) way to do it that involves `circular` method but requires to convert center and "last" coordinates in EPSG:4326.
Given the same polygonal approximation (128 sides), the two methods return the same output so I decided to use the less verbose one.

- For circles, the "segment" tooltip (radius) is no longer displayed near mouse pointer but it's displayed in the interior point of the feature, along with the area measure.  

Feature preview:

[circle_measurement.webm](https://github.com/user-attachments/assets/ea505e4d-87d9-4e5b-b999-a5e872fade23)




Funded by Etra
