### PR TITLE
Tests - Remove DB user and password from QGS files, use only the PG s…

### DIFF
--- a/tests/qgis-projects/tests/children_in_relation_div.qgs
+++ b/tests/qgis-projects/tests/children_in_relation_div.qgs
@@ -22,7 +22,7 @@
     <customproperties>
       <Option/>
     </customproperties>
-    <layer-tree-layer legend_exp="" checked="Qt::Checked" legend_split_behavior="0" name="natural_areas" id="natural_areas_8babd542_8324_458a_adf6_91dd0d06fe4a" expanded="0" providerKey="postgres" source="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)" patch_size="-1,-1">
+    <layer-tree-layer legend_exp="" checked="Qt::Checked" legend_split_behavior="0" name="natural_areas" id="natural_areas_8babd542_8324_458a_adf6_91dd0d06fe4a" expanded="0" providerKey="postgres" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)" patch_size="-1,-1">
       <customproperties>
         <Option/>
       </customproperties>
@@ -998,7 +998,7 @@ def my_form_open(dialog, layer, feature):
         <relation referencedLayer="birds_24d54d9c_ea99_42e6_809a_c4006102e2a7" layerName="birds" name="birds_birds_area" id="birds_area_bird_id_birds_24d5_id" referencingLayer="birds_areas_8981c855_f375_45da_898f_6e716f0744aa" layerId="birds_24d54d9c_ea99_42e6_809a_c4006102e2a7" providerKey="postgres" strength="Association" dataSource="service='lizmapdb' sslmode=disable key='id' checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;birds&quot;">
           <fieldRef referencedField="id" referencingField="bird_id"/>
         </relation>
-        <relation referencedLayer="natural_areas_8babd542_8324_458a_adf6_91dd0d06fe4a" layerName="natural_areas" name="natural_areas_birds_areas" id="birds_area_natural_area_id_natural_ar_id" referencingLayer="birds_areas_8981c855_f375_45da_898f_6e716f0744aa" layerId="natural_areas_8babd542_8324_458a_adf6_91dd0d06fe4a" providerKey="postgres" strength="Association" dataSource="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)">
+        <relation referencedLayer="natural_areas_8babd542_8324_458a_adf6_91dd0d06fe4a" layerName="natural_areas" name="natural_areas_birds_areas" id="birds_area_natural_area_id_natural_ar_id" referencingLayer="birds_areas_8981c855_f375_45da_898f_6e716f0744aa" layerId="natural_areas_8babd542_8324_458a_adf6_91dd0d06fe4a" providerKey="postgres" strength="Association" dataSource="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)">
           <fieldRef referencedField="id" referencingField="natural_area_id"/>
         </relation>
       </referencedLayers>
@@ -1308,7 +1308,7 @@ def my_form_open(dialog, layer, feature):
       </geometryOptions>
       <legend type="default-vector" showLabelLegend="0"/>
       <referencedLayers>
-        <relation referencedLayer="natural_areas_8babd542_8324_458a_adf6_91dd0d06fe4a" layerName="natural_areas" name="nat_areas_birds_spots" id="birds_spot_area_id_natural_ar_id" referencingLayer="birds_spots_ccccabfa_802e_4ee4_8526_1d90fd0c9c50" layerId="natural_areas_8babd542_8324_458a_adf6_91dd0d06fe4a" providerKey="postgres" strength="Association" dataSource="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)">
+        <relation referencedLayer="natural_areas_8babd542_8324_458a_adf6_91dd0d06fe4a" layerName="natural_areas" name="nat_areas_birds_spots" id="birds_spot_area_id_natural_ar_id" referencingLayer="birds_spots_ccccabfa_802e_4ee4_8526_1d90fd0c9c50" layerId="natural_areas_8babd542_8324_458a_adf6_91dd0d06fe4a" providerKey="postgres" strength="Association" dataSource="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)">
           <fieldRef referencedField="id" referencingField="area_id"/>
         </relation>
       </referencedLayers>
@@ -1473,7 +1473,7 @@ def my_form_open(dialog, layer, feature):
         <ymax>43.45587426605017356</ymax>
       </wgs84extent>
       <id>natural_areas_8babd542_8324_458a_adf6_91dd0d06fe4a</id>
-      <datasource>service='lizmapdb' user='lizmap' password='lizmap1234!' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table="tests_projects"."natural_areas" (geom)</datasource>
+      <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table="tests_projects"."natural_areas" (geom)</datasource>
       <shortname>natural_areas</shortname>
       <title>Natural areas</title>
       <keywordList>
@@ -2380,7 +2380,7 @@ def my_form_open(dialog, layer, feature):
       </spatialrefsys>
     </CoordinateCustomCrs>
   </ProjectDisplaySettings>
