### PR TITLE
Features Table : add an event when an item is highlighted

### DIFF
--- a/assets/src/components/FeaturesTable.js
+++ b/assets/src/components/FeaturesTable.js
@@ -15,6 +15,7 @@ import { mainLizmap, mainEventDispatcher } from '../modules/Globals.js';
  * @summary Allows to display a compact list of vector layer features labels
  * @augments HTMLElement
  * @element lizmap-features-table
+ * @fires features.table.item.highlighted
  * @fires features.table.item.dragged
  * @fires features.table.rendered
  * @example <caption>Example of use</caption>
@@ -491,45 +492,17 @@ export default class FeaturesTable extends HTMLElement {
                         title="${lizDict['featuresTable.toolbar.previous']}"
                         @click=${event => {
                         // Click on the previous item
-                        const oldFeatureDiv = this.querySelector(`tr.lizmap-features-table-item[data-line-id="${this.activeItemLineNumber}"]`);
                         const lineNumber = this.activeItemLineNumber - 1;
-                        const newFeatureDiv = this.querySelector(`tr.lizmap-features-table-item[data-line-id="${lineNumber}"]`);
-
-                        /**
-                         * When the user press the "previous" button
-                         * @event features.table.item.previous.button
-                         * @property {string} itemOldFeatureId The feature ID of the old element
-                         * @property {string} itemNewFeatureId The feature ID of the new element
-                         */
-                        mainEventDispatcher.dispatch({
-                            type: 'features.table.item.previous.button',
-                            itemOldFeatureId: oldFeatureDiv.dataset.featureId, 
-                            itemNewFeatureId: newFeatureDiv.dataset.featureId,
-                        });
-                        
-                        if (newFeatureDiv) newFeatureDiv.click();
+                        const featureDiv = this.querySelector(`tr.lizmap-features-table-item[data-line-id="${lineNumber}"]`);
+                        if (featureDiv) featureDiv.click();
                     }}></button>
                     <button class="btn btn-mini next-popup"
                         title="${lizDict['featuresTable.toolbar.next']}"
                         @click=${event => {
                         // Click on the next item
-                        const oldFeatureDiv = this.querySelector(`tr.lizmap-features-table-item[data-line-id="${this.activeItemLineNumber}"]`);
                         const lineNumber = this.activeItemLineNumber + 1;
-                        const newFeatureDiv = this.querySelector(`tr.lizmap-features-table-item[data-line-id="${lineNumber}"]`);
-
-                        /**
-                         * When the user press the "next" button
-                         * @event features.table.item.previous.button
-                         * @property {string} itemOldFeatureId The feature ID of the old element
-                         * @property {string} itemNewFeatureId The feature ID of the new element
-                         */
-                        mainEventDispatcher.dispatch({
-                            type: 'features.table.item.next.button',
-                            itemOldFeatureId: oldFeatureDiv.dataset.featureId,
-                            itemNewFeatureId: newFeatureDiv.dataset.featureId,
-                        });
-                        
-                        if (newFeatureDiv) newFeatureDiv.click();
+                        const featureDiv = this.querySelector(`tr.lizmap-features-table-item[data-line-id="${lineNumber}"]`);
+                        if (featureDiv) featureDiv.click();
                     }}></button>
                     <button class="btn btn-mini close-popup"
                         title="${lizDict['featuresTable.toolbar.close']}"

--- a/assets/src/components/FeaturesTable.js
+++ b/assets/src/components/FeaturesTable.js
@@ -491,17 +491,45 @@ export default class FeaturesTable extends HTMLElement {
                         title="${lizDict['featuresTable.toolbar.previous']}"
                         @click=${event => {
                         // Click on the previous item
+                        const oldFeatureDiv = this.querySelector(`tr.lizmap-features-table-item[data-line-id="${this.activeItemLineNumber}"]`);
                         const lineNumber = this.activeItemLineNumber - 1;
-                        const featureDiv = this.querySelector(`tr.lizmap-features-table-item[data-line-id="${lineNumber}"]`);
-                        if (featureDiv) featureDiv.click();
+                        const newFeatureDiv = this.querySelector(`tr.lizmap-features-table-item[data-line-id="${lineNumber}"]`);
+
+                        /**
+                         * When the user press the "previous" button
+                         * @event features.table.item.previous.button
+                         * @property {string} itemOldFeatureId The feature ID of the old element
+                         * @property {string} itemNewFeatureId The feature ID of the new element
+                         */
+                        mainEventDispatcher.dispatch({
+                            type: 'features.table.item.previous.button',
+                            itemOldFeatureId: oldFeatureDiv.dataset.featureId, 
+                            itemNewFeatureId: newFeatureDiv.dataset.featureId,
+                        });
+                        
+                        if (newFeatureDiv) newFeatureDiv.click();
                     }}></button>
                     <button class="btn btn-mini next-popup"
                         title="${lizDict['featuresTable.toolbar.next']}"
                         @click=${event => {
                         // Click on the next item
+                        const oldFeatureDiv = this.querySelector(`tr.lizmap-features-table-item[data-line-id="${this.activeItemLineNumber}"]`);
                         const lineNumber = this.activeItemLineNumber + 1;
-                        const featureDiv = this.querySelector(`tr.lizmap-features-table-item[data-line-id="${lineNumber}"]`);
-                        if (featureDiv) featureDiv.click();
+                        const newFeatureDiv = this.querySelector(`tr.lizmap-features-table-item[data-line-id="${lineNumber}"]`);
+
+                        /**
+                         * When the user press the "next" button
+                         * @event features.table.item.previous.button
+                         * @property {string} itemOldFeatureId The feature ID of the old element
+                         * @property {string} itemNewFeatureId The feature ID of the new element
+                         */
+                        mainEventDispatcher.dispatch({
+                            type: 'features.table.item.next.button',
+                            itemOldFeatureId: oldFeatureDiv.dataset.featureId,
+                            itemNewFeatureId: newFeatureDiv.dataset.featureId,
+                        });
+                        
+                        if (newFeatureDiv) newFeatureDiv.click();
                     }}></button>
                     <button class="btn btn-mini close-popup"
                         title="${lizDict['featuresTable.toolbar.close']}"

--- a/assets/src/components/FeaturesTable.js
+++ b/assets/src/components/FeaturesTable.js
@@ -254,6 +254,16 @@ export default class FeaturesTable extends HTMLElement {
                     "geojson",
                     "EPSG:4326",
                 );
+
+                /**
+                 * When the user has selected an item and highlighted it
+                 * @event features.table.item.highlighted
+                 * @property {string} itemFeatureId The feature ID of the selected item
+                 */
+                mainEventDispatcher.dispatch({
+                    type: 'features.table.item.highlighted',
+                    itemFeatureId: feature.properties.feature_id,
+                });
             }
 
             // Center the map on the clicked element if the feature has a geometry


### PR DESCRIPTION
Improvements for the `<lizmap-features-table>` web component:

* Now, when an item is highlighted, an event `features.table.item.highlighted` is sent with the item's `feature_id`.

Funded by Andromède Océanologie https://www.andromede-ocean.com/

Ticket : #5146