### PR TITLE
[Bugfix] JS Atlas: features were not projected to map

### DIFF
--- a/assets/src/legacy/atlas.js
+++ b/assets/src/legacy/atlas.js
@@ -533,7 +533,11 @@ import { getCenter } from 'ol/extent.js';
              * @param feature
              */
             function runAtlasItem(feature) {
-                const olFeature = (new GeoJSON()).readFeature(feature);
+                const options = {
+                    featureProjection: lizMap.map.getProjection(),
+                    dataProjection: 'EPSG:4326'
+                };
+                const olFeature = (new GeoJSON()).readFeature(feature, options);
 
                 // Zoom to feature
                 if (lizAtlasConfig['zoom']) {

--- a/tests/end2end/playwright/viewport.spec.js
+++ b/tests/end2end/playwright/viewport.spec.js
@@ -168,7 +168,10 @@ test.describe('Viewport mobile', () => {
         await expect(page.locator('#right-dock')).toBeInViewport();
 
         // Choose a feature and check getFeatureInfo
-        let getFeatureInfoRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeatureInfo') === true);
+        let getFeatureInfoRequestPromise = page.waitForRequest(
+            request => request.method() === 'POST' &&
+            request.postData()?.includes('GetFeatureInfo') === true
+        );
         await page.locator('#liz-atlas-select').selectOption('2');
         let getFeatureInfoRequest = await getFeatureInfoRequestPromise;
         let getFeatureInfoResponse = await getFeatureInfoRequest.response();


### PR DESCRIPTION
The features were not projection to map projection when they were used to zoom to. Regression introduced by  Zoom to features with a max scale constraint #4897

Funded By WPD Onshore France