### PR TITLE
fix: In Guzzle, provided HTTP headers is an array

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/OGCRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/OGCRequest.php
@@ -247,7 +247,7 @@ abstract class OGCRequest
 
         $message = 'The HTTP OGC request to QGIS Server ended with an error.';
 
-        $xRequestId = $headers['X-Request-Id'] ?? '';
+        $xRequestId = Proxy::httpRequestId($headers);
         if ($xRequestId !== '') {
             $message .= ' The X-Request-Id `'.$xRequestId.'`.';
         }

--- a/lizmap/modules/lizmap/lib/Request/Proxy.php
+++ b/lizmap/modules/lizmap/lib/Request/Proxy.php
@@ -283,6 +283,24 @@ class Proxy
     }
 
     /**
+     * Get the X-Request-Id of the request from the given headers.
+     *
+     * @param array<string, array<string>> $headers The headers to check
+     *
+     * @return string
+     */
+    public static function httpRequestId($headers)
+    {
+        $xRequestId = $headers['X-Request-Id'] ?? '';
+
+        if (is_string($xRequestId)) {
+            return '';
+        }
+
+        return implode(',', $xRequestId);
+    }
+
+    /**
      * @param string $url
      * @param array  $options
      *
@@ -329,9 +347,9 @@ class Proxy
     /**
      * Log if the HTTP code is a 4XX or 5XX error code.
      *
-     * @param int                   $httpCode The HTTP code of the request
-     * @param string                $url      The URL of the request, for logging
-     * @param array<string, string> $headers  The headers of the response
+     * @param int                          $httpCode The HTTP code of the request
+     * @param string                       $url      The URL of the request, for logging
+     * @param array<string, array<string>> $headers  The headers of the response
      */
     protected static function logRequestIfError($httpCode, $url, $headers = array())
     {
@@ -339,7 +357,7 @@ class Proxy
             return;
         }
 
-        $xRequestId = $headers['X-Request-Id'] ?? '';
+        $xRequestId = self::httpRequestId($headers);
 
         $lizmapAdmin = 'An HTTP request ended with an error, please check the main error log.';
         $lizmapAdmin .= ' HTTP code '.$httpCode.'.';


### PR DESCRIPTION
fix: In Guzzle, provided HTTP headers is an array

Superseeds #5510 