### PR TITLE
OGC Service WFS: Forbidden direct access without rights

### DIFF
--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -538,6 +538,12 @@ class lizMapCtrl extends jController
 
         $rep->body->assign($assign);
 
+        $request_headers = \jApp::coord()->request->headers();
+        $_SESSION['html_map_token'] = md5(json_encode(array(
+            'Host' => $request_headers['Host'],
+            'User-Agent' => $request_headers['User-Agent'],
+        )));
+
         // Log
         $eventParams = array(
             'key' => 'viewmap',

--- a/lizmap/modules/view/locales/en_US/default.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/default.UTF-8.properties
@@ -7,6 +7,9 @@ home.menu=Home
 server.information.error=This map cannot be displayed. Please contact the server administrator to check the server information panel.
 server.information.error.admin=Maps cannot be displayed. Please check the server information panel.
 
+service.access.denied=Access denied to the service.
+service.access.forbidden=Access forbidden to the service.
+
 project.access.denied=Access denied for this project.
 project.title.label=Title
 project.abstract.label=Abstract


### PR DESCRIPTION
The WFS service is needed by the lizmap web user interface, but the direct access is managed by 'Allow export of vector layers' right.

Funded by Andromède Océanologie