### PR TITLE
API - Retrieve invalid layers between GetCapabilities en CFG file

### DIFF
--- a/assets/src/modules/Config.js
+++ b/assets/src/modules/Config.js
@@ -67,6 +67,7 @@ export class Config {
         this._options = null;
         this._layers = null;
         this._layerTree = null;
+        this._invalidLayers = null;
         this._baselayers = null;
         this._layersOrder = null;
         this._hasMetadata = true;
@@ -182,9 +183,25 @@ export class Config {
      */
     get layerTree() {
         if (this._layerTree == null) {
-            this._layerTree = buildLayerTreeConfig(this._theWmsCapabilities.Capability.Layer, this.layers);
+            this._invalidLayers = [];
+            this._layerTree = buildLayerTreeConfig(
+                this._theWmsCapabilities.Capability.Layer,
+                this.layers,
+                this._invalidLayers,
+            );
         }
         return this._layerTree;
+    }
+
+    /**
+     * List of invalid layers, not found in the Lizmap configuration file, but found in the WMS GetCapabilities.
+     * @type {string[]}
+     */
+    get invalidLayersNotFoundInCfg() {
+        if (this._invalidLayers == null) {
+            this.layerTree;
+        }
+        return this._invalidLayers;
     }
 
     /**

--- a/assets/src/modules/State.js
+++ b/assets/src/modules/State.js
@@ -61,7 +61,11 @@ export class State extends EventDispatcher {
      */
     get layersAndGroupsCollection() {
         if (this._collection == null) {
-            this._collection = new LayersAndGroupsCollection(this._initialConfig.layerTree, this._initialConfig.layersOrder, this._initialConfig.options.hideGroupCheckbox);
+            this._collection = new LayersAndGroupsCollection(
+                this._initialConfig.layerTree,
+                this._initialConfig.layersOrder,
+                this._initialConfig.options.hideGroupCheckbox,
+            );
             // Dispatch events from groups and layers
             this._collection.addListener(this.dispatch.bind(this), 'group.visibility.changed');
             this._collection.addListener(this.dispatch.bind(this), 'group.opacity.changed');

--- a/assets/src/modules/config/LayerTree.js
+++ b/assets/src/modules/config/LayerTree.js
@@ -12,7 +12,7 @@ import { AttributionConfig } from './Attribution.js';
 import { LayerConfig, LayersConfig } from './Layer.js';
 
 /**
- * Class representing a wMS layer Geographic Bounding Box
+ * Class representing a WMS layer Geographic Bounding Box
  * @class
  * @augments Extent
  */
@@ -403,29 +403,33 @@ export class LayerTreeGroupConfig extends LayerTreeItemConfig {
 /**
  * Function to build layer tree items config based on WMS capabilities
  * @function
- * @param {object}       wmsCapaLayerGroup - the wms layer capabilities
+ * @param {object}       wmsCapaLayerGroup - the WMS layer capabilities
  * @param {LayersConfig} layersCfg         - the lizmap layers config instance
- * @param {number}       level             - the wms layer level
- * @returns {LayerTreeItemConfig[]} the layer tree items of the wms layer
+ * @param {number}       level             - the WMS layer level
+ * @param {string[]}     invalid           - List of invalid WMS layer name
+ * @returns {LayerTreeItemConfig[]}        - The layer tree items of the WMS layer
  */
-function buildLayerTreeGroupConfigItems(wmsCapaLayerGroup, layersCfg, level) {
+function buildLayerTreeGroupConfigItems(wmsCapaLayerGroup, layersCfg, level, invalid = []) {
     let items = [];
+
     if (!wmsCapaLayerGroup.hasOwnProperty('Layer')) {
         return items;
     }
+
     for(const wmsCapaLayer of wmsCapaLayerGroup.Layer) {
         const wmsName = wmsCapaLayer.Name;
         const cfg = layersCfg.getLayerConfigByWmsName(wmsName);
         if (cfg == null) {
-            console.log('The WMS layer name `'+ wmsName +'` is unknown!');
+            invalid.push(wmsName);
             continue;
         }
-        if (wmsCapaLayer.hasOwnProperty('Layer') && wmsCapaLayer.Layer.length != 0) {
-            const groupItems = buildLayerTreeGroupConfigItems(wmsCapaLayer, layersCfg, level+1);
+
+        if (wmsCapaLayer.hasOwnProperty('Layer') && wmsCapaLayer.Layer.length !== 0) {
+            const groupItems = buildLayerTreeGroupConfigItems(wmsCapaLayer, layersCfg, level+1, invalid);
             items.push(new LayerTreeGroupConfig(cfg.name, level+1, groupItems, wmsCapaLayer, cfg));
         } else {
             // avoid to add the baseLayers group to the map if it doesn't contain any layer.
-            if(wmsName.toLowerCase() != 'baselayers') {
+            if(wmsName.toLowerCase() !== 'baselayers') {
                 items.push(new LayerTreeLayerConfig(cfg.name, level+1, wmsCapaLayer, cfg));
             }
 
@@ -437,11 +441,12 @@ function buildLayerTreeGroupConfigItems(wmsCapaLayerGroup, layersCfg, level) {
 /**
  * Function to build the root layer tree config based on WMS capabilities
  * @function
- * @param {object}       wmsCapaLayerRoot - the wms root layer capabilities
+ * @param {object}       wmsCapaLayerRoot - the WMS root layer capabilities
  * @param {LayersConfig} layersCfg        - the lizmap layers config instance
- * @returns {LayerTreeGroupConfig} The root layer tree config based on WMS capabilities
+ * @param {string[]}     invalid          - List of invalid WMS layer name
+ * @returns {LayerTreeGroupConfig}        - The root layer tree config based on WMS capabilities
  */
-export function buildLayerTreeConfig(wmsCapaLayerRoot, layersCfg) {
-    let items = buildLayerTreeGroupConfigItems(wmsCapaLayerRoot, layersCfg, 0);
+export function buildLayerTreeConfig(wmsCapaLayerRoot, layersCfg, invalid = []) {
+    let items = buildLayerTreeGroupConfigItems(wmsCapaLayerRoot, layersCfg, 0, invalid);
     return new LayerTreeGroupConfig('root', 0, items, wmsCapaLayerRoot);
 }

--- a/tests/js-units/node/config/baselayer.test.js
+++ b/tests/js-units/node/config/baselayer.test.js
@@ -619,8 +619,9 @@ describe('BaseLayersConfig', function () {
         config.layers[blName] = blGroupCfg;
 
         const layers = new LayersConfig(config.layers);
-        const root = buildLayerTreeConfig(capabilities.Capability.Layer, layers);
-
+        let invalid = [];
+        const root = buildLayerTreeConfig(capabilities.Capability.Layer, layers, invalid);
+        expect(invalid).to.have.length(0);
         expect(root).to.be.instanceOf(LayerTreeGroupConfig)
         expect(root.name).to.be.eq('root')
         expect(root.type).to.be.eq('group')
@@ -665,8 +666,9 @@ describe('BaseLayersConfig', function () {
         expect(config).to.not.be.undefined
 
         const layers = new LayersConfig(config.layers);
-        const root = buildLayerTreeConfig(capabilities.Capability.Layer, layers);
-
+        let invalid = [];
+        const root = buildLayerTreeConfig(capabilities.Capability.Layer, layers, invalid);
+        expect(invalid).to.have.length(0);
         expect(root).to.be.instanceOf(LayerTreeGroupConfig)
         expect(root.name).to.be.eq('root')
         expect(root.type).to.be.eq('group')
@@ -870,8 +872,10 @@ describe('BaseLayersConfig', function () {
             });
         }
 
-        const root = buildLayerTreeConfig(capabilities.Capability.Layer, layers);
+        let invalid = [];
+        const root = buildLayerTreeConfig(capabilities.Capability.Layer, layers, invalid);
 
+        expect(invalid).to.have.length(0);
         expect(root).to.be.instanceOf(LayerTreeGroupConfig)
         expect(root.name).to.be.eq('root')
         expect(root.type).to.be.eq('group')
@@ -1016,8 +1020,10 @@ describe('BaseLayersConfig', function () {
             });
         }
 
-        const root = buildLayerTreeConfig(capabilities.Capability.Layer, layers);
+        let invalid = [];
+        const root = buildLayerTreeConfig(capabilities.Capability.Layer, layers, invalid);
 
+        expect(invalid).to.have.length(0);
         expect(root).to.be.instanceOf(LayerTreeGroupConfig)
         expect(root.name).to.be.eq('root')
         expect(root.type).to.be.eq('group')

--- a/tests/js-units/node/config/layerTree.test.js
+++ b/tests/js-units/node/config/layerTree.test.js
@@ -176,7 +176,10 @@ describe('buildLayerTreeConfig', function () {
 
         const layers = new LayersConfig(config.layers);
 
-        const root = buildLayerTreeConfig(capabilities.Capability.Layer, layers);
+        let invalid = [];
+        const root = buildLayerTreeConfig(capabilities.Capability.Layer, layers, invalid);
+
+        expect(invalid).to.have.length(0);
         expect(root).to.be.instanceOf(LayerTreeGroupConfig)
         expect(root.name).to.be.eq('root')
         expect(root.type).to.be.eq('group')
@@ -301,7 +304,10 @@ describe('buildLayerTreeConfig', function () {
 
       const layers = new LayersConfig(config.layers);
 
-      const root = buildLayerTreeConfig(capabilities.Capability.Layer, layers);
+      let invalid = [];
+      const root = buildLayerTreeConfig(capabilities.Capability.Layer, layers, invalid);
+
+      expect(invalid).to.have.length(0);
       expect(root).to.be.instanceOf(LayerTreeGroupConfig)
       expect(root.name).to.be.eq('root')
       expect(root.type).to.be.eq('group')

--- a/tests/js-units/node/config/layersOrder.test.js
+++ b/tests/js-units/node/config/layersOrder.test.js
@@ -52,8 +52,10 @@ describe('buildLayersOrder', function () {
 
         const layers = new LayersConfig(config.layers);
 
-        const root = buildLayerTreeConfig(capabilities.Capability.Layer, layers);
+        let invalid = [];
+        const root = buildLayerTreeConfig(capabilities.Capability.Layer, layers, invalid);
 
+        expect(invalid).to.have.length(0);
         const layersOrder = buildLayersOrder(config, root);
         expect(layersOrder).to.have.ordered.members([
             "points_of_interest",

--- a/tests/js-units/node/state/externallayertree.test.js
+++ b/tests/js-units/node/state/externallayertree.test.js
@@ -35,7 +35,10 @@ function getRootLayerTreeGroupState(name) {
 
     const layers = new LayersConfig(config.layers);
 
-    const rootCfg = buildLayerTreeConfig(capabilities.Capability.Layer, layers);
+    let invalid = [];
+    const rootCfg = buildLayerTreeConfig(capabilities.Capability.Layer, layers, invalid);
+
+    expect(invalid).to.have.length(0);
     expect(rootCfg).to.be.instanceOf(LayerTreeGroupConfig)
 
     const layersOrder = buildLayersOrder(config, rootCfg);

--- a/tests/js-units/node/state/externalmaplayer.test.js
+++ b/tests/js-units/node/state/externalmaplayer.test.js
@@ -34,8 +34,10 @@ function getRootMapGroupState(name) {
 
 	const layers = new LayersConfig(config.layers);
 
-	const rootCfg = buildLayerTreeConfig(capabilities.Capability.Layer, layers);
+	let invalid = [];
+	const rootCfg = buildLayerTreeConfig(capabilities.Capability.Layer, layers, invalid);
 	expect(rootCfg).to.be.instanceOf(LayerTreeGroupConfig)
+	expect(invalid).to.have.length(0);
 
 	const layersOrder = buildLayersOrder(config, rootCfg);
 

--- a/tests/js-units/node/state/layer.test.js
+++ b/tests/js-units/node/state/layer.test.js
@@ -32,7 +32,10 @@ function getRootLayerGroupState(name) {
 
     const layers = new LayersConfig(config.layers);
 
-    const rootCfg = buildLayerTreeConfig(capabilities.Capability.Layer, layers);
+    let invalid = [];
+    const rootCfg = buildLayerTreeConfig(capabilities.Capability.Layer, layers, invalid);
+
+    expect(invalid).to.have.length(0);
     expect(rootCfg).to.be.instanceOf(LayerTreeGroupConfig)
 
     const layersOrder = buildLayersOrder(config, rootCfg);
@@ -63,7 +66,10 @@ function getLayersAndGroupsCollection(name) {
 
     const layers = new LayersConfig(config.layers);
 
-    const rootCfg = buildLayerTreeConfig(capabilities.Capability.Layer, layers);
+    let invalid = [];
+    const rootCfg = buildLayerTreeConfig(capabilities.Capability.Layer, layers, invalid);
+
+    expect(invalid).to.have.length(0);
     expect(rootCfg).to.be.instanceOf(LayerTreeGroupConfig)
 
     const layersOrder = buildLayersOrder(config, rootCfg);
@@ -1670,7 +1676,10 @@ describe('LayersAndGroupsCollection', function () {
             "group-without-children"
         )
 
-        const rootCfg = buildLayerTreeConfig(capabilities.Capability.Layer, layers);
+        let invalid = [];
+        const rootCfg = buildLayerTreeConfig(capabilities.Capability.Layer, layers, invalid);
+
+        expect(invalid).to.have.length(0);
         expect(rootCfg).to.be.instanceOf(LayerTreeGroupConfig)
 
         // `group-without-children` has a layerTree config and it is a layer not a group

--- a/tests/js-units/node/state/layerTree.test.js
+++ b/tests/js-units/node/state/layerTree.test.js
@@ -37,7 +37,10 @@ function getRootLayerTreeGroupState(name) {
 
     const layers = new LayersConfig(config.layers);
 
-    const rootCfg = buildLayerTreeConfig(capabilities.Capability.Layer, layers);
+    let invalid = [];
+    const rootCfg = buildLayerTreeConfig(capabilities.Capability.Layer, layers, invalid);
+
+    expect(invalid).to.have.length(0);
     expect(rootCfg).to.be.instanceOf(LayerTreeGroupConfig)
 
     const layersOrder = buildLayersOrder(config, rootCfg);

--- a/tests/js-units/node/state/maplayer.test.js
+++ b/tests/js-units/node/state/maplayer.test.js
@@ -32,7 +32,10 @@ function getRootMapGroupState(name) {
 
     const layers = new LayersConfig(config.layers);
 
-    const rootCfg = buildLayerTreeConfig(capabilities.Capability.Layer, layers);
+    let invalid = [];
+    const rootCfg = buildLayerTreeConfig(capabilities.Capability.Layer, layers, invalid);
+
+    expect(invalid).to.have.length(0);;
     expect(rootCfg).to.be.instanceOf(LayerTreeGroupConfig)
 
     const layersOrder = buildLayersOrder(config, rootCfg);


### PR DESCRIPTION
I'm keen to have some feedbacks here.

For now, globally in Lizmap, if an error occurs, there is nothing displayed in the user interface. The only way is to open the developer tools, which is not a good advice, our admin end-users shouldn't open the web developer tools.

It would be nice, at the end of loading a map, a UI box is displayed if there were any "error" during loading the map ?

Just to keen to have ideas