### PR TITLE
PHP: caching QGIS Server metadata

### DIFF
--- a/lizmap/composer.json
+++ b/lizmap/composer.json
@@ -14,7 +14,8 @@
     "proj4php/proj4php": "~2.0.0",
     "violet/streaming-json-encoder": "^1.1.5",
     "guzzlehttp/guzzle": "^7.7.0",
-    "halaxa/json-machine": "^1.1"
+    "halaxa/json-machine": "^1.1",
+    "kevinrob/guzzle-cache-middleware": "^6.0"
   },
   "minimum-stability": "stable",
   "config": {

--- a/lizmap/modules/lizmap/install/upgrade_requestscache.php
+++ b/lizmap/modules/lizmap/install/upgrade_requestscache.php
@@ -1,0 +1,24 @@
+<?php
+
+class lizmapModuleUpgrader_requestscache extends jInstallerModule
+{
+    public $targetVersions = array(
+        '3.9.0-pre',
+    );
+    public $date = '2025-01-29';
+
+    public function install()
+    {
+        if ($this->firstExec('cacherequests')) {
+            $profiles = new \Jelix\IniFile\IniModifier(jApp::varConfigPath('profiles.ini.php'));
+            if (!$profiles->isSection('jcache:requests')) {
+                $profiles->setValues(array(
+                    'enabled' => 1,
+                    'driver' => 'file',
+                    'ttl' => 0,
+                ), 'jcache:requests');
+                $profiles->save();
+            }
+        }
+    }
+}

--- a/lizmap/modules/lizmap/lib/Request/QgisServerMetadataRequestMatcher.php
+++ b/lizmap/modules/lizmap/lib/Request/QgisServerMetadataRequestMatcher.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * QGIS Server metadata request matcher to cache response.
+ *
+ * @author    3liz
+ * @copyright 2025 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+namespace Lizmap\Request;
+
+use Kevinrob\GuzzleCache\Strategy\Delegate\RequestMatcherInterface;
+use Psr\Http\Message\RequestInterface;
+
+class QgisServerMetadataRequestMatcher implements RequestMatcherInterface
+{
+    /**
+     * The QGIS Server host.
+     *
+     * @var string
+     */
+    protected $qgisServerHost;
+
+    /**
+     * The QGIS Server Metadata path.
+     *
+     * @var string
+     */
+    protected $qgisServerMetadataPath;
+
+    /**
+     * @param string $qgisServerMetadataUrl The QGIS Server metadata URL - It could be provided by Lizmap Services
+     */
+    public function __construct(string $qgisServerMetadataUrl)
+    {
+        $urlInfo = parse_url($qgisServerMetadataUrl);
+        $this->qgisServerHost = $urlInfo['host'] ?? 'localhost';
+        $this->qgisServerMetadataPath = $urlInfo['path'] ?? '';
+    }
+
+    /**
+     * @param RequestInterface $request
+     *
+     * @return bool
+     */
+    public function matches($request)
+    {
+        return strpos($request->getUri()->getHost(), $this->qgisServerHost) !== false
+        && strpos($request->getUri()->getPath(), $this->qgisServerMetadataPath) !== false;
+    }
+}

--- a/lizmap/modules/lizmap/lib/Request/RequestCacheStorage.php
+++ b/lizmap/modules/lizmap/lib/Request/RequestCacheStorage.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Request cache storage to use in GuzzleCache with jCache.
+ *
+ * @author    3liz
+ * @copyright 2025 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+namespace Lizmap\Request;
+
+use Kevinrob\GuzzleCache\CacheEntry;
+use Kevinrob\GuzzleCache\Storage\CacheStorageInterface;
+
+class RequestCacheStorage implements CacheStorageInterface
+{
+    /**
+     * @var string jCache profile
+     */
+    protected $profile;
+
+    /**
+     * @param string $profile the jCache profile
+     */
+    public function __construct(string $profile)
+    {
+        $this->profile = $profile;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return null|CacheEntry the data or false
+     */
+    public function fetch($key)
+    {
+        try {
+            $cache = unserialize(\jCache::get($key, $this->profile));
+            if ($cache instanceof CacheEntry) {
+                return $cache;
+            }
+        } catch (\Exception $ignored) {
+            \jLog::logEx($ignored, 'error');
+
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string     $key
+     * @param CacheEntry $data
+     *
+     * @return bool
+     */
+    public function save($key, $data)
+    {
+        try {
+            $lifeTime = $data->getTTL();
+            if ($lifeTime === 0) {
+                return \jCache::set(
+                    $key,
+                    serialize($data),
+                    null,
+                    $this->profile
+                );
+            }
+            if ($lifeTime > 0) {
+                return \jCache::set(
+                    $key,
+                    serialize($data),
+                    $lifeTime,
+                    $this->profile
+                );
+            }
+        } catch (\Exception $ignored) {
+            // No fail if we can't save it the storage
+            \jLog::logEx($ignored, 'error');
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function delete($key)
+    {
+        return \jCache::delete($key, $this->profile);
+    }
+}

--- a/lizmap/var/config/profiles.ini.php.dist
+++ b/lizmap/var/config/profiles.ini.php.dist
@@ -90,7 +90,7 @@ searchGroupBaseDN=""
 
 ; name of the default profil to use for cache
 default=lizmap
-
+; the other jcache could be : qgisprojects, acl2db, tiles, requests
 
 [jcache:lizmap]
 ; disable or enable cache for this profile

--- a/lizmap/var/config/profiles.ini.php.dist
+++ b/lizmap/var/config/profiles.ini.php.dist
@@ -139,8 +139,8 @@ cache_file_umask=
 
 [jcache:qgisprojects]
 enabled=1
-driver=file
 ttl=0
+driver=file
 
 ;driver=redis_ext
 ; docker host
@@ -158,6 +158,19 @@ ttl=0
 ;db=2
 ;ttl=0
 
+
+[jcache:requests]
+enabled=1
+ttl=0
+driver=file
+
+;driver=redis_ext
+; docker host
+;host=redis
+; local host
+;host=127.0.0.1
+;port=6379
+;db=0
 
 [smtp:mailer]
 ;; to send emails via smtp, uncomment these lines and indicate all needed values.

--- a/tests/docker-conf/phpfpm/profiles.ini.php
+++ b/tests/docker-conf/phpfpm/profiles.ini.php
@@ -145,10 +145,8 @@ cache_file_umask=
 ;servers =
 
 [jcache:qgisprojects]
-;enabled=1
-;ttl=0
-;driver=file
-
+enabled=1
+ttl=0
 driver=redis_ext
 host=redis
 port=6379
@@ -156,11 +154,19 @@ db=1
 
 [jcache:acl2db]
 enabled=1
+ttl=0
 driver=redis_ext
 host=redis
 port=6379
 db=2
+
+[jcache:requests]
+enabled=1
 ttl=0
+driver=redis_ext
+host=redis
+port=6379
+db=0
 
 [webdav:default]
 baseUri=http://webdav/

--- a/tests/units/classes/Request/QgisServerMetadataRequestMatcherTest.php
+++ b/tests/units/classes/Request/QgisServerMetadataRequestMatcherTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Psr7\Request;
+use Lizmap\Request\QgisServerMetadataRequestMatcher;
+
+class QgisServerMetadataRequestMatcherTest extends TestCase
+{
+    public function testMapHost()
+    {
+        $matcher = new QgisServerMetadataRequestMatcher('http://map:8080/lizmap/server.json');
+        $request = new Request(
+            'GET',
+            'http://map:8080/lizmap/server.json',
+        );
+        $this->assertTrue($matcher->matches($request));
+
+        $request = new Request(
+            'GET',
+            'http://map:8080/ows/?SERVICE=WMS&REQUEST=Getcapabilities',
+        );
+        $this->assertFalse($matcher->matches($request));
+
+        $request = new Request(
+            'GET',
+            'http://localhost/qgis_mapserv.fcgi/lizmap/server.json',
+        );
+        $this->assertFalse($matcher->matches($request));
+    }
+
+    public function testLocalHost()
+    {
+        $matcher = new QgisServerMetadataRequestMatcher('http://localhost/qgis_mapserv.fcgi/lizmap/server.json');
+        $request = new Request(
+            'GET',
+            'http://localhost/qgis_mapserv.fcgi/lizmap/server.json',
+        );
+        $this->assertTrue($matcher->matches($request));
+
+        $request = new Request(
+            'GET',
+            'http://map:8080/lizmap/server.json',
+        );
+        $this->assertFalse($matcher->matches($request));
+
+        $request = new Request(
+            'GET',
+            'http://localhost/qgis_mapserv.fcgi?SERVICE=WMS&REQUEST=Getcapabilities',
+        );
+        $this->assertFalse($matcher->matches($request));
+    }
+}


### PR DESCRIPTION
Adding [Kevinrob/guzzle-cache-middleware](https://github.com/Kevinrob/guzzle-cache-middleware), to defined cache strategy for caching QGIS Server metadata.

The main goal is to reduce the number of request to QGIS Server to get it's metadata. The QGIS Server metadata request's result will be stored during 60 seconds. During this time, no more QGIS Server metadata request will be performed.

Adding a new `jCache` profile : `requests`.