### PR TITLE
Tests - Improve debug when the length is not the same

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -284,6 +284,17 @@ jobs:
         run: |
           npx playwright test --workers 1 --grep @write ${{ env.PLAYWRIGHT_OPTIONS }}
 
+      - name: Debug
+        if: always()
+        working-directory: tests
+        run: |
+          find . -type d -name "test-results"
+          echo $GITHUB_WORKSPACE
+          echo ${{ github.workspace }}
+          echo ${{ github.workspace }}/tests/end2end/test-results/
+          ls -l $GITHUB_WORKSPACE/tests/end2end/test-results/
+          ls ${{ github.workspace }}/tests/end2end/test-results/
+
       - name: Send screenshots if necessary about all Playwright tests, if one failed
         if: |
           failure() &&

--- a/tests/end2end/playwright/globals.js
+++ b/tests/end2end/playwright/globals.js
@@ -219,6 +219,25 @@ export async function getEchoRequestParams(page, url) {
     return new URLSearchParams((new URL(originalUrl).search));
 }
 
+/**
+ * Similar to "toHaveLength", but display the list of members if it fails.
+ * @param {string}                        title Check title, for testing and debug
+ * @param {Array}                         parameters List of parameters to check
+ * @param {int}                           expectedLength Expected size length
+ * @param {string[]}                      expectedParameters List of expected parameters, only for debug for the print
+ */
+export async function expectToHaveLengthCompare(title, parameters, expectedLength, expectedParameters) {
+    await expect(
+        parameters,
+        `${title} → wrong length list :\n
+            Got    : ${parameters.length} items\n
+            With   : ${parameters.join(', ')}\n
+            To have: ${expectedLength} items\n
+            Debug  : ${expectedParameters.join(', ')}\n
+            Debug count : ${expectedParameters.length} items`
+    ).toHaveLength(expectedLength);
+}
+
 /* eslint-disable jsdoc/check-types */
 /**
  * Check parameters against an object containing expected parameters

--- a/tests/end2end/playwright/print.spec.js
+++ b/tests/end2end/playwright/print.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-import { gotoMap, expectParametersToContain, getAuthStorageStatePath } from './globals';
+import { gotoMap, expectParametersToContain, getAuthStorageStatePath, expectToHaveLengthCompare } from './globals';
 
 test.describe('Print', () => {
 
@@ -77,11 +77,9 @@ test.describe('Print', () => {
             // Disabled because of the migration when project is saved with QGIS >= 3.32
             // 'multiline_label': 'Multiline label',
         })
-        let getPrintParams = await expectParametersToContain('Print requests 1', getPrintRequest.postData() ?? '', expectedParameters1)
-        await expect(
-            Array.from(getPrintParams.keys()),
-            `Wrong length list with : ${Array.from(getPrintParams.keys()).join(', ')}`
-        ).toHaveLength(15);
+        let name = "Print requests";
+        let getPrintParams = await expectParametersToContain(name, getPrintRequest.postData() ?? '', expectedParameters1)
+        await expectToHaveLengthCompare(name, Array.from(getPrintParams.keys()), 15, Object.keys(expectedParameters1));
 
         // Close message
         await page.locator('.btn-close').click();
@@ -103,8 +101,9 @@ test.describe('Print', () => {
             'map0:STYLES': 'default,défaut,défaut',
             'map0:OPACITIES': '204,255,255',
         })
-        getPrintParams = await expectParametersToContain('Print requests 2', getPrintRequest.postData() ?? '', expectedParameters2)
-        await expect(Array.from(getPrintParams.keys())).toHaveLength(13)
+        name = 'Print requests 2';
+        getPrintParams = await expectParametersToContain(name, getPrintRequest.postData() ?? '', expectedParameters2)
+        await expectToHaveLengthCompare(name, Array.from(getPrintParams.keys()), 13, Object.keys(expectedParameters2));
 
         // Test `print_overview` template
         await page.locator('#print-template').selectOption('2');
@@ -129,8 +128,9 @@ test.describe('Print', () => {
             'map1:OPACITIES': '204,255,255',
             'map0:EXTENT': /761864.\d+,6274266.\d+,779334.\d+,6284518.\d+/,
         })
-        getPrintParams = await expectParametersToContain('Print requests 3', getPrintRequest.postData() ?? '', expectedParameters3)
-        await expect(Array.from(getPrintParams.keys())).toHaveLength(14)
+        name = 'Print requests 3';
+        getPrintParams = await expectParametersToContain(name, getPrintRequest.postData() ?? '', expectedParameters3)
+        await expectToHaveLengthCompare(name, Array.from(getPrintParams.keys()), 14, Object.keys(expectedParameters3));
 
         // Redlining with circle
         await page.locator('#button-draw').click();
@@ -200,8 +200,9 @@ test.describe('Print', () => {
             // 'multiline_label': 'Multiline label',
         })
         /* eslint-enable no-useless-escape, @stylistic/js/max-len */
