### PR TITLE
Add a log if saving the feature has failed

### DIFF
--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -767,6 +767,11 @@ class editionCtrl extends jController
         // Some errors where encountered
         if (!$check || !$pkvals) {
             // Redirect to the display action
+            jLog::log(
+                'Error in project '.$this->repository->getKey().'/'.$this->project->getKey().', '.
+                'layer '.$this->layerId.' while saving the feature '.$this->featureIdParam,
+                'lizmapadmin'
+            );
             $rep->params['status'] = '1';
             $rep->action = 'lizmap~edition:editFeature';
 


### PR DESCRIPTION
Ticket #3084

It seems there is already some log in the function `saveToDb`, to have some better details.


Quite linked to #5105 and #5066, we should a have static method from PR #5066 to format a string according to the given PHP array with ordered list of expected keys first.