### PR TITLE
Lizmap-Features-Table - Evaluate QGIS expressions which are in lizmap-field

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisExpressionUtils.class.php
+++ b/lizmap/modules/lizmap/classes/qgisExpressionUtils.class.php
@@ -155,19 +155,29 @@ class qgisExpressionUtils
      * A filter can be used to retrieve the virtual fields values only
      * for a subset of features.
      *
-     * @param qgisVectorLayer $layer         A QGIS vector layer
-     * @param array           $virtualFields The expressions' list to evaluate as key
-     * @param string          $filter        A filter to restrict virtual fields creation
-     * @param string          $withGeometry  'true' to get geometries of features
-     * @param string          $fields        A list of field names separated by comma. E.g. 'name,code'
-     * @param int             $limit         The maximum number of features to return
-     * @param null|string     $sortingField  The field to sort by E.g. 'desc'
-     * @param null|string     $sortingOrder  The order to sort by E.g. 'name'
+     * @param qgisVectorLayer $layer             A QGIS vector layer
+     * @param array           $virtualFields     The expressions' list to evaluate as key
+     * @param string          $filter            A filter to restrict virtual fields creation
+     * @param string          $withGeometry      'true' to get geometries of features
+     * @param string          $fields            A list of field names separated by comma. E.g. 'name,code'
+     * @param int             $limit             The maximum number of features to return
+     * @param null|string     $sortingField      The field to sort by E.g. 'desc'
+     * @param null|string     $sortingOrder      The order to sort by E.g. 'name'
+     * @param null|array      $safeVirtualFields List of expressions to be evaluated carefully
      *
      * @return null|array the features with virtual fields
      */
-    public static function virtualFields($layer, $virtualFields, $filter = null, $withGeometry = 'true', $fields = '', $limit = 1000, $sortingField = null, $sortingOrder = 'asc')
-    {
+    public static function virtualFields(
+        $layer,
+        $virtualFields,
+        $filter = null,
+        $withGeometry = 'true',
+        $fields = '',
+        $limit = 1000,
+        $sortingField = null,
+        $sortingOrder = 'asc',
+        $safeVirtualFields = null,
+    ) {
         // Evaluate the expression by qgis
         $project = $layer->getProject();
         $params = array(
@@ -186,6 +196,10 @@ class qgisExpressionUtils
         if ($sortingField) {
             $params['sorting_field'] = $sortingField;
             $params['sorting_order'] = in_array(strtolower($sortingOrder), array('asc', 'desc')) ? $sortingOrder : 'asc';
+        }
+
+        if ($safeVirtualFields) {
+            $params['safe_virtuals'] = json_encode($safeVirtualFields);
         }
 
         // Request virtual fields

--- a/lizmap/modules/lizmap/controllers/features.classic.php
+++ b/lizmap/modules/lizmap/controllers/features.classic.php
@@ -161,17 +161,11 @@ class featuresCtrl extends jController
         try {
             $additionalFields = json_decode($this->param('additionalFields', '[]'), true);
         } catch (Exception $e) {
-            $content['error'] = 'An error occurred while replacing the expression text !';
+            $content['error'] = 'An error occurred while evaluating additional fields';
             $rep->data = $content;
 
             return $rep;
         }
-
-        foreach ($additionalFields as $key => $value) {
-            $additionalFields[$key] = $this->regexCheck($value);
-        }
-
-        $expressions = array_merge($expressions, $additionalFields);
 
         $sortingField = trim($this->param('sorting_field', null));
 
@@ -190,6 +184,7 @@ class featuresCtrl extends jController
             $limit,
             $sortingField,
             $sortingOrder,
+            $additionalFields,
         );
 
         // If the returned content is null, an error occurred
@@ -210,28 +205,5 @@ class featuresCtrl extends jController
         $rep->data = $content;
 
         return $rep;
-    }
-
-    /**
-     * Check if the expression is valid.
-     *
-     * @param $expression string  The expression to check
-     *
-     * @return string The expression if it is valid, 'INVALID EXPRESSION' otherwise
-     */
-    private function regexCheck($expression): string
-    {
-        // Allowing only fields like "libsquart" and not expressions like rand(10,34)
-        $regex = '/^[a-zA-Z0-9_\- ]+$/';
-
-        $expression = str_replace('"', '', $expression);
-
-        preg_match($regex, $expression, $matches);
-
-        if (count($matches) == 0) {
-            return "'INVALID EXPRESSION'";
-        }
-
-        return '"'.$expression.'"';
     }
 }

--- a/tests/end2end/playwright/lizmap-features-table.spec.js
+++ b/tests/end2end/playwright/lizmap-features-table.spec.js
@@ -44,6 +44,7 @@ test.describe('Display lizmap-features-table component in popup from QGIS toolti
         await expect(lizmapFeaturesTable.locator('thead tr th:nth-child(1)')).toHaveText('');
         await expect(lizmapFeaturesTable.locator('thead tr th:nth-child(2)')).toHaveText('Virtual code');
         await expect(lizmapFeaturesTable.locator('thead tr th:nth-child(3)')).toHaveText('Virtual area');
+        await expect(lizmapFeaturesTable.locator('thead tr th:nth-child(4)')).toHaveText('Forbidden');
 
         // Get first item and check it
         let firstItem = lizmapFeaturesTable.locator(
@@ -52,7 +53,8 @@ test.describe('Display lizmap-features-table component in popup from QGIS toolti
         await expect(firstItem).toHaveAttribute('data-feature-id', '17');
         await expect(firstItem.locator('td:nth-child(1)')).not.toBeEmpty();
         await expect(firstItem.locator('td:nth-child(2)')).toHaveText('MCN');
-        await expect(firstItem.locator('td:nth-child(3)')).toHaveText('INVALID EXPRESSION');
+        await expect(firstItem.locator('td:nth-child(3)')).toContainText(new RegExp('\\d+.\\d+'));
+        await expect(firstItem.locator('td:nth-child(4)')).toHaveText('not allowed');
 
         // Click on first item and check sub-popup
         await firstItem.click();

--- a/tests/qgis-projects/tests/lizmap_features_table.qgs
+++ b/tests/qgis-projects/tests/lizmap_features_table.qgs
@@ -1002,7 +1002,8 @@ def my_form_open(dialog, layer, feature):
   draggable="yes"
 &gt;
   &lt;lizmap-field data-alias="Virtual code" data-description="Virtual code"&gt;"squartmno"&lt;/lizmap-field&gt;
-  &lt;lizmap-field data-alias="Virtual area" data-description="Virtual area"&gt;$area&lt;/lizmap-field&gt;
+  &lt;lizmap-field data-alias="Virtual area" data-description="Virtual area"&gt;round($area,2)&lt;/lizmap-field&gt;
+  &lt;lizmap-field data-alias="Forbidden" data-description="Virtual forbidden"&gt;env('TEST')&lt;/lizmap-field&gt;
 &lt;/lizmap-features-table&gt;</mapTip>
     </maplayer>
     <maplayer autoRefreshMode="Disabled" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="1" legendPlaceholderImage="" maxScale="0" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="0" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="MultiPolygon">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6f79577b-24de-4be8-a592-b28db9850a5f)

Thanks to https://github.com/3liz/qgis-lizmap-server-plugin/pull/109, it is possible to have more QGIS expressions to be evaluated which are in `lizmap-fields`