### PR TITLE
[Bugfix] Multiple calls of editableFeatures method breaks php

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -1174,9 +1174,11 @@ class qgisVectorLayer extends qgisMapLayer
      * when there is a filter by login (or by polygon). This allows to deactivate the editing icon
      * for the non-editable features inside the popup and attribute table.
      *
+     * @param array<string, string> $wfsParams Extra WFS parameters to filter the layer : FEATUREID or EXP_FILTER could be use
+     *
      * @return array Data containing the status (restricted|unrestricted) and the features if restricted
      */
-    public function editableFeatures()
+    public function editableFeatures($wfsParams = array())
     {
         // Editable features are a restricted list
         $restricted_empty_data = array(
@@ -1254,6 +1256,8 @@ class qgisVectorLayer extends qgisMapLayer
             'OUTPUTFORMAT' => 'GeoJSON',
             'GEOMETRYNAME' => 'none',
         );
+
+        $params = array_merge($params, $wfsParams);
 
         // Perform the request to get the editable features
         $wfsRequest = new WFSRequest($project, $params, lizmap::getServices());

--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -781,8 +781,16 @@ class WMSRequest extends OGCRequest
             // edition can be restricted on current feature
             $qgisLayer = $this->project->getLayer($layerId);
 
+            // get wfs name
             /** @var \qgisVectorLayer $qgisLayer */
-            $editableFeatures = $qgisLayer->editableFeatures();
+            $typename = $qgisLayer->getWfsTypeName();
+
+            // additional WFS parameter for features filtering
+            $wfsParams = array(
+                'FEATUREID' => $typename.'.'.$id,
+            );
+
+            $editableFeatures = $qgisLayer->editableFeatures($wfsParams);
             $editionRestricted = '';
             if (array_key_exists('status', $editableFeatures) && $editableFeatures['status'] === 'restricted') {
                 $editionRestricted = 'edition-restricted="true"';


### PR DESCRIPTION
When a popup is displayed the system checks first whether the user can edit the feature or not, so as to configure the `lizmap-feature-toolbar` HTML element correctly.

At time being, if the layer is `filtered by user` (`Attribute filtering` tab in Lizmap plugin), the system queries all the features of the layers and then filters the entire list by feature id to perform the check.

https://github.com/3liz/lizmap-web-client/blob/25ba42bac31e7fc60df93a1fbd4785c8749e7529/lizmap/modules/lizmap/lib/Request/WMSRequest.php#L785

This operation is executed for every feature on popup, even if features belonging to same layer.

If the layer has a lot of feature then this operation easily leads to php exceptions (`max_execution_time` on master branch with `jsonmachine`, memory error for Lizmap <= 3.8 )

I didn't use the `isFeatureEditable` method (which seems suitable for this job) because it requires a `feature` object that you can't get from a WMS request (like the `Popup` request) so, as a first solution, I chose to parameterize the `editableFeatures` function.

Backport to 3.8 and 3.9, if possible

Funded by Faunalia
