### PR TITLE
Fix WKT geometry string provided by QGIS Server in GetFeatureInfo

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapWkt.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapWkt.class.php
@@ -7,6 +7,10 @@
  *
  * @license Mozilla Public License : http://www.mozilla.org/MPL/
  */
+
+/**
+ * @phpstan-type WktMatches array{geomType: string, dim: string, str: string}
+ */
 class lizmapWkt
 {
     /** @var array<string, string> */
@@ -24,7 +28,7 @@ class lizmapWkt
      *
      * @param string $wkt A WKT string
      *
-     * @return array|false The WKT string is well formed
+     * @return false|WktMatches The WKT string is well formed
      */
     public static function check($wkt)
     {
@@ -42,11 +46,53 @@ class lizmapWkt
             return false;
         }
 
+        $geomType = strtolower($matches[1]);
+        $dim = strtolower($matches[2]);
+        $str = $matches[3];
+
+        if (substr($geomType, -2) === 'zm') {
+            $geomType = substr($geomType, 0, -2);
+            $dim = 'zm';
+        } elseif (substr($geomType, -2) === 'mz') {
+            $geomType = substr($geomType, 0, -2);
+            $dim = 'mz';
+        } elseif (substr($geomType, -1) === 'z') {
+            $geomType = substr($geomType, 0, -1);
+            $dim = 'z';
+        } elseif (substr($geomType, -1) === 'm') {
+            $geomType = substr($geomType, 0, -1);
+            $dim = 'm';
+        }
+
         return array(
-            'geomType' => strtolower($matches[1]),
-            'dim' => strtolower($matches[2]),
-            'str' => $matches[3],
+            'geomType' => $geomType,
+            'dim' => $dim,
+            'str' => $str,
         );
+    }
+
+    /**
+     * Return a WKT string corrected with space between geometry type and dimension as upper case.
+     *
+     * @param string $wkt A WKT string
+     *
+     * @return null|string The WKT string corrected with space between geometry type and dimension as upper case
+     */
+    public static function fix($wkt)
+    {
+        // Checking and extracting geometry type, dimension and coordinates
+        $matches = self::check($wkt);
+        if (!$matches) {
+            return null;
+        }
+
+        $nWkt = $matches['geomType'];
+        if ($matches['dim'] !== '') {
+            $nWkt .= ' '.$matches['dim'];
+        }
+        $nWkt .= ' ('.$matches['str'].')';
+
+        return strtoupper($nWkt);
     }
 
     /**
@@ -66,20 +112,6 @@ class lizmapWkt
         $geomType = $matches['geomType'];
         $dim = $matches['dim'];
         $str = $matches['str'];
-
-        if (substr($geomType, -2) === 'zm') {
-            $geomType = substr($geomType, 0, -2);
-            $dim = 'zm';
-        } elseif (substr($geomType, -2) === 'mz') {
-            $geomType = substr($geomType, 0, -2);
-            $dim = 'mz';
-        } elseif (substr($geomType, -1) === 'z') {
-            $geomType = substr($geomType, 0, -1);
-            $dim = 'z';
-        } elseif (substr($geomType, -1) === 'm') {
-            $geomType = substr($geomType, 0, -1);
-            $dim = 'm';
-        }
 
         // Get coordinates
         $coordinates = null;

--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -761,7 +761,11 @@ class WMSRequest extends OGCRequest
                         'maxy' => 'bbox-maxy',
                     );
                     if ($feature->BoundingBox) {
-                        $hiddenGeometry .= '<input type="hidden" value="'.$attribute['value'].'" class="lizmap-popup-layer-feature-geometry"/>'.PHP_EOL;
+                        // Fix geometry by adding space between geometry type and Z, M or ZM
+                        $geom = \lizmapWkt::fix($attribute['value']);
+                        // Insert geometry as an hidden input
+                        $hiddenGeometry .= '<input type="hidden" value="'.$geom.'" class="lizmap-popup-layer-feature-geometry"/>'.PHP_EOL;
+                        // Insert bounding box data as hidden inputs
                         $bbox = $feature->BoundingBox[0];
                         foreach ($props as $prop => $class) {
                             $hiddenGeometry .= '<input type="hidden" value="'.$bbox[$prop].'" class="lizmap-popup-layer-feature-'.$class.'"/>'.PHP_EOL;

--- a/tests/units/classes/lizmapWktTest.php
+++ b/tests/units/classes/lizmapWktTest.php
@@ -24,7 +24,32 @@ class lizmapWktTest extends TestCase {
             'GEOMETRY (((30 10, 40 40, 20 40, 10 20, 30 10)))',
         );
         foreach($wktArray as $wkt) {
-            $this->assertIsArray(lizmapWkt::check($wkt), 'The '.$wkt.' has not been checked!');
+            $checked = lizmapWkt::check($wkt);
+            $this->assertIsArray($checked, 'The '.$wkt.' has not been checked!');
+            $this->assertArrayHasKey('geomType', $checked);
+            $this->assertArrayHasKey('dim', $checked);
+            $this->assertEquals('', $checked['dim']);
+            $this->assertArrayHasKey('str', $checked);
+        }
+
+        $zWktArray = array(
+            'POINT Z (30 10 0)',
+            'POINT Z(30 10 0)',
+            'POINTZ(30 10 0)',
+            'LINESTRING Z (30 10 0, 10 30 1, 40 40 2)',
+            'LINESTRING Z(30 10 0, 10 30 1, 40 40 2)',
+            'LINESTRINGZ(30 10 0, 10 30 1, 40 40 2)',
+            'POLYGON Z ((30 10 0, 40 40 2, 20 40 1, 10 20 2, 30 10 0))',
+            'POLYGON Z((30 10 0, 40 40 2, 20 40 1, 10 20 2, 30 10 0))',
+            'POLYGONZ((30 10 0, 40 40 2, 20 40 1, 10 20 2, 30 10 0))',
+        );
+        foreach($zWktArray as $wkt) {
+            $checked = lizmapWkt::check($wkt);
+            $this->assertIsArray($checked, 'The '.$wkt.' has not been checked!');
+            $this->assertArrayHasKey('geomType', $checked);
+            $this->assertArrayHasKey('dim', $checked);
+            $this->assertEquals('z', $checked['dim']);
+            $this->assertArrayHasKey('str', $checked);
         }
 
         $notWktArray = array(
@@ -39,6 +64,35 @@ class lizmapWktTest extends TestCase {
         foreach($notWktArray as $wkt) {
             $this->assertFalse(lizmapWkt::check($wkt), 'The '.$wkt.' has been checked!');
         }
+    }
+
+    function testFixing() {
+        // Unfixed WKT
+        $wkt = 'POINT (30 10)';
+        $nWkt = lizmapWkt::fix($wkt);
+        $this->assertEquals($wkt, $nWkt);
+
+        $wkt = 'POINT Z (30 10 0)';
+        $nWkt = lizmapWkt::fix($wkt);
+        $this->assertEquals($wkt, $nWkt);
+
+        $wkt = 'POINT M (30 10 0)';
+        $nWkt = lizmapWkt::fix($wkt);
+        $this->assertEquals($wkt, $nWkt);
+
+        $wkt = 'POINT ZM (30 10 0 0)';
+        $nWkt = lizmapWkt::fix($wkt);
+        $this->assertEquals($wkt, $nWkt);
+
+        // Fixed WKT
+        $expectedWkt = 'POINT Z (30 10 0)';
+        $wkt = 'POINT Z(30 10 0)';
+        $nWkt = lizmapWkt::fix($wkt);
+        $this->assertEquals($expectedWkt, $nWkt);
+
+        $wkt = 'POINTZ(30 10 0)';
+        $nWkt = lizmapWkt::fix($wkt);
+        $this->assertEquals($expectedWkt, $nWkt);
     }
 
     function testPoint() {


### PR DESCRIPTION
The WKT geometry provided by QGIS Server in GetFeatureInfo does not contain a space between the geometry type and the dimension.

Funded by Syslor https://syslor.net