### PR TITLE
Header - Add authenticated user organization in hidden fields

### DIFF
--- a/lizmap/modules/lizmap/templates/user_menu.tpl
+++ b/lizmap/modules/lizmap/templates/user_menu.tpl
@@ -14,6 +14,7 @@
                 <span id="info-user-login" title="{$user->firstname} {$user->lastname}">{$user->login|eschtml}</span>
                 <span class="hide" id="info-user-firstname">{$user->firstname}</span>
                 <span class="hide" id="info-user-lastname">{$user->lastname}</span>
+                <span class="hide" id="info-user-organization">{$user->organization}</span>
             </span>
         </a>
         <ul class="dropdown-menu dropdown-menu-end">

--- a/tests/end2end/playwright/header.spec.js
+++ b/tests/end2end/playwright/header.spec.js
@@ -1,0 +1,57 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+import {ProjectPage} from "./pages/project";
+
+test.describe('Header',
+    {
+        tag: ['@readonly'],
+    },
+    () => {
+
+    test('Login info as user A on the landing page', async ({ browser }) => {
+        const userA = await browser.newContext({ storageState: 'playwright/.auth/user_in_group_a.json' });
+        const page = await userA.newPage();
+        await page.goto('index.php');
+
+        // Fixme, class "hide" but visible ?
+        await expect(page.locator("#info-user-login")).toHaveText("user_in_group_a");
+        await expect(page.locator("#info-user-firstname")).toHaveText("User A");
+        await expect(page.locator("#info-user-firstname")).toHaveClass("hide");
+        await expect(page.locator("#info-user-firstname")).toBeVisible();
+        await expect(page.locator("#info-user-lastname")).toHaveText("Testadiferro");
+        await expect(page.locator("#info-user-lastname")).toHaveClass("hide");
+        await expect(page.locator("#info-user-lastname")).toBeVisible();
+        await expect(page.locator("#info-user-organization")).toHaveText("Make it KISS");
+        await expect(page.locator("#info-user-organization")).toHaveClass("hide");
+        await expect(page.locator("#info-user-organization")).toBeVisible();
+    });
+
+    test('Login info as user A on project page', async ({ browser }) => {
+        const userA = await browser.newContext({ storageState: 'playwright/.auth/user_in_group_a.json' });
+        const userPage = await userA.newPage();
+        const projectPage = new ProjectPage(userPage, 'world-3857');
+        await projectPage.open();
+
+        await expect(userPage.locator("#info-user-login")).toHaveText("user_in_group_a");
+        await expect(userPage.locator("#info-user-firstname")).toHaveText("User A");
+        await expect(userPage.locator("#info-user-firstname")).toHaveClass("hide");
+        await expect(userPage.locator("#info-user-firstname")).not.toBeVisible();
+        await expect(userPage.locator("#info-user-lastname")).toHaveText("Testadiferro");
+        await expect(userPage.locator("#info-user-lastname")).toHaveClass("hide");
+        await expect(userPage.locator("#info-user-lastname")).not.toBeVisible();
+        await expect(userPage.locator("#info-user-organization")).toHaveText("Make it KISS");
+        await expect(userPage.locator("#info-user-organization")).toHaveClass("hide");
+        await expect(userPage.locator("#info-user-organization")).not.toBeVisible();
+    });
+
+    test('Login info as anonymous on the landing page', async ({ page }) => {
+        await page.goto('index.php');
+        await expect(page.locator("#headermenu .login")).toHaveText("Connect");
+    });
+
+    test('Login info as anonymous on project page', async ({ page }) => {
+        const projectPage = new ProjectPage(page, 'world-3857');
+        await projectPage.open();
+        await expect(page.locator("#headermenu .login")).toHaveText("Connect");
+    });
+});

--- a/tests/qgis-projects/tests/set_tests_respository_rights.sql
+++ b/tests/qgis-projects/tests/set_tests_respository_rights.sql
@@ -13,11 +13,11 @@ INSERT INTO lizmap.jacl2_group(
 
 -- Users
 INSERT INTO lizmap.jlx_user(
-	usr_login, usr_email, usr_password, status, create_date)
+	usr_login, usr_email, usr_password, status, create_date, firstname, lastname, organization)
 	VALUES
-	('user_in_group_a', 'user_in_group_a@nomail.nomail', '$2y$10$d2KZfxeYJP0l3YbNyDMZYe2vGSA3JWa8kFJSdecmSEIqInjnunTJ.', 1, NOW()),
-	('user_in_group_b', 'user_in_group_b@nomail.nomail', '$2y$10$d2KZfxeYJP0l3YbNyDMZYe2vGSA3JWa8kFJSdecmSEIqInjnunTJ.', 1, NOW()),
-	('publisher', 'publisher@nomail.nomail', '$2y$10$d2KZfxeYJP0l3YbNyDMZYe2vGSA3JWa8kFJSdecmSEIqInjnunTJ.', 1, NOW())
+	('user_in_group_a', 'user_in_group_a@nomail.nomail', '$2y$10$d2KZfxeYJP0l3YbNyDMZYe2vGSA3JWa8kFJSdecmSEIqInjnunTJ.', 1, NOW(), 'User A', 'Testadiferro', 'Make it KISS'),
+	('user_in_group_b', 'user_in_group_b@nomail.nomail', '$2y$10$d2KZfxeYJP0l3YbNyDMZYe2vGSA3JWa8kFJSdecmSEIqInjnunTJ.', 1, NOW(), 'User B', 'Testillano', 'Make it KISS'),
+	('publisher', 'publisher@nomail.nomail', '$2y$10$d2KZfxeYJP0l3YbNyDMZYe2vGSA3JWa8kFJSdecmSEIqInjnunTJ.', 1, NOW(), 'Publisher', 'Testla', 'Make it KISS')
 	ON CONFLICT DO NOTHING
 	;
 


### PR DESCRIPTION
This allows a JavaScript script to get the current user organization and use it in the editing form.

<!--
Add the word "fix" in front of "#" if it fixes the ticket
or do nothing to only mention it.

funded by NAME
If funded by someone else than 3Liz, please add label "sponsored development"

Please mention if the PR should be backported and to which versions.

Please add new tests if possible (JS, PHP, End2End…)
-->

Ticket : #

Funded by Ville d'Avignon https://cartes.mairie-avignon.com
