### PR TITLE
Fix: incorrect replacement in `<a href="media/"><img src="media/"></a>`

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -23,6 +23,8 @@ class WMSRequest extends OGCRequest
 {
     protected $tplExceptions = 'lizmap~wms_exception';
 
+    protected static $regexp_media_urls = '#["\']((\.\./)?media/.+?\.\w{3,10})["\']{1}#';
+
     private $forceRequest = false;
 
     public function getForceRequest()
@@ -670,7 +672,7 @@ class WMSRequest extends OGCRequest
                 $templateConfigured = true;
                 // first replace all "media/bla/bla/media.ext" by full url
                 $popupTemplate = preg_replace_callback(
-                    '#(["\']){1}((\.\./)?media/.+\.\w{3,10})(["\']){1}#U',
+                    self::$regexp_media_urls,
                     array($this, 'replaceMediaPathByMediaUrl'),
                     $popupTemplate
                 );
@@ -749,7 +751,7 @@ class WMSRequest extends OGCRequest
                 if ($attribute['name'] == 'maptip') {
                     // first replace all "media/bla/bla/media.ext" by full url
                     $maptipValue = preg_replace_callback(
-                        '#(["\']){1}((\.\./)?media/.+\.\w{3,10})(["\']){1}#U',
+                        self::$regexp_media_urls,
                         array($this, 'replaceMediaPathByMediaUrl'),
                         $attribute['value']
                     );
@@ -876,14 +878,13 @@ class WMSRequest extends OGCRequest
     protected function replaceMediaPathByMediaUrl($matches)
     {
         $appContext = $this->appContext;
-        $req = $appContext->getCoord()->request;
         $return = '"';
         $return .= $appContext->getFullUrl(
             'view~media:getMedia',
             array(
                 'repository' => $this->repository->getKey(),
                 'project' => $this->project->getKey(),
-                'path' => $matches[2],
+                'path' => $matches[1],
             )
         );
         $return .= '"';

--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -670,7 +670,7 @@ class WMSRequest extends OGCRequest
                 $templateConfigured = true;
                 // first replace all "media/bla/bla/media.ext" by full url
                 $popupTemplate = preg_replace_callback(
-                    '#(["\']){1}((\.\./)?media/.+\.\w{3,10})(["\']){1}#',
+                    '#(["\']){1}((\.\./)?media/.+\.\w{3,10})(["\']){1}#U',
                     array($this, 'replaceMediaPathByMediaUrl'),
                     $popupTemplate
                 );
@@ -749,7 +749,7 @@ class WMSRequest extends OGCRequest
                 if ($attribute['name'] == 'maptip') {
                     // first replace all "media/bla/bla/media.ext" by full url
                     $maptipValue = preg_replace_callback(
-                        '#(["\']){1}((\.\./)?media/.+\.\w{3,10})(["\']){1}#',
+                        '#(["\']){1}((\.\./)?media/.+\.\w{3,10})(["\']){1}#U',
                         array($this, 'replaceMediaPathByMediaUrl'),
                         $attribute['value']
                     );

--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -23,7 +23,7 @@ class WMSRequest extends OGCRequest
 {
     protected $tplExceptions = 'lizmap~wms_exception';
 
-    protected static $regexp_media_urls = '#["\']((\.\./)?media/.+?\.\w{3,10})["\']{1}#';
+    protected static $regexp_media_urls = '#["\']((\.\./)?media/.+?\.\w{2,10})["\']{1}#';
 
     private $forceRequest = false;
 

--- a/tests/end2end/playwright/popup.spec.js
+++ b/tests/end2end/playwright/popup.spec.js
@@ -263,6 +263,11 @@ test.describe('Popup',
             await expect(project.map.locator('#liz_layer_popup')).toBeVisible();
             await expect(project.map.locator('#liz_layer_popup_contentDiv > div > div > div > ul > li > button.active')).toBeVisible();
             await expect(project.map.locator('#liz_layer_popup_contentDiv > div > div > div > ul > li:nth-child(2) > button')).toBeVisible();
+
+            // Assert media links are replaced by the lizmap media service
+            const mediaLink = 'http://localhost:8130/index.php/view/media/getMedia?repository=testsrepository&project=popup&path=media%2Fimages%2Fmontpellier.qgs.webp';
+            await expect(page.locator('#popup_dd_1_tab1 a')).toHaveAttribute('href', mediaLink);
+            await expect(page.locator('#popup_dd_1_tab1 a img')).toHaveAttribute('src', mediaLink);
         });
 
         test('changes popup tab', async ({ page }) => {

--- a/tests/qgis-projects/tests/popup.qgs
+++ b/tests/qgis-projects/tests/popup.qgs
@@ -1,4 +1,4 @@
-<qgis projectname="" saveDateTime="2024-07-15T10:32:53" saveUser="nboisteault" saveUserFull="nboisteault" version="3.34.8-Prizren">
+<qgis projectname="" saveDateTime="2025-01-28T11:44:14" saveUser="nboisteault" saveUserFull="nboisteault" version="3.34.15-Prizren">
   <homePath path=""></homePath>
   <title></title>
   <transaction mode="Disabled"></transaction>
@@ -43,8 +43,8 @@
   </layer-tree-group>
   <snapping-settings enabled="0" intersection-snapping="0" maxScale="0" minScale="0" mode="2" scaleDependencyMode="0" self-snapping="0" tolerance="12" type="1" unit="1">
     <individual-layer-settings>
-      <layer-setting enabled="0" id="dnd_popup_3b9d335a_5491_45fa_8a8b_8dca1ca7ff3b" maxScale="0" minScale="0" tolerance="12" type="1" units="1"></layer-setting>
       <layer-setting enabled="0" id="townhalls_pg_6c85c4bf_fe76_46b1_8445_0041d55d6e76" maxScale="0" minScale="0" tolerance="12" type="1" units="1"></layer-setting>
+      <layer-setting enabled="0" id="dnd_popup_3b9d335a_5491_45fa_8a8b_8dca1ca7ff3b" maxScale="0" minScale="0" tolerance="12" type="1" units="1"></layer-setting>
     </individual-layer-settings>
   </snapping-settings>
   <relations>
@@ -1057,6 +1057,7 @@ def my_form_open(dialog, layer, feature):
                         )
                         ELSE ''
                     END %]
+	&lt;a href="media/images/montpellier.qgs.webp" target="_blank"&gt;&lt;img src="media/images/montpellier.qgs.webp"&gt;&lt;/a&gt;
   &lt;/div&gt;
 
   &lt;div id="popup_dd_[% $id %]_tab2" class="tab-pane "&gt;
@@ -1114,18 +1115,6 @@ def my_form_open(dialog, layer, feature):
 </mapTip>
     </maplayer>
     <maplayer autoRefreshMode="Disabled" autoRefreshTime="0" geometry="Point" hasScaleBasedVisibilityFlag="0" labelsEnabled="0" legendPlaceholderImage="" maxScale="0" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyLocal="0" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="Point">
-      <extent>
-        <xmin>763818.78410616668406874</xmin>
-        <ymin>6274272.6375590842217207</ymin>
-        <xmax>776574.44688994809985161</xmax>
-        <ymax>6286437.04803071543574333</ymax>
-      </extent>
-      <wgs84extent>
-        <xmin>3.78966504381948344</xmin>
-        <ymin>43.56338375897173165</ymin>
-        <xmax>3.94929342688383667</xmax>
-        <ymax>43.67409308240065258</ymax>
-      </wgs84extent>
       <id>townhalls_pg_6c85c4bf_fe76_46b1_8445_0041d55d6e76</id>
       <datasource>service='lizmapdb' key='id' estimatedmetadata=true srid=2154 type=Point checkPrimaryKeyUnicity='1' table="tests_projects"."townhalls_pg" (geom)</datasource>
       <shortname>townhalls_pg</shortname>
@@ -1749,7 +1738,7 @@ def my_form_open(dialog, layer, feature):
   <Sensors></Sensors>
   <ProjectViewSettings UseProjectScales="0" rotation="0">
     <Scales></Scales>
-    <DefaultViewExtent xmax="782045.32394637318793684" xmin="763479.4154808419989422" ymax="6285886.84987394418567419" ymin="6274133.31412096228450537">
+    <DefaultViewExtent xmax="783337.28149422956630588" xmin="762187.45793298562057316" ymax="6285756.67271297331899405" ymin="6274263.49128193315118551">
       <spatialrefsys nativeFormat="Wkt">
         <wkt>PROJCRS["RGF93 v1 / Lambert-93",BASEGEOGCRS["RGF93 v1",DATUM["Reseau Geodesique Francais 1993 v1",ELLIPSOID["GRS 1980",6378137,298.257222101,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4171]],CONVERSION["Lambert-93",METHOD["Lambert Conic Conformal (2SP)",ID["EPSG",9802]],PARAMETER["Latitude of false origin",46.5,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8821]],PARAMETER["Longitude of false origin",3,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8822]],PARAMETER["Latitude of 1st standard parallel",49,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8823]],PARAMETER["Latitude of 2nd standard parallel",44,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8824]],PARAMETER["Easting at false origin",700000,LENGTHUNIT["metre",1],ID["EPSG",8826]],PARAMETER["Northing at false origin",6600000,LENGTHUNIT["metre",1],ID["EPSG",8827]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Engineering survey, topographic mapping."],AREA["France - onshore and offshore, mainland and Corsica."],BBOX[41.15,-9.86,51.56,10.38]],ID["EPSG",2154]]</wkt>
         <proj4>+proj=lcc +lat_0=46.5 +lon_0=3 +lat_1=49 +lat_2=44 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>

--- a/tests/units/classes/Request/WMSRequestTest.php
+++ b/tests/units/classes/Request/WMSRequestTest.php
@@ -248,4 +248,96 @@ class WMSRequestTest extends TestCase
         $this->assertEquals($expectedUseCache, $useCache);
         $this->assertEquals($expectedWmsClient, $wmsClient);
     }
+
+    public function testRegexpMediaUrls(): void
+    {
+        $testContext = new ContextForTests();
+        $wms = new WMSRequestForTests(new ProjectForOGCForTests($testContext), array(), null);
+
+        // src attribute for media directory
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'src="media/foo.bar"',
+            $matches,
+        );
+        $this->assertCount(2, $matches);
+        $this->assertEquals(
+            'media/foo.bar',
+            $matches[1],
+        );
+        // href attribute for media directory
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'href="media/foo.bar"',
+            $matches,
+        );
+        $this->assertCount(2, $matches);
+        $this->assertEquals(
+            'media/foo.bar',
+            $matches[1],
+        );
+
+        // src attribute for parent media directory
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'src="../media/foo.bar"',
+            $matches,
+        );
+        $this->assertCount(3, $matches);
+        $this->assertEquals(
+            '../media/foo.bar',
+            $matches[1],
+        );
+
+        // href attribute for parent media directory
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'href="../media/foo.bar"',
+            $matches,
+        );
+        $this->assertCount(3, $matches);
+        $this->assertEquals(
+            '../media/foo.bar',
+            $matches[1],
+        );
+
+        // multiple attributes like in a maptip
+        $maptipValue = preg_replace_callback(
+            $wms->getRegexpMediaUrlsForTests(),
+            array($wms, 'replaceMediaPathByMediaUrlForTests'),
+            '<a href="media/foo.bar"><img src="media/foo.bar"></a>',
+        );
+        $this->assertEquals(
+            '<a href="getMedia?path=media/foo.bar"><img src="getMedia?path=media/foo.bar"></a>',
+            $maptipValue,
+        );
+
+        // does not match directory
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'src="media/"',
+            $matches,
+        );
+        $this->assertCount(0, $matches);
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'src="media/foo/bar/"',
+            $matches,
+        );
+        $this->assertCount(0, $matches);
+        // does not match no extension
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'src="media/foo/bar"',
+            $matches,
+        );
+        $this->assertCount(0, $matches);
+        // does not match only extension
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'src="media/.bar"',
+            $matches,
+        );
+        $this->assertCount(0, $matches);
+    }
 }

