### PR TITLE
fix authenticating layers against qGIS auth config

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -285,17 +285,18 @@ class qgisVectorLayer extends qgisMapLayer
                 // when qgis authentication config is used to authenticate a layer against, it requires to have preconfigured jdb::profile to align with the login credentials set in qgis authcfg
                 if (!empty($dtParams->authcfg)) {
                     $jdbParams['authcfg'] = $dtParams->authcfg;
-                    // retrieving user/password from the corresponding jdb::profile in profiles.ini.php. 
+                    // retrieving user/password from the corresponding jdb::profile in profiles.ini.php.
                     $ini = new \Jelix\IniFile\IniModifier(jApp::varConfigPath('profiles.ini.php'));
-					$profiles = $ini->getSectionList();
-					foreach ($profiles as $profile) {
-						if ($profile == 'jdb:'.$dtParams->authcfg) {
-							$options = $ini->getValues($profile);
-							$jdbParams['user'] = $options['user'];
-							$jdbParams['password'] = $options['password'];
-							break;
-						}
-					}
+                    $profiles = $ini->getSectionList();
+                    foreach ($profiles as $profile) {
+                        if ($profile == 'jdb:'.$dtParams->authcfg) {
+                            $options = $ini->getValues($profile);
+                            $jdbParams['user'] = $options['user'];
+                            $jdbParams['password'] = $options['password'];
+
+                            break;
+                        }
+                    }
                 }
             }
             if (!empty($dtParams->schema) && $setSearchPathFromLayer) {

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -211,7 +211,7 @@ class qgisVectorLayer extends qgisMapLayer
         );
         $parameters = array(
             'dbname', 'service', 'host', 'port', 'user', 'password',
-            'sslmode', 'key', 'estimatedmetadata', 'selectatid',
+            'sslmode', 'authcfg', 'key', 'estimatedmetadata', 'selectatid',
             'srid', 'type', 'checkPrimaryKeyUnicity',
             'table', 'geocol', 'sql', 'schema', 'tablename',
         );

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -282,6 +282,21 @@ class qgisVectorLayer extends qgisMapLayer
                 if (!empty($dtParams->sslmode)) {
                     $jdbParams['sslmode'] = $dtParams->sslmode;
                 }
