### PR TITLE
fix: The version of LWC has a commit number in the version name, drop it for comparing to modules version

### DIFF
--- a/lizmap/modules/admin/controllers/server_information.classic.php
+++ b/lizmap/modules/admin/controllers/server_information.classic.php
@@ -1,5 +1,6 @@
 <?php
 
+use Lizmap\App\VersionTools;
 use Lizmap\Server\Server;
 use LizmapAdmin\ModulesInfo\ModulesChecker;
 
@@ -77,11 +78,12 @@ class server_informationCtrl extends jController
 
         // Set the HTML content
         $tpl = new jTpl();
+        $semanticVersion = VersionTools::dropBuildId($data['info']['version']);
         $assign = array(
             'data' => $data,
             'baseUrlApplication' => jServer::getServerURI().jApp::urlBasePath(),
             'modules' => $modules->getList(false, false, true),
-            'installationComplete' => $modules->compareLizmapCoreModulesVersions($data['info']['version']),
+            'installationComplete' => $modules->compareLizmapCoreModulesVersions($semanticVersion),
             'qgisServerNeedsUpdate' => $qgisServerNeedsUpdate,
             'updateQgisServer' => $updateQgisServer,
             'lizmapQgisServerNeedsUpdate' => $lizmapQgisServerNeedsUpdate,

--- a/lizmap/modules/admin/zones/project_list.zone.php
+++ b/lizmap/modules/admin/zones/project_list.zone.php
@@ -1,6 +1,7 @@
 <?php
 
 use Jelix\Core\Infos\AppInfos;
+use Lizmap\App\VersionTools;
 use Lizmap\Project\ProjectMetadata;
 use Lizmap\Server\Server;
 
@@ -81,10 +82,12 @@ class project_listZone extends jZone
             }
             $maps[$r] = $lizmapViewItem;
         }
+        // Fixme, to move in VersionTools
         $lizmapTargetVersionInt = jApp::config()->minimumRequiredVersion['lizmapWebClientTargetVersion'];
         $humanLizmapTargetVersion = substr($lizmapTargetVersionInt, 0, 1);  // Major
         $humanLizmapTargetVersion .= '.'.ltrim(substr($lizmapTargetVersionInt, 2, 1), ''); // Minor
 
+        // Fixme, to move in VersionTools
         $lizmapDesktopInt = jApp::config()->minimumRequiredVersion['lizmapDesktopPlugin'];
         $lizmapDesktopRecommended = substr($lizmapDesktopInt, 0, 1);  // Major
         $lizmapDesktopRecommended .= '.'.ltrim(substr($lizmapDesktopInt, 2, 1), '');  // Minor
@@ -121,11 +124,13 @@ class project_listZone extends jZone
             $serverVersions['qgis_server_version'] = $qgisServerVersion;
             $explode = explode('.', $qgisServerVersion);
             // Keep only major and minor version
+            // Like 3.40
+            // Fixme, to move in VersionTools
             $qgisServerVersionInt = intval($explode[0].str_pad($explode[1], 2, '0', STR_PAD_LEFT));
             $serverVersions['qgis_server_version_int'] = $qgisServerVersionInt;
-            $serverVersions['qgis_server_version_human_readable'] = $this->qgisMajMinHumanVersion($qgisServerVersionInt);
-            $serverVersions['qgis_server_version_old'] = $this->qgisMajMinHumanVersion($qgisServerVersionInt - $oldQgisVersionDelta - 2);
-            $serverVersions['qgis_server_version_next'] = $this->qgisMajMinHumanVersion($qgisServerVersionInt + 2);
+            $serverVersions['qgis_server_version_human_readable'] = VersionTools::qgisMajMinHumanVersion($qgisServerVersionInt);
+            $serverVersions['qgis_server_version_old'] = VersionTools::qgisMajMinHumanVersion($qgisServerVersionInt - $oldQgisVersionDelta - 2);
+            $serverVersions['qgis_server_version_next'] = VersionTools::qgisMajMinHumanVersion($qgisServerVersionInt + 2);
             // Lizmap server plugin
             $serverVersions['lizmap_plugin_server_version'] = $data['info']['version'];
         }