--- a/tests/units/classes/Request/WMSRequestTest.php
+++ b/tests/units/classes/Request/WMSRequestTest.php
@@ -312,6 +312,18 @@ class WMSRequestTest extends TestCase
             $maptipValue,
         );
 
+        // Accepted extensions with 2 characters
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'src="media/foobar.7z"',
+            $matches,
+        );
+        $this->assertCount(2, $matches);
+        $this->assertEquals(
+            'media/foobar.7z',
+            $matches[1],
+        );
+
         // does not match directory
         preg_match(
             $wms->getRegexpMediaUrlsForTests(),
@@ -336,6 +348,13 @@ class WMSRequestTest extends TestCase
         preg_match(
             $wms->getRegexpMediaUrlsForTests(),
             'src="media/.bar"',
+            $matches,
+        );
+        $this->assertCount(0, $matches);
+        // does not match extension with 1 character
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'src="media/foobar.z"',
             $matches,
         );
         $this->assertCount(0, $matches);

--- a/tests/units/testslib/WMSRequestForTests.php
+++ b/tests/units/testslib/WMSRequestForTests.php
@@ -18,4 +18,14 @@ class WMSRequestForTests extends WMSRequest
     {
         return $this->useCache($configLayer, $params, $profile);
     }
+
+    public function getRegexpMediaUrlsForTests()
+    {
+        return self::$regexp_media_urls;
+    }
+
+    public function replaceMediaPathByMediaUrlForTests($matches)
+    {
+        return '"getMedia?path='.$matches[1].'"';
+    }
 }


### PR DESCRIPTION
`#(["\']){1}((\.\./)?media/.+\.\w{3,10})(["\']){1}#` is replaced by `#["\']((\.\./)?media/.+?\.\w{3,10})["\']#`

`.+` part is made ungreedy

Funded by AUDIAR
Funded by Terre de Provence Agglomération
