### PR TITLE
Use correct online help and Git repository according to the correct QGIS Server wrapper used

### DIFF
--- a/lizmap/app/system/mainconfig.ini.php
+++ b/lizmap/app/system/mainconfig.ini.php
@@ -35,7 +35,7 @@ fallbackLocale=en_US
 ; QGIS server required minimum version
 qgisServer="3.28"
 ; Lizmap server QGIS plugin required minimum version
-lizmapServerPlugin="2.11.2"
+lizmapServerPlugin="2.12.0"
 ; Lizmap QGIS desktop plugin required/recommended minimum version for newly or updated project only
 ; This version MUST match at least on https://plugins.qgis.org/plugins/lizmap/#plugin-versions
 ; with the minimum QGIS server version supported above.

--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -272,7 +272,6 @@ server.information.qgis.label=QGIS Server
 server.information.qgis.metadata=Version
 server.information.qgis.version=Number
 server.information.qgis.name=Name
-server.information.qgis.commit_id=Commit ID
 server.information.qgis.action=Action
 
 server.information.qgis.plugins=Plugins
@@ -280,6 +279,8 @@ server.information.qgis.plugins.version=Version number
 server.information.qgis.plugin=Plugin
 server.information.qgis.plugin.version=Version
 server.information.qgis.plugin.help=Help
+server.information.qgis.wrapper=QJazz or Py-QGIS-Server
+server.information.qgis.wrapper.not.installed=Not installed
 
 server.information.qgis.test.ok=QGIS Server is correctly installed and returns the expected response for OGC requests.
 server.information.qgis.test.error=QGIS Server is not correctly installed in your server or the URL for OGC requests given in Lizmap configuration is not correct.

--- a/lizmap/modules/admin/templates/server_information.tpl
+++ b/lizmap/modules/admin/templates/server_information.tpl
@@ -115,6 +115,8 @@
             <td>
                 <a href="https://github.com/qgis/QGIS/releases/tag/{$data['qgis_server_info']['metadata']['tag']}" target="_blank">
                     {$data['qgis_server_info']['metadata']['version']}
+                </a> - <a href="https://github.com/qgis/QGIS/commit/{$data['qgis_server_info']['metadata']['commit_id']}" target="_blank">
+                    {$data['qgis_server_info']['metadata']['commit_id']}
                 </a>
             </td>
         </tr>
@@ -123,32 +125,38 @@
             <td>{$data['qgis_server_info']['metadata']['name']}</td>
         </tr>
         <tr>
-            <th>{@admin.server.information.qgis.commit_id@}</th>
-            <td><a href="https://github.com/qgis/QGIS/commit/{$data['qgis_server_info']['metadata']['commit_id']}" target="_blank">{$data['qgis_server_info']['metadata']['commit_id']}</a></td>
-        </tr>
-        <tr>
-            <th>Py-QGIS-Server <a href="https://docs.3liz.org/py-qgis-server" target="_blank"><span class='badge rounded-pill bg-secondary'>{@admin.server.information.qgis.plugin.help@}</span></a></th>
-            <td>
-                {if $data['qgis_server_info']['py_qgis_server']['found']}
+            {if $data['qgis_server_info']['py_qgis_server']['found']}
+                <th>
+                    {$data['qgis_server_info']['py_qgis_server']['name']}
+                    {if $data['qgis_server_info']['py_qgis_server']['documentation_url']}
+                        <a href="{$data['qgis_server_info']['py_qgis_server']['documentation_url']}" target="_blank">
+                            <span class='badge rounded-pill bg-secondary'>{@admin.server.information.qgis.plugin.help@}</span>
+                        </a>
+                    {/if}
+                </th>
+                <td>
                     {if $data['qgis_server_info']['py_qgis_server']['stable']}
                         {if $data['qgis_server_info']['py_qgis_server']['version'] == 'n/a'}
                             {* If the value is n/a, Py-QGIS-Server failed to fetch the version *}
                             {* https://github.com/3liz/py-qgis-server/blob/b11bba45495d32e348457c0802fe08f2bf952b8b/pyqgisserver/version.py#L17 *}
                             {$data['qgis_server_info']['py_qgis_server']['version']}
                         {else}
-                            <a href="https://github.com/3liz/py-qgis-server/releases/tag/{$data['qgis_server_info']['py_qgis_server']['version']}" target="_blank">
-                                {$data['qgis_server_info']['py_qgis_server']['version']}
-                            </a>
+                            {if $data['qgis_server_info']['py_qgis_server']['git_repository_url']}
+                                <a href="{$data['qgis_server_info']['py_qgis_server']['git_repository_url']}/releases/tag/{$data['qgis_server_info']['py_qgis_server']['version']}" target="_blank">
+                                    {$data['qgis_server_info']['py_qgis_server']['version']}
+                                </a>
+                            {/if}
                         {/if}
                     {else}
-                    <a href="https://github.com/3liz/py-qgis-server/commit/{$data['qgis_server_info']['py_qgis_server']['commit_id']}" target="_blank">
-                        {$data['qgis_server_info']['py_qgis_server']['version']} - {$data['qgis_server_info']['py_qgis_server']['commit_id']}
-                    </a>
+                        <a href="{$data['qgis_server_info']['py_qgis_server']['git_repository_url']}/commit/{$data['qgis_server_info']['py_qgis_server']['commit_id']}" target="_blank">
+                            {$data['qgis_server_info']['py_qgis_server']['version']} - {$data['qgis_server_info']['py_qgis_server']['commit_id']}
+                        </a>
                     {/if}
-                {else}
-                    {$data['qgis_server_info']['py_qgis_server']['version']}
-                {/if}
-            </td>
+                </td>
+            {else}
+                {* When Py-QGIS-Server and QJazz were not found *}
+                <th>{@admin.server.information.qgis.wrapper@}</th><td>{@admin.server.information.qgis.wrapper.not.installed@}</td>
+            {/if}
         </tr>
         {if $qgisServerNeedsUpdate }
         <tr>

--- a/tests/end2end/playwright/server-information.spec.js
+++ b/tests/end2end/playwright/server-information.spec.js
@@ -38,7 +38,7 @@ test.describe('Server information', () => {
         }
         // Check that QGIS Server table contains 4 lines
         const qgisServerRows = page.locator('#lizmap_server_information table.table-qgis-server tr')
-        await expect(qgisServerRows).toHaveCount(4);
+        await expect(qgisServerRows).toHaveCount(3);
         for (const row of await qgisServerRows.all()) {
             await expect(row.locator('th')).toHaveCount(1);
             await expect(await row.locator('th').innerText()).not.toEqual('');


### PR DESCRIPTION
As now, it's not only Py-QGIS-Server which can be used, it can also be QJazz : 

![image](https://github.com/user-attachments/assets/27ca56c1-9b6f-43b8-9185-06727abeac2f)

CF work started in https://github.com/3liz/qgis-lizmap-server-plugin/pull/100

I also moved the commit ID next to the version number, same as for LWC main version and plugins.

PS : I have changed the name, **temporary**, in source code itself for the screenshot, for trying for now, waiting on https://github.com/3liz/qgis-lizmap-server-plugin/pull/102 and https://github.com/3liz/lizmap-web-client/pull/4991