### PR TITLE
Update lizmapServices.class.php

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapServices.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapServices.class.php
@@ -627,7 +627,7 @@ class lizmapServices
     {
         if (empty($this->lizmapPluginAPIURL)) {
             // When the Lizmap API URL is not set, we use the WMS server URL only
-            // and we add '/lizmap'/ at then end
+            // and we add '/lizmap' at then end
             return rtrim($this->wmsServerURL, '/').'/lizmap';
         }
 

--- a/lizmap/modules/lizmap/classes/lizmapServices.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapServices.class.php
@@ -628,7 +628,7 @@ class lizmapServices
         if (empty($this->lizmapPluginAPIURL)) {
             // When the Lizmap API URL is not set, we use the WMS server URL only
             // and we add '/lizmap'/ at then end
-            return rtrim($this->wmsServerURL, '/').'/lizmap/';
+            return rtrim($this->wmsServerURL, '/').'/lizmap';
         }
 
         // When the Lizmap API URL is set


### PR DESCRIPTION
Causes of bad url construction such as http://myhost/cgi-bin/qgis_mapserv.fcgi/lizmap//server.json adding a double slash before of server.json and avoid the correct recognization of Lizmap server plugin on Master

<!--
Add the word "fix" in front of "#" if it fixes the ticket
or do nothing to only mention it.

funded by NAME
If funded by someone else than 3Liz, please add label "sponsored development"

Please mention if the PR should be backported and to which versions.

Please add new tests if possible (JS, PHP, End2End…)
-->

