### PR TITLE
Add error log panel in admin

### DIFF
--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -239,14 +239,18 @@ logs.email.popup.body=A user has opened a feature information popup.
 logs.email.editionSaveFeature.body=A user has created or modified a feature.
 logs.email.editionDeleteFeature.body=A user has deleted a feature.
 
-logs.error.title=Error log
-logs.error.sentence=Last lines of the Lizmap Web Client application error log file
-logs.error.file.too.big=The error log file is too big. Consider using log rotation for Lizmap Web Client logs.
-logs.error.file.erase=Erase the error log file
-logs.error.file.erase.confirm=Are you sure you want to erase the error log file?
-logs.error.file.erase.ok=The error log file has successfully been erased.
-logs.error.no.delete.right=You have no right to delete the logs.
+logs.title=Logs
+logs.file.too.big=The log file is too big. Consider using log rotation for this log.
 
+logs.error.title=Error log
+logs.error.sentence=Last lines of the error log file
+
+logs.admin.title=Admin log
+logs.admin.sentence=Last lines of the admin log file
+logs.admin.file.erase=Erase the admin log file
+logs.admin.file.erase.confirm=Are you sure you want to erase the admin log file?
+logs.admin.file.erase.ok=The admin log file has successfully been erased.
+logs.admin.no.delete.right=You have no right to delete the logs.
 
 upload.image.error.file.missing=File is missing
 upload.image.error.file.bigger=The uploaded file exceeds the maximum file size allowed

--- a/lizmap/modules/admin/templates/logs_view.tpl
+++ b/lizmap/modules/admin/templates/logs_view.tpl
@@ -1,3 +1,5 @@
+{meta_html js $j_basepath.'assets/js/admin/scroll_to_bottom_textarea.js', ['defer' => '']}
+
 {jmessage_bootstrap}
 
   <h1>{@admin~admin.menu.lizmap.logs.label@}</h1>
@@ -39,14 +41,36 @@
 
 
   <div>
-    <h2>{@admin~admin.logs.error.title@}</h2>
+    <h2>{@admin~admin.logs.title@}</h2>
 
-    <p>{@admin~admin.logs.error.sentence@}</p>
+    <h3>{@admin~admin.logs.admin.title@}</h3>
 
-<textarea rows="10" style="width:90%;">{if $errorLog != 'toobig'}{$errorLog}{else}{@admin~admin.logs.error.file.too.big@}{/if}</textarea>
+    <p>{@admin~admin.logs.admin.sentence@} : <code>{$lizmapLogBaseName}</code></p>
+
+    <textarea id="lizmap-admin-log" rows="{$lizmapLogTextArea}" style="width:90%;">
+        {if $lizmapLog != 'toobig'}
+            {$lizmapLog}
+        {else}
+            {@admin~admin.logs.file.too.big@}
+        {/if}
+    </textarea>
     {ifacl2 'lizmap.admin.lizmap.log.delete'}
     <div class="form-actions">
-      <a class="btn" href="{jurl 'admin~logs:eraseError'}" onclick="return confirm(`{@admin~admin.logs.error.file.erase.confirm@}`);">{@admin~admin.logs.error.file.erase@}</a>
+      <a class="btn" href="{jurl 'admin~logs:eraseError'}" onclick="return confirm(`{@admin~admin.logs.admin.file.erase.confirm@}`);">{@admin~admin.logs.admin.file.erase@}</a>
     </div>
     {/ifacl2}
+
+    {if $errorLogDisplay}
+        <h3>{@admin~admin.logs.error.title@}</h3>
+
+        <p>{@admin~admin.logs.error.sentence@} : <code>{$errorLogBaseName}</code></p>
+
+        <textarea id="lizmap-error-log" rows="{$errorLogTextArea}"" style="width:90%;">
+            {if $errorLog != 'toobig'}
+                {$errorLog}
+            {else}
+                {@admin~admin.logs.file.too.big@}
+            {/if}
+        </textarea>
+    {/if}
   </div>

--- a/lizmap/www/assets/js/admin/scroll_to_bottom_textarea.js
+++ b/lizmap/www/assets/js/admin/scroll_to_bottom_textarea.js
@@ -1,0 +1,9 @@
+window.onload = () => {
+    let textarea = document.getElementById('lizmap-admin-log');
+    textarea.scrollTop = textarea.scrollHeight;
+
+    textarea = document.getElementById('lizmap-error-log');
+    if (textarea) {
+        textarea.scrollTop = textarea.scrollHeight;
+    }
+};


### PR DESCRIPTION
Logs are important, this panel should be more advertised and used. Some upgrades should be done, in this PR and later.

Some review on the log panel :
* Increase from 50 to 200 lines, can we increase more ? Or we should a way to scroll more up if necessary, later.
* Rename "Log" to "Admin log", following #3831
* Adding a text area for the "error log", https://github.com/3liz/lizmap-web-client/issues/5106#issuecomment-2536554681. I didn't add the "Erase button" for this log.
* The new text area is hidden or not according to the flag "sensitive data flag".
![image](https://github.com/user-attachments/assets/afbcd2b0-58ef-4844-884b-30d7f2d2384a)
