### PR TITLE
E2E - Add some tags on CORS tests and flaky OpenLayers

### DIFF
--- a/tests/end2end/playwright/cors.spec.js
+++ b/tests/end2end/playwright/cors.spec.js
@@ -1,8 +1,12 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Cors', function () {
+test.describe('CORS',
+  {
+    tag: ['@localonly'],
+  }, () => {
 
   test('send authorized request', async function ({ page }, testInfo) {
+    test.skip(process.env.CI, 'Not working on GH Action');
     await page.goto('http://othersite.local:8130');
     await page.locator('#launch-request').click();
     await expect(page.locator('#status')).toHaveText('200');
@@ -13,6 +17,7 @@ test.describe('Cors', function () {
 
 
   test('send unauthorized request', async function ({ page }, testInfo) {
+    test.skip(process.env.CI, 'Not working on GH Action');
     await page.goto(
       'http://othersite.local:8130');
     await page.locator('#launch-request-bad').click();

--- a/tests/end2end/playwright/custom-javascript-api.spec.js
+++ b/tests/end2end/playwright/custom-javascript-api.spec.js
@@ -6,7 +6,9 @@ test.describe('Maps management', () => {
 
     test.use({ storageState: 'playwright/.auth/admin.json' });
 
-    test('OpenLayers', async ({ page }) => {
+    test('OpenLayers', {
+        tag: '@flaky',
+    }, async ({ page }) => {
         // Allow themes/javascript codes for tests repository
         await page.goto('admin.php');
         await page.getByRole('link', { name: 'Maps management' }).click();


### PR DESCRIPTION
E2E - Add some tags on CORS tests and flaky OpenLayers

`@flaky` and `@localonly`

https://playwright.dev/docs/test-annotations#skip-a-test
