### PR TITLE
Avoid an admin to NOT see some projects in the administration panel

### DIFF
--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -331,6 +331,7 @@ project.rules.list.plugin.warnings.html=The project has <strong>at least one</st
 project.list.column.repository.label=Repository
 project.list.column.path.label=Path
 project.list.column.project.label=Project
+project.list.column.project.acl=The project is not accessible because of some group restrictions.
 project.list.column.inspection.file.time.label=Inspection time
 project.list.column.project.abstract.label=Abstract
 project.list.column.project.has.log.label=QGIS Server logs

--- a/lizmap/modules/admin/templates/project_list_zone.tpl
+++ b/lizmap/modules/admin/templates/project_list_zone.tpl
@@ -67,7 +67,7 @@ to view the hidden columns data and when there is no data for these columns -->
     {foreach $mapItems as $mi}
     {if $mi->type == 'rep'}
         {foreach $mi->childItems as $p}
-        <tr>
+        <tr data-repository-id="{$p['repository_id']}" data-project-id="{$p['id']}">
             <!-- Empty first column to use with the responsive (contains the triangle to open line details) -->
             <td title="{@admin.project.list.column.show.line.hidden.columns@}">
             </td>
@@ -75,7 +75,7 @@ to view the hidden columns data and when there is no data for these columns -->
             <!-- repository -->
             {* Warning : KEEP the line break after the title to improve the tooltip readability *}
             <td title="{if !empty($mi->title)}{$mi->title|strip_tags|eschtml}{/if}
-{@admin.project.list.column.path.label@ . ' : ' . $p['folder_repository']}">
+{@admin.project.list.column.path.label@ . ' : ' . $p['repository_id']}/">
             {* End of warning *}
                 <a target="_blank" href="{$p['url_repository']}">{$mi->id}</a>
             </td>
@@ -85,9 +85,13 @@ to view the hidden columns data and when there is no data for these columns -->
             <td title="{if !empty($p['title'])}{$p['title']|strip_tags|eschtml}{/if}
 {if !empty($p['abstract'])}{$p['abstract']|strip_tags|eschtml|truncate:150}{/if}">
             {* End of warning *}
-            {if $p['needs_update_error']}
-                {*The project cannot be displayed, do not provide a link to open it.*}
+            {if $p['needs_update_error'] || $p['acl_no_access']}
+                {* The project cannot be displayed, either it is too old, or the user has no access to it. *}
+                {* Do not provide a link to open it.*}
                 {$p['id']}
+                {if $p['acl_no_access']}
+                    <span title='{@admin.project.list.column.project.acl@}'>🔒</span>
+                {/if}
             {else}
                 <a target="_blank" href="{$p['url']}">{$p['id']}</a>
             {/if}

--- a/lizmap/modules/lizmap/classes/lizmapRepository.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapRepository.class.php
@@ -159,11 +159,13 @@ class lizmapRepository
     /**
      * Get the repository projects metadata.
      *
+     * @param bool $checkAcl If the ACL must be checked, according to the current user, default to true
+     *
      * @return Lizmap\Project\ProjectMetadata[]
      */
-    public function getProjectsMetadata()
+    public function getProjectsMetadata($checkAcl = true)
     {
-        return $this->repo->getProjectsMetadata();
+        return $this->repo->getProjectsMetadata($checkAcl);
     }
 
     public function getProjectsMainData()

--- a/lizmap/modules/lizmap/lib/Project/Repository.php
+++ b/lizmap/modules/lizmap/lib/Project/Repository.php
@@ -358,9 +358,11 @@ class Repository
     /**
      * Get the repository projects metadata.
      *
+     * @param bool $checkAcl If the ACL must be checked, according to the current user, default to true
+     *
      * @return ProjectMetadata[]
      */
-    public function getProjectsMetadata()
+    public function getProjectsMetadata($checkAcl = true)
     {
         $data = array();
         $dir = $this->getPath();
@@ -387,8 +389,11 @@ class Repository
                             $keepReference = false;
                             $proj = $this->getProject(substr($qgsFile, 0, -4), $keepReference);
                             // Get the project metadata and add it to the returned object
-                            // only if the authenticated user can access the project
-                            if ($proj != null && $proj->checkAcl()) {
+                            // only if the authenticated user can access the project (or if checkACL is disabled)
+                            if ($proj != null) {
+                                if ($checkAcl && !$proj->checkAcl()) {
+                                    continue;
+                                }
                                 $data[] = $proj->getMetadata();
                             }
                         } catch (UnknownLizmapProjectException $e) {

--- a/tests/end2end/playwright/admin-qgis-projects.spec.js
+++ b/tests/end2end/playwright/admin-qgis-projects.spec.js
@@ -1,0 +1,29 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+import { getAuthStorageStatePath } from './globals';
+import {AdminPage} from "./pages/admin";
+
+test.describe('QGIS Projects page', () => {
+
+    test.use({ storageState: getAuthStorageStatePath('admin') });
+
+    test('Project ACL', async ({ page }) => {
+        const adminPage = new AdminPage(page);
+        await adminPage.open();
+        await adminPage.openPage('QGIS projects');
+
+        const title = 'td:nth-child(3)';
+        const project = '[data-repository-id="tests"]';
+        const projects = await adminPage.page.locator('#lizmap_project_list');
+
+        // Project is restricted to user_in_group_a
+        const projectAclRow = await projects.locator(`tr${project}[data-project-id="project_acl"]`);
+        await expect(projectAclRow.locator(title)).toContainText('project_acl');
+        await expect(projectAclRow.locator(title)).toContainText('🔒');
+
+        // Project does not have any restriction
+        const dndFormRow = await projects.locator(`tr${project}[data-project-id="dnd_form"]`);
+        await expect(dndFormRow.locator(title)).toContainText('dnd_form');
+        await expect(dndFormRow.locator(title)).not.toContainText('🔒');
+    });
+});

--- a/tests/end2end/playwright/pages/admin.js
+++ b/tests/end2end/playwright/pages/admin.js
@@ -37,6 +37,14 @@ export class AdminPage extends BasePage {
     }
 
     /**
+     * open function
+     * Open the URL on the home page.
+     */
+    async open(){
+        await this.page.goto('admin.php');
+    }
+
+    /**
      * Navigate in the administrator menu by clicking in the menu
      * @param {string} expected Name of the page
      */


### PR DESCRIPTION
Due to #5399, the `admin` in the Lizmap docker test stack couldn't see a QGIS project, limited to sub set of group (but not `admin` group)

![image](https://github.com/user-attachments/assets/18c439ed-6704-480f-8cb0-131c1b8afd52)


I'm not sure if we should backport to 3.8 ? (let's say no)