@@ -196,7 +201,7 @@ class project_listZone extends jZone
             'cfg_warnings' => $projectMetadata->projectCfgWarnings(),
             'lizmap_web_client_target_version' => $projectMetadata->getLizmapWebClientTargetVersion(),
             // convert int to string orderable
-            'lizmap_plugin_version' => $this->pluginIntVersionToSortableString($projectMetadata->getLizmapPluginVersion()),
+            'lizmap_plugin_version' => VersionTools::intVersionToSortableString($projectMetadata->getLizmapPluginVersion()),
             'lizmap_plugin_update' => $projectMetadata->qgisLizmapPluginUpdateNeeded(),
             'file_time' => $projectMetadata->getFileTime(),
             'layer_count' => $projectMetadata->getLayerCount(),
@@ -208,6 +213,7 @@ class project_listZone extends jZone
         $qgisVersionInt = $projectMetadata->getQgisProjectVersion();
         // Create a human readable version, but suitable for string ordering
         // Ex: 3.06.02 instead of 3.6.2
+        // Fixme, to move in VersionTools
         $qgisVersion = substr($qgisVersionInt, 0, 1);
         $qgisVersion .= '.'.ltrim(substr($qgisVersionInt, 1, 2), '');
         $qgisVersion .= '.'.ltrim(substr($qgisVersionInt, 3, 2), '');
@@ -321,42 +327,5 @@ class project_listZone extends jZone
         }
 
         return $inspectionData;
-    }
-
-    private function qgisMajMinHumanVersion($qgisIntVersion): string
-    {
-        // NOTE Will work as long a Major version is on 1 Digit
-        return substr($qgisIntVersion, 0, 1).'.'.substr($qgisIntVersion, -2);
-    }
-
-    /**
-     * Transform int formatted version (from 5 or 6 integer) to sortable string .
-     *
-     * Transform "10102" into "01.01.02"
-     * Transform "050912" into "05.09.12"
-     *
-     * @param string $intVersion the lizmap QGIS plugin version (not always int !!)
-     *
-     * @return string the version as sortable string
-     */
-    private function pluginIntVersionToSortableString(string $intVersion): string
-    {
-        if ($intVersion == 'master' || $intVersion == 'dev') {
-            return '00.00.00';
-        }
-
-        // in some old plugin the version is already human readable
-        if (strpos($intVersion, '.') != false) {
-            list($majorVersion, $minorVersion, $patchVersion) = explode('.', $intVersion);
-            // add 0 to 1 digit version
-            $majorVersion = (strlen($majorVersion) == 1 ? '0'.$majorVersion : $majorVersion);
-            $minorVersion = (strlen($minorVersion) == 1 ? '0'.$minorVersion : $minorVersion);
-            $patchVersion = (strlen($patchVersion) == 1 ? '0'.$patchVersion : $patchVersion);
-        } else {
-            $intVersion6Digit = (strlen($intVersion) == 6 ? $intVersion : '0'.$intVersion);
-            list($majorVersion, $minorVersion, $patchVersion) = str_split($intVersion6Digit, 2);
-        }
-
-        return $majorVersion.'.'.$minorVersion.'.'.$patchVersion;
     }
 }