-  <ProjectGpsSettings autoCommitFeatures="0" destinationLayerName="natural_areas" destinationFollowsActiveLayer="1" destinationLayerProvider="postgres" autoAddTrackVertices="0" destinationLayer="natural_areas_8babd542_8324_458a_adf6_91dd0d06fe4a" destinationLayerSource="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)">
+  <ProjectGpsSettings autoCommitFeatures="0" destinationLayerName="natural_areas" destinationFollowsActiveLayer="1" destinationLayerProvider="postgres" autoAddTrackVertices="0" destinationLayer="natural_areas_8babd542_8324_458a_adf6_91dd0d06fe4a" destinationLayerSource="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)">
     <timeStampFields/>
   </ProjectGpsSettings>
 </qgis>

--- a/tests/qgis-projects/tests/get_feature_info_style.qgs
+++ b/tests/qgis-projects/tests/get_feature_info_style.qgs
@@ -22,7 +22,7 @@
     <customproperties>
       <Option/>
     </customproperties>
-    <layer-tree-layer name="natural_areas" providerKey="postgres" patch_size="-1,-1" id="natural_areas_d4a1a538_3bff_4998_a186_38237507ac1e" legend_exp="" legend_split_behavior="0" source="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)" checked="Qt::Checked" expanded="0">
+    <layer-tree-layer name="natural_areas" providerKey="postgres" patch_size="-1,-1" id="natural_areas_d4a1a538_3bff_4998_a186_38237507ac1e" legend_exp="" legend_split_behavior="0" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)" checked="Qt::Checked" expanded="0">
       <customproperties>
         <Option/>
       </customproperties>
@@ -147,7 +147,7 @@
         <ymax>43.45587426605017356</ymax>
       </wgs84extent>
       <id>natural_areas_d4a1a538_3bff_4998_a186_38237507ac1e</id>
-      <datasource>service='lizmapdb' user='lizmap' password='lizmap1234!' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table="tests_projects"."natural_areas" (geom)</datasource>
+      <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table="tests_projects"."natural_areas" (geom)</datasource>
       <shortname>natural_areas</shortname>
       <keywordList>
         <value></value>
@@ -1449,7 +1449,7 @@ def my_form_open(dialog, layer, feature):
       </spatialrefsys>
     </CoordinateCustomCrs>
   </ProjectDisplaySettings>
-  <ProjectGpsSettings destinationLayer="natural_areas_d4a1a538_3bff_4998_a186_38237507ac1e" autoCommitFeatures="0" autoAddTrackVertices="0" destinationLayerName="natural_areas" destinationLayerProvider="postgres" destinationFollowsActiveLayer="1" destinationLayerSource="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)">
+  <ProjectGpsSettings destinationLayer="natural_areas_d4a1a538_3bff_4998_a186_38237507ac1e" autoCommitFeatures="0" autoAddTrackVertices="0" destinationLayerName="natural_areas" destinationLayerProvider="postgres" destinationFollowsActiveLayer="1" destinationLayerSource="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)">
     <timeStampFields/>
   </ProjectGpsSettings>
 </qgis>

--- a/tests/qgis-projects/tests/google_apikey_basemap.qgs
+++ b/tests/qgis-projects/tests/google_apikey_basemap.qgs
@@ -22,7 +22,7 @@
     <customproperties>
       <Option/>
     </customproperties>
-    <layer-tree-layer legend_split_behavior="0" name="natural_areas" providerKey="postgres" checked="Qt::Checked" source="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)" patch_size="-1,-1" legend_exp="" expanded="1" id="natural_areas_e89a32a9_3a6e_4256_948f_ed8ca0ec687d">
+    <layer-tree-layer legend_split_behavior="0" name="natural_areas" providerKey="postgres" checked="Qt::Checked" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)" patch_size="-1,-1" legend_exp="" expanded="1" id="natural_areas_e89a32a9_3a6e_4256_948f_ed8ca0ec687d">
       <customproperties>
         <Option/>
       </customproperties>
@@ -1025,7 +1025,7 @@
         <ymax>43.45587426605017356</ymax>
       </wgs84extent>
       <id>natural_areas_e89a32a9_3a6e_4256_948f_ed8ca0ec687d</id>
-      <datasource>service='lizmapdb' user='lizmap' password='lizmap1234!' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table="tests_projects"."natural_areas" (geom)</datasource>
+      <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table="tests_projects"."natural_areas" (geom)</datasource>
       <shortname>natural_areas</shortname>
       <keywordList>
         <value></value>

--- a/tests/qgis-projects/tests/google_basemap.qgs
+++ b/tests/qgis-projects/tests/google_basemap.qgs
@@ -22,7 +22,7 @@
     <customproperties>
       <Option/>
     </customproperties>