-        getPrintParams = await expectParametersToContain('Print requests 4', getPrintRequest.postData() ?? '', expectedParameters4)
-        await expect(Array.from(getPrintParams.keys())).toHaveLength(17)
+        name = 'Print requests 4';
+        getPrintParams = await expectParametersToContain(name, getPrintRequest.postData() ?? '', expectedParameters4)
+        await expectToHaveLengthCompare(name, Array.from(getPrintParams.keys()), 17, Object.keys(expectedParameters4));
     });
 
     test('Print requests with selection', async ({ page }) => {
@@ -239,8 +240,10 @@ test.describe('Print', () => {
             'simple_label': 'simple label',
             'SELECTIONTOKEN': /[a-z\d]+/,
         }
-        const getPrintParams = await expectParametersToContain('Print requests with selection', getPrintRequest.postData() ?? '', expectedParameters)
-        await expect(Array.from(getPrintParams.keys())).toHaveLength(16)
+        const name = "Print requests with selection";
+        const getPrintParams = await expectParametersToContain(name, getPrintRequest.postData() ?? '', expectedParameters)
+        await expectToHaveLengthCompare(name, Array.from(getPrintParams.keys()), 16, Object.keys(expectedParameters));
+
     });
 
     test('Print requests with filter', async ({ page }) => {
@@ -288,8 +291,9 @@ test.describe('Print', () => {
             'simple_label': 'simple label',
             'FILTERTOKEN': /[a-z\d]+/,
         }
-        const getPrintParams = await expectParametersToContain('Print requests with filter', getPrintRequest.postData() ?? '', expectedParameters)
-        await expect(Array.from(getPrintParams.keys())).toHaveLength(16)
+        const name = 'Print requests with filter';
+        const getPrintParams = await expectParametersToContain(name, getPrintRequest.postData() ?? '', expectedParameters)
+        await expectToHaveLengthCompare(name, Array.from(getPrintParams.keys()), 16, Object.keys(expectedParameters));
     });
 });
 
@@ -343,8 +347,10 @@ test.describe('Print in popup', () => {
             'LAYER': 'quartiers',
             'EXP_FILTER': '$id IN (1)',
         }
-        const getPrintParams = await expectParametersToContain('Atlas print in popup requests', getPrintRequest.postData() ?? '', expectedParameters)
-        await expect(Array.from(getPrintParams.keys())).toHaveLength(10)
+        const name = 'Atlas print in popup requests';
+        const getPrintParams = await expectParametersToContain(name, getPrintRequest.postData() ?? '', expectedParameters)
+        await expectToHaveLengthCompare(name, Array.from(getPrintParams.keys()), 10, Object.keys(expectedParameters));
+
         await expect(getPrintParams.has('CRS')).toBe(false)
         await expect(getPrintParams.has('LAYERS')).toBe(false)
         await expect(getPrintParams.has('ATLAS_PK')).toBe(false)
@@ -525,8 +531,9 @@ test.describe('Print 3857', () => {
             // Disabled because of the migration when project is saved with QGIS >= 3.32
             // 'multiline_label': 'Multiline label',
         })
-        let getPrintParams = await expectParametersToContain('Print requests 1', getPrintRequest.postData() ?? '', expectedParameters1)
-        await expect(Array.from(getPrintParams.keys())).toHaveLength(15)
+        let name = "Print requests 1";
+        let getPrintParams = await expectParametersToContain(name, getPrintRequest.postData() ?? '', expectedParameters1)
+        await expectToHaveLengthCompare(name, Array.from(getPrintParams.keys()), 15, Object.keys(expectedParameters1));
 
         // Test `print_map` template
         await page.locator('#print-template').selectOption('1');
@@ -552,8 +559,9 @@ test.describe('Print 3857', () => {
             'map0:STYLES': 'default,défaut,défaut',
             'map0:OPACITIES': '204,255,255',
         })
-        getPrintParams = await expectParametersToContain('Print requests 2', getPrintRequest.postData() ?? '', expectedParameters2)
-        await expect(Array.from(getPrintParams.keys())).toHaveLength(13)
+        name = 'Print requests 2';
+        getPrintParams = await expectParametersToContain(name, getPrintRequest.postData() ?? '', expectedParameters2)
+        await expectToHaveLengthCompare(name, Array.from(getPrintParams.keys()), 13, Object.keys(expectedParameters2));
 
         // Close message
         await page.locator('.btn-close').click();
@@ -625,8 +633,9 @@ test.describe('Print 3857', () => {
             // 'multiline_label': 'Multiline label',
         })
         /* eslint-enable no-useless-escape, @stylistic/js/max-len */
-        getPrintParams = await expectParametersToContain('Print requests 3', getPrintRequest.postData() ?? '', expectedParameters3)
-        await expect(Array.from(getPrintParams.keys())).toHaveLength(17)
+        name = 'Print requests 3';
+        getPrintParams = await expectParametersToContain(name, getPrintRequest.postData() ?? '', expectedParameters3)
+        await expectToHaveLengthCompare(name, Array.from(getPrintParams.keys()), 17, Object.keys(expectedParameters3));
     });
 });
 
