### PR TITLE
Fix: zoom in form filter

### DIFF
--- a/assets/src/legacy/filter.js
+++ b/assets/src/legacy/filter.js
@@ -1474,8 +1474,7 @@ var lizLayerFilterTool = function () {
                 if (!bounds || abounds.length != 4) {
                     return false;
                 }
-                var extent = new OpenLayers.Bounds(abounds[0], abounds[1], abounds[2], abounds[3]);
-                lizMap.map.zoomToExtent(extent);
+                lizMap.mainLizmap.map.getView().fit(abounds);
                 return false;
             }
 


### PR DESCRIPTION
Sometimes the zoom stops to work correctly
Let's use the OL10 map to zoom

Ticket : paid support 3413

Funded by SMICA