-    <layer-tree-layer legend_split_behavior="0" name="natural_areas" providerKey="postgres" checked="Qt::Checked" source="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)" patch_size="-1,-1" legend_exp="" expanded="1" id="natural_areas_e89a32a9_3a6e_4256_948f_ed8ca0ec687d">
+    <layer-tree-layer legend_split_behavior="0" name="natural_areas" providerKey="postgres" checked="Qt::Checked" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)" patch_size="-1,-1" legend_exp="" expanded="1" id="natural_areas_e89a32a9_3a6e_4256_948f_ed8ca0ec687d">
       <customproperties>
         <Option/>
       </customproperties>
@@ -1025,7 +1025,7 @@
         <ymax>43.45587426605017356</ymax>
       </wgs84extent>
       <id>natural_areas_e89a32a9_3a6e_4256_948f_ed8ca0ec687d</id>
-      <datasource>service='lizmapdb' user='lizmap' password='lizmap1234!' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table="tests_projects"."natural_areas" (geom)</datasource>
+      <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table="tests_projects"."natural_areas" (geom)</datasource>
       <shortname>natural_areas</shortname>
       <keywordList>
         <value></value>
@@ -1578,7 +1578,7 @@
       </spatialrefsys>
     </CoordinateCustomCrs>
   </ProjectDisplaySettings>
-  <ProjectGpsSettings destinationLayerSource="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)" destinationLayer="natural_areas_e89a32a9_3a6e_4256_948f_ed8ca0ec687d" autoAddTrackVertices="0" autoCommitFeatures="0" destinationFollowsActiveLayer="1" destinationLayerName="natural_areas" destinationLayerProvider="postgres">
+  <ProjectGpsSettings destinationLayerSource="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)" destinationLayer="natural_areas_e89a32a9_3a6e_4256_948f_ed8ca0ec687d" autoAddTrackVertices="0" autoCommitFeatures="0" destinationFollowsActiveLayer="1" destinationLayerName="natural_areas" destinationLayerProvider="postgres">
     <timeStampFields/>
   </ProjectGpsSettings>
 </qgis>

--- a/tests/qgis-projects/tests/groups_checkboxes.qgs
+++ b/tests/qgis-projects/tests/groups_checkboxes.qgs
@@ -22,7 +22,7 @@
     <customproperties>
       <Option/>
     </customproperties>
-    <layer-tree-layer checked="Qt::Checked" patch_size="-1,-1" id="shop_bakery_pg_5f35874c_8fb3_484f_8488_118a8fdbb030" providerKey="postgres" legend_split_behavior="0" name="shop_bakery_pg" legend_exp="" source="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;shop_bakery_pg&quot; (geom)" expanded="1">
+    <layer-tree-layer checked="Qt::Checked" patch_size="-1,-1" id="shop_bakery_pg_5f35874c_8fb3_484f_8488_118a8fdbb030" providerKey="postgres" legend_split_behavior="0" name="shop_bakery_pg" legend_exp="" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;shop_bakery_pg&quot; (geom)" expanded="1">
       <customproperties>
         <Option/>
       </customproperties>
@@ -33,12 +33,12 @@
           <Option type="QString" value="tramway" name="wmsShortName"/>
         </Option>
       </customproperties>
-      <layer-tree-layer checked="Qt::Checked" patch_size="-1,-1" id="tramway_stops_f076f3cd_5ab0_4df5_9a53_81ebe7ea35e5" providerKey="postgres" legend_split_behavior="0" name="tramway_stops" legend_exp="" source="service='lizmapdb' user='lizmap' sslmode=disable key='id_stop' estimatedmetadata=true srid=2154 type=Point checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;tramway_stops&quot; (geom)" expanded="1">
+      <layer-tree-layer checked="Qt::Checked" patch_size="-1,-1" id="tramway_stops_f076f3cd_5ab0_4df5_9a53_81ebe7ea35e5" providerKey="postgres" legend_split_behavior="0" name="tramway_stops" legend_exp="" source="service='lizmapdb' sslmode=disable key='id_stop' estimatedmetadata=true srid=2154 type=Point checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;tramway_stops&quot; (geom)" expanded="1">
         <customproperties>
           <Option/>
         </customproperties>
       </layer-tree-layer>
