### PR TITLE
[Bugfix] Edition : exec a DELETE can return 0 in some cases

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -956,9 +956,11 @@ class qgisVectorLayer extends qgisMapLayer
      *                                                - attribute: filter attribute from the layer
      * @param null|jDbConnection $connection          DBConnection, if not null then the parameter conneciton is used, default value null
      *
-     * @return int
+     * @return bool|int the number of affected rows. False if the query has failed.
      *
      * @throws Exception
+     *
+     * @see jDbConnection::exec() Launch a SQL Query (update, delete..) which doesn't return rows.
      */
     public function deleteFeature($feature, $loginFilteredLayers, $connection = null)
     {

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -1161,7 +1161,7 @@ class editionCtrl extends jController
                 $feature = $this->featureData->features[0];
                 $rs = $qgisForm->deleteFromDb($feature, $cnx);
 
-                if ($rs) {
+                if ($rs !== false) {
                     jMessage::add(jLocale::get('view~edition.message.success.delete'), 'success');
                     $eventParams['deleteFiles'] = $deleteFiles;
                     $eventParams['success'] = true;

--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -1330,6 +1330,12 @@ class QgisForm implements QgisFormControlsInterface
      *
      * @param mixed               $feature
      * @param null|\jDbConnection $cnx     DBConnection, passed along QGISVectorLayer deleteFeature method
+     *
+     * @return bool|int the number of affected rows. False if the query has failed.
+     *
+     * @throws \Exception
+     *
+     * @see \jDbConnection::exec() Launch a SQL Query (update, delete..) which doesn't return rows.
      */
     public function deleteFromDb($feature, $cnx = null)
     {
@@ -1355,7 +1361,7 @@ class QgisForm implements QgisFormControlsInterface
             return 1;
         }
         if ($event->allResponsesByKeyAreFalse('cancelDelete') === false) {
-            return 0;
+            return false;
         }
         $result = $this->layer->deleteFeature($feature, $loginFilteredLayers, $cnx);
         $this->appContext->eventNotify('LizmapEditionFeaturePostDelete', $eventParams);


### PR DESCRIPTION
`jDbConnection::exec()` returns the number of affected rows or False if the query has failed.

In some cases, for exemple a `DELETE` on a view or a `DELETE` catched by a trigger, this method can return no affected rows. So Lizmap has to `rollback()` executed requests only if a query has failed.

Funded by Conseil Départemental du Calvados and Ville d'Avignon