### PR TITLE
Change the PHP namespace for JSON Machine

### DIFF
--- a/lizmap/modules/dataviz/classes/datavizPlot.class.php
+++ b/lizmap/modules/dataviz/classes/datavizPlot.class.php
@@ -10,7 +10,7 @@
  */
 
 use GuzzleHttp\Psr7;
-use JsonMachine;
+use JsonMachine as Json;
 use Lizmap\Project\Project;
 use Lizmap\Project\UnknownLizmapProjectException;
 use Lizmap\Request\WFSRequest;
@@ -514,7 +514,7 @@ class datavizPlot
 
             // Features as iterator
             $featureStream = Psr7\StreamWrapper::getResource($wfsresponse->getBodyAsStream());
-            $features = JsonMachine\Items::fromStream($featureStream, array('pointer' => '/features'));
+            $features = Json\Items::fromStream($featureStream, array('pointer' => '/features'));
 
             $f1 = null;
             $traceBuilders = array();


### PR DESCRIPTION
Fix regression from #5434 

The **body** contains a HTML string about a PHP warning sometimes :(

```html
 Error while parsing to JSON : 
SyntaxError: Unexpected token '<', "<br />
<b>"... is not valid JSON
<br />
<b>Warning</b>:  The use statement with non-compound name 'JsonMachine' has no effect in <b>/srv/lzm/lizmap/modules/dataviz/classes/datavizPlot.class.php</b> on line <b>13</b><br />
{"title":"Municipalities","data":[{"type":"bar","name":"id","y":[0,1,2,3,4,5,6,7,8,9],"x":["Grabels","Clapiers","Montferrier-sur-Lez","Saint-Jean-de-
```

instead of plain JSON.

I think there is a misconfiguration issue from the PHP side as well.