### PR TITLE
Add X-Request-Id in request to QGIS Server headers

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/Proxy.php
+++ b/lizmap/modules/lizmap/lib/Request/Proxy.php
@@ -307,6 +307,7 @@ class Proxy
             $options['headers'] = array_merge(
                 self::userHttpHeader(),
                 self::$services->wmsServerHeaders,
+                array('X-Request-Id' => uniqid().'-'.bin2hex(random_bytes(10))),
                 $options['headers']
             );
         }

--- a/lizmap/modules/lizmap/lib/Request/Proxy.php
+++ b/lizmap/modules/lizmap/lib/Request/Proxy.php
@@ -626,6 +626,7 @@ class Proxy
                 return new ProxyResponse(
                     200,
                     'text/json',
+                    array('Content-Type' => 'text/json'),
                     $stream
                 );
             }
@@ -680,11 +681,13 @@ class Proxy
         }
 
         $response = $client->send($request, $reqOptions);
-        self::logRequestIfError($response->getStatusCode(), $url, $response->getHeaders());
+        $headers = $response->getHeaders();
+        self::logRequestIfError($response->getStatusCode(), $url, $headers);
 
         return new ProxyResponse(
             $response->getStatusCode(),
             $response->getHeader('Content-Type')[0],
+            $headers,
             $response->getBody()
         );
     }

--- a/lizmap/modules/lizmap/lib/Request/Proxy.php
+++ b/lizmap/modules/lizmap/lib/Request/Proxy.php
@@ -680,7 +680,7 @@ class Proxy
         }
 
         $response = $client->send($request, $reqOptions);
-        self::logRequestIfError($response->getStatusCode(), $url);
+        self::logRequestIfError($response->getStatusCode(), $url, $response->getHeaders());
 
         return new ProxyResponse(
             $response->getStatusCode(),

--- a/lizmap/modules/lizmap/lib/Request/Proxy.php
+++ b/lizmap/modules/lizmap/lib/Request/Proxy.php
@@ -487,17 +487,30 @@ class Proxy
     /**
      * Log if the HTTP code is a 4XX or 5XX error code.
      *
-     * @param int    $httpCode The HTTP code of the request
-     * @param string $url      The URL of the request, for logging
+     * @param int                   $httpCode The HTTP code of the request
+     * @param string                $url      The URL of the request, for logging
+     * @param array<string, string> $headers  The headers of the response
      */
-    protected static function logRequestIfError($httpCode, $url)
+    protected static function logRequestIfError($httpCode, $url, $headers = array())
     {
         if ($httpCode < 400) {
             return;
         }
 
-        \jLog::log('An HTTP request ended with an error, please check the main error log. HTTP code '.$httpCode, 'lizmapadmin');
-        \jLog::log('The HTTP request ended with an error. HTTP code '.$httpCode.' → '.$url, 'error');
+        $xRequestId = $headers['X-Request-Id'] ?? '';
+
+        $lizmapAdmin = 'An HTTP request ended with an error, please check the main error log.';
+        $lizmapAdmin .= ' HTTP code '.$httpCode.'.';
+        $error = 'The HTTP request ended with an error.';
+        $error .= ' HTTP code '.$httpCode.'.';
+        if ($xRequestId !== '') {
+            $lizmapAdmin .= ' The X-Request-Id `'.$xRequestId.'`.';
+            $error .= ' X-Request-Id `'.$xRequestId.'` → '.$url;
+        } else {
+            $error .= ' → '.$url;
+        }
+        \jLog::log($lizmapAdmin, 'lizmapadmin');
+        \jLog::log($error, 'error');
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/Request/Proxy.php
+++ b/lizmap/modules/lizmap/lib/Request/Proxy.php
@@ -323,7 +323,7 @@ class Proxy
      * @param string $url
      * @param array  $options
      *
-     * @return array{0: string, 1: string, 2: int} Array containing data (0: string), mime type (1: string) and HTTP code (2: int)
+     * @return array{0: string, 1: string, 2: int, 3: array} Array containing data (0: string), mime type (1: string), HTTP code (2: int) and headers
      */
     protected static function curlProxy($url, $options)
     {
@@ -331,7 +331,7 @@ class Proxy
         $http_code = null;
 
         $ch = curl_init();
-        curl_setopt($ch, CURLOPT_HEADER, 0);
+        curl_setopt($ch, CURLOPT_HEADER, 1);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
@@ -382,10 +382,29 @@ class Proxy
                 curl_setopt($ch, CURLOPT_POSTFIELDS, $options['body']);
             }
         }
+
         $data = curl_exec($ch);
         if (!$data) {
             $data = '';
         }
+        $header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+        $headers_str = substr($data, 0, $header_size);
+        $data = substr($data, $header_size);
+
+        $headers_arr = array_filter(explode("\r\n", $headers_str));
+        $status_message = array_shift($headers_arr);
+        $headers = array();
+        foreach ($headers_arr as $value) {
+            if (false !== ($matches = explode(':', $value, 2))) {
+                $key = str_replace(
+                    ' ',
+                    '-',
+                    ucwords(strtolower(str_replace('-', ' ', $matches[0])))
+                );
+                $headers["{$key}"] = trim($matches[1]);
+            }
+        }
+
         $info = curl_getinfo($ch);
         $mime = $info['content_type'];
         $http_code = (int) $info['http_code'];
@@ -396,14 +415,14 @@ class Proxy
 
         curl_close($ch);
 
-        return array($data, $mime, $http_code);
+        return array($data, $mime, $http_code, $headers);
     }
 
     /**
      * @param string $url
      * @param array  $options
      *
-     * @return array{0: string, 1: string, 2: int} Array containing data (0: string), mime type (1: string) and HTTP code (2: int)
+     * @return array{0: string, 1: string, 2: int, 3: array} Array containing data (0: string), mime type (1: string), HTTP code (2: int) and headers
      */
     protected static function fileProxy($url, $options)
     {
@@ -460,18 +479,30 @@ class Proxy
             $data = '';
         }
         $mime = 'image/png';
