### PR TITLE
Tests - Check client side logs

### DIFF
--- a/tests/end2end/playwright/dnd-form.spec.js
+++ b/tests/end2end/playwright/dnd-form.spec.js
@@ -13,7 +13,7 @@ test.describe(
 
     test('With new geom data creation, not remove data', async function ({ page }) {
         const project = new ProjectPage(page, 'dnd_form');
-        await project.open();
+        await project.open(true);
         await project.openEditingFormWithLayer('dnd_form_geom');
         await project.dock.getByText('tab2').click();
         await project.editingField('field_in_dnd_form').fill('value in DND form');

--- a/tests/end2end/playwright/pages/admin.js
+++ b/tests/end2end/playwright/pages/admin.js
@@ -9,7 +9,7 @@ import { BasePage } from './base';
  */
 
 /**
- * Playwright Page
+ * Playwright Locator
  * @typedef {import('@playwright/test').Locator} Locator
  */
 

--- a/tests/end2end/playwright/pages/base.js
+++ b/tests/end2end/playwright/pages/base.js
@@ -8,13 +8,30 @@ import { expect } from '@playwright/test';
  */
 
 /**
- * Playwright Page
+ * Playwright Locator
  * @typedef {import('@playwright/test').Locator} Locator
+ */
+
+/**
+ * @typedef {Object} logMessage
+ * @property {string} type - the log type :One of the following values:
+ * 'log', 'debug', 'info', 'error', 'warning', 'dir', 'dirxml', 'table',
+ * 'trace', 'clear', 'startGroup', 'startGroupCollapsed', 'endGroup',
+ * 'assert', 'profile', 'profileEnd', 'count', 'timeEnd'.
+ * @property {string} message - the log message text
+ * @property {string} location - the log message location in one line
+ * @see https://playwright.dev/docs/api/class-consolemessage
  */
 
 export class BasePage {
     /** @type {Page} */
     page;
+
+    /**
+     * Logs collected
+     * @type {logMessage[]}
+     */
+    logs = [];
 
     /**
      * Header menu
@@ -36,6 +53,21 @@ export class BasePage {
         this.page = page;
         this.headerMenu = page.locator('#headermenu');
         this.alert = page.locator('.alert');
+
+        const logs = this.logs;
+        page.on('console', message => {
+            // Default message from jQuery: JQMIGRATE: Migrate is installed, version 3.3.1
+            // Do not stored it - will be removed when we are sure that this log will not appear
+            if (message.type() === 'log' && message.text().startsWith('JQMIGRATE: Migrate is installed')) {
+                return;
+            }
+            const location = message.location()
+            logs.push({
+                type: message.type(),
+                message: message.text(),
+                location: `${location.url}:${location.lineNumber}:${location.columnNumber}`
+            })
+        })
     }
 
     /**

--- a/tests/end2end/playwright/pages/homepage.js
+++ b/tests/end2end/playwright/pages/homepage.js
@@ -7,7 +7,7 @@ import { BasePage } from './base';
  */
 
 /**
- * Playwright Page
+ * Playwright Locator
  * @typedef {import('@playwright/test').Locator} Locator
  */
 

--- a/tests/end2end/playwright/pages/project.js
+++ b/tests/end2end/playwright/pages/project.js
@@ -3,13 +3,14 @@ import { expect } from '@playwright/test';
 import { gotoMap } from '../globals';
 import { BasePage } from './base';
 
+
 /**
  * Playwright Page
  * @typedef {import('@playwright/test').Page} Page
  */
 
 /**
- * Playwright Page
+ * Playwright Locator
  * @typedef {import('@playwright/test').Locator} Locator
  */
 
@@ -136,9 +137,13 @@ export class ProjectPage extends BasePage {
     /**
      * open function
      * Open the URL for the given project and repository
+     * @param {boolean} assertEmptyClientLog If loading the map mustn't trigger some logs.
      */
-    async open(){
+    async open(assertEmptyClientLog = false){
         await gotoMap(`/index.php/view/map?repository=${this.repository}&project=${this.project}`, this.page);
+        if(assertEmptyClientLog){
+            expect(this.logs).toHaveLength(0);
+        }
     }
 
     /**


### PR DESCRIPTION
Superseeds #5226 from @rldhont 

I'm not a fan of this new parameter, because then we end with similar parameters in `gotoMap` ...

But if want to check for client side logs, better to do it step by step, without to many projects.

I was thinking about Playwright tags, with `testinfo` https://playwright.dev/docs/api/class-testinfo#test-info-tags