### PR TITLE
Guzzle - Content-Type is not always provided

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/Proxy.php
+++ b/lizmap/modules/lizmap/lib/Request/Proxy.php
@@ -465,9 +465,14 @@ class Proxy
         $options = self::buildOptions($options, $method, $debug);
         $response = self::sendRequest($url, $options);
 
+        $contentType = 'application/octet-stream';
+        if ($response->hasHeader('Content-Type')) {
+            $contentType = $response->getHeader('Content-Type')[0];
+        }
+
         return array(
             (string) $response->getBody(),
-            $response->getHeader('Content-Type')[0],
+            $contentType,
             $response->getStatusCode(),
             $response->getHeaders(),
         );
@@ -490,9 +495,14 @@ class Proxy
 
         $response = self::sendRequest($url, $options);
 
+        $contentType = 'application/octet-stream';
+        if ($response->hasHeader('Content-Type')) {
+            $contentType = $response->getHeader('Content-Type')[0];
+        }
+
         return new ProxyResponse(
             $response->getStatusCode(),
-            $response->getHeader('Content-Type')[0],
+            $contentType,
             $response->getHeaders(),
             $response->getBody()
         );


### PR DESCRIPTION
Follow up from #4998 


```
2025-01-27 16:09:19	172.18.0.1	error	The HTTP request ended with an error. HTTP code 422. → http://map:8080/ows/?map=tests%2Frasters%2Eqgs&request=getcapabilities&service=WFS&version=1%2E0%2E0&Lizmap%5FUser=admin&Lizmap%5FUser%5FGroups=admins&Lizmap%5FOverride%5FFilter=1
[2]	Undefined array key 0
  /srv/lzm/lizmap/modules/lizmap/lib/Request/Proxy.php	470
```

I haven't really checked what to add instead...
https://stackoverflow.com/questions/1176022/unknown-file-type-mime
