### PR TITLE
X-Request-Id : it is sometimes an array, add repository and project name in it

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/OGCRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/OGCRequest.php
@@ -247,7 +247,16 @@ abstract class OGCRequest
 
         $message = 'The HTTP OGC request to QGIS Server ended with an error.';
 
-        $xRequestId = $headers['X-Request-Id'] ?? '';
+        if (isset($headers['X-Request-Id'])) {
+            if (is_array($headers['X-Request-Id'])) {
+                $xRequestId = implode(',', $headers['X-Request-Id']);
+            } else {
+                $xRequestId = $headers['X-Request-Id'];
+            }
+        } else {
+            $xRequestId = '';
+        }
+
         if ($xRequestId !== '') {
             $message .= ' The X-Request-Id `'.$xRequestId.'`.';
         }

--- a/tests/units/classes/Request/ProxyTest.php
+++ b/tests/units/classes/Request/ProxyTest.php
@@ -240,6 +240,7 @@ class ProxyTest extends TestCase
             $this->assertEquals($value, $result['headers'][$header]);
         }
         $this->assertArrayHasKey('X-Request-Id', $result['headers']);
+        $this->assertIsString($result['headers']['X-Request-Id']);
         $this->assertEquals($expectedBody, $result['body']);
         if ($expectedUrl) {
             $this->assertEquals($expectedUrl, $url);


### PR DESCRIPTION
I'm pretty sure this is not the correct fix, why we have an array in `X-Request-Id`. That's why as draft.
I can 100% replicate with a local GetPrint requests. We can see the error in production https://demo.lizmap.com/lizmap/ as well

Side question, why 2 random substrings in the ID ? 
