### PR TITLE
don't use xpath to search embedded layers, but layer objet info

### DIFF
--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -403,11 +403,9 @@ class QgisProject
             }
         }
 
-        // search for embedded layers with xpath ("maplayer id='XXX'" means the layer is embedded)
+        // search for embedded layers only
         foreach ($layers as $layer) {
-            $xpathEmbedded = "//maplayer[@id='{$layer['id']}']";
-            $embeddedLayer = $this->xpathQuery($xpathEmbedded);
-            if (!$embeddedLayer) {
+            if (!array_key_exists('embedded', $layer) || $layer['embedded'] != 1) {
                 continue;
             }
             $qgisProject = $this->getEmbeddedQgisProject($layer['id']);

--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -378,14 +378,14 @@ class QgisProject
     protected function setLayerOpacity(ProjectConfig $cfg)
     {
         /**
-         * NOTE : searching for embedded layers with opacity is time consuming :
-         * need to loop over all layers to find embedded, then peform xpath on new Project files
-         * so : 1st loop to find all layers with opacity (non embedded)
-         * 2nd loop will find embedded layers and parse project file searching for opacity
+         * NOTE : xpath queries are time consumming, need to performs the least we can do.
+         *
+         * so : 1st loop to find all layers with opacity (non embedded) (1 xpath query)
+         * 2nd loop will find embedded layers and parse project file searching for opacity (xpath query as much as embedded layers)
          */
         $layers = $this->layers;
         $xpathOpacity = '//maplayer/layerOpacity[.!=1]/parent::* | //maplayer/pipe/rasterrenderer/@opacity[.!=1]/ancestor::maplayer';
-        // non-embedded layers
+        // non-embedded layers contains "layerOpacity" or "pipe"
         $layerWithOpacities = $this->xpathQuery($xpathOpacity);
         if ($layerWithOpacities) {
             foreach ($layerWithOpacities as $layerWithOpacity) {
@@ -406,33 +406,35 @@ class QgisProject
         // search for embedded layers only
         foreach ($layers as $layer) {
             if (!array_key_exists('embedded', $layer) || $layer['embedded'] != 1) {
+                // ignore non embedded layers
+
                 continue;
             }
             $qgisProject = $this->getEmbeddedQgisProject($layer['id']);
             if (is_null($qgisProject)) {
+                // no such project, ignore
+
                 continue;
             }
-            // same xpath query as 1st loop, to search opacity
-            $layerWithOpacities = $qgisProject->xpathQuery($xpathOpacity);
-            if ($layerWithOpacities) {
-                // search layers from source project with same id
-                foreach ($layerWithOpacities as $layerWithOpacity) {
-                    // FIXME : Use xpath query to find matching id directly ?
-                    if ($layerWithOpacity->id == $layer['id']) {
-                        $name = (string) $layerWithOpacity[0]->layername;
-                        $layerCfg = $cfg->getLayer($name);
-                        $opacity = 1;
-                        if ($layerCfg) {
-                            if (isset($layerWithOpacity[0]->layerOpacity)) {
-                                $opacity = (float) $layerWithOpacity[0]->layerOpacity;
-                            } elseif (isset($layerWithOpacity[0]->pipe->rasterrenderer['opacity'])) {
-                                $opacity = (float) $layerWithOpacity[0]->pipe->rasterrenderer['opacity'];
-                            }
-                            $layerCfg->opacity = $opacity;
+
+            $xpathOpacityWithID = '//maplayer[id=\''.$layer['id'].'\']/layerOpacity[.!=1]/parent::* | //maplayer[id=\''.$layer['id'].'\']/pipe/rasterrenderer/@opacity[.!=1]/ancestor::maplayer';
+            // same xpath query as 1st loop, but with layer ID to match layer
+            $layerWithOpacities = $qgisProject->xpathQuery($xpathOpacityWithID);
+            if ($layerWithOpacities && count($layerWithOpacities) == 1) {
+                $layerWithOpacity = $layerWithOpacities[0];
+                if ($layerWithOpacity->id == $layer['id']) {
+                    $name = (string) $layerWithOpacity->layername;
+                    $layerCfg = $cfg->getLayer($name);
+                    $opacity = 1;
+                    if ($layerCfg) {
+                        if (isset($layerWithOpacity->layerOpacity)) {
+                            $opacity = (float) $layerWithOpacity->layerOpacity;
+                        } elseif (isset($layerWithOpacity->pipe->rasterrenderer['opacity'])) {
+                            $opacity = (float) $layerWithOpacity->pipe->rasterrenderer['opacity'];
                         }
+                        $layerCfg->opacity = $opacity;
                     }
                 }
-
             }
         }
     }


### PR DESCRIPTION
Follow #5193 

It seems xpath queries are time consumming, so : 
- improvement to use objet info instead of xpath to search for embedded layers (prevent as many xpath queries as layers).
- xpath query in source project for embedded layer search the right layer directly

Ticket : #

Funded by 3Liz