-        $matches = array();
         $http_code = 0;
+        $headers = array();
         // $http_response_header is created by file_get_contents
         foreach ($http_response_header as $header) {
-            if (preg_match('#^Content-Type:\s+([\w/\.+]+)(;\s+charset=(\S+))?#i', $header, $matches)) {
-                $mime = $matches[1];
-                if (count($matches) > 3) {
-                    $mime .= '; charset='.$matches[3];
-                }
-            } elseif (substr($header, 0, 5) === 'HTTP/') {
+            if (substr($header, 0, 5) === 'HTTP/') {
                 list($version, $code, $phrase) = explode(' ', $header, 3) + array('', false, '');
                 $http_code = (int) $code;
+
+                continue;
+            }
+            if (false !== ($matches = explode(':', $header, 2))) {
+                $key = str_replace(
+                    ' ',
+                    '-',
+                    ucwords(strtolower(str_replace('-', ' ', $matches[0])))
+                );
+                $headers["{$key}"] = trim($matches[1]);
+                if ($key === 'Content-Type'
+                    && preg_match('#^Content-Type:\s+([\w/\.+]+)(;\s+charset=(\S+))?#i', $header, $matches)) {
+                    $mime = $matches[1];
+                    if (count($matches) > 3) {
+                        $mime .= '; charset='.$matches[3];
+                    }
+                }
             }
         }
         // optional debug
@@ -481,7 +512,7 @@ class Proxy
             \jLog::dump($http_response_header, 'getRemoteData, bad response, response headers', 'error');
         }
 
-        return array($data, $mime, $http_code);
+        return array($data, $mime, $http_code, $headers);
     }
 
     /**
@@ -530,7 +561,7 @@ class Proxy
      * @param string|string[]   $method  deprecated. the http method.
      *                                   it is ignored if $options is an array.
      *
-     * @return array{0: string, 1: string, 2: int} Array containing data (0: string), mime type (1: string) and HTTP code (2: int)
+     * @return array{0: string, 1: string, 2: int, 3: array} Array containing data (0: string), mime type (1: string), HTTP code (2: int) and headers
      */
     public static function getRemoteData($url, $options = null, $debug = null, $method = 'get')
     {
@@ -548,6 +579,7 @@ class Proxy
                     $content,
                     'text/json',
                     200,
+                    array(),
                 );
             }
             // All requests are logged
@@ -558,13 +590,13 @@ class Proxy
         if (extension_loaded('curl') && $options['proxyHttpBackend'] != 'php') {
             // With curl
             $curlRequest = self::curlProxy($url, $options);
-            self::logRequestIfError($curlRequest[2], $url);
+            self::logRequestIfError($curlRequest[2], $url, $curlRequest[3]);
 
             return $curlRequest;
         }
         // With file_get_contents
         $request = self::fileProxy($url, $options);