-      <layer-tree-layer checked="Qt::Checked" patch_size="-1,-1" id="tramway_lines_fe7cbcb0_8ed3_4cf6_a687_485143aa5608" providerKey="postgres" legend_split_behavior="0" name="tramway_lines" legend_exp="" source="service='lizmapdb' user='lizmap' sslmode=disable key='id_line' estimatedmetadata=true srid=2154 type=LineString checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;tramway_lines&quot; (geom)" expanded="1">
+      <layer-tree-layer checked="Qt::Checked" patch_size="-1,-1" id="tramway_lines_fe7cbcb0_8ed3_4cf6_a687_485143aa5608" providerKey="postgres" legend_split_behavior="0" name="tramway_lines" legend_exp="" source="service='lizmapdb' sslmode=disable key='id_line' estimatedmetadata=true srid=2154 type=LineString checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;tramway_lines&quot; (geom)" expanded="1">
         <customproperties>
           <Option/>
         </customproperties>
@@ -50,7 +50,7 @@
           <Option type="QString" value="buildings" name="wmsShortName"/>
         </Option>
       </customproperties>
-      <layer-tree-layer checked="Qt::Checked" patch_size="-1,-1" id="townhalls_pg_718ccf2c_c558_43a1_b2a9_26274b66c6f3" providerKey="postgres" legend_split_behavior="0" name="townhalls_pg" legend_exp="" source="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=2154 type=Point checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;townhalls_pg&quot; (geom)" expanded="1">
+      <layer-tree-layer checked="Qt::Checked" patch_size="-1,-1" id="townhalls_pg_718ccf2c_c558_43a1_b2a9_26274b66c6f3" providerKey="postgres" legend_split_behavior="0" name="townhalls_pg" legend_exp="" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=2154 type=Point checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;townhalls_pg&quot; (geom)" expanded="1">
         <customproperties>
           <Option/>
         </customproperties>
@@ -62,7 +62,7 @@
           <Option type="QString" value="gianni" name="wmsShortName"/>
         </Option>
       </customproperties>
-      <layer-tree-layer checked="Qt::Checked" patch_size="-1,-1" id="sousquartiers_da0922bd_dd96_4fe2_af13_43ee5528af99" providerKey="postgres" legend_split_behavior="0" name="sousquartiers" legend_exp="" source="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=2154 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;sousquartiers&quot; (geom)" expanded="1">
+      <layer-tree-layer checked="Qt::Checked" patch_size="-1,-1" id="sousquartiers_da0922bd_dd96_4fe2_af13_43ee5528af99" providerKey="postgres" legend_split_behavior="0" name="sousquartiers" legend_exp="" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=2154 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;sousquartiers&quot; (geom)" expanded="1">
         <customproperties>
           <Option/>
         </customproperties>
@@ -73,7 +73,7 @@
             <Option type="QString" value="sub-group1" name="wmsShortName"/>
           </Option>
         </customproperties>
-        <layer-tree-layer checked="Qt::Checked" patch_size="-1,-1" id="quartiers_a58783cc_1adb_4961_8f46_3701ec2d5b62" providerKey="postgres" legend_split_behavior="0" name="quartiers" legend_exp="" source="service='lizmapdb' user='lizmap' sslmode=disable key='quartier' estimatedmetadata=true srid=4326 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;quartiers&quot; (geom)" expanded="1">
+        <layer-tree-layer checked="Qt::Checked" patch_size="-1,-1" id="quartiers_a58783cc_1adb_4961_8f46_3701ec2d5b62" providerKey="postgres" legend_split_behavior="0" name="quartiers" legend_exp="" source="service='lizmapdb' sslmode=disable key='quartier' estimatedmetadata=true srid=4326 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;quartiers&quot; (geom)" expanded="1">
           <customproperties>
             <Option/>
           </customproperties>
@@ -243,7 +243,7 @@
         <ymax>43.65337122449288643</ymax>
       </wgs84extent>
       <id>quartiers_a58783cc_1adb_4961_8f46_3701ec2d5b62</id>
-      <datasource>service='lizmapdb' user='lizmap' password='lizmap1234!' sslmode=disable key='quartier' estimatedmetadata=true srid=4326 type=MultiPolygon checkPrimaryKeyUnicity='1' table="tests_projects"."quartiers" (geom)</datasource>
+      <datasource>service='lizmapdb' sslmode=disable key='quartier' estimatedmetadata=true srid=4326 type=MultiPolygon checkPrimaryKeyUnicity='1' table="tests_projects"."quartiers" (geom)</datasource>
       <shortname>quartiers_1</shortname>
       <keywordList>
         <value></value>
@@ -609,7 +609,7 @@
         <ymax>43.68764871034932895</ymax>
       </wgs84extent>
       <id>shop_bakery_pg_5f35874c_8fb3_484f_8488_118a8fdbb030</id>
-      <datasource>service='lizmapdb' user='lizmap' password='lizmap1234!' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table="tests_projects"."shop_bakery_pg" (geom)</datasource>
+      <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table="tests_projects"."shop_bakery_pg" (geom)</datasource>
       <shortname>shop_bakery_pg</shortname>
       <title>shop_bakery_pg</title>
       <keywordList>
