### PR TITLE
[Refactoring] Rely on relation id for children popup positioning

### DIFF
--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -1090,7 +1090,8 @@ window.lizMap = function() {
 
                     // prepare utilities object
                     let rUtilities = {
-                        rLayerId : rLayerId // pivot id or table id
+                        rLayerId : rLayerId, // pivot id or table id
+                        relationId: relation.relationId, // relationId
                     };
                     const pivotAttributeLayerConf = lizMap.getLayerConfigById( rLayerId, lizMap.config.attributeLayers, 'layerId' );
                     // check if child is a pivot table
@@ -1144,7 +1145,8 @@ window.lizMap = function() {
                         if ( rGetLayerConfig ) {
                             preProcessRequest = {
                                 oneToN:true,
-                                layer:rGetLayerConfig[1]
+                                layer:rGetLayerConfig[1],
+                                relationId:relation.relationId,
                             }
                             let ut = {
                                 referencingField: relation.referencingField,
@@ -1332,7 +1334,10 @@ window.lizMap = function() {
 
                                 parentDiv.append(childPopup);
 
-                                childPopupElements.push(childPopup);
+                                childPopupElements.push({
+                                    childPopupElement:childPopup,
+                                    relationId:utilities.relationId,
+                                });
 
                                 // Trigger event for single popup children
                                 lizMap.events.triggerEvent(
@@ -1366,33 +1371,11 @@ window.lizMap = function() {
 
                         // place children in the right div, if any
                         let relations = parentDiv.children('.container.popup_lizmap_dd').find(".popup_lizmap_dd_relation");
-                        relations.each((ind,relation) => {
-                            let referencingLayerId = $(relation).attr('data-referencing-layer-id');
-                            if (referencingLayerId) {
-                                let relLayerId = null;
-                                let referencingLayerConfig = lizMap.getLayerConfigById( referencingLayerId, lizMap.config.attributeLayers, 'layerId' );
-                                if (referencingLayerConfig && referencingLayerConfig[1]?.pivot == 'True' && config.relations.pivot && config.relations.pivot[referencingLayerId]) {
-                                    // relation is a pivot, search for "m" child layers
-                                    let mLayer = Object.keys(config.relations.pivot[referencingLayerId]).filter((k)=>{ return k !== layerId})
-                                    if (mLayer.length == 1) {
-                                        relLayerId = mLayer[0];
-                                    }
-                                } else {
-                                    // relation is 1:n, search for n layer
-                                    relLayerId = referencingLayerId;
-                                }
-
-                                if (relLayerId) {
-                                    let childLayer = childPopupElements.filter((child)=>{
-                                        let lName = child.attr("data-layername");
-                                        let lId = lName ? lizMap.config.layers?.[lName]?.id : '';
-                                        return relLayerId == lId;
-                                    })
-
-                                    if(childLayer.length == 1) {
-                                        $(relation).append(childLayer[0])
-                                    }
-                                }
+                        relations.each((ind, relation) => {
+                            let relationId = relation.dataset.relationId;
+                            let elementToMove = childPopupElements.filter(c => c.relationId == relationId);
+                            if (elementToMove.length == 1) {
+                                $(relation).append(elementToMove[0].childPopupElement);
                             }
                         });
 
@@ -1401,7 +1384,7 @@ window.lizMap = function() {
                             "lizmappopupallchildrendisplayed",
                             {
                                 parentPopupElement: self.parents('.lizmapPopupSingleFeature'),
-                                childPopupElements: childPopupElements
+                                childPopupElements: childPopupElements.map(c => c.childPopupElement)
                             }
                         );
                     });


### PR DESCRIPTION
PR related to https://github.com/3liz/lizmap-web-client/pull/4768

Probably situational, the PR covers the case where the `Popup` includes more than one relation that involves the same layer as a child. In this case it is safer to rely on the `relation id` to correctly position the children rather than the `layer id`. 

Backport to 3.8 and 3.9, if possible

Funded by Faunalia
