### PR TITLE
Fix edition form child with relation

### DIFF
--- a/assets/src/legacy/edition.js
+++ b/assets/src/legacy/edition.js
@@ -1617,19 +1617,13 @@ var lizEdition = function() {
                 } else {
                     var select = form.find('select[name="'+relationRefField+'"]');
                     if( select.length == 1 ){
-                        // Disable the select, the value will be stored in an hidden input
-                        select.val(parentFeatProp)
-                            .attr('disabled','disabled');
-                        // Create hidden input to store value because the select is disabled
-                        var hiddenInput = $('<input type="hidden"></input>')
-                            .attr('id', select.attr('id')+'_hidden')
-                            .attr('name', relationRefField)
-                            .attr('value', parentFeatProp);
-                        form.find('div.jforms-hiddens').append(hiddenInput);
-                        // Disable required constraint
-                        jFormsJQ.getForm(form.attr('id'))
-                            .getControl(relationRefField)
-                            .required=false;
+                        // select the option via jquery (and fire event with "change", will update depending controls)
+                        select.val(parentFeatProp).change();
+                        // create a disabled input with selected option value (will look alike a select)
+                        let readOnlyInput4Select = $('<input type="text" disabled value="'+$("select[name="+relationRefField+"] option:selected").html() +'" />');
+                        select.parent().append(readOnlyInput4Select);
+                        // hide the select, we don't want to see it, but it need to still be enable for controls that depends of its value
+                        select.addClass('hide');
                     } else {
                         var input = form.find('input[name="'+relationRefField+'"]');
                         if( input.length == 1 && input.attr('type') != 'hidden'){

--- a/tests/end2end/cypress/integration/feature_toolbar-ghaction.js
+++ b/tests/end2end/cypress/integration/feature_toolbar-ghaction.js
@@ -442,8 +442,8 @@ describe('Feature Toolbar in popup', function () {
 
         cy.wait(300)
 
-        // Parent_id is disabled in form when edition is started from parent form
-        cy.get('#jforms_view_edition_parent_id').should('be.disabled')
+        // Parent_id is hidden in form when edition is started from parent form
+        cy.get('#jforms_view_edition_parent_id').should('have.class', 'hide');
 
         // Parent_id input should have the value 2 selected
         cy.get('#jforms_view_edition_parent_id').find('option:selected').should('have.value', '2');
@@ -459,8 +459,8 @@ describe('Feature Toolbar in popup', function () {
 
         cy.wait(300)
 
-        // Parent_id is disabled in form when edition is started from parent form
-        cy.get('#jforms_view_edition_parent_id').should('be.disabled')
+        // Parent_id is hidden in form when edition is started from parent form
+        cy.get('#jforms_view_edition_parent_id').should('have.class', 'hide');
 
         // Parent_id input should have the value 2 selected
         cy.get('#jforms_view_edition_parent_id').find('option:selected').should('have.value', '2');


### PR DESCRIPTION
Fix edition form when lauchind children creation from attriute table button : 
if there's a relation between parent id (in a select) and an other control, the value weren't updated.

the `select` is now not set as `disabled` but hidden and a disabled input is added ( look alike a select)
![edition_child_parent_relation](https://github.com/user-attachments/assets/f725ffd2-a344-486c-bc54-37a4d774a706)

Also mini fix on attribute table : the children table didn't work in some case.


Ticket : #4898

Funded by 3Liz
