### PR TITLE
Allow same-origin for iframe

### DIFF
--- a/assets/src/modules/Utils.js
+++ b/assets/src/modules/Utils.js
@@ -211,7 +211,7 @@ export default class Utils {
     static sanitizeGFIContent(content) {
         DOMPurify.addHook('afterSanitizeAttributes', node => {
             if (node.nodeName === 'IFRAME') {
-                node.setAttribute('sandbox','allow-scripts allow-forms');
+                node.setAttribute('sandbox','allow-scripts allow-forms allow-same-origin');
             }
         });
         return DOMPurify.sanitize(content, {


### PR DESCRIPTION
https://github.com/3liz/lizmap-web-client/issues/4863#issuecomment-2604626722

CC @josemvm I don't know if it fixes your problem.
Maybe you can try to add it in **QGIS** (not the JS)

This kind of addition looks like end-less, we will always encounter new users with different `sandbox` usages : https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox

I'm wondering if setAttribute is the correct method to use. Shouldn't it be like appendAttributes to not change existing attributes ?

```js
            if (node.nodeName === 'IFRAME') {
                let sandbox = '';
                if (node.getAttribute('sandbox')) {
                    sandbox = node.getAttribute('sandbox');
                }
                if (!sandbox.includes("allow-scripts")){sandbox += ' allow-scripts'}
                if (!sandbox.includes("allow-forms")){sandbox += ' allow-forms'}
                if (!sandbox.includes("allow-same-origin")){sandbox += ' allow-same-origin'}
                node.setAttribute('sandbox', sandbox);
            }
```
?

Paid support 3155