### PR TITLE
e2e: replace `data-original-title` by `title`

### DIFF
--- a/tests/end2end/playwright/n_to_m_relations.spec.js
+++ b/tests/end2end/playwright/n_to_m_relations.spec.js
@@ -55,14 +55,14 @@ test.describe('N to M relations', () => {
         let naturalAreasTableFeatureToolbar = attrTable.locator("tbody tr").all();
         for (const tr of await naturalAreasTableFeatureToolbar) {
             const featToolbar = tr.locator("td").nth(0).locator("lizmap-feature-toolbar");
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Select']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Filter']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Zoom']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Center']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Edit']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Delete']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Unlink child']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Create feature']")).toBeVisible();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Select']")).toBeVisible();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Filter']")).toBeHidden();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Zoom']")).toBeVisible();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Center']")).toBeVisible();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Edit']")).toBeVisible();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Delete']")).toBeVisible();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Unlink child']")).toBeHidden();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Create feature']")).toBeVisible();
             await expect(featToolbar.locator(".feature-toolbar .feature-create-child ul li a")).toHaveText("Bird sposts");
 
         }
@@ -94,14 +94,14 @@ test.describe('N to M relations', () => {
         let mTableFeatureToolbarFirst = nRelatedAttrTable.locator("tbody tr").all();
         for (const tr of await mTableFeatureToolbarFirst) {
             const featToolbar = tr.locator("td").nth(0).locator("lizmap-feature-toolbar");
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Select']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Filter']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Zoom']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Center']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Edit']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Delete']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Unlink child']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Create feature']")).toBeHidden();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Select']")).toBeVisible();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Filter']")).toBeHidden();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Zoom']")).toBeHidden();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Center']")).toBeHidden();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Edit']")).toBeVisible();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Delete']")).toBeHidden();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Unlink child']")).toBeVisible();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Create feature']")).toBeHidden();
         }
 
         // change main record
@@ -121,14 +121,14 @@ test.describe('N to M relations', () => {
         let mTableFeatureToolbarSecond = nRelatedAttrTable.locator("tbody tr").all();
         for (const tr of await mTableFeatureToolbarSecond) {
             const featToolbar = tr.locator("td").nth(0).locator("lizmap-feature-toolbar");
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Select']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Filter']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Zoom']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Center']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Edit']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Delete']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Unlink child']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Create feature']")).toBeHidden();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Select']")).toBeVisible();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Filter']")).toBeHidden();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Zoom']")).toBeHidden();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Center']")).toBeHidden();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Edit']")).toBeVisible();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Delete']")).toBeHidden();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Unlink child']")).toBeVisible();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Create feature']")).toBeHidden();
         }
 
         // back to first record
@@ -156,20 +156,20 @@ test.describe('N to M relations', () => {
         let oneToNTableFeatureToolbar = oneToNAttrTable.locator("tbody tr").all();
         for (const tr of await oneToNTableFeatureToolbar) {
             const featToolbar = tr.locator("td").nth(0).locator("lizmap-feature-toolbar");
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Select']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Filter']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Zoom']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Center']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Edit']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Delete']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Unlink child']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-original-title='Create feature']")).toBeHidden();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Select']")).toBeVisible();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Filter']")).toBeHidden();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Zoom']")).toBeHidden();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Center']")).toBeHidden();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Edit']")).toBeVisible();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Delete']")).toBeVisible();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Unlink child']")).toBeVisible();
+            await expect(featToolbar.locator(".feature-toolbar button[title='Create feature']")).toBeHidden();
         }
 
         // unlink bird spot from second natural area record
         let unlinkOneToN = page.waitForRequest(request => request.method() === 'POST' && request.url().includes('unlinkChild'));
 
-        await oneToNAttrTable.locator("tbody tr").nth(0).locator("td").nth(0).locator("lizmap-feature-toolbar").locator(".feature-toolbar button[data-original-title='Unlink child']").click();
+        await oneToNAttrTable.locator("tbody tr").nth(0).locator("td").nth(0).locator("lizmap-feature-toolbar").locator(".feature-toolbar button[title='Unlink child']").click();
         await unlinkOneToN;
 
         //wait for UI to relaod properly
@@ -273,7 +273,7 @@ test.describe('N to M relations', () => {
         });
 
         let unlinkPivotFeature = page.waitForResponse(response => response.request().method() === 'POST' && response.request().postData()?.includes('%22bird_id%22+%3D+%279%27') === true)
-        await childNaturalAreasTable.locator("tbody tr").nth(0).locator("td").nth(0).locator("lizmap-feature-toolbar").locator(".feature-toolbar button[data-original-title='Unlink child']").click();
+        await childNaturalAreasTable.locator("tbody tr").nth(0).locator("td").nth(0).locator("lizmap-feature-toolbar").locator(".feature-toolbar button[title='Unlink child']").click();
         await unlinkPivotFeature;
 
 
