### PR TITLE
[Bugfix] Wrong measure when both angle and dimension constraints are set on drawing tool

### DIFF
--- a/assets/src/modules/Digitizing.js
+++ b/assets/src/modules/Digitizing.js
@@ -1000,9 +1000,9 @@ export class Digitizing {
 
                 // Display clockwise or anticlockwise angle
                 // Closest from cursor is displayed
-                if (getLength(
+                if (this.getProjectedLength(
                     new LineString([closestClockwise, cursorPointCoords])
-                ) < getLength(
+                ) < this.getProjectedLength(
                     new LineString([closestAntiClockwise, cursorPointCoords])
                 )) {
                     constrainedAngleLineString = constrainedAngleClockwise.clone();
@@ -1011,7 +1011,7 @@ export class Digitizing {
                 }
 
                 if (this._distanceConstraint) {
-                    const ratio = this._distanceConstraint / getLength(constrainedAngleLineString);
+                    const ratio = this._distanceConstraint / this.getProjectedLength(constrainedAngleLineString);
                     constrainedAngleLineString.scale(ratio, ratio, constrainedAngleLineString.getLastCoordinate());
 
                     constrainedPointCoords = constrainedAngleLineString.getFirstCoordinate();
@@ -1098,12 +1098,26 @@ export class Digitizing {
     }
 
     /**
+     * Get spherical length of a geometry based on provided projection
+     * @param {Geometry} geom The geom.
+     * @param {null|string} projection The projection.
+     * @returns {number} The calculated spherical length.
+     */
+    getProjectedLength(geom, projection = null) {
+        if(!projection) {
+            projection = this._map.getView().getProjection();
+        }
+
+        return getLength(geom, {projection: projection});
+    }
+
+    /**
      * Format length output.
      * @param {Geometry} geom The geom.
      * @returns {string} The formatted length.
      */
     formatLength(geom) {
-        const length = getLength(geom, {projection: this._map.getView().getProjection()});
+        const length = this.getProjectedLength(geom);
         let output;
         if (length > 100) {
             output = Math.round((length / 1000) * 100) / 100 + ' ' + 'km';

--- a/tests/end2end/playwright/pages/drawpage.js
+++ b/tests/end2end/playwright/pages/drawpage.js
@@ -1,0 +1,100 @@
+// @ts-check
+import { ProjectPage } from './project';
+
+/**
+ * Playwright Page
+ * @typedef {import('@playwright/test').Page} Page
+ */
+
+/**
+ * Playwright Page
+ * @typedef {import('@playwright/test').Locator} Locator
+ */
+
+export class DrawPage extends ProjectPage {
+    // Metadata
+    /**
+     * The print panel
+     * @type {Locator}
+     */
+    drawPanel;
+
+    /**
+     * The print button on menu
+     * @type {Locator}
+     */
+    drawSwitcherButton;
+
+    /**
+     * The static tooltip containing the measurement of a finalized geometry.
+     * @type {Locator}
+     */
+    mapAnnotationToolTipStatic;
+
+    /**
+     * The measure tooltip containing the measurement of a not finalized geometry.
+     * @type {Locator}
+     */
+    mapAnnotationToolTipMeasure;
+
+    /**
+     * Constructor for a QGIS project page
+     * @param {Page} page The playwright page
+     * @param {string} project The project name
+     * @param {string} repository The repository name, default to testsrepository
+     */
+    constructor(page, project, repository = 'testsrepository') {
+        super(page, project, repository);
+
+        this.drawPanel = page.locator('#draw');
+        this.drawSwitcherButton = page.locator('#button-draw');
+        this.mapAnnotationToolTipStatic = page.locator('.ol-tooltip.ol-tooltip-static');
+        this.mapAnnotationToolTipMeasure = page.locator('.ol-tooltip.ol-tooltip-measure');
+    }
+
+    /**
+     * openDrawPanel function
+     * Opens the draw panel
+     */
+    async openDrawPanel() {
+        await this.drawSwitcherButton.click();
+    }
+
+    /**
+     * selectGeometry function
+     * Select the geometry to draw
+     * @param {string} type The geometry type.
+     *                      Possible values 'point', 'line', 'polygon','box','circle','freehand','text'.
+     */
+    async selectGeometry(type) {
+        await this.drawPanel.locator('button.dropdown-toggle:nth-child(2)').click();
+        await this.drawPanel.locator(`.digitizing-${type} > svg`).click();
+    }
+
+    /**
+     * toggleMeasure function
+     * Toggle the measure tool
+     */
+    async toggleMeasure() {
+        await this.drawPanel.locator('button.digitizing-toggle-measure').click();
+    }
+
+    /**
+     * setMeasureConstraint function
+     * @param {string} type The constraint type type. Possible values 'distance', 'angle'.
+     * @param {string} value The constraint value.
+     */
+    async setMeasureConstraint(type, value) {
+        await this.drawPanel.locator(`.digitizing-constraint-${type} input.${type}`).fill(value);
+    }
+
+    /**
+     * deleteAllDrawings function
+     * Delete all drawn features
+     */
+    async deleteAllDrawings(){
+        this.page.once('dialog', (dialog) => dialog.accept());
+
+        await this.drawPanel.locator('.digitizing-all').click();
+    }
+}

--- a/tests/end2end/playwright/pages/project.js
+++ b/tests/end2end/playwright/pages/project.js
@@ -251,6 +251,16 @@ export class ProjectPage extends BasePage {
     }
 
     /**
+     * dblClickOnMap function
+     * Double click on the map at the given position
+     * @param {number} x Position X on the map
+     * @param {number} y Position Y on the map
+     */
+    async dblClickOnMap(x, y){
+        await this.map.dblclick({position: {x: x, y: y}});
+    }
+
+    /**
      * clickOnMapLegacy function
      * Click on the OL 2map at the given position
      * @param {number} x Position X on the map


### PR DESCRIPTION
When both dimension and angle constraints are set in the drawing tool, the resulting `linestring` length measurement is incorrect.

![measurement_!](https://github.com/user-attachments/assets/6fe41db0-6261-4853-b3a8-01b8b52124b8)

![measurement_2](https://github.com/user-attachments/assets/4e342d76-fd5d-4e9e-a4e5-adffbd12f9ab)


TEST NOTICE:
@Gustry,

I assumed that the `draw.spec.js` test will be refactored to be POM compliant, so for now I just added a new subtest in the "traditional" way. It makes more sense to me to refactor all the code at once, so I think it's best to keep it in a separate PR.

Backport 3.8, 3.9

Funded by Etra
