### PR TITLE
[Bugfix] Digitizing: hide text feature point geometry on print output

### DIFF
--- a/assets/src/modules/Digitizing.js
+++ b/assets/src/modules/Digitizing.js
@@ -975,16 +975,17 @@ export class Digitizing {
             return null;
         }
         const color = this.featureDrawn[index].get('color') || this._drawColor;
+        let opacityFactor = this.featureDrawn[index].get('mode') == 'textonly' ? 0 : 1;
         let symbolizer = '';
         let strokeAndFill =
         `<Stroke>
             <SvgParameter name="stroke">${color}</SvgParameter>
-            <SvgParameter name="stroke-opacity">1</SvgParameter>
+            <SvgParameter name="stroke-opacity">${1*opacityFactor}</SvgParameter>
             <SvgParameter name="stroke-width">${this._strokeWidth}</SvgParameter>
         </Stroke>
         <Fill>
             <SvgParameter name="fill">${color}</SvgParameter>
-            <SvgParameter name="fill-opacity">${this._fillOpacity}</SvgParameter>
+            <SvgParameter name="fill-opacity">${this._fillOpacity*opacityFactor}</SvgParameter>
         </Fill>`;
 
         // We consider LINESTRING and POLYGON together currently


### PR DESCRIPTION
The print output of a text label added with the `Digitizing` tool includes the point point symbol associated with the label:

![image](https://github.com/user-attachments/assets/48739b3b-33f3-4cb0-9767-11346126a7f0)

Since this point is only used to place the text label on the map, it should be hidden in the print output. 

The solution proposed (the simplest I guess) is to set `fill` and `stroke` opacity symbol parameter to 0 for `textonly` feature only:
![image](https://github.com/user-attachments/assets/c231a093-cc86-4c3c-966e-64512e04d97a)

Backport to 3.8

Funded by Faunalia
