### PR TITLE
Log all error and warning in the console, and display them

### DIFF
--- a/assets/src/components/Print.js
+++ b/assets/src/components/Print.js
@@ -408,8 +408,7 @@ export default class Print extends HTMLElement {
 
             document.querySelector('#message .print-in-progress button').click();
         }, (errorEvent) => {
-            console.error(errorEvent)
-            mainLizmap._lizmap3.addMessage(lizDict['print.error'], 'danger', true).addClass('print-error');
+            mainLizmap._lizmap3.addMessage(lizDict['print.error'], 'danger', true, errorEvent).addClass('print-error');
         });
     }
 

--- a/assets/src/legacy/edition.js
+++ b/assets/src/legacy/edition.js
@@ -2073,7 +2073,6 @@ var lizEdition = function() {
             sendFormPromise.then(function(data) {
                 formResult = data;
             }).catch(e => {
-                console.error(e);
                 $('#edition-waiter').hide();
                 // Display the message
                 addEditionMessage(lizDict['edition.message.error.send.feature'], 'error', true);

--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -1905,12 +1905,13 @@ window.lizMap = function() {
      *
      * Returns:
      * {jQuery Object} The message added.
-     * @param aMessage
-     * @param aType
-     * @param aClose
-     * @param aTimeout
+     * @function mAddMessage
+     * @param aMessage The message to display
+     * @param aType The level of the message : 'info', 'danger', 'success'
+     * @param aClose If the message can be closed
+     * @param aTimeout Timeout for the message
      */
-    function mAddMessage( aMessage, aType, aClose, aTimeout ) {
+    function mAddMessage( aMessage, aType, aClose, aTimeout, errorDetailed ) {
         var mType = 'info';
         var mTypeList = ['info', 'error', 'danger', 'success'];
         var mClose = false;
@@ -1924,12 +1925,31 @@ window.lizMap = function() {
             mType = 'danger';
         }
 
+        // Logs which are either errors or warnings are logged in the console
+        switch (mType) {
+            case 'danger':
+                console.error(aMessage);
+                break;
+            case 'warn':
+                // warn is missing for now
+                console.warn(aMessage);
+                break;
+        }
+
         if ( aClose ){
             mClose = true;
         }
 
         var html = '<div class="alert alert-'+mType+' alert-dismissible fade show" role="alert" data-alert="alert">';
         html += '<p>'+aMessage+'</p>';
+
+        if (document.body.dataset.lizmapAdminUser == 1) {
+            if (errorDetailed) {
+                // If the user is an admin, and a detailed error is provided
+                html += '<button type="button" class="btn btn-link" data-bs-toggle="collapse" data-bs-target="#errorDetailed" aria-expanded="false" aria-controls="errorDetailed">Details</button>';
+                html += '<div class="collapse" id="errorDetailed"><pre>' + errorDetailed + '</pre></div>';
+            }
+        }
 
         if ( mClose ){
             html += '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>';
@@ -2840,14 +2860,15 @@ window.lizMap = function() {
         },
 
         /**
-         * Method: addMessage
-         * @param aMessage
-         * @param aType
-         * @param aClose
-         * @param aTimeout
+         * Add a message in the web interface
+         * @function addMessage
+         * @param aMessage The message to display
+         * @param aType The level of the message : 'info', 'error', 'danger', 'success'
+         * @param aClose If the message can be closed
+         * @param aTimeout Timeout for the message
          */
-        addMessage: function( aMessage, aType, aClose, aTimeout ) {
-            return mAddMessage( aMessage, aType, aClose, aTimeout );
+        addMessage: function( aMessage, aType, aClose, aTimeout, errorDetailed ) {
+            return mAddMessage( aMessage, aType, aClose, aTimeout, errorDetailed );
         },
 
         /**

--- a/assets/src/modules/Action.js
+++ b/assets/src/modules/Action.js
@@ -12,6 +12,7 @@ import GeoJSON from 'ol/format/GeoJSON.js';
 import Point from 'ol/geom/Point.js';
 import { fromExtent } from 'ol/geom/Polygon.js';
 import WKT from 'ol/format/WKT.js';
+import {mainLizmap} from "./Globals.js";
 
 /**
  * @class
@@ -498,8 +499,7 @@ export default class Action {
             this.ACTIVE_LIZMAP_ACTION = this.buildActionInstanceUniqueId(action.name, scope, layerId, featureId);
 
         } catch (error) {
-            // Display the error
-            console.warn(error);
+            mainLizmap._lizmap3.addMessage(lizDict['action.error'], 'danger', true, error);
 
             // Reset the action
             this.resetLizmapAction(true, true, true, true);

--- a/assets/src/modules/Tooltip.js
+++ b/assets/src/modules/Tooltip.js
@@ -125,8 +125,8 @@ export default class Tooltip {
             });
 
             this._activeTooltipLayer.getSource().on('featuresloaderror', () => {
-                this._lizmap3.addMessage(lizDict['tooltip.loading.error'], 'danger', true);
-                console.warn(`Tooltip layer '${layerName}' could not be loaded.`);
+                const detail = `Tooltip layer '${layerName}' could not be loaded.`
+                this._lizmap3.addMessage(lizDict['tooltip.loading.error'], 'danger', true, detail);
             });
 
             mainEventDispatcher.dispatch('tooltip.loading');

--- a/lizmap/modules/view/locales/en_US/dictionnary.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/dictionnary.UTF-8.properties
@@ -265,6 +265,7 @@ overviewbar.displayoverview.hover=Display/Hide overview
 action.title=Actions
 action.choose=Choose an action to run
 action.close=Close
+action.error=An error occurred while loading the data
 action.form.button.run.label=Run
 action.form.button.run.help=Run the selected action
 action.form.button.deactivate.label=Deactivate


### PR DESCRIPTION
Linked to #4938 

Similar request in my PR #5304 : An error was raised in the console about invalid layer, but the admin user was not aware about it.

I think all `console.warn` and `console.error` should be reviewed, and we should use a kind of proxy to display in UI the error message, and a more detailed error message if the user is an admin.

Errors logged in the console are not visible, which make difficult for Lizmap users who doesn't know this feature and do not think about it.

I think only the "proxy" should do the `console.error`, and a corresponding Javascript error must be displayed with a collapsible div like : 

An error occured while running the action "name"

<details>
<summary>See more detail about the error</summary>
<br/>
Error: No fill, stroke, point, or text symbolizer properties in style: {"graphicName":"circle","pointRadius":6,"fill":true,"fillColor":"lightred","fillOpacity":0.3,"stroke":true,"strokeWidth":4,"strokeColor":"red","strokeOpacity":0.8}
</details>


PR totally broken for now, but I want some ideas before digging. I noticed there are different `addMessage`, there is also a `Message` component.