-        self::logRequestIfError($request[2], $url);
+        self::logRequestIfError($request[2], $url, $request[3]);
 
         return $request;
     }

--- a/lizmap/modules/lizmap/lib/Request/ProxyResponse.php
+++ b/lizmap/modules/lizmap/lib/Request/ProxyResponse.php
@@ -27,6 +27,11 @@ class ProxyResponse
     protected $mime;
 
     /**
+     * @var array<string, string> the headers of the response
+     */
+    protected $headers;
+
+    /**
      * @var StreamInterface the response body as a stream
      */
     protected $body;
@@ -34,14 +39,16 @@ class ProxyResponse
     /**
      * constructor.
      *
-     * @param int             $code the HTTP status code of the response
-     * @param string          $mime the MIME type of the response
-     * @param StreamInterface $body the response body as a string
+     * @param int                   $code    the HTTP status code of the response
+     * @param string                $mime    the MIME type of the response
+     * @param array<string, string> $headers the headers of the response
+     * @param StreamInterface       $body    the response body as a string
      */
-    public function __construct($code, $mime, $body)
+    public function __construct($code, $mime, $headers, $body)
     {
         $this->code = $code;
         $this->mime = $mime;
+        $this->headers = $headers;
         $this->body = $body;
     }
 
@@ -63,6 +70,16 @@ class ProxyResponse
     public function getMime()
     {
         return $this->mime;
+    }
+
+    /**
+     * Get the headers of the response.
+     *
+     * @return array<string, string>
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
     }
 
     /**

--- a/tests/end2end/cypress/integration/requests-wfs-ghaction.js
+++ b/tests/end2end/cypress/integration/requests-wfs-ghaction.js
@@ -1247,7 +1247,11 @@ describe('Request service', function () {
                 .then((result) => {
                     expect(result.code).to.eq(0)
                     expect(result.stdout).to.contain('An HTTP request ended with an error, please check the main error log.')
-                    expect(result.stdout).to.contain('HTTP code 400')
+                    expect(result.stdout).to.contain('HTTP code 400.')
+                    expect(result.stdout).to.contain('The HTTP OGC request to QGIS Server ended with an error.')
+                    expect(result.stdout).to.contain(
+                        'HTTP code 400 on "REPOSITORY" = \'testsrepository\' & "PROJECT" = \'selection\' & "SERVICE" = \'WFS\' & "REQUEST" = \'getfeature\''
+                    )
                     clearLizmapAdminLog()
                 })
             clearErrorsLog()

--- a/tests/units/classes/Request/ProxyResponseTest.php
+++ b/tests/units/classes/Request/ProxyResponseTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Lizmap\Request;
+
+class ProxyResponseTest extends TestCase
+{
+    public function testGetter() : void
+    {
+        $response = new Request\ProxyResponse(
+            200,
+            'text/json',
+            array('Content-Type' => 'text/json'),
+            \GuzzleHttp\Psr7\Utils::streamFor('{}')
+        );
+        $this->assertEquals(200, $response->getCode());
+        $this->assertEquals('text/json', $response->getMime());
+        $this->assertEquals(array('Content-Type' => 'text/json'), $response->getHeaders());
+    }
+}

--- a/tests/units/classes/Request/ProxyTest.php
+++ b/tests/units/classes/Request/ProxyTest.php
@@ -235,7 +235,11 @@ class ProxyTest extends TestCase
         $url = 'http://localhost?test=test';
         ProxyForTests::setServices((object)array('wmsServerURL' => 'http://localhost', 'wmsServerHeaders' => array()));
         list($url, $result) = ProxyForTests::buildHeadersForTests($url, $options);
-        $this->assertEquals($expectedHeaders, $result['headers']);
+        foreach ($expectedHeaders as $header => $value) {
+            $this->assertArrayHasKey($header, $result['headers']);
+            $this->assertEquals($value, $result['headers'][$header]);
+        }
+        $this->assertArrayHasKey('X-Request-Id', $result['headers']);
         $this->assertEquals($expectedBody, $result['body']);
         if ($expectedUrl) {
             $this->assertEquals($expectedUrl, $url);


### PR DESCRIPTION
`X-Request-Id` correlates HTTP requests between a client and server. It will help to correlate logs between Lizmap Web client and QGIS Server. `X-Request-Id` is supported by Py-QGIS-Server.