@@ -292,8 +292,8 @@ test.describe('N to M relations', () => {
             && response.request().postData()?.includes('GetFeature') === true
             && response.request().postData()?.includes('birds') === true
             && response.request().postData()?.includes('extent') === true)
-        await expect(birdsTable.locator("tbody tr").nth(6).locator("td").nth(0).locator("lizmap-feature-toolbar").locator(".feature-toolbar button[data-original-title='Delete']")).toHaveCount(1);
-        await birdsTable.locator("tbody tr").nth(6).locator("td").nth(0).locator("lizmap-feature-toolbar").locator(".feature-toolbar button[data-original-title='Delete']").click();
+        await expect(birdsTable.locator("tbody tr").nth(6).locator("td").nth(0).locator("lizmap-feature-toolbar").locator(".feature-toolbar button[title='Delete']")).toHaveCount(1);
+        await birdsTable.locator("tbody tr").nth(6).locator("td").nth(0).locator("lizmap-feature-toolbar").locator(".feature-toolbar button[title='Delete']").click();
         await deleteBirdFeature;
 
         await expect(birdsTable.locator("tbody tr")).toHaveCount(8);
@@ -333,14 +333,14 @@ test.describe('N to M relations', () => {
         });
 
         let unlinkPivotFeature = page.waitForResponse(response => response.request().method() === 'GET' && response.request().url().includes('deleteFeature'));
-        await page.locator(".lizmapPopupContent .lizmapPopupChildren").nth(0).locator(".lizmapPopupSingleFeature").nth(0).locator(".lizmapPopupDiv lizmap-feature-toolbar .feature-toolbar button[data-original-title='Unlink child']").click();
+        await page.locator(".lizmapPopupContent .lizmapPopupChildren").nth(0).locator(".lizmapPopupSingleFeature").nth(0).locator(".lizmapPopupDiv lizmap-feature-toolbar .feature-toolbar button[title='Unlink child']").click();
         await unlinkPivotFeature;
 
         await expect(page.locator(".lizmapPopupContent .lizmapPopupChildren").nth(0).locator(".lizmapPopupSingleFeature").nth(0).locator(".lizmapPopupDiv")).toHaveCount(0)
 
         // add a new bird from natural areas popup
         let editFeatureRequestPromise = page.waitForResponse(response => response.url().includes('editFeature'));
-        await page.locator('.lizmapPopupContent > .lizmapPopupSingleFeature').nth(0).locator("lizmap-feature-toolbar").first().locator(".feature-toolbar button[data-original-title='Edit']").click()
+        await page.locator('.lizmapPopupContent > .lizmapPopupSingleFeature').nth(0).locator("lizmap-feature-toolbar").first().locator(".feature-toolbar button[title='Edit']").click()
         await editFeatureRequestPromise;
 
         await expect(page.locator("#edition-child-tab-natural_areas-birds")).toHaveCount(1);

--- a/tests/end2end/playwright/print.spec.js
+++ b/tests/end2end/playwright/print.spec.js
@@ -505,13 +505,13 @@ test.describe('Print in popup', () => {
         // "quartiers" layer has one atlas (name "atlas_quartiers") button configured with a custom icon
         const featureAtlasQuartiers = page.locator('#popupcontent lizmap-feature-toolbar[value="quartiers_cc80709a_cd4a_41de_9400_1f492b32c9f7.1"] .feature-atlas');
         await expect(featureAtlasQuartiers).toHaveCount(1);
-        await expect(featureAtlasQuartiers.locator('button')).toHaveAttribute('data-original-title', 'atlas_quartiers');
+        await expect(featureAtlasQuartiers.locator('button')).toHaveAttribute('title', 'atlas_quartiers');
         await expect(featureAtlasQuartiers.locator('img')).toHaveAttribute('src', '/index.php/view/media/getMedia?repository=testsrepository&project=print&path=media/svg/tree-fill.svg');
 
         // "sousquartiers" layer has one atlas (name "atlas_sousquartiers") button configured with the default icon
         const featureAtlasSousQuartiers = page.locator('#popupcontent lizmap-feature-toolbar[value="sousquartiers_e27e6af0_dcc5_4700_9730_361437f69862.2"] .feature-atlas');
         await expect(featureAtlasSousQuartiers).toHaveCount(1);
-        await expect(featureAtlasSousQuartiers.locator('button')).toHaveAttribute('data-original-title', 'atlas_sousquartiers');
+        await expect(featureAtlasSousQuartiers.locator('button')).toHaveAttribute('title', 'atlas_sousquartiers');
         await expect(featureAtlasSousQuartiers.locator('svg use')).toHaveAttribute('xlink:href', '#map-print');
     });
 

--- a/tests/end2end/playwright/webdav-upload.spec.js
+++ b/tests/end2end/playwright/webdav-upload.spec.js
@@ -60,7 +60,7 @@ test.describe('WebDAV Server', () => {
         await expect(attrTable).toHaveCount(1);
         await expect(attrTable.locator("tr").nth(1).locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/logo.png");
         let editFeatureRequestPromise = page.waitForResponse(response => response.url().includes('editFeature'));
-        await attrTable.locator("tr").nth(1).locator("td").nth(0).locator("button[data-original-title='Edit']").click();
+        await attrTable.locator("tr").nth(1).locator("td").nth(0).locator("button[title='Edit']").click();
         await editFeatureRequestPromise;
         await page.waitForTimeout(300);
 


### PR DESCRIPTION
It is necessary as bootstrap tooltips have been disactivated for some buttons in ab01c62e7c323f309a6b52e1b5b592c3c812b831