### PR TITLE
Rector - PHP instant Upgrades and Automated Refactoring

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,3 +64,23 @@ jobs:
 
       - name: Run ESLint
         run: npm run pretest-fix
+
+  rector:
+      name: "Rector 🛠️"
+      runs-on: ubuntu-latest
+      steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "latest"
+
+      - uses: "ramsey/composer-install@v3"
+        with:
+          working-directory: "tests/units"
+
+      - name: "Execute Rector"
+        working-directory: "tests/units"
+        run: composer rector

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,7 +75,7 @@ jobs:
 
       - uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "latest"
+          php-version: "8.1"
 
       - uses: "ramsey/composer-install@v3"
         with:

--- a/lizmap/modules/lizmap/classes/lizmap.class.php
+++ b/lizmap/modules/lizmap/classes/lizmap.class.php
@@ -340,7 +340,7 @@ class lizmap
      */
     public static function updateRepository($key, $data)
     {
-        if (!key_exists($key, self::$repositoryInstances)) {
+        if (!array_key_exists($key, self::$repositoryInstances)) {
             return false;
         }
 

--- a/lizmap/modules/lizmap/classes/lizmapTiler.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapTiler.class.php
@@ -250,7 +250,7 @@ class lizmapTiler
                 );
 
                 while ($scaleDenominator > $minScale) {
-                    $scaleDenominator = $scaleDenominator / 2;
+                    $scaleDenominator /= 2;
                     $scale = $scaleDenominator;
                     $res = 0.28E-3 * $scale / $METERS_PER_INCH / $INCHES_PER_UNIT[$unit];
                     // $res = $scale / ($INCHES_PER_UNIT[ $unit ] * 96.0);
@@ -351,7 +351,7 @@ class lizmapTiler
     {
         $cfgLayers = $project->getLayers();
         $layers = array();
-        foreach ($cfgLayers as $n => $l) {
+        foreach ($cfgLayers as $l) {
             if ($l->cached == 'True' && $l->singleTile != 'True' && strtolower($l->name) != 'overview') {
                 $layer = lizmapTiler::getLayerTileInfo($l->name, $project, $wms_xml, $tileMatrixSetList);
                 if ($layer) {

--- a/lizmap/modules/lizmap/classes/qgisExpressionUtils.class.php
+++ b/lizmap/modules/lizmap/classes/qgisExpressionUtils.class.php
@@ -39,7 +39,7 @@ class qgisExpressionUtils
     public static function getCriteriaFromExpressions($expressions)
     {
         $criteriaFrom = array();
-        foreach ($expressions as $id => $exp) {
+        foreach ($expressions as $exp) {
             if ($exp === null || trim($exp) === '') {
                 continue;
             }

--- a/lizmap/modules/lizmap/classes/qgisVectorLayerDatasource.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayerDatasource.class.php
@@ -121,7 +121,7 @@ class qgisVectorLayerDatasource
 
                 // Complex sub-query
                 if (substr($table, 0, 1) == '(' and substr($table, -1) == ')') {
-                    $table = $table.' fooliz';
+                    $table .= ' fooliz';
                 }
                 // Simple "schemaname"."table_name"
                 elseif (preg_match('#"."#', $table)) {

--- a/lizmap/modules/lizmap/classes/tools.class.php
+++ b/lizmap/modules/lizmap/classes/tools.class.php
@@ -31,22 +31,20 @@ class tools
      *
      * @param string $string     String passed
      * @param bool   $accent     Replace the accents ?
-     * @param bool   $speciaux   Replace special chars with underscores ?
-     * @param bool   $accent     Delete underscores ?
-     * @param bool   $accent     Replace capital letters ?
-     * @param mixed  $underscore
-     * @param mixed  $majuscule
+     * @param bool   $special    Replace special chars with underscores ?
+     * @param bool   $underscore Delete underscores ?
+     * @param bool   $capital    Replace capital letters ?
      *
      * @return string
      */
-    public function stringSimplify($string, $accent, $speciaux, $underscore, $majuscule)
+    public function stringSimplify($string, $accent, $special, $underscore, $capital)
     {
         // accents
         if ($accent) {
             $string = $this->unaccent($string);
         }
         // special chars
-        if ($speciaux) {
+        if ($special) {
             $search = array('@[^a-zA-Z0-9_]@');
             $replace = array('_');
             $string = preg_replace($search, $replace, $string);
@@ -58,7 +56,7 @@ class tools
             $string = str_replace($search, $replace, $string);
         }
         // capital
-        if ($majuscule) {
+        if ($capital) {
             $string = strtolower($string);
         }
 
@@ -69,23 +67,23 @@ class tools
      * Human readable file size.
      * Replace octets with appropriate value. Ex : 1024 -> 1 Mo.
      *
-     * @param string $fichier File from which to display the size
+     * @param string $file File from which to display the size
      *
-     * @return string $taille Formated file size
+     * @return string $filesize Formated file size
      */
-    public function displayFileSize($fichier)
+    public function displayFileSize($file)
     {
-        $taille_fichier = filesize($fichier);
-        if ($taille_fichier >= 1073741824) {
-            $taille_fichier = round($taille_fichier / 1073741824 * 100) / 100 .' Go';
-        } elseif ($taille_fichier >= 1048576) {
-            $taille_fichier = round($taille_fichier / 1048576 * 100) / 100 .' Mo';
-        } elseif ($taille_fichier >= 1024) {
-            $taille_fichier = round($taille_fichier / 1024 * 100) / 100 .' Ko';
+        $filesize = filesize($file);
+        if ($filesize >= 1073741824) {
+            $filesize = round($filesize / 1073741824 * 100) / 100 .' Go';
+        } elseif ($filesize >= 1048576) {
+            $filesize = round($filesize / 1048576 * 100) / 100 .' Mo';
+        } elseif ($filesize >= 1024) {
+            $filesize = round($filesize / 1024 * 100) / 100 .' Ko';
         } else {
-            $taille_fichier .= ' o';
+            $filesize .= ' o';
         }
 
-        return $taille_fichier;
+        return $filesize;
     }
 }

--- a/lizmap/modules/lizmap/classes/tools.class.php
+++ b/lizmap/modules/lizmap/classes/tools.class.php
@@ -83,7 +83,7 @@ class tools
         } elseif ($taille_fichier >= 1024) {
             $taille_fichier = round($taille_fichier / 1024 * 100) / 100 .' Ko';
         } else {
-            $taille_fichier = $taille_fichier.' o';
+            $taille_fichier .= ' o';
         }
 
         return $taille_fichier;

--- a/lizmap/modules/lizmap/lib/CliHelpers/WMTSCache.php
+++ b/lizmap/modules/lizmap/lib/CliHelpers/WMTSCache.php
@@ -340,7 +340,7 @@ class WMTSCache
                             if ($verbose && $tileProgress * 100 / $tileCount >= $tileStep) {
                                 $tileStep = floor($tileProgress * 100 / $tileCount);
                                 $outputCallback('Progression: '.$tileStep.'%, '.$tileProgress.' tiles generated on '.$tileCount.' tiles');
-                                $tileStep = $tileStep + $tileStepHeight;
+                                $tileStep += $tileStepHeight;
                             }
                         }
                         ++$row;

--- a/lizmap/modules/lizmap/lib/Commands/ProjectLoad.php
+++ b/lizmap/modules/lizmap/lib/Commands/ProjectLoad.php
@@ -34,7 +34,7 @@ class ProjectLoad extends \Jelix\Scripts\ModuleCommandAbstract
             return 1;
         }
         $checker = new \Lizmap\CliHelpers\RepositoryWMSChecker();
-        $checker->checkAllRepository($nb, function ($str) use ($output) {$output->writeln($str); });
+        $checker->checkAllRepository($nb, function ($str) use ($output): void {$output->writeln($str); });
 
         return 0;
     }

--- a/lizmap/modules/lizmap/lib/Commands/WMTSCacheClean.php
+++ b/lizmap/modules/lizmap/lib/Commands/WMTSCacheClean.php
@@ -27,7 +27,7 @@ class WMTSCacheClean extends \Jelix\Scripts\ModuleCommandAbstract
         $fakeServer = new \Jelix\FakeServerConf\ApacheMod(\jApp::wwwPath(), '/index.php');
         $fakeServer->setHttpRequest($req->getServerURI());
 
-        $WMTSCache = new \Lizmap\CliHelpers\WMTSCache(function ($str) use ($output) {$output->writeln($str); });
+        $WMTSCache = new \Lizmap\CliHelpers\WMTSCache(function ($str) use ($output): void {$output->writeln($str); });
         $WMTSCache->clean(
             $input->getArgument('repository'),
             $input->getArgument('project'),

--- a/lizmap/modules/lizmap/lib/Commands/WMTSCapabilities.php
+++ b/lizmap/modules/lizmap/lib/Commands/WMTSCapabilities.php
@@ -29,7 +29,7 @@ class WMTSCapabilities extends \Jelix\Scripts\ModuleCommandAbstract
         $fakeServer = new \Jelix\FakeServerConf\ApacheMod(\jApp::wwwPath(), '/index.php');
         $fakeServer->setHttpRequest($req->getServerURI());
 
-        $WMTSCache = new \Lizmap\CliHelpers\WMTSCache(function ($str) use ($output) {$output->writeln($str); });
+        $WMTSCache = new \Lizmap\CliHelpers\WMTSCache(function ($str) use ($output): void {$output->writeln($str); });
 
         return $WMTSCache->capabilities(
             $input->getArgument('repository'),

--- a/lizmap/modules/lizmap/lib/Commands/WMTSSeed.php
+++ b/lizmap/modules/lizmap/lib/Commands/WMTSSeed.php
@@ -46,7 +46,7 @@ class WMTSSeed extends \Jelix\Scripts\ModuleCommandAbstract
 
             return 1;
         }
-        $WMTSCache = new \Lizmap\CliHelpers\WMTSCache(function ($str) use ($output) {$output->writeln($str); });
+        $WMTSCache = new \Lizmap\CliHelpers\WMTSCache(function ($str) use ($output): void {$output->writeln($str); });
 
         return $WMTSCache->seed(
             $input->getArgument('repository'),

--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -193,7 +193,7 @@ class QgisForm implements QgisFormControlsInterface
         // we need some QgisFormControl data in some case where we have only the jForms object,
         // not the QgisForm object (like in jForms datasource objects etc.)
         $privateData['qgis_controls'] = array();
-        foreach ($this->formControls as $fieldName => $formControl) {
+        foreach ($this->formControls as $formControl) {
             $privateData['qgis_controls'][$formControl->ref] = array(
                 'valueRelationData' => $formControl->valueRelationData,
             );
@@ -1283,7 +1283,7 @@ class QgisForm implements QgisFormControlsInterface
             }
             if (substr($newStorageUrl, -1) == '/') {
                 // it's a directory, this should't happen, maybe it's better to throw an exception
-                $newStorageUrl = $newStorageUrl.$filename;
+                $newStorageUrl .= $filename;
             }
             // temp file on local file system
             $newFileToCopy = $uploadCtrl->getTempFile($form->getContainer()->privateData[$ref]['newfile']);

--- a/lizmap/modules/lizmap/lib/Logger/Config.php
+++ b/lizmap/modules/lizmap/lib/Logger/Config.php
@@ -98,8 +98,8 @@ class Config
      */
     public function getLogItem($key)
     {
-        if (!key_exists($key, $this->logItems)) {
-            if (!key_exists('item:'.$key, $this->data)) {
+        if (!array_key_exists($key, $this->logItems)) {
+            if (!array_key_exists('item:'.$key, $this->data)) {
                 return null;
             }
             $this->logItems[$key] = new Item($key, $this->data['item:'.$key], $this->appContext);

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -825,7 +825,7 @@ class Project
         if ($attributeLayers) {
             $hasDisplayedLayer = !$onlyDisplayedLayers;
             if ($onlyDisplayedLayers) {
-                foreach ($attributeLayers as $key => $obj) {
+                foreach ($attributeLayers as $obj) {
                     if (!property_exists($obj, 'hideLayer')
                         || strtolower($obj->hideLayer) != 'true'
                     ) {

--- a/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
@@ -537,7 +537,7 @@ class ProjectConfig
         $layersWithLabeledFields = array();
 
         // Attribute layers
-        foreach ($this->getAttributeLayers() as $key => $config) {
+        foreach ($this->getAttributeLayers() as $config) {
             if ($config->hideLayer == 'True') {
                 continue;
             }
@@ -545,7 +545,7 @@ class ProjectConfig
         }
 
         // Dataviz layers
-        foreach ($this->getDatavizLayers() as $o => $config) {
+        foreach ($this->getDatavizLayers() as $config) {
             $layerId = $config->layerId;
             if (array_key_exists($layerId, $layersWithLabeledFields)) {
                 continue;
@@ -554,7 +554,7 @@ class ProjectConfig
         }
 
         // Form filter layers
-        foreach ($this->getFormFilterLayers() as $o => $config) {
+        foreach ($this->getFormFilterLayers() as $config) {
             $layerId = $config->layerId;
             if (array_key_exists($layerId, $layersWithLabeledFields)) {
                 continue;
@@ -601,7 +601,7 @@ class ProjectConfig
     {
         // Get the correspondance between the plot uid & the plot ID (integer)
         $plotUidToId = array();
-        foreach ($this->datavizLayers as $id => $plot) {
+        foreach ($this->datavizLayers as $plot) {
             // If a uuid exists in the config, use it
             if (property_exists($plot, 'uuid')) {
                 $plotUidToId[$plot->uuid] = $plot->order;

--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -526,7 +526,7 @@ class QgisProject
 
         // unset displayInLegend for geometryType none or unknown
         $layers = $cfg->getLayers();
-        foreach ($layers as $key => $layerCfg) {
+        foreach ($layers as $layerCfg) {
             if (property_exists($layerCfg, 'geometryType')
                 && ($layerCfg->geometryType == 'none'
                     || $layerCfg->geometryType == 'unknown')
@@ -873,7 +873,7 @@ class QgisProject
         }
 
         $project = Qgis\ProjectInfo::fromQgisPath($this->path);
-        foreach ($editionLayers as $key => $obj) {
+        foreach ($editionLayers as $obj) {
             $layer = $project->getLayerById($obj->layerId);
             if ($layer === null) {
                 continue;
@@ -1018,7 +1018,7 @@ class QgisProject
 
         $project = Qgis\ProjectInfo::fromQgisPath($this->path);
         // Get field order & visibility
-        foreach ($attributeLayers as $key => $obj) {
+        foreach ($attributeLayers as $obj) {
             // Improve performance by getting custom_config status directly from config
             // Available for lizmap plugin >= 3.3.3
             if (property_exists($obj, 'custom_config') && $obj->custom_config != 'True') {
@@ -1313,7 +1313,7 @@ class QgisProject
     {
         $edittypes = array();
         $fieldConfiguration = $layerXml->fieldConfiguration;
-        foreach ($fieldConfiguration->field as $key => $field) {
+        foreach ($fieldConfiguration->field as $field) {
             $editWidget = $field->editWidget;
             $fieldName = (string) $field->attributes()->name;
             $fieldEditType = (string) $editWidget->attributes()->type;

--- a/lizmap/modules/lizmap/lib/Request/WFSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WFSRequest.php
@@ -128,7 +128,7 @@ class WFSRequest extends OGCRequest
 
         // Merge login filter
         $attribute = '';
-        foreach ($loginFilters as $typename => $lfilter) {
+        foreach ($loginFilters as $lfilter) {
             $expFilters[] = '( '.$lfilter['filter'].' )';
             $attribute = $lfilter['filterAttribute'];
         }

--- a/lizmap/modules/lizmap/lib/Server/Server.php
+++ b/lizmap/modules/lizmap/lib/Server/Server.php
@@ -223,7 +223,7 @@ class Server
         $data = array();
         $modules = new ModulesChecker();
 
-        foreach ($modules->getList(false) as $module => $info) {
+        foreach ($modules->getList(false) as $info) {
             $data[$info->slug] = array(
                 'version' => $info->version,
                 'core' => $info->isCore,

--- a/lizmap/modules/view/classes/lizmapMapDockItem.class.php
+++ b/lizmap/modules/view/classes/lizmapMapDockItem.class.php
@@ -98,7 +98,7 @@ function mapDockItemsMerge($itemsA, $itemsB)
         $maps[$item->id] = $item;
     }
     $items = array();
-    foreach ($maps as $id => $item) {
+    foreach ($maps as $item) {
         $items[] = $item;
     }
     usort($items, 'mapDockItemSort');

--- a/tests/README.md
+++ b/tests/README.md
@@ -303,6 +303,21 @@ npm run pretest
 npm run pretest:fix
 ```
 
+## PHP Rector
+
+PHP Rector can be run if you're located in `tests/units`.
+
+```bash
+# Install composer dependencies
+composer install
+
+# Run PHP Rector without fixing issues
+composer rector
+
+# Run PHP Rector and fix issues
+composer rector:fix
+```
+
 ## Using LDAP
 
 Into `lizmap/var/config/localconfig.ini.php`:

--- a/tests/units/composer.json
+++ b/tests/units/composer.json
@@ -16,5 +16,8 @@
         "classmap": ["../../lizmap/modules/lizmap/classes/" ],
         "psr-4": {"Lizmap\\": "../../lizmap/modules/lizmap/lib/"}
     },
-    "minimum-stability": "stable"
+    "minimum-stability": "stable",
+    "require-dev": {
+        "rector/rector": "1.2.*"
+    }
 }

--- a/tests/units/composer.json
+++ b/tests/units/composer.json
@@ -10,7 +10,8 @@
     "require": {
         "php": ">=8.1.0",
         "phpunit/phpunit": "^10.5.29",
-        "phpstan/phpstan": "1.11.11"
+        "phpstan/phpstan": "1.11.11",
+        "symfony/console": "*"
     },
     "autoload": {
         "classmap": ["../../lizmap/modules/lizmap/classes/" ],
@@ -19,5 +20,9 @@
     "minimum-stability": "stable",
     "require-dev": {
         "rector/rector": "1.2.*"
+    },
+    "scripts": {
+        "rector": "php listRules.php && vendor/bin/rector --dry-run",
+        "rector:fix": "php listRules.php && vendor/bin/rector"
     }
 }

--- a/tests/units/listRules.php
+++ b/tests/units/listRules.php
@@ -1,0 +1,55 @@
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+require __DIR__ . '/rector.php';
+
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+use Rector\Config\Level\TypeDeclarationLevel;
+use Rector\Config\Level\DeadCodeLevel;
+use Rector\Config\Level\CodeQualityLevel;
+
+$levelTypeCoverage = getLevelTypeCoverage();
+$levelDeadCode = getLevelDeadCode();
+$levelCodeQuality = getLevelCodeQuality();
+
+$coverageList = [];
+
+$coverageList["withTypeCoverageLevel"] = [
+    $levelTypeCoverage,
+    TypeDeclarationLevel::RULES
+];
+$coverageList["withDeadCodeLevel"] = [
+    $levelDeadCode,
+    DeadCodeLevel::RULES
+];
+$coverageList["withCodeQualityLevel"] = [
+    $levelCodeQuality,
+    CodeQualityLevel::RULES
+];
+
+$output = new ConsoleOutput();
+
+foreach ($coverageList as $key => $value) {
+    $level = $value[0] + 1;
+
+    if ($level <= 0) {
+        continue;
+    }
+
+    $totalRules = count($value[1]);
+
+    if ($level > $totalRules) {
+        $level = $totalRules;
+    }
+
+    $output->writeln(sprintf("<fg=green>For %s, you're using %d rule(s) out of %d :</fg=green>", $key, $level, $totalRules));
+    for ($i = 0; $i < $level; $i++) {
+        $rule = $value[1][$i];
+        $ruleFormatted = basename(str_replace('\\', '/', $rule));
+        $output->writeln(sprintf("<fg=yellow>\t* %s</fg=yellow>", $ruleFormatted));
+    }
+
+    $output->writeln("");
+}
+

--- a/tests/units/rector.php
+++ b/tests/units/rector.php
@@ -4,6 +4,29 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 
+// Set the level of type coverage
+$levelTypeCoverage = 0;
+$levelDeadCode = 0;
+$levelCodeQuality = 0;
+
+function getLevelTypeCoverage(): int
+{
+    global $levelTypeCoverage;
+    return $levelTypeCoverage;
+}
+
+function getLevelDeadCode(): int
+{
+    global $levelDeadCode;
+    return $levelDeadCode;
+}
+
+function getLevelCodeQuality(): int
+{
+    global $levelCodeQuality;
+    return $levelCodeQuality;
+}
+
 return RectorConfig::configure()
     ->withPaths([
         __DIR__ . '/../../lizmap/modules/lizmap/classes/',
@@ -20,4 +43,6 @@ return RectorConfig::configure()
     ])
     // uncomment to reach your current PHP version
     // ->withPhpSets()
-    ->withTypeCoverageLevel(0);
+    ->withTypeCoverageLevel($levelTypeCoverage)
+    ->withDeadCodeLevel($levelDeadCode)
+    ->withCodeQualityLevel($levelCodeQuality);

--- a/tests/units/rector.php
+++ b/tests/units/rector.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/../../lizmap/modules/lizmap/classes/',
+        __DIR__ . '/../../lizmap/modules/lizmap/lib/',
+        __DIR__ . '/../../lizmap/modules/view/classes/',
+        __DIR__ . '/../../lizmap/modules/admin/classes/',
+        __DIR__ . '/../../lizmap/modules/admin/lib/',
+        __DIR__ . '/../../lizmap/modules/dataviz/classes/',
+        __DIR__ . '/../../lizmap/modules/action/classes/',
+        __DIR__ . '/../../lizmap/modules/filter/classes/',
+        __DIR__ . '/classes',
+        __DIR__ . '/edition',
+        __DIR__ . '/testslib',
+    ])
+    // uncomment to reach your current PHP version
+    // ->withPhpSets()
+    ->withTypeCoverageLevel(0);

--- a/tests/units/testslib/ContextForTests.php
+++ b/tests/units/testslib/ContextForTests.php
@@ -214,7 +214,7 @@ class ContextForTests implements AppContextInterface
     {
         // simple url build
         $keyWithVal4QueryString = array();
-        array_walk($params, function($v ,$key) use (&$keyWithVal4QueryString) {$keyWithVal4QueryString[]=$key.'='.$v;});
+        array_walk($params, function($v ,$key) use (&$keyWithVal4QueryString): void {$keyWithVal4QueryString[]=$key.'='.$v;});
         return $selector.'?'.implode("&", $keyWithVal4QueryString);
     }
 


### PR DESCRIPTION
<!--
Add the word "fix" in front of "#" if it fixes the ticket
or do nothing to only mention it.

funded by NAME
If funded by someone else than 3Liz, please add label "sponsored development"

Please mention if the PR should be backported and to which versions.

Please add new tests if possible (JS, PHP, End2End…)
-->

_Improvement of #5352_

## Description

[Rector](https://github.com/rectorphp/rector) instantly upgrades and refactors the PHP code of your application. It can help you in 2 major areas:
* Instant Upgrades
* Automated Refactoring

Rector can help us to upgrades and refactors Lizmap step by step with levels https://getrector.com/documentation/levels

## Addition of Rector

* Now we can execute `composer rector` in order to upgrade/refactor PHP code
* Added a `listRules.php` that is executed before `rector` work. It is done to summarize which rule is applied depending on which level we put in `rector.php` for each set of rules.
_I put this in another file because `rector.php` is called multiple times when we launch it so it would have sent the summarize multiple times_
* Added it in the `lint` workflow

Example : 

![Capture d’écran du 2025-02-17 13-33-46](https://github.com/user-attachments/assets/8b7af9a1-eb72-404e-bb14-fa14865213c9)

Funded by 3Liz
