### PR TITLE
GH Action - Refactor versions used about PHP and Node, remove 3.7 from cron

### DIFF
--- a/.github/workflows/cron_e2e.yml
+++ b/.github/workflows/cron_e2e.yml
@@ -27,9 +27,3 @@ jobs:
         with:
           event-type: run-e2e-branches
           client-payload: '{"branch": "release_3_8"}'
-
-      - name: Branch 3.7
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          event-type: run-e2e-branches
-          client-payload: '{"branch": "release_3_7"}'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,9 @@ on:
       - release_3_*
   workflow_dispatch:
 
+env:
+  NODE_VERSION: "21"
+
 permissions:
   id-token: write
   pages: write
@@ -25,10 +28,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Setup node
+      - name: "Setup Node ${{ env.NODE_VERSION }}"
         uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: ${{ github.workspace }}/package.json
 
       - name: Change tokens about versions
         run: |

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -10,6 +10,9 @@ on:
   repository_dispatch:
     types: [ run-e2e-branches ]
 
+env:
+  NODE_VERSION: "21"
+
 #concurrency:
 #  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 #  cancel-in-progress: true
@@ -187,9 +190,10 @@ jobs:
         run: |
             sudo echo "127.0.0.1 othersite.local" | sudo tee -a /etc/hosts
 
-      - uses: actions/setup-node@v4
+      - name: "Setup Node ${{ env.NODE_VERSION }}"
+        uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           cache-dependency-path: ${{ github.workspace }}/package.json
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,10 @@ on:
       - master
       - release_3_*
 
+env:
+  PHP_VERSION: "8.1"
+  NODE_VERSION: "21"
+
 jobs:
   php-cs-fixer:
     name: "PHP-CS-Fixer"
@@ -33,9 +37,10 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: "Setup Node ${{ env.NODE_VERSION }}"
+        uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           cache-dependency-path: ${{ github.workspace }}/package.json
 
@@ -53,9 +58,10 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: "Setup Node ${{ env.NODE_VERSION }}"
+        uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           cache-dependency-path: ${{ github.workspace }}/package.json
 
@@ -73,11 +79,13 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v4
 
-      - uses: "shivammathur/setup-php@v2"
+      - name: "Setup PHP ${{ env.PHP_VERSION }}"
+        uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: ${{ env.PHP_VERSION }}
 
-      - uses: "ramsey/composer-install@v3"
+      - name: "Install composer tools in tests/units"
+        uses: ramsey/composer-install@v3
         with:
           working-directory: "tests/units"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,10 @@ on:
       - master
       - release_3_*
 
+env:
+  PHP_VERSION: "8.1"
+  NODE_VERSION: "21"
+
 jobs:
   php-tests:
     name: "🐘 PHP-Unit"
@@ -52,9 +56,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: "Setup Node ${{ env.NODE_VERSION }}"
+        uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: ${{ github.workspace }}/package.json
 
       - name: Install lizmap dependencies
         run: npm install

--- a/tests/README.md
+++ b/tests/README.md
@@ -305,7 +305,7 @@ npm run pretest:fix
 
 ## PHP Rector
 
-PHP Rector can be run if you're located in `tests/units`.
+[PHP Rector](https://getrector.com/) can be run if you're located in `tests/units`.
 
 ```bash
 # Install composer dependencies


### PR DESCRIPTION
GH Action - Refactor versions used about PHP and Node, remove 3.7 from cron