### PR TITLE
Drop pixelmatch from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "ol": "^10.4.0",
         "ol-ext": "^4.0.24",
         "ol-wfs-capabilities": "^2.0.0",
-        "pixelmatch": "^5.3.0",
         "playwright-ctrf-json-reporter": "^0.0.18",
         "postcss-lit": "^1.2.0",
         "proj4": "^2.11.0",
@@ -6629,18 +6628,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/pixelmatch": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
-      "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
-      "dev": true,
-      "dependencies": {
-        "pngjs": "^6.0.0"
-      },
-      "bin": {
-        "pixelmatch": "bin/pixelmatch"
-      }
-    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -6753,15 +6740,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/pngjs": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.13.0"
       }
     },
     "node_modules/posix-character-classes": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "ol": "^10.4.0",
     "ol-ext": "^4.0.24",
     "ol-wfs-capabilities": "^2.0.0",
-    "pixelmatch": "^5.3.0",
     "playwright-ctrf-json-reporter": "^0.0.18",
     "postcss-lit": "^1.2.0",
     "proj4": "^2.11.0",


### PR DESCRIPTION
I do not find any occurences about `pixelmatch`, CF #5489

We could see PixelMatch in some PR, like https://github.com/3liz/lizmap-web-client/pull/3029

https://github.com/search?q=repo%3A3liz%2Flizmap-web-client%20pixelmatch&type=code

Even in 3.8 branch.