### PR TITLE
Tests - Add helper to retrieve the QGS file path on the file system

### DIFF
--- a/tests/end2end/playwright/globals.js
+++ b/tests/end2end/playwright/globals.js
@@ -34,6 +34,12 @@ const __filename = fileURLToPath(import.meta.url);
 export const __dirname = path.dirname(__filename);
 
 /**
+ * The file directory path
+ * @member string
+ */
+export const testsDirectory = path.join(__dirname, '..', '..');
+
+/**
  * Get the current file path according the list of given arguments.
  * @returns {string} The final file path
  */
@@ -43,6 +49,16 @@ export function playwrightTestFile()   {
         finalPath = path.join(finalPath, arguments[i]);
     }
     return finalPath;
+}
+
+/**
+ * Get the given QGS file path.
+ * @param {string} file_name The file name without extension
+ * @param {string} directory The directory name, default to 'tests'
+ * @returns {string} The QGS file path
+ */
+export function qgsTestFile(file_name, directory = 'tests')   {
+    return path.join(testsDirectory, 'qgis-projects', directory, file_name + '.qgs');
 }
 
 /**

--- a/tests/end2end/playwright/pages/project.js
+++ b/tests/end2end/playwright/pages/project.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { expect } from '@playwright/test';
-import { gotoMap } from '../globals';
+import { gotoMap, qgsTestFile } from '../globals';
 import { BasePage } from './base';
 
 /**
@@ -98,6 +98,12 @@ export class ProjectPage extends BasePage {
      * @type {Locator}
      */
     warningMessage;
+
+    /**
+     * Path to the QGS file
+     * @type {string}
+     */
+    qgsFile = () => qgsTestFile(this.project, this.repository);
 
     /**
      * Attribute table for the given layer name


### PR DESCRIPTION
Helper for fixing tests related to QGIS Desktop 3.40