+                // when qgis authentication config is used to authenticate a layer against, it requires to have preconfigured jdb::profile to align with the login credentials set in qgis authcfg
+                if (!empty($dtParams->authcfg)) {
+                    $jdbParams['authcfg'] = $dtParams->authcfg;
+                    // retrieving user/password from the corresponding jdb::profile in profiles.ini.php. 
+                    $ini = new \Jelix\IniFile\IniModifier(jApp::varConfigPath('profiles.ini.php'));
+        			$profiles = $ini->getSectionList();
+		            foreach($profiles as $profile) {
+	        			if ($profile == 'jdb:'.$dtParams->authcfg) {
+	        				$options = $ini->getValues($profile);
+			            	$jdbParams['user'] = $options["user"];
+			            	$jdbParams['password'] = $options["password"];
+			            	break;
+	        			}
+	        		}
+                }
             }
             if (!empty($dtParams->schema) && $setSearchPathFromLayer) {
                 $jdbParams['search_path'] = '"'.$dtParams->schema.'",public';

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -282,7 +282,8 @@ class qgisVectorLayer extends qgisMapLayer
                 if (!empty($dtParams->sslmode)) {
                     $jdbParams['sslmode'] = $dtParams->sslmode;
                 }
-                // when qgis authentication config is used to authenticate a layer against, it requires to have preconfigured jdb::profile to align with the login credentials set in qgis authcfg
+                // When the QGIS authentication config is used to authenticate a layer,
+                // it requires to have set up "jdb::profile" to align with the login credentials set in QGIS "authcfg"
                 if (!empty($dtParams->authcfg)) {
                     $jdbParams['authcfg'] = $dtParams->authcfg;
                     // retrieving user/password from the corresponding jdb::profile in profiles.ini.php.

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -287,15 +287,15 @@ class qgisVectorLayer extends qgisMapLayer
                     $jdbParams['authcfg'] = $dtParams->authcfg;
                     // retrieving user/password from the corresponding jdb::profile in profiles.ini.php. 
                     $ini = new \Jelix\IniFile\IniModifier(jApp::varConfigPath('profiles.ini.php'));
-        			$profiles = $ini->getSectionList();
-		            foreach($profiles as $profile) {
-	        			if ($profile == 'jdb:'.$dtParams->authcfg) {
-	        				$options = $ini->getValues($profile);
-			            	$jdbParams['user'] = $options["user"];
-			            	$jdbParams['password'] = $options["password"];
-			            	break;
-	        			}
-	        		}
+					$profiles = $ini->getSectionList();
+					foreach ($profiles as $profile) {
+						if ($profile == 'jdb:'.$dtParams->authcfg) {
+							$options = $ini->getValues($profile);
+							$jdbParams['user'] = $options['user'];
+							$jdbParams['password'] = $options['password'];
+							break;
+						}
+					}
                 }
             }
             if (!empty($dtParams->schema) && $setSearchPathFromLayer) {

--- a/lizmap/modules/lizmap/classes/qgisVectorLayerDatasource.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayerDatasource.class.php
@@ -22,6 +22,7 @@ class qgisVectorLayerDatasource
         'user' => "user='?([^ ']+)'? ",
         'password' => "password='?([^ ']+)'? ",
         'sslmode' => "sslmode='?([^ ']+)'? ",
+        'authcfg' => "authcfg='?([^ ']+)'? ",
         'key' => "key='?([^ ']+)'? ",
         'estimatedmetadata' => 'estimatedmetadata=([^ ]+) ',
         'selectatid' => 'selectatid=([^ ]+) ',

--- a/tests/units/edition/qgisVectorLayerDatasourceTest.php
+++ b/tests/units/edition/qgisVectorLayerDatasourceTest.php
@@ -23,6 +23,7 @@ class qgisVectorLayerDatasourceTest extends TestCase
         $this->assertEquals('5432', $element->getDatasourceParameter('port'));
         $this->assertEquals('test_user', $element->getDatasourceParameter('user'));
         $this->assertEquals('test_password', $element->getDatasourceParameter('password'));
+        $this->assertEquals('', $element->getDatasourceParameter('authcfg'));
         $this->assertEquals('disable', $element->getDatasourceParameter('sslmode'));
         $this->assertEquals('id', $element->getDatasourceParameter('key'));
         $this->assertEquals('', $element->getDatasourceParameter('estimatedmetadata'));
@@ -47,6 +48,7 @@ class qgisVectorLayerDatasourceTest extends TestCase
         $this->assertEquals('5432', $element->getDatasourceParameter('port'));
         $this->assertEquals('test_user', $element->getDatasourceParameter('user'));
         $this->assertEquals('test_password', $element->getDatasourceParameter('password'));
+        $this->assertEquals('', $element->getDatasourceParameter('authcfg'));
         $this->assertEquals('disable', $element->getDatasourceParameter('sslmode'));
         $this->assertEquals('id', $element->getDatasourceParameter('key'));
         $this->assertEquals('', $element->getDatasourceParameter('estimatedmetadata'));
@@ -74,6 +76,7 @@ class qgisVectorLayerDatasourceTest extends TestCase
         $this->assertEquals('5432', $element->getDatasourceParameter('port'));
         $this->assertEquals('test_user', $element->getDatasourceParameter('user'));
         $this->assertEquals('test_password', $element->getDatasourceParameter('password'));
+        $this->assertEquals('', $element->getDatasourceParameter('authcfg'));
         $this->assertEquals('disable', $element->getDatasourceParameter('sslmode'));
         $this->assertEquals('id', $element->getDatasourceParameter('key'));
         $this->assertEquals('true', $element->getDatasourceParameter('estimatedmetadata'));
@@ -101,6 +104,7 @@ class qgisVectorLayerDatasourceTest extends TestCase
         $this->assertEquals('', $element->getDatasourceParameter('port'));
         $this->assertEquals('', $element->getDatasourceParameter('user'));
         $this->assertEquals('', $element->getDatasourceParameter('password'));
+        $this->assertEquals('', $element->getDatasourceParameter('authcfg'));
         $this->assertEquals('disable', $element->getDatasourceParameter('sslmode'));
         $this->assertEquals('id', $element->getDatasourceParameter('key'));
         $this->assertEquals('', $element->getDatasourceParameter('estimatedmetadata'));
@@ -128,6 +132,63 @@ class qgisVectorLayerDatasourceTest extends TestCase
         $this->assertEquals('', $element->getDatasourceParameter('port'));
         $this->assertEquals('', $element->getDatasourceParameter('user'));
         $this->assertEquals('', $element->getDatasourceParameter('password'));
+        $this->assertEquals('', $element->getDatasourceParameter('authcfg'));
+        $this->assertEquals('disable', $element->getDatasourceParameter('sslmode'));
+        $this->assertEquals('id', $element->getDatasourceParameter('key'));
+        $this->assertEquals('', $element->getDatasourceParameter('estimatedmetadata'));
+        $this->assertEquals('', $element->getDatasourceParameter('selectatid'));
+        $this->assertEquals('2193', $element->getDatasourceParameter('srid'));
+        $this->assertEquals('', $element->getDatasourceParameter('type'));
+        $this->assertEquals('1', $element->getDatasourceParameter('checkPrimaryKeyUnicity'));
+        $this->assertEquals('"public"."EditTest"', $element->getDatasourceParameter('table'));
+        $this->assertEquals('EditTest', $element->getDatasourceParameter('tablename'));
+        $this->assertEquals('public', $element->getDatasourceParameter('schema'));
+        $this->assertEquals('', $element->getDatasourceParameter('geocol'));
+        $this->assertEquals('', $element->getDatasourceParameter('sql'));
+    }
+
+    public function testPostgresqlDatasourceWithAuthcfg()
+    {
+        $provider = 'postgres';
+        $datasource = "dbname='test_dbname' host=127.0.0.1 port=5432 authcfg='lizmap-test' sslmode=disable key='id' srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=\"test_schema\".\"test_table\" (geom) sql=";
+
+        $element = new qgisVectorLayerDatasource($provider, $datasource);
+
+        $this->assertEquals('test_dbname', $element->getDatasourceParameter('dbname'));
+        $this->assertEquals('', $element->getDatasourceParameter('service'));
+        $this->assertEquals('127.0.0.1', $element->getDatasourceParameter('host'));
+        $this->assertEquals('5432', $element->getDatasourceParameter('port'));
+        $this->assertEquals('', $element->getDatasourceParameter('user'));
+        $this->assertEquals('', $element->getDatasourceParameter('password'));
+        $this->assertEquals('lizmap-test', $element->getDatasourceParameter('authcfg'));
+        $this->assertEquals('disable', $element->getDatasourceParameter('sslmode'));
+        $this->assertEquals('id', $element->getDatasourceParameter('key'));
+        $this->assertEquals('', $element->getDatasourceParameter('estimatedmetadata'));
+        $this->assertEquals('', $element->getDatasourceParameter('selectatid'));
+        $this->assertEquals('4326', $element->getDatasourceParameter('srid'));
+        $this->assertEquals('Polygon', $element->getDatasourceParameter('type'));
+        $this->assertEquals('1', $element->getDatasourceParameter('checkPrimaryKeyUnicity'));
+        $this->assertEquals('"test_schema"."test_table"', $element->getDatasourceParameter('table'));
+        $this->assertEquals('test_table', $element->getDatasourceParameter('tablename'));
+        $this->assertEquals('test_schema', $element->getDatasourceParameter('schema'));
+        $this->assertEquals('geom', $element->getDatasourceParameter('geocol'));
+        $this->assertEquals('', $element->getDatasourceParameter('sql'));
+    }
+
+    public function testPostgresqlDatasourceWithoutGeometryWithAuthcfgWithoutSql()
+    {
+        $provider = 'postgres';
+        $datasource = "dbname='test_dbname' host=127.0.0.1 port=5432 authcfg='lizmap-test' sslmode=disable key='id' srid=2193 checkPrimaryKeyUnicity='1' table=\"public\".\"EditTest\"";
+
+        $element = new qgisVectorLayerDatasource($provider, $datasource);
+
+        $this->assertEquals('test_dbname', $element->getDatasourceParameter('dbname'));
+        $this->assertEquals('', $element->getDatasourceParameter('service'));
+        $this->assertEquals('127.0.0.1', $element->getDatasourceParameter('host'));
+        $this->assertEquals('5432', $element->getDatasourceParameter('port'));
+        $this->assertEquals('', $element->getDatasourceParameter('user'));
+        $this->assertEquals('', $element->getDatasourceParameter('password'));
+        $this->assertEquals('lizmap-test', $element->getDatasourceParameter('authcfg'));
         $this->assertEquals('disable', $element->getDatasourceParameter('sslmode'));
         $this->assertEquals('id', $element->getDatasourceParameter('key'));
         $this->assertEquals('', $element->getDatasourceParameter('estimatedmetadata'));
@@ -155,6 +216,7 @@ class qgisVectorLayerDatasourceTest extends TestCase
         $this->assertEquals('5432', $element->getDatasourceParameter('port'));
         $this->assertEquals('test_user', $element->getDatasourceParameter('user'));
         $this->assertEquals('test_password', $element->getDatasourceParameter('password'));
+        $this->assertEquals('', $element->getDatasourceParameter('authcfg'));
         $this->assertEquals('disable', $element->getDatasourceParameter('sslmode'));
         $this->assertEquals('id_lieux', $element->getDatasourceParameter('key'));
         $this->assertEquals('', $element->getDatasourceParameter('estimatedmetadata'));
@@ -182,6 +244,7 @@ class qgisVectorLayerDatasourceTest extends TestCase
         $this->assertEquals('5432', $element->getDatasourceParameter('port'));
         $this->assertEquals('test_user', $element->getDatasourceParameter('user'));
         $this->assertEquals('test_password', $element->getDatasourceParameter('password'));
+        $this->assertEquals('', $element->getDatasourceParameter('authcfg'));
         $this->assertEquals('disable', $element->getDatasourceParameter('sslmode'));
         $this->assertEquals('id', $element->getDatasourceParameter('key'));
         $this->assertEquals('', $element->getDatasourceParameter('estimatedmetadata'));


### PR DESCRIPTION
Fix to authente layers against qGIS auth config when applying a filter in lizmap web client 3.8.1

Fixes #4470

Extend #4794

Funded by sponsored development