### PR TITLE
Display a generic error in case of action failure to the end-user

### DIFF
--- a/lizmap/modules/action/controllers/service.classic.php
+++ b/lizmap/modules/action/controllers/service.classic.php
@@ -54,7 +54,7 @@ class serviceCtrl extends jController
         // Redirect if the user has no right to access this repository
         if (!$lizmapProject->checkAcl()) {
             $errors = array(
-                'title' => 'Access forbiden',
+                'title' => 'Access forbidden',
                 'detail' => jLocale::get('view~default.repository.access.denied'),
             );
 
@@ -201,10 +201,14 @@ class serviceCtrl extends jController
                 $data = json_decode($r->data);
             }
         } catch (Exception $e) {
-            jLog::log('Error in project '.$repository.'/'.$project.', layer '.$layerId.', while running the query : '.$sql, 'lizmapadmin');
+            jLog::log(
+                'Error in project '.$repository.'/'.$project.', layer '.$layerId.', '.
+                'while running the action with the PostgreSQL query : '.$sql.' → '.$e->getMessage(),
+                'lizmapadmin'
+            );
             $errors = array(
-                'title' => 'An error occurred while running the PostgreSQL query !',
-                'detail' => $e->getMessage(),
+                'title' => 'An error occurred while processing the request',
+                'detail' => 'Please contact the GIS administrator to look to the administrator logs.',
             );
 
             return $this->error($errors);


### PR DESCRIPTION
When **not** connected on the instance @mdouchin 

Does the action writer is using `raise` to show error to the end user ?

![image](https://github.com/user-attachments/assets/823a233a-423e-4a3c-8d6d-0b29394622a9)