@@ -948,7 +948,7 @@
         <ymax>43.65374993426367922</ymax>
       </wgs84extent>
       <id>sousquartiers_da0922bd_dd96_4fe2_af13_43ee5528af99</id>
-      <datasource>service='lizmapdb' user='lizmap' password='lizmap1234!' sslmode=disable key='id' estimatedmetadata=true srid=2154 type=MultiPolygon checkPrimaryKeyUnicity='1' table="tests_projects"."sousquartiers" (geom)</datasource>
+      <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=2154 type=MultiPolygon checkPrimaryKeyUnicity='1' table="tests_projects"."sousquartiers" (geom)</datasource>
       <shortname>sousquartiers</shortname>
       <keywordList>
         <value></value>
@@ -1314,7 +1314,7 @@
         <ymax>43.67409308240065258</ymax>
       </wgs84extent>
       <id>townhalls_pg_718ccf2c_c558_43a1_b2a9_26274b66c6f3</id>
-      <datasource>service='lizmapdb' user='lizmap' password='lizmap1234!' sslmode=disable key='id' estimatedmetadata=true srid=2154 type=Point checkPrimaryKeyUnicity='1' table="tests_projects"."townhalls_pg" (geom)</datasource>
+      <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=2154 type=Point checkPrimaryKeyUnicity='1' table="tests_projects"."townhalls_pg" (geom)</datasource>
       <shortname>townhalls_pg</shortname>
       <keywordList>
         <value></value>
@@ -1652,7 +1652,7 @@
         <ymax>43.67959702962155433</ymax>
       </wgs84extent>
       <id>tramway_lines_fe7cbcb0_8ed3_4cf6_a687_485143aa5608</id>
-      <datasource>service='lizmapdb' user='lizmap' password='lizmap1234!' sslmode=disable key='id_line' estimatedmetadata=true srid=2154 type=LineString checkPrimaryKeyUnicity='1' table="tests_projects"."tramway_lines" (geom)</datasource>
+      <datasource>service='lizmapdb' sslmode=disable key='id_line' estimatedmetadata=true srid=2154 type=LineString checkPrimaryKeyUnicity='1' table="tests_projects"."tramway_lines" (geom)</datasource>
       <shortname>tramway_lines</shortname>
       <keywordList>
         <value></value>
@@ -1986,7 +1986,7 @@
         <ymax>43.67838964885666542</ymax>
       </wgs84extent>
       <id>tramway_stops_f076f3cd_5ab0_4df5_9a53_81ebe7ea35e5</id>
-      <datasource>service='lizmapdb' user='lizmap' password='lizmap1234!' sslmode=disable key='id_stop' estimatedmetadata=true srid=2154 type=Point checkPrimaryKeyUnicity='1' table="tests_projects"."tramway_stops" (geom)</datasource>
+      <datasource>service='lizmapdb' sslmode=disable key='id_stop' estimatedmetadata=true srid=2154 type=Point checkPrimaryKeyUnicity='1' table="tests_projects"."tramway_stops" (geom)</datasource>
       <shortname>tramway_stops</shortname>
       <keywordList>
         <value></value>
@@ -2536,7 +2536,7 @@
       </spatialrefsys>
     </CoordinateCustomCrs>
   </ProjectDisplaySettings>
-  <ProjectGpsSettings autoAddTrackVertices="0" destinationLayerSource="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;shop_bakery_pg&quot; (geom)" destinationLayerProvider="postgres" destinationFollowsActiveLayer="1" destinationLayer="shop_bakery_pg_5f35874c_8fb3_484f_8488_118a8fdbb030" autoCommitFeatures="0" destinationLayerName="shop_bakery_pg">
+  <ProjectGpsSettings autoAddTrackVertices="0" destinationLayerSource="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;shop_bakery_pg&quot; (geom)" destinationLayerProvider="postgres" destinationFollowsActiveLayer="1" destinationLayer="shop_bakery_pg_5f35874c_8fb3_484f_8488_118a8fdbb030" autoCommitFeatures="0" destinationLayerName="shop_bakery_pg">
     <timeStampFields/>
   </ProjectGpsSettings>
 </qgis>

--- a/tests/qgis-projects/tests/multiple_geom.qgs
+++ b/tests/qgis-projects/tests/multiple_geom.qgs
@@ -27,12 +27,12 @@
           <Option value="double_geom" type="QString" name="wmsShortName"/>
         </Option>
       </customproperties>