@@ -672,8 +681,9 @@ test.describe('Print base layers', () => {
             'map0:STYLES': 'défaut',
             'map0:OPACITIES': '255',
         })
-        let getPrintParams = await expectParametersToContain('Print requests 1', getPrintRequest.postData() ?? '', expectedParameters1)
-        await expect(Array.from(getPrintParams.keys())).toHaveLength(13)
+        let name = 'Print requests 1';
+        let getPrintParams = await expectParametersToContain(name, getPrintRequest.postData() ?? '', expectedParameters1)
+        await expectToHaveLengthCompare(name, Array.from(getPrintParams.keys()), 13, Object.keys(expectedParameters1));
 
         let getPrintResponse = await getPrintRequest.response();
         await expect(getPrintResponse?.status()).toBe(200)
@@ -702,8 +712,9 @@ test.describe('Print base layers', () => {
             'map0:STYLES': 'défaut,default',
             'map0:OPACITIES': '255,255',
         })
-        getPrintParams = await expectParametersToContain('Print requests 2', getPrintRequest.postData() ?? '', expectedParameters2)
-        await expect(Array.from(getPrintParams.keys())).toHaveLength(13)
+        name = 'Print requests 2';
+        getPrintParams = await expectParametersToContain(name, getPrintRequest.postData() ?? '', expectedParameters2)
+        await expectToHaveLengthCompare(name, Array.from(getPrintParams.keys()), 13, Object.keys(expectedParameters2));
 
         getPrintResponse = await getPrintRequest.response();
         await expect(getPrintResponse?.status()).toBe(200)
@@ -731,8 +742,9 @@ test.describe('Print base layers', () => {
             'map0:STYLES': 'default',
             'map0:OPACITIES': '255',
         })
-        getPrintParams = await expectParametersToContain('Print requests 3', getPrintRequest.postData() ?? '', expectedParameters3)
-        await expect(Array.from(getPrintParams.keys())).toHaveLength(13)
+        name = 'Print requests 3';
+        getPrintParams = await expectParametersToContain(name, getPrintRequest.postData() ?? '', expectedParameters3)
+        await expectToHaveLengthCompare(name, Array.from(getPrintParams.keys()), 13, Object.keys(expectedParameters3));
 
         getPrintResponse = await getPrintRequest.response();
         await expect(getPrintResponse?.status()).toBe(200)
@@ -760,8 +772,9 @@ test.describe('Print base layers', () => {
             'map0:STYLES': 'default,default',
             'map0:OPACITIES': '255,255',
         })
-        getPrintParams = await expectParametersToContain('Print requests 4', getPrintRequest.postData() ?? '', expectedParameters4)
-        await expect(Array.from(getPrintParams.keys())).toHaveLength(13)
+        name = 'Print requests 4';
+        getPrintParams = await expectParametersToContain(name, getPrintRequest.postData() ?? '', expectedParameters4)
+        await expectToHaveLengthCompare(name, Array.from(getPrintParams.keys()), 13, Object.keys(expectedParameters4));
 
         getPrintResponse = await getPrintRequest.response();
         await expect(getPrintResponse?.status()).toBe(200)


### PR DESCRIPTION
Tests - Improve debug when the length is not the same


I'm not fond of this function, but it helps on current failing tests on 3.40 (and for later).

We could argue that we can check members instead of length...