### PR TITLE
Makefile - remove PHP-CS-Fixer command installed on the local machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,17 +254,11 @@ docker-release:
 docker-hub:
 	cd docker && push-to-docker-hub --clean
 
-php-cs-fixer-test:
-	php-cs-fixer fix --config=.php-cs-fixer.dist.php --allow-risky=yes --dry-run --diff
-
 php-cs-fixer-test-docker:
 	# TODO Switch to PHP-CS-Fixer official image, which are more up to date (3.65.0)
 	# Current 3.26.0 tag is 3.40.0 inside the docker image... :/
 	# Version must match the one in the GitHub workflow
 	docker run --rm -w=/app -v ${PWD}:/app oskarstark/php-cs-fixer-ga:3.26.0 --allow-risky=yes --config=.php-cs-fixer.dist.php  --dry-run --diff
-
-php-cs-fixer-apply:
-	php-cs-fixer fix --config=.php-cs-fixer.dist.php --allow-risky=yes
 
 php-cs-fixer-apply-docker:
 	# TODO Switch to PHP-CS-Fixer official image, which are more up to date (3.65.0)


### PR DESCRIPTION
If I'm not wrong, nobody run `php-cs-fixer` from the OS, but I think always in Docker instead ?

CC @mind84 @rldhont @nboisteault @mdouchin @nworr @laurentj  Put your emoji if we can remove this ;-) 
