### PR TITLE
Tests - Use toHaveLength

### DIFF
--- a/tests/end2end/playwright/globals.js
+++ b/tests/end2end/playwright/globals.js
@@ -193,7 +193,7 @@ export async function expectParametersToContain(title, parameters, expectedParam
 
     await expect(
         searchParams.size,
-        `Check "${title}" : Not enough parameters compared to expected!`
+        `Check "${title}" : Not enough parameters compared to expected :\nGot ${Array.from(searchParams.keys()).join(', ')}!`
     ).toBeGreaterThanOrEqual(Object.keys(expectedParameters).length)
 
     for (const param in expectedParameters) {
@@ -206,13 +206,13 @@ export async function expectParametersToContain(title, parameters, expectedParam
         if (expectedValue instanceof RegExp) {
             await expect(
                 searchParams.get(param),
-                `Title "${title}" : ${param} does not match the expected value : expected "${expectedValue}" versus got "${searchParams.get(param)}"`
+                `Title "${title}" : ${param} does not match the expected value :\nExpected "${expectedValue}"\nGot "${searchParams.get(param)}"`
             ).toMatch(expectedValue)
 
         } else {
             await expect(
                 searchParams.get(param),
-                `Title "${title}" : ${param} has not the right value : expected "${expectedValue}" versus got "${searchParams.get(param)}"`
+                `Title "${title}" : ${param} has not the right value :\nExpected "${expectedValue}"\nGot "${searchParams.get(param)}"`
             ).toBe(expectedValue)
         }
     }

--- a/tests/end2end/playwright/map-projects-switcher.spec.js
+++ b/tests/end2end/playwright/map-projects-switcher.spec.js
@@ -34,13 +34,13 @@ test.describe('Map projects switcher', () => {
         await expect(page.locator('#_projectSwitcher')).toHaveText('Off');
     })
 
-    test('Switcher form map to map', async ({ page }) => {
+    test('Switcher from map to map', async ({ page }) => {
         await gotoMap('index.php/view/map?repository=testsrepository&project=base_layers', page);
 
         // Check scale
         await expect(page.locator('#overview-bar .ol-scale-text')).toHaveText('1 : ' + (144448).toLocaleString(locale));
 
-        // Go to an other map
+        // Go to another map
         await page.locator('#button-projects').click();
         await page.locator('li').filter({ hasText: 'base_layers_user_defined' }).getByRole('link').nth(1).click();
 
@@ -56,7 +56,7 @@ test.describe('Map projects switcher', () => {
         // Wait for OL transition
         await page.waitForTimeout(1000);
 
-        // Go to an other map
+        // Go to another map
         await page.locator('#button-projects').click();
         await page.locator('li').filter({ hasText: 'base_layers' }).getByRole('link').nth(1).click();
 
@@ -81,7 +81,7 @@ test.describe('Map projects switcher', () => {
         // Check scale
         await expect(page.locator('#overview-bar .ol-scale-text')).toHaveText('1 : ' + (72224).toLocaleString(locale));
 
-        // Go to an other map
+        // Go to another map
         await page.locator('#button-projects').click();
         await page.locator('li').filter({ hasText: 'attribute_table' }).getByRole('link').nth(1).click();
 
@@ -110,7 +110,7 @@ test.describe('Map projects switcher', () => {
         // Check scale
         await expect(page.locator('#overview-bar .ol-scale-text')).toHaveText('1 : ' + (10000).toLocaleString(locale));
 
-        // Go to an other map
+        // Go to another map
         await page.locator('#button-projects').click();
         await page.locator('li').filter({ hasText: 'base_layers_user_defined' }).getByRole('link').nth(1).click();
 
@@ -133,7 +133,7 @@ test.describe('Map projects switcher', () => {
         // Wait for OL transition
         await page.waitForTimeout(1000);
 
-        // Go to an other map
+        // Go to another map
         await page.locator('#button-projects').click();
         await page.locator('li').filter({ hasText: 'base_layers' }).getByRole('link').nth(1).click();
 

--- a/tests/end2end/playwright/print.spec.js
+++ b/tests/end2end/playwright/print.spec.js
@@ -78,7 +78,7 @@ test.describe('Print', () => {
             // 'multiline_label': 'Multiline label',
         })
         let getPrintParams = await expectParametersToContain('Print requests 1', getPrintRequest.postData() ?? '', expectedParameters1)
-        await expect(getPrintParams.size).toBe(15)
+        await expect(Array.from(getPrintParams.keys())).toHaveLength(15)
 
         // Close message
         await page.locator('.btn-close').click();
@@ -101,7 +101,7 @@ test.describe('Print', () => {
             'map0:OPACITIES': '204,255,255',
         })
         getPrintParams = await expectParametersToContain('Print requests 2', getPrintRequest.postData() ?? '', expectedParameters2)
-        await expect(getPrintParams.size).toBe(13)
+        await expect(Array.from(getPrintParams.keys())).toHaveLength(13)
 
         // Test `print_overview` template
         await page.locator('#print-template').selectOption('2');
@@ -127,7 +127,7 @@ test.describe('Print', () => {
             'map0:EXTENT': /761864.\d+,6274266.\d+,779334.\d+,6284518.\d+/,
         })
         getPrintParams = await expectParametersToContain('Print requests 3', getPrintRequest.postData() ?? '', expectedParameters3)
-        await expect(getPrintParams.size).toBe(14)
+        await expect(Array.from(getPrintParams.keys())).toHaveLength(14)
 
         // Redlining with circle
         await page.locator('#button-draw').click();
@@ -196,7 +196,7 @@ test.describe('Print', () => {
         })
         /* eslint-enable no-useless-escape */
         getPrintParams = await expectParametersToContain('Print requests 4', getPrintRequest.postData() ?? '', expectedParameters4)
-        await expect(getPrintParams.size).toBe(17)
+        await expect(Array.from(getPrintParams.keys())).toHaveLength(17)
     });
 
     test('Print requests with selection', async ({ page }) => {
@@ -235,7 +235,7 @@ test.describe('Print', () => {
             'SELECTIONTOKEN': /[a-z\d]+/,
         }
         const getPrintParams = await expectParametersToContain('Print requests with selection', getPrintRequest.postData() ?? '', expectedParameters)
-        await expect(getPrintParams.size).toBe(16)
+        await expect(Array.from(getPrintParams.keys())).toHaveLength(16)
     });
 
     test('Print requests with filter', async ({ page }) => {
@@ -284,7 +284,7 @@ test.describe('Print', () => {
             'FILTERTOKEN': /[a-z\d]+/,
         }
         const getPrintParams = await expectParametersToContain('Print requests with filter', getPrintRequest.postData() ?? '', expectedParameters)
-        await expect(getPrintParams.size).toBe(16)
+        await expect(Array.from(getPrintParams.keys())).toHaveLength(16)
     });
 });
 
@@ -339,7 +339,7 @@ test.describe('Print in popup', () => {
             'EXP_FILTER': '$id IN (1)',
         }
         const getPrintParams = await expectParametersToContain('Atlas print in popup requests', getPrintRequest.postData() ?? '', expectedParameters)
-        await expect(getPrintParams.size).toBe(10)
+        await expect(Array.from(getPrintParams.keys())).toHaveLength(10)
         await expect(getPrintParams.has('CRS')).toBe(false)
         await expect(getPrintParams.has('LAYERS')).toBe(false)
         await expect(getPrintParams.has('ATLAS_PK')).toBe(false)
@@ -521,7 +521,7 @@ test.describe('Print 3857', () => {
             // 'multiline_label': 'Multiline label',
         })
         let getPrintParams = await expectParametersToContain('Print requests 1', getPrintRequest.postData() ?? '', expectedParameters1)
-        await expect(getPrintParams.size).toBe(15)
+        await expect(Array.from(getPrintParams.keys())).toHaveLength(15)
 
         // Test `print_map` template
         await page.locator('#print-template').selectOption('1');
@@ -548,7 +548,7 @@ test.describe('Print 3857', () => {
             'map0:OPACITIES': '204,255,255',
         })
         getPrintParams = await expectParametersToContain('Print requests 2', getPrintRequest.postData() ?? '', expectedParameters2)
-        await expect(getPrintParams.size).toBe(13)
+        await expect(Array.from(getPrintParams.keys())).toHaveLength(13)
 
         // Close message
         await page.locator('.btn-close').click();
@@ -619,7 +619,7 @@ test.describe('Print 3857', () => {
         })
         /* eslint-enable no-useless-escape */
         getPrintParams = await expectParametersToContain('Print requests 3', getPrintRequest.postData() ?? '', expectedParameters3)
-        await expect(getPrintParams.size).toBe(17)
+        await expect(Array.from(getPrintParams.keys())).toHaveLength(17)
     });
 });
 
@@ -666,7 +666,7 @@ test.describe('Print base layers', () => {
             'map0:OPACITIES': '255',
         })
         let getPrintParams = await expectParametersToContain('Print requests 1', getPrintRequest.postData() ?? '', expectedParameters1)
-        await expect(getPrintParams.size).toBe(13)
+        await expect(Array.from(getPrintParams.keys())).toHaveLength(13)
 
         let getPrintResponse = await getPrintRequest.response();
         await expect(getPrintResponse?.status()).toBe(200)
@@ -696,7 +696,7 @@ test.describe('Print base layers', () => {
             'map0:OPACITIES': '255,255',
         })
         getPrintParams = await expectParametersToContain('Print requests 2', getPrintRequest.postData() ?? '', expectedParameters2)
-        await expect(getPrintParams.size).toBe(13)
+        await expect(Array.from(getPrintParams.keys())).toHaveLength(13)
 
         getPrintResponse = await getPrintRequest.response();
         await expect(getPrintResponse?.status()).toBe(200)
@@ -725,7 +725,7 @@ test.describe('Print base layers', () => {
             'map0:OPACITIES': '255',
         })
         getPrintParams = await expectParametersToContain('Print requests 3', getPrintRequest.postData() ?? '', expectedParameters3)
-        await expect(getPrintParams.size).toBe(13)
+        await expect(Array.from(getPrintParams.keys())).toHaveLength(13)
 
         getPrintResponse = await getPrintRequest.response();
         await expect(getPrintResponse?.status()).toBe(200)
@@ -754,7 +754,7 @@ test.describe('Print base layers', () => {
             'map0:OPACITIES': '255,255',
         })
         getPrintParams = await expectParametersToContain('Print requests 4', getPrintRequest.postData() ?? '', expectedParameters4)
-        await expect(getPrintParams.size).toBe(13)
+        await expect(Array.from(getPrintParams.keys())).toHaveLength(13)
 
         getPrintResponse = await getPrintRequest.response();
         await expect(getPrintResponse?.status()).toBe(200)

--- a/tests/end2end/playwright/print_in_project_projection.spec.js
+++ b/tests/end2end/playwright/print_in_project_projection.spec.js
@@ -99,7 +99,7 @@ test.describe('Print in project projection', () => {
             // 'multiline_label': 'Multiline label',
         }
         const getPrintParams = await expectParametersToContain('Print external baselayer', getPrintRequest.postData() ?? '', expectedParameters)
-        await expect(getPrintParams.size).toBe(14)
+        await expect(Array.from(getPrintParams.keys())).toHaveLength(14)
         await getPrintRequest.response()
         await page.unroute('**/service*')
     })

--- a/tests/end2end/playwright/timemanage.spec.js
+++ b/tests/end2end/playwright/timemanage.spec.js
@@ -62,8 +62,14 @@ test.describe('Time Manager', () => {
             ];
             // Check if WMS Request params are as expected
             for (let obj of expectedParamValue) {
-                await expect(urlObj.has(obj.param), obj.param+' not in ['+Array.from(urlObj.keys()).join(', ')+']').toBeTruthy();
-                await expect(urlObj.get(obj.param), obj.param+'='+obj.expectedvalue+' not in ['+urlObj.toString().split('&').join(', ')+']').toBe(obj.expectedvalue);
+                await expect(
+                    urlObj.has(obj.param),
+                    obj.param+' not in ['+Array.from(urlObj.keys()).join(', ')+']'
+                ).toBeTruthy();
+                await expect(
+                    urlObj.get(obj.param),
+                    obj.param+'='+obj.expectedvalue+' not in ['+urlObj.toString().split('&').join(', ')+']'
+                ).toBe(obj.expectedvalue);
             }
         }
 


### PR DESCRIPTION
Before, it was a "poor" debug info : 

```
Error: expect(received).toBe(expected) // Object.is equality
    Expected: 15
    Received: 14
      522 |         })
      523 |         let getPrintParams = await expectParametersToContain('Print requests 1', getPrintRequest.postData() ?? '', expectedParameters1)
    > 524 |         await expect(getPrintParams.size).toBe(15)
```

Which is not meaning ful, because we don't know what was in the list before. I expect `toHaveLength` to show the list content ?
Otherwise, we will add a flag in `expectParametersToContain` to check the size of parameters and to display them nicely if faulty