-      <layer-tree-layer checked="Qt::Checked" expanded="1" legend_exp="" legend_split_behavior="0" providerKey="postgres" id="double_geom_geom_d_b4e77421_397c_45c9_834b_1dde70abb7a8" source="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;double_geom&quot; (geom_d)" patch_size="-1,-1" name="double_geom.geom_d">
+      <layer-tree-layer checked="Qt::Checked" expanded="1" legend_exp="" legend_split_behavior="0" providerKey="postgres" id="double_geom_geom_d_b4e77421_397c_45c9_834b_1dde70abb7a8" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;double_geom&quot; (geom_d)" patch_size="-1,-1" name="double_geom.geom_d">
         <customproperties>
           <Option/>
         </customproperties>
       </layer-tree-layer>
-      <layer-tree-layer checked="Qt::Checked" expanded="1" legend_exp="" legend_split_behavior="0" providerKey="postgres" id="double_geom_geom_2bac18c8_6cd8_4ce1_9ba8_6aeb048a9da6" source="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;double_geom&quot; (geom)" patch_size="-1,-1" name="double_geom.geom">
+      <layer-tree-layer checked="Qt::Checked" expanded="1" legend_exp="" legend_split_behavior="0" providerKey="postgres" id="double_geom_geom_2bac18c8_6cd8_4ce1_9ba8_6aeb048a9da6" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;double_geom&quot; (geom)" patch_size="-1,-1" name="double_geom.geom">
         <customproperties>
           <Option/>
         </customproperties>
@@ -44,17 +44,17 @@
           <Option value="triple_geom" type="QString" name="wmsShortName"/>
         </Option>
       </customproperties>
-      <layer-tree-layer checked="Qt::Checked" expanded="1" legend_exp="" legend_split_behavior="0" providerKey="postgres" id="triple_geom_geom_p_0457ccc0_2028_41c8_bd04_dc1396a14b3a" source="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;triple_geom&quot; (geom_p)" patch_size="-1,-1" name="triple_geom.geom_p">
+      <layer-tree-layer checked="Qt::Checked" expanded="1" legend_exp="" legend_split_behavior="0" providerKey="postgres" id="triple_geom_geom_p_0457ccc0_2028_41c8_bd04_dc1396a14b3a" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;triple_geom&quot; (geom_p)" patch_size="-1,-1" name="triple_geom.geom_p">
         <customproperties>
           <Option/>
         </customproperties>
       </layer-tree-layer>
-      <layer-tree-layer checked="Qt::Checked" expanded="1" legend_exp="" legend_split_behavior="0" providerKey="postgres" id="triple_geom_geom_l_9c402a6d_ca66_43d6_9e90_bbf80e652d41" source="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=LineString checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;triple_geom&quot; (geom_l)" patch_size="-1,-1" name="triple_geom.geom_l">
+      <layer-tree-layer checked="Qt::Checked" expanded="1" legend_exp="" legend_split_behavior="0" providerKey="postgres" id="triple_geom_geom_l_9c402a6d_ca66_43d6_9e90_bbf80e652d41" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=LineString checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;triple_geom&quot; (geom_l)" patch_size="-1,-1" name="triple_geom.geom_l">
         <customproperties>
           <Option/>
         </customproperties>
       </layer-tree-layer>
-      <layer-tree-layer checked="Qt::Checked" expanded="1" legend_exp="" legend_split_behavior="0" providerKey="postgres" id="triple_geom_geom_f67b1b17_8b15_48ba_8dd3_ff60eb0165dc" source="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;triple_geom&quot; (geom)" patch_size="-1,-1" name="triple_geom.geom">
+      <layer-tree-layer checked="Qt::Checked" expanded="1" legend_exp="" legend_split_behavior="0" providerKey="postgres" id="triple_geom_geom_f67b1b17_8b15_48ba_8dd3_ff60eb0165dc" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;triple_geom&quot; (geom)" patch_size="-1,-1" name="triple_geom.geom">
         <customproperties>
           <Option/>
         </customproperties>
@@ -202,7 +202,7 @@
         <ymax>43.61289847078509752</ymax>
       </wgs84extent>
       <id>double_geom_geom_2bac18c8_6cd8_4ce1_9ba8_6aeb048a9da6</id>
-      <datasource>service='lizmapdb' user='lizmap' password='lizmap1234!' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table="tests_projects"."double_geom" (geom)</datasource>
+      <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table="tests_projects"."double_geom" (geom)</datasource>
       <shortname>double_geom_geom</shortname>
       <title>double_geom</title>
       <keywordList>
@@ -545,7 +545,7 @@
         <ymax>43.6403660127874673</ymax>
       </wgs84extent>
       <id>double_geom_geom_d_b4e77421_397c_45c9_834b_1dde70abb7a8</id>