--- a/lizmap/modules/lizmap/lib/App/VersionTools.php
+++ b/lizmap/modules/lizmap/lib/App/VersionTools.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Version tools for Lizmap.
+ *
+ * @author    3Liz
+ * @copyright 2025 3liz
+ *
+ * @see      https://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+namespace Lizmap\App;
+
+class VersionTools
+{
+    /**
+     * Drop the build ID from a semantic version name.
+     * For instance, 3.10.0-pre.8697 → 3.10.0-pre.
+     *
+     * @param string $version The version to clean
+     *
+     * @return string The cleaned version
+     */
+    public static function dropBuildId(string $version): string
+    {
+        $version = explode('.', $version);
+        $version = array_slice($version, 0, 3);
+
+        return implode('.', $version);
+    }
+
+    /**
+     * Transform integer QGIS version major minor to the human name.
+     * For instance, 0340 → 3.40.
+     *
+     * @param mixed $qgisIntVersion
+     *
+     * @return string The cleaned version
+     */
+    public static function qgisMajMinHumanVersion($qgisIntVersion): string
+    {
+        // NOTE Will work as long a Major version is on 1 Digit
+        return substr($qgisIntVersion, 0, 1).'.'.substr($qgisIntVersion, -2);
+    }
+
+    /**
+     * Transform int formatted version (from 5 or 6 integer) to a sortable string.
+     *
+     * Transform "10102" into "01.01.02"
+     * Transform "050912" into "05.09.12"
+     *
+     * @param string $intVersion the lizmap QGIS plugin version (not always int !!)
+     *
+     * @return string the version as sortable string
+     */
+    public static function intVersionToSortableString(string $intVersion): string
+    {
+        if ($intVersion == 'master' || $intVersion == 'dev') {
+            return '00.00.00';
+        }
+
+        // in some old plugin the version is already human readable
+        if (strpos($intVersion, '.') != false) {
+            list($majorVersion, $minorVersion, $patchVersion) = explode('.', $intVersion);
+            // add 0 to 1 digit version
+            $majorVersion = (strlen($majorVersion) == 1 ? '0'.$majorVersion : $majorVersion);
+            $minorVersion = (strlen($minorVersion) == 1 ? '0'.$minorVersion : $minorVersion);
+            $patchVersion = (strlen($patchVersion) == 1 ? '0'.$patchVersion : $patchVersion);
+        } else {
+            $intVersion6Digit = (strlen($intVersion) == 6 ? $intVersion : '0'.$intVersion);
+            list($majorVersion, $minorVersion, $patchVersion) = str_split($intVersion6Digit, 2);
+        }
+
+        return $majorVersion.'.'.$minorVersion.'.'.$patchVersion;
+    }
+}

--- a/tests/units/classes/App/VersionToolsTest.php
+++ b/tests/units/classes/App/VersionToolsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Lizmap\App\VersionTools;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+class VersionToolsTest extends TestCase
+{
+    public function testDropBuildId(): void
+    {
+        $this->assertEquals('3.10.0-pre', VersionTools::dropBuildId('3.10.0-pre.8697'));
+        $this->assertEquals('3.10.0-pre', VersionTools::dropBuildId('3.10.0-pre'));
+        $this->assertEquals('3.10.0', VersionTools::dropBuildId('3.10.0'));
+        $this->assertEquals('3.10', VersionTools::dropBuildId('3.10'));
+    }
+
+    public function testQgisMajMinHumanVersion(): void
+    {
+        $this->assertEquals('3.40', VersionTools::qgisMajMinHumanVersion('340'));
+        $this->assertEquals('1.40', VersionTools::qgisMajMinHumanVersion('1040')); // Fixme when QGIS 10 is released :)
+    }
+
+    public function testIntVersionToSortableString(): void
+    {
+        $this->assertEquals('01.01.02', VersionTools::intVersionToSortableString('01.01.02'));
+        $this->assertEquals('01.01.02', VersionTools::intVersionToSortableString('1.01.02'));
+        $this->assertEquals('01.01.02', VersionTools::intVersionToSortableString('1.1.2'));
+        $this->assertEquals('01.01.02', VersionTools::intVersionToSortableString('10102'));
+        $this->assertEquals('05.09.12', VersionTools::intVersionToSortableString('050912'));
+        $this->assertEquals('00.00.00', VersionTools::intVersionToSortableString('master'));
+        $this->assertEquals('00.00.00', VersionTools::intVersionToSortableString('dev'));
+    }
+}


### PR DESCRIPTION
Fix regression from #5478

On Snap servers, the version is `3.10.0-pre.8697` while module versions are like `3.10.0-pre`. This was raising the message from PR #5478

AS this is for 3.8 branch, I will do another refactoring by moving version functions to this new file in another PR targeting only 3.9.