### PR TITLE
Fix PHP Warning about Lizmap\Project\Qgis\LayerTreeGroup->items null

### DIFF
--- a/lizmap/modules/lizmap/lib/Project/Qgis/LayerTreeGroup.php
+++ b/lizmap/modules/lizmap/lib/Project/Qgis/LayerTreeGroup.php
@@ -31,6 +31,12 @@ class LayerTreeGroup extends BaseQgisXmlObject
         'items',
     );
 
+    /** @var array The default values for properties */
+    protected $defaultValues = array(
+        'customproperties' => array(),
+        'items' => array(),
+    );
+
     /** @var string The XML element local name */
     protected static $qgisLocalName = 'layer-tree-group';
 

--- a/tests/units/classes/Project/Qgis/LayerTreeGroupTest.php
+++ b/tests/units/classes/Project/Qgis/LayerTreeGroupTest.php
@@ -42,15 +42,40 @@ class LayerTreeGroupTest extends TestCase
         $this->assertEquals('Buildings', $treeGroup->name);
         $this->assertFalse($treeGroup->mutuallyExclusive);
 
+        $this->assertNotNull($treeGroup->customproperties);
+        $this->assertIsArray($treeGroup->customproperties);
         $expectedCustomproperties = array(
             'wmsShortName' => 'Buildings',
         );
         $this->assertEquals($expectedCustomproperties, $treeGroup->customproperties);
 
+        $this->assertNotNull($treeGroup->items);
+        $this->assertIsArray($treeGroup->items);
         $this->assertCount(2, $treeGroup->items);
         $this->assertInstanceOf(Qgis\LayerTreeLayer::class, $treeGroup->items[0]);
         $this->assertEquals('publicbuildings', $treeGroup->items[0]->name);
         $this->assertInstanceOf(Qgis\LayerTreeLayer::class, $treeGroup->items[1]);
         $this->assertEquals('publicbuildings_tramstop', $treeGroup->items[1]->name);
+    }
+
+    public function testEmpty(): void
+    {
+        $xmlStr = '
+      <layer-tree-group expanded="1" groupLayer="" name="Buildings" checked="Qt::Checked">
+      </layer-tree-group>
+      ';
+        $oXml = App\XmlTools::xmlReaderFromString($xmlStr);
+        $treeGroup = Qgis\LayerTreeGroup::fromXmlReader($oXml);
+
+        $this->assertEquals('Buildings', $treeGroup->name);
+        $this->assertFalse($treeGroup->mutuallyExclusive);
+
+        $this->assertNotNull($treeGroup->customproperties);
+        $this->assertIsArray($treeGroup->customproperties);
+        $this->assertCount(0, $treeGroup->customproperties);
+
+        $this->assertNotNull($treeGroup->items);
+        $this->assertIsArray($treeGroup->items);
+        $this->assertCount(0, $treeGroup->items);
     }
 }


### PR DESCRIPTION
The `Lizmap\Project\Qgis\LayerTreeGroup->items` could be null if the `layer-tree-group` element has no children.

Defined default value, fixed it.