-      <datasource>service='lizmapdb' user='lizmap' password='lizmap1234!' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table="tests_projects"."double_geom" (geom_d)</datasource>
+      <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table="tests_projects"."double_geom" (geom_d)</datasource>
       <shortname>double_geom_geom_d</shortname>
       <title>double_geom_d</title>
       <keywordList>
@@ -888,7 +888,7 @@
         <ymax>43.60345650322176425</ymax>
       </wgs84extent>
       <id>triple_geom_geom_f67b1b17_8b15_48ba_8dd3_ff60eb0165dc</id>
-      <datasource>service='lizmapdb' user='lizmap' password='lizmap1234!' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table="tests_projects"."triple_geom" (geom)</datasource>
+      <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table="tests_projects"."triple_geom" (geom)</datasource>
       <shortname>triple_geom_geom</shortname>
       <title>triple_geom_point</title>
       <keywordList>
@@ -1241,7 +1241,7 @@
         <ymax>43.61633191353537597</ymax>
       </wgs84extent>
       <id>triple_geom_geom_l_9c402a6d_ca66_43d6_9e90_bbf80e652d41</id>
-      <datasource>service='lizmapdb' user='lizmap' password='lizmap1234!' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=LineString checkPrimaryKeyUnicity='1' table="tests_projects"."triple_geom" (geom_l)</datasource>
+      <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=LineString checkPrimaryKeyUnicity='1' table="tests_projects"."triple_geom" (geom_l)</datasource>
       <shortname>triple_geom_geom_l</shortname>
       <title>triple_geom_line</title>
       <keywordList>
@@ -1602,7 +1602,7 @@
         <ymax>43.64379945553774576</ymax>
       </wgs84extent>
       <id>triple_geom_geom_p_0457ccc0_2028_41c8_bd04_dc1396a14b3a</id>
-      <datasource>service='lizmapdb' user='lizmap' password='lizmap1234!' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table="tests_projects"."triple_geom" (geom_p)</datasource>
+      <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table="tests_projects"."triple_geom" (geom_p)</datasource>
       <shortname>triple_geom_geom_p</shortname>
       <title>triple_geom_polygon</title>
       <keywordList>

--- a/tests/qgis-projects/tests/text_widget.qgs
+++ b/tests/qgis-projects/tests/text_widget.qgs
@@ -22,7 +22,7 @@
     <customproperties>
       <Option/>
     </customproperties>
-    <layer-tree-layer source="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;text_widget_point_edit&quot; (geom)" patch_size="-1,-1" expanded="1" checked="Qt::Checked" legend_exp="" legend_split_behavior="0" name="text_widget_point_edit" id="text_widget_point_edit_87ab8b55_b3f5_4bf5_ad25_5c540dcd5a97" providerKey="postgres">
+    <layer-tree-layer source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;text_widget_point_edit&quot; (geom)" patch_size="-1,-1" expanded="1" checked="Qt::Checked" legend_exp="" legend_split_behavior="0" name="text_widget_point_edit" id="text_widget_point_edit_87ab8b55_b3f5_4bf5_ad25_5c540dcd5a97" providerKey="postgres">
       <customproperties>
         <Option/>
       </customproperties>
@@ -379,7 +379,7 @@
         <ymax>43.6008655218749368</ymax>
       </wgs84extent>
       <id>text_widget_point_edit_87ab8b55_b3f5_4bf5_ad25_5c540dcd5a97</id>
-      <datasource>service='lizmapdb' user='lizmap' password='lizmap1234!' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table="tests_projects"."text_widget_point_edit" (geom)</datasource>
+      <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table="tests_projects"."text_widget_point_edit" (geom)</datasource>
       <shortname>text_widget_point_edit</shortname>
       <title>Point edit</title>
       <keywordList>
@@ -1162,7 +1162,7 @@ def my_form_open(dialog, layer, feature):
       </spatialrefsys>
     </CoordinateCustomCrs>
   </ProjectDisplaySettings>
-  <ProjectGpsSettings destinationLayer="text_widget_point_edit_87ab8b55_b3f5_4bf5_ad25_5c540dcd5a97" destinationFollowsActiveLayer="1" autoCommitFeatures="0" destinationLayerSource="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;text_widget_point_edit&quot; (geom)" destinationLayerProvider="postgres" autoAddTrackVertices="0" destinationLayerName="text_widget_point_edit">
+  <ProjectGpsSettings destinationLayer="text_widget_point_edit_87ab8b55_b3f5_4bf5_ad25_5c540dcd5a97" destinationFollowsActiveLayer="1" autoCommitFeatures="0" destinationLayerSource="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;text_widget_point_edit&quot; (geom)" destinationLayerProvider="postgres" autoAddTrackVertices="0" destinationLayerName="text_widget_point_edit">
     <timeStampFields/>
   </ProjectGpsSettings>
 </qgis>

