### PR TITLE
Admin - Display if the installation is not complete according to versions in installed modules

### DIFF
--- a/lizmap/modules/admin/controllers/server_information.classic.php
+++ b/lizmap/modules/admin/controllers/server_information.classic.php
@@ -80,7 +80,8 @@ class server_informationCtrl extends jController
         $assign = array(
             'data' => $data,
             'baseUrlApplication' => jServer::getServerURI().jApp::urlBasePath(),
-            'modules' => $modules->getList(false),
+            'modules' => $modules->getList(false, false, true),
+            'installationComplete' => $modules->compareLizmapCoreModulesVersions($data['info']['version']),
             'qgisServerNeedsUpdate' => $qgisServerNeedsUpdate,
             'updateQgisServer' => $updateQgisServer,
             'lizmapQgisServerNeedsUpdate' => $lizmapQgisServerNeedsUpdate,

--- a/lizmap/modules/admin/lib/ModulesInfo/ModulesChecker.php
+++ b/lizmap/modules/admin/lib/ModulesInfo/ModulesChecker.php
@@ -6,40 +6,88 @@ use Jelix\IniFile\IniReader;
 
 class ModulesChecker
 {
-    private const coreModules = array('jelix',
+    private const coreExternalModules = array(
+        'jelix',
         'jacl2',
         'jacl2db',
         'jcommunity',
-        'admin',
-        'dataviz',
-        'filter',
-        'action',
-        'lizmap',
-        'proj4php',
-        'view',
         'jacl2db_admin',
         'jauthdb_admin',
         'master_admin',
     );
+    private const coreLizmapModules = array(
+        'action',
+        'admin',
+        'dataviz',
+        'filter',
+        'lizmap',
+        'proj4php',
+        'view',
+    );
 
-    public function getList($withCore = false)
+    /**
+     * Get the list of installed modules with their metadata.
+     *
+     * @param bool $withExternalCore Include or not core external modules (Jelix, JCommunity…). False by default.
+     * @param bool $withLizmapCore   Include or not core Lizmap modules (Action, Dataviz…). False by default.
+     * @param bool $withAdditional   Include or not Lizmap additional modules (AltiProfil, MapBuilder…). True by default.
+     *
+     * @return array[ModuleMetaData] The list of installed modules
+     */
+    public function getList($withExternalCore = false, $withLizmapCore = false, $withAdditional = true)
     {
         $moduleConfig = \jApp::config()->modules;
         $installReader = new IniReader(\jApp::varConfigPath('installer.ini.php'));
 
-        $enabledModuleName = array();
+        $enabledModuleNames = array();
         foreach ($moduleConfig as $paramName => $value) {
             if (preg_match('/(\w*)\.enabled/', $paramName, $matches) && $value == '1') {
                 $moduleSlug = $matches[1];
-                $coreModule = in_array($moduleSlug, self::coreModules);
-                if ($coreModule && !$withCore) {
+                $coreExternalModule = in_array($moduleSlug, self::coreExternalModules);
+                if ($coreExternalModule && !$withExternalCore) {
+                    continue;
+                }
+                $coreLizmapModule = in_array($moduleSlug, self::coreLizmapModules);
+                if ($coreLizmapModule && !$withLizmapCore) {
+                    continue;
+                }
+                if (!$coreExternalModule && !$coreLizmapModule && !$withAdditional) {
+                    // If the module is not "core external" and not "core Lizmap",
+                    // it means it's an additional module, such as AltiProfil, MapBuilder…
+                    // We might don't want them
                     continue;
                 }
                 $version = $installReader->getValue($moduleSlug.'.version', 'modules');
-                $enabledModuleName[] = new ModuleMetaData($moduleSlug, $version, $coreModule);
+                $enabledModuleNames[] = new ModuleMetaData(
+                    $moduleSlug,
+                    $version,
+                    $coreExternalModule || $coreLizmapModule
+                );
             }
         }
 
-        return $enabledModuleName;
+        return $enabledModuleNames;
+    }
+
+    /**
+     * Compare the list of Lizmap core modules to a given version.
+     * It returns True if all versions are the same within all Lizmap core modules.
+     * It means migrations are done correctly.
+     *
+     * @param string $version
+     *
+     * @return bool
+     */
+    public function compareLizmapCoreModulesVersions($version)
+    {
+        // We only want Lizmap core modules, without additional modules such as (AltiProfil, MapBuilder…)
+        $modules = $this->getList(false, true, false);
+        foreach ($modules as $module) {
+            if ($version != $module->version) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -262,6 +262,7 @@ upload.image.error.file.invalid=Invalid file
 upload.image.error.file.wrongType=Wrong file type. Only images are allowed
 upload.image.error.file.save=An error occurred during the save
 
+server.information.installation.not.complete.html=Your installation is not complete. Did you run <code>lizmap/install/installer.php</code> ?
 server.information.lizmap.label=Lizmap Web Client
 server.information.lizmap.info=Information
 server.information.lizmap.info.version=Version

--- a/lizmap/modules/admin/templates/server_information.tpl
+++ b/lizmap/modules/admin/templates/server_information.tpl
@@ -8,6 +8,11 @@
 
     <h3>{@admin.server.information.lizmap.label@}</h3>
     <h4>{@admin.server.information.lizmap.info@}</h4>
+    {if !$installationComplete}
+      <div class="alert alert-danger" role="alert">
+          {@admin.server.information.installation.not.complete.html@}
+      </div>
+    {/if}
     <table class="table table-striped table-bordered table-server-info table-lizmap-web-client">
         <tr>
             <th>{@admin.server.information.lizmap.info.version@}</th>

--- a/lizmap/modules/lizmap/lib/Server/Server.php
+++ b/lizmap/modules/lizmap/lib/Server/Server.php
@@ -225,7 +225,7 @@ class Server
         $data = array();
         $modules = new ModulesChecker();
 
-        foreach ($modules->getList(false) as $info) {
+        foreach ($modules->getList(false, false, true) as $info) {
             $data[$info->slug] = array(
                 'version' => $info->version,
                 'core' => $info->isCore,

--- a/lizmap/modules/view/controllers/app.classic.php
+++ b/lizmap/modules/view/controllers/app.classic.php
@@ -2,12 +2,13 @@
 
 use Lizmap\Events\LizmapMetadataEvent;
 use Lizmap\Server\Server;
+use LizmapAdmin\ModulesInfo\ModulesChecker;
 
 /**
  * Methods providing information about Lizmap application.
  *
  * @author    3liz
- * @copyright 2016-2022 3liz
+ * @copyright 2016-2025 3liz
  *
  * @see      http://3liz.com
  *
@@ -35,6 +36,10 @@ class appCtrl extends jController
         // Get server metadata from LWC and QGIS Server Lizmap plugin
         $server = new Server();
         $data = $server->getMetadata();
+
+        // Add if the installation is completed
+        $modules = new ModulesChecker();
+        $data['info']['installation_complete'] = $modules->compareLizmapCoreModulesVersions($data['info']['version']);
 
         // Only show QGIS related data for admins
         $serverInfoAccess = (jAcl2::check('lizmap.admin.access') || jAcl2::check('lizmap.admin.server.information.view'));

--- a/tests/end2end/playwright/requests-metadata.spec.js
+++ b/tests/end2end/playwright/requests-metadata.spec.js
@@ -35,6 +35,7 @@ test.describe('Not connected from context, so testing basic auth',
         test('As anonymous', async ({request}) => {
             const response = await request.get(url, {});
             const json = await checkJson(response);
+            expect(json.info.installation_complete).toBe(true)
             // Only testing the access to qgis_server_info
             expect(json.qgis_server_info.error).toBe("NO_ACCESS")
         });


### PR DESCRIPTION
It's checking the version in `project.xml` against all "core Lizmap" modules thanks to the `installer.ini.php`.

![image](https://github.com/user-attachments/assets/4a89b101-19b6-40a7-95d4-ea4e98a3ef3d)

It's to avoid some possible migrations issues

It will be manually backported to 3.9 and 3.8 due to Bootstrap 5.
