### PR TITLE
Show not found layers in the CFG for admins

### DIFF
--- a/assets/src/modules/ExecuteJSFromServer.js
+++ b/assets/src/modules/ExecuteJSFromServer.js
@@ -1,13 +1,17 @@
 /**
+ * LizDict
+ * @typedef {object} lizDict
+ */
+
+/**
  * Execute JS from server
  */
 export default function executeJSFromServer() {
     lizMap.events.on({
         uicreated: () => {
-            // skipWarningsDisplay is used in tests, to skip a possible warnings about old QGIS plugin used
-            if (!document.body.dataset.skipWarningsDisplay){
-                displayWarningsAdministrator();
-            }
+            const withDisplay = !document.body.dataset.skipWarningsDisplay;
+            displayWarningsAdministrator(withDisplay);
+            checkInvalidLayersCfgFile(withDisplay);
 
             if (document.body.dataset.lizmapHideLegend) {
                 document.querySelector('li.switcher.active #button-switcher')?.click();
@@ -22,7 +26,8 @@ export default function executeJSFromServer() {
                 $('#content').addClass('embed');
 
                 // move tooltip placement to bottom
-                const tooltipTriggerList = document.querySelectorAll('#mapmenu .nav-list > li > a');
+                const tooltipTriggerList = document.querySelectorAll(
+                    '#mapmenu .nav-list > li > a');
                 [...tooltipTriggerList].map(tooltipTriggerEl => {
                     bootstrap.Tooltip.getInstance(tooltipTriggerEl).dispose();
                     new bootstrap.Tooltip(tooltipTriggerEl, { placement: 'bottom', trigger: 'hover' });
@@ -32,7 +37,9 @@ export default function executeJSFromServer() {
                 var search = $('#nominatim-search');
                 if (search.length != 0) {
                     $('#mapmenu').append(search);
-                    $('#nominatim-search div.dropdown-menu').removeClass('pull-right').addClass('pull-left');
+                    $(
+                        '#nominatim-search div.dropdown-menu'
+                    ).removeClass('pull-right').addClass('pull-left');
                 }
 
                 //calculate dock position and size
@@ -54,7 +61,11 @@ export default function executeJSFromServer() {
                     document.getElementById('button-switcher')?.click();
                 }
 
-                $('#mapmenu .nav-list > li.permaLink a').attr('data-bs-toggle', 'tooltip').attr('data-bs-title', lizDict['embed.open.map']);
+                $('#mapmenu .nav-list > li.permaLink a').attr(
+                    'data-bs-toggle', 'tooltip'
+                ).attr(
+                    'data-bs-title', lizDict['embed.open.map']
+                );
             },
             dockopened: () => {
                 // one tool at a time
@@ -73,7 +84,8 @@ export default function executeJSFromServer() {
                     // autocompletion items for locatebylayer feature
                     $('div.locate-layer select').hide();
                     $('span.custom-combobox').show();
-                    $('#locate div.locate-layer input.custom-combobox-input').autocomplete('option', 'position', { my: 'left top', at: 'left bottom' });
+                    $('#locate div.locate-layer input.custom-combobox-input'
+                    ).autocomplete('option', 'position', { my: 'left top', at: 'left bottom' });
                 }
 
                 if (evt.id == 'permaLink') {
@@ -87,30 +99,101 @@ export default function executeJSFromServer() {
 }
 
 /**
- * Display messages to the user about deprecated features or outdated versions.
+ * Display a message about invalid layers, detected on the client side.
+ *
+ * A message is logged in the console in English.
+ * Another message is translated and displayed for GIS administrators.
+ *
+ * @param {boolean} withDisplay If the message must be displayed in the web interface, only in the console otherwise.
  */
-function displayWarningsAdministrator() {
-    if (document.body.dataset.lizmapPluginUpdateWarningUrl) {
-        var messageOutdatedWarning = lizDict['project.plugin.outdated.warning'];
-        messageOutdatedWarning += `<br><a href="${document.body.dataset.lizmapPluginUpdateWarningUrl}">`;
-        messageOutdatedWarning += lizDict['visit.admin.panel.project.page'];
-        messageOutdatedWarning += '</a>';
-        messageOutdatedWarning += '<br>';
-        messageOutdatedWarning += lizDict['project.admin.panel.info'];
-        // The plugin can be easily updated, the popup can not be closed
-        lizMap.addMessage(messageOutdatedWarning, 'warning', false).attr('id', 'lizmap-warning-message');
-    } else if (document.body.dataset.lizmapPluginHasWarningsUrl) {
-        var messageHasWarnings = lizDict['project.has.warnings'];
-        messageHasWarnings += `<br><a href="${document.body.dataset.lizmapPluginHasWarningsUrl}">`;
-        messageHasWarnings += lizDict['visit.admin.panel.project.page'];
-        messageHasWarnings += '</a>';
-        messageHasWarnings += '<br>';
-        messageHasWarnings += lizDict['project.admin.panel.info'];
-        // It can take times to fix these issues, the popup can be closed
-        lizMap.addMessage(messageHasWarnings, 'warning', true).attr('id', 'lizmap-warning-message');
+function checkInvalidLayersCfgFile(withDisplay){
+    const invalidLayers = lizMap.mainLizmap.initialConfig.invalidLayersNotFoundInCfg;
+    if (invalidLayers.length === 0) {
+        return;
+    }
+
+    let message = `WMS layers "${invalidLayers.join(', ')}" are not found in the Lizmap configuration. `;
+    message += `Is the Lizmap configuration file "${lizUrls.params.project}.qgs.cfg" up to date ?`;
+    console.warn(message);
+
+    if (!withDisplay){
+        return;
+    }
+
+    if (!document.body.dataset.lizmapAdminUser){
+        return;
+    }
+
+    const layersNotFound = `
+        ${lizDict['project.has.not.found.layers']}<br>
+        <code>${invalidLayers.join(', ')}</code>`;
+
+    lizMap.addMessage(
+        layersNotFound,
+        'warning',
+        true
+    ).attr('id', 'lizmap-warning-message');
+}
+
+/**
+ * Display messages to the administrator about deprecated features or outdated versions.
+ *
+ * The message is translated and displayed for GIS administrators.
+ * A message is logged in the console in English.
+ *
+ * @param {boolean} withDisplay If the message must be displayed in the web interface, only in the console otherwise.
+ */
+function displayWarningsAdministrator(withDisplay) {
+    if (document.body.dataset.lizmapPluginUpdateWarning) {
+        console.warn('The plugin in QGIS is not up to date.');
+
+        if (document.body.dataset.lizmapPluginUpdateWarningUrl && withDisplay) {
+            let messageOutdatedWarning = lizDict['project.plugin.outdated.warning'];
+            messageOutdatedWarning += `<br><a href="${document.body.dataset.lizmapPluginUpdateWarningUrl}">`;
+            messageOutdatedWarning += lizDict['visit.admin.panel.project.page'];
+            messageOutdatedWarning += '</a>';
+            messageOutdatedWarning += '<br>';
+            messageOutdatedWarning += lizDict['project.admin.panel.info'];
+
+            // The plugin can be easily updated, the popup can not be closed
+            lizMap.addMessage(
+                messageOutdatedWarning,
+                'warning',
+                false
+            ).attr('id', 'lizmap-warning-message');
+        }
+
+    } else if (document.body.dataset.lizmapPluginHasWarnings) {
+        console.warn('The project has some warnings in the Lizmap plugin.');
+
+        if (document.body.dataset.lizmapPluginHasWarningsUrl && withDisplay) {
+            let messageHasWarnings = lizDict['project.has.warnings'];
+            messageHasWarnings += `<br><a href="${document.body.dataset.lizmapPluginHasWarningsUrl}">`;
+            messageHasWarnings += lizDict['visit.admin.panel.project.page'];
+            messageHasWarnings += '</a>';
+            messageHasWarnings += '<br>';
+            messageHasWarnings += lizDict['project.admin.panel.info'];
+
+            // It can take times to fix these issues, the popup can be closed
+            lizMap.addMessage(
+                messageHasWarnings,
+                'warning',
+                true
+            ).attr('id', 'lizmap-outdated-plugin');
+        }
     }
 
     if (document.body.dataset.lizmapActionWarningOld) {
-        lizMap.addMessage(document.body.dataset.lizmapActionWarningOld,'info',true).attr('id','lizmap-action-message');
+        let message = 'The project uses deprecated Action JSON format. ';
+        message += 'Read https://docs.lizmap.com/current/en/publish/lizmap_plugin/actions.html for more information';
+        console.warn(message);
+
+        if (document.body.dataset.lizmapAdminUser && withDisplay) {
+            lizMap.addMessage(
+                document.body.dataset.lizmapActionWarningOld,
+                'info',
+                true
+            ).attr('id','lizmap-action-message');
+        }
     }
 }

--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -533,14 +533,22 @@ class lizMapCtrl extends jController
             $assign['googleAnalyticsID'] = $lser->googleAnalyticsID;
         }
 
-        if (jAcl2::check('lizmap.admin.access') || jAcl2::check('lizmap.admin.server.information.view')) {
-            if ($lproj->qgisLizmapPluginUpdateNeeded()) {
+        $isAdmin = jAcl2::check('lizmap.admin.access') || jAcl2::check('lizmap.admin.server.information.view');
+        if ($isAdmin) {
+            // Add body attribute to tell if current user is admin
+            $rep->setBodyAttributes(array('data-lizmap-admin-user' => true));
+        }
+
+        if ($lproj->qgisLizmapPluginUpdateNeeded()) {
+            $rep->setBodyAttributes(array('data-lizmap-plugin-update-warning' => true));
+            if ($isAdmin) {
                 $rep->setBodyAttributes(array('data-lizmap-plugin-update-warning-url' => jUrl::get('admin~qgis_projects:index')));
-            } elseif ($lproj->projectCountCfgWarnings() >= 1) {
+            }
+        } elseif ($lproj->projectCountCfgWarnings() >= 1) {
+            $rep->setBodyAttributes(array('data-lizmap-plugin-has-warnings' => true));
+            if ($isAdmin) {
                 $rep->setBodyAttributes(array('data-lizmap-plugin-has-warnings-url' => jUrl::get('admin~qgis_projects:index')));
             }
-            // add body attribute to tell if current user is admin
-            $rep->setBodyAttributes(array('data-lizmap-admin-user' => true));
         }
 
         $rep->body->assign($assign);

--- a/lizmap/modules/view/locales/en_US/dictionnary.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/dictionnary.UTF-8.properties
@@ -6,6 +6,7 @@ startup.goToProject=Home
 startup.goToRepositoryAdmin=Maps management page
 startup.projectWithoutJSLink=This map without additional JavaScript
 
+project.has.not.found.layers=Some layers are in the WMS capabilities (*.qgs file) but are not found in the Lizmap configuration file (*.qgs.cfg). Is the Lizmap configuration file up to date ?
 project.has.warnings=The project has some warnings in the QGIS desktop Lizmap plugin which must be fixed.
 project.plugin.outdated.warning=The project has been recently updated in QGIS Desktop, but with an outdated version of the Lizmap plugin. You must upgrade your plugin in QGIS Desktop.
 project.admin.panel.info=Only administrators or publishers can see this message.


### PR DESCRIPTION
Follow up from #5304, it displays a message for admins about layers which are not found in the CFG file (but present in the WMS GetCapabilities)

Related to #5424 about how we want to manage admin/not admins in LWC, and also how to report "broken" project to the GIS administrator about errors reported on the "client" side.

Another change : we always log in the console in case of warning about the QGIS project, even if the user is not an GIS administrator