--- a/tests/units/classes/Project/Ressources/readLayers_310.qgs
+++ b/tests/units/classes/Project/Ressources/readLayers_310.qgs
@@ -19,7 +19,7 @@
   </projectCrs>
   <layer-tree-group>
     <customproperties></customproperties>
-    <layer-tree-layer checked="Qt::Checked" expanded="1" id="form_edition_line_2154_0de013b5_f8d1_49d1_a6b8_3a025207da1c" name="form_edition_line_2154" providerKey="postgres" source="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=2154 type=LineString checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;form_edition_line_2154&quot; (geom) sql=">
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="form_edition_line_2154_0de013b5_f8d1_49d1_a6b8_3a025207da1c" name="form_edition_line_2154" providerKey="postgres" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=2154 type=LineString checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;form_edition_line_2154&quot; (geom) sql=">
       <customproperties></customproperties>
     </layer-tree-layer>
     <custom-order enabled="0">
@@ -70,7 +70,7 @@
   <projectlayers>
     <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Line" hasScaleBasedVisibilityFlag="0" labelsEnabled="0" maxScale="0" minScale="1e+08" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="0" simplifyMaxScale="1" styleCategories="AllStyleCategories" type="vector" wkbType="LineString">
       <id>form_edition_line_2154_0de013b5_f8d1_49d1_a6b8_3a025207da1c</id>
-      <datasource>service='lizmapdb' user='lizmap' password='lizmap1234!' sslmode=disable key='id' estimatedmetadata=true srid=2154 type=LineString checkPrimaryKeyUnicity='1' table="tests_projects"."form_edition_line_2154" (geom) sql=</datasource>
+      <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=2154 type=LineString checkPrimaryKeyUnicity='1' table="tests_projects"."form_edition_line_2154" (geom) sql=</datasource>
       <keywordList>
         <value></value>
       </keywordList>

--- a/tests/units/classes/Project/Ressources/readLayers_316.qgs
+++ b/tests/units/classes/Project/Ressources/readLayers_316.qgs
@@ -19,7 +19,7 @@
   </projectCrs>
   <layer-tree-group>
     <customproperties></customproperties>
-    <layer-tree-layer checked="Qt::Checked" expanded="1" id="form_edition_line_2154_0de013b5_f8d1_49d1_a6b8_3a025207da1c" legend_exp="" legend_split_behavior="0" name="form_edition_line_2154" patch_size="-1,-1" providerKey="postgres" source="service='lizmapdb' user='lizmap' sslmode=disable key='id' estimatedmetadata=true srid=2154 type=LineString checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;form_edition_line_2154&quot; (geom)">
+    <layer-tree-layer checked="Qt::Checked" expanded="1" id="form_edition_line_2154_0de013b5_f8d1_49d1_a6b8_3a025207da1c" legend_exp="" legend_split_behavior="0" name="form_edition_line_2154" patch_size="-1,-1" providerKey="postgres" source="service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=2154 type=LineString checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;form_edition_line_2154&quot; (geom)">
       <customproperties></customproperties>
     </layer-tree-layer>
     <custom-order enabled="0">
@@ -118,7 +118,7 @@
   <projectlayers>
     <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Line" hasScaleBasedVisibilityFlag="0" labelsEnabled="0" maxScale="0" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="0" simplifyMaxScale="1" styleCategories="AllStyleCategories" type="vector" wkbType="LineString">
       <id>form_edition_line_2154_0de013b5_f8d1_49d1_a6b8_3a025207da1c</id>
-      <datasource>service='lizmapdb' user='lizmap' password='lizmap1234!' sslmode=disable key='id' estimatedmetadata=true srid=2154 type=LineString checkPrimaryKeyUnicity='1' table="tests_projects"."form_edition_line_2154" (geom)</datasource>
+      <datasource>service='lizmapdb' sslmode=disable key='id' estimatedmetadata=true srid=2154 type=LineString checkPrimaryKeyUnicity='1' table="tests_projects"."form_edition_line_2154" (geom)</datasource>
       <keywordList>
         <value></value>
       </keywordList>


### PR DESCRIPTION
Remove `user` and `password` from QGS files in `tests` folder. These projects are deployed in different endpoints such as 

https://sandbox.lizmap.com/lizmap_3_7
https://sandbox.lizmap.com/lizmap_3_8/
https://sandbox.lizmap.com/lizmap_3_9/

with different PG services, edited on runtime.

@mind84 It seems to mainly come from your QGIS Desktop, can you check and edit your connection in QGIS to drop the user and password. Thanks.

It will be manually backported to 3.9 and 3.8
