### PR TITLE
Merge fallback locales in lizDict

### DIFF
--- a/lizmap/modules/view/controllers/translate.classic.php
+++ b/lizmap/modules/view/controllers/translate.classic.php
@@ -3,7 +3,7 @@
 use Lizmap\App\LocalesLoader;
 
 /**
- * Service to provide translation dictionnary.
+ * Service to provide translation dictionary.
  *
  * @author    3liz
  * @copyright 2011-2022 3liz
@@ -15,7 +15,7 @@ use Lizmap\App\LocalesLoader;
 class translateCtrl extends jController
 {
     /**
-     * Get text/javascript containing all translation for the dictionnary.
+     * Get text/javascript containing all translation for the dictionary.
      *
      * @urlparam string $lang Language. Ex: fr_FR (optional)
      *
@@ -36,6 +36,11 @@ class translateCtrl extends jController
         }
 
         $data = LocalesLoader::getLocalesFrom('view~dictionnary', $lang);
+
+        if (strpos(\jApp::config()->jResponseHtml['plugins'], 'debugbar') !== false) {
+            $fallback = LocalesLoader::getLocalesFrom('view~dictionnary', \jApp::config()->fallbackLocale);
+            $data = array_merge($fallback, $data);
+        }
         $rep->content = 'var lizDict = '.json_encode($data).';';
 
         return $rep;


### PR DESCRIPTION
New PR like #5139 or #5131 adding new strings in `lizDict` are missing translations when using LWC in another language than English, until we do the update with [Lizmap locales process](https://github.com/3liz/lizmap-locales).

I'm clearly not sure if it's the purpose in this file to add the fallback, or if it must be done elsewhere, upstream etc.