### PR TITLE
Tests - Run arbitrary command written in composer.json such as rector

### DIFF
--- a/tests/docker-conf/phpfpm/appctl.sh
+++ b/tests/docker-conf/phpfpm/appctl.sh
@@ -112,6 +112,10 @@ function composerInstall() {
 
 }
 
+function composerRun() {
+    composer --working-dir=$ROOTDIR/tests/units/ run $*
+}
+
 function composerUpdate() {
     composer update --prefer-dist --no-progress --no-ansi --no-interaction --working-dir=$APPDIR
     chown -R $APP_USER:$APP_GROUP $APPDIR/vendor $APPDIR/composer.lock
@@ -223,6 +227,8 @@ case $COMMAND in
         setRights;;
     composer_install)
         composerInstall;;
+    composer_run)
+        composerRun ${*:2};;
     composer_update)
         composerUpdate;;
     unittests)

--- a/tests/lizmap-ctl
+++ b/tests/lizmap-ctl
@@ -24,7 +24,8 @@ if [ "$COMMAND" == "" ]; then
     echo "Error: command is missing"
     echo "Possible commands: "
     echo " - clean, clean-tmp, reset, reset-sqlite, ldap-reset, rights"
-    echo " - install,  composer-install, composer-update"
+    echo " - install, composer-install, composer-update"
+    echo " - composer-run [Any command in the 'tests/units/composer.json' 'scripts' section]"
     echo " - psql, redis-cli, shell, shell-root, shell-pgsql, shell-nginx"
     echo " - phpstan, unit-tests, ldap-users"
     exit 1;
@@ -100,6 +101,8 @@ case $COMMAND in
         execInPhp rights;;
     composer-install | composer_install)
         execInPhp composer_install;;
+    composer-run | composer_run)
+        execInPhp composer_run $EXTRA;;
     composer-update | composer_update)
         execInPhp composer_update;;
     unit-tests | unittests)

--- a/tests/units/composer.json
+++ b/tests/units/composer.json
@@ -11,6 +11,7 @@
         "php": ">=8.1.0",
         "phpunit/phpunit": "^10.5.29",
         "phpstan/phpstan": "1.11.11",
+        "rector/rector": "1.2.*",
         "symfony/console": "*"
     },
     "autoload": {
@@ -18,9 +19,6 @@
         "psr-4": {"Lizmap\\": "../../lizmap/modules/lizmap/lib/"}
     },
     "minimum-stability": "stable",
-    "require-dev": {
-        "rector/rector": "1.2.*"
-    },
     "scripts": {
         "rector": "php listRules.php && vendor/bin/rector --dry-run",
         "rector:fix": "php listRules.php && vendor/bin/rector"


### PR DESCRIPTION
Follow up from #5419 

Quite long command, but possible to use `rector` from inside the PHP container.

More work are following about PHPStan, PHP-CS-Fixer and also pre-commit

it will be manually backported

CC @rldhont @neo-garaix
