### PR TITLE
Form filter - Also search for NULL values when empty string is checked

### DIFF
--- a/assets/src/legacy/filter.js
+++ b/assets/src/legacy/filter.js
@@ -653,6 +653,9 @@ var lizLayerFilterTool = function () {
                 var filter = null;
                 var field = field_item['field'];
                 if (clist.length) {
+                    // Check if the value '' is present. If so, we should also search for NULL
+                    let hasEmptyValue = false;
+
                     // If there is a separator in the field values, and we need
                     // to explode the values into single items, we need to use
                     // LIKE statements joined with OR
@@ -669,17 +672,35 @@ var lizLayerFilterTool = function () {
                         }
                         for (var i in clist) {
                             var cval = clist[i];
+                            // If cval is '', we should store this information
+                            if (cval === '') {
+                                hasEmptyValue = true;
+                            }
+
+                            // Create the filter for this value
                             filter += sep + '"' + field + '"' + " " + lk + " '%" + cval + "%' ";
                             // We need to use a OR to display features with
                             // 'Theatre, Culture' or 'Theatre', or 'Culture, Information'
                             // When 'Theatre' and 'Culture' are checked in the list
                             sep = ' OR ';
                         }
+                        // Add NULL values
+                        if (hasEmptyValue) {
+                            filter += ` OR "${field}" IS NULL `;
+                        }
                         filter += ' ) ';
                     } else {
+                        // Search for empty values (to add the rule OR "field" IS NULL )
+                        if (clist.includes('')) {
+                            hasEmptyValue = true;
+                        }
                         // If there is not separator in the field values, use IN to get all features
                         // corresponding to one of the checked values
                         filter = '"' + field + '"' + " IN ( '" + clist.join("' , '") + "' ) ";
+                        // Add NULL values
+                        if (hasEmptyValue) {
+                            filter = ` ( ${filter} OR "${field}" IS NULL ) `;
+                        }
                     }
                 }
                 globalThis['filterConfig'][field_item.order]['filter'] = filter;


### PR DESCRIPTION
In Lizmap form filter, you can use a field containing several values by configuring a "Unique values" field type.
Lizmap show a list of checkboxes which allow the user to check which values should be used for the filter. For example:

![image](https://github.com/user-attachments/assets/941fbb18-ab31-4ede-ab0d-3a860d9c5aff)

In the example above, the checkbox with no label corresponds to the features which have a `NULL` value for this field.

This modification fixes the previous behaviour which triggered a filter `"acces" IN ( '' )` by adding a test on the `NULL` value. The new filter is the correct : ` ( "acces" IN ( '' ) OR acces IS NULL ) ` 

Funded by Destination Bretagne Sud - Golfe du Morbihan https://destination-bretagnesud.bzh/ 
