### PR TITLE
[Bugfix] Trully stream data from iterable

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/OGCResponse.php
+++ b/lizmap/modules/lizmap/lib/Request/OGCResponse.php
@@ -145,8 +145,30 @@ class OGCResponse
 
             return Psr7\Utils::streamFor($this->data);
         }
+
         if (is_iterable($this->data)) {
-            return Psr7\Utils::streamFor($this->data);
+            $iterData = $this->data;
+
+            return Psr7\Utils::streamFor(function ($length) use ($iterData) {
+                $result = '';
+                $resultLength = 0;
+
+                try {
+                    foreach ($iterData as $step) {
+                        $result .= $step;
+                        $resultLength += strlen($step);
+                        if ($resultLength >= $length) {
+                            break;
+                        }
+                    }
+                } finally {
+                    if ($resultLength) {
+                        return $result;
+                    }
+
+                    return false;
+                }
+            });
         }
 
         return $this->data;


### PR DESCRIPTION
`GuzzleHttp\Psr7\Utils::streamFor` is building a PumpStream for callable resource and requested the resource with and length to building the data as string step by step.

Because, lizmap builds a stream with a function without the length parameter, all the content is build as string before sending it to output.

Try to fix it, by providing a function with the length parameter around our iterator.