### PR TITLE
Admin - Move the drop commit ID into the modules checker class, because it is needed twice

### DIFF
--- a/lizmap/modules/admin/controllers/server_information.classic.php
+++ b/lizmap/modules/admin/controllers/server_information.classic.php
@@ -1,6 +1,5 @@
 <?php
 
-use Lizmap\App\VersionTools;
 use Lizmap\Server\Server;
 use LizmapAdmin\ModulesInfo\ModulesChecker;
 
@@ -78,12 +77,11 @@ class server_informationCtrl extends jController
 
         // Set the HTML content
         $tpl = new jTpl();
-        $semanticVersion = VersionTools::dropBuildId($data['info']['version']);
         $assign = array(
             'data' => $data,
             'baseUrlApplication' => jServer::getServerURI().jApp::urlBasePath(),
             'modules' => $modules->getList(false, false, true),
-            'installationComplete' => $modules->compareLizmapCoreModulesVersions($semanticVersion),
+            'installationComplete' => $modules->compareLizmapCoreModulesVersions($data['info']['version']),
             'qgisServerNeedsUpdate' => $qgisServerNeedsUpdate,
             'updateQgisServer' => $updateQgisServer,
             'lizmapQgisServerNeedsUpdate' => $lizmapQgisServerNeedsUpdate,

--- a/lizmap/modules/admin/lib/ModulesInfo/ModulesChecker.php
+++ b/lizmap/modules/admin/lib/ModulesInfo/ModulesChecker.php
@@ -81,13 +81,14 @@ class ModulesChecker
      */
     public function compareLizmapCoreModulesVersions($version)
     {
+        $semanticVersion = VersionTools::dropBuildId($version);
         // We only want Lizmap core modules, without additional modules such as (AltiProfil, MapBuilder…)
         $modules = $this->getList(false, true, false);
         foreach ($modules as $module) {
             // It should be improved
             // 3.9.0-beta.2    → 3.9.0-beta
             // 3.10.0-pre.8697 → 3.10.0-pre
-            if ($version != VersionTools::dropBuildId($module->version)) {
+            if ($semanticVersion != VersionTools::dropBuildId($module->version)) {
 
                 return false;
             }


### PR DESCRIPTION
The backport in 3.9 is included in PR #5577 that's why I only added label to 3.8 about backport.