### PR TITLE
[Test] Refactoring e2e tests due to popup html changes

### DIFF
--- a/tests/end2end/playwright/embedded-relation.spec.js
+++ b/tests/end2end/playwright/embedded-relation.spec.js
@@ -1,104 +1,101 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-import { gotoMap } from './globals';
+import {ProjectPage} from "./pages/project";
 
-test.describe('Display embedded relation in popup', () => {
-    test.beforeEach(async ({ page }) => {
-        const url = '/index.php/view/map/?repository=testsrepository&project=relations_project_embed';
-        await gotoMap(url, page);
-        await page.locator('#dock-close').click();
-    });
+test.describe('Display embedded relation in popup',
+    {
+        tag: ['@readonly'],
+    }, () =>
+    {
 
-    test('Visualize popup for embedded layers', async ({ page }) => {
+        test('Visualize popup for embedded layers', async ({ page }) => {
 
-        let getFeatureInfoRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeatureInfo') === true);
+            const project = new ProjectPage(page, 'relations_project_embed');
+            await project.open();
+            await project.closeLeftDock();
 
-        //first point
-        await page.locator('#newOlMap').click({
-            position: {
-                x: 74,
-                y: 40
-            }
+            let getFeatureInfoRequestPromise = page.waitForRequest(
+                request => request.method() === 'POST'
+                && request.postData()?.includes('GetFeatureInfo') === true
+            );
+
+            //first point
+            await project.clickOnMap(74, 40);
+
+            await getFeatureInfoRequestPromise;
+
+            //time for rendering the popup
+            await page.waitForTimeout(500);
+
+            let popup = await project.identifyContentLocator(
+                '3',
+                'father_layer_79f5a996_39db_4a1f_b270_dfe21d3e44ff'
+            );
+
+            await expect(popup.locator('.lizmapPopupTitle').first()).toHaveText('father_layer');
+
+            let fatherElements = popup.locator(".container.popup_lizmap_dd").first().locator(".before-tabs .control-group");
+            await expect(fatherElements).toHaveCount(3);
+            await expect(fatherElements.nth(0).locator('label')).toHaveText("fid");
+            await expect(fatherElements.nth(0).locator('.jforms-control-input')).toHaveText("3");
+            await expect(fatherElements.nth(1).locator('label')).toHaveText("ref_id");
+            await expect(fatherElements.nth(1).locator('.jforms-control-input')).toHaveText("1");
+            await expect(fatherElements.nth(2).locator('label')).toHaveText("description");
+            await expect(fatherElements.nth(2).locator('.jforms-control-input')).toHaveText("Father 1");
+
+            //check childrens
+            let childrenElements = popup.locator('.lizmapPopupChildren .lizmapPopupSingleFeature');
+            await expect(childrenElements).toHaveCount(2);
+
+            // first children
+            let firstChildRows = childrenElements.nth(0).getByRole('table').locator('tbody tr');
+            await expect(firstChildRows).toHaveCount(3);
+            await expect(firstChildRows.nth(0).locator("td")).toHaveText("2");
+            await expect(firstChildRows.nth(1).locator("td")).toHaveText("1");
+            await expect(firstChildRows.nth(2).locator("td")).toHaveText("Child 2");
+            // second children
+            let secondChildRow = childrenElements.nth(1).getByRole('table').locator('tbody tr');
+            await expect(secondChildRow.nth(0).locator("td")).toHaveText("1");
+            await expect(secondChildRow.nth(1).locator("td")).toHaveText("1");
+            await expect(secondChildRow.nth(2).locator("td")).toHaveText("Child 1");
+
+            //clear screen
+            await project.closeLeftDock();
+
+            //second point
+            await project.clickOnMap(392, 257);
+            await getFeatureInfoRequestPromise;
+
+            //time for rendering the popup
+            await page.waitForTimeout(500);
+
+            popup = await project.identifyContentLocator(
+                '4',
+                'father_layer_79f5a996_39db_4a1f_b270_dfe21d3e44ff'
+            );
+
+            await expect(popup.locator('.lizmapPopupTitle').first()).toHaveText('father_layer');
+
+            fatherElements = popup.locator(".container.popup_lizmap_dd").first().locator(".before-tabs .control-group");
+            await expect(fatherElements).toHaveCount(3);
+            await expect(fatherElements.nth(0).locator('label')).toHaveText("fid");
+            await expect(fatherElements.nth(0).locator('.jforms-control-input')).toHaveText("4");
+            await expect(fatherElements.nth(1).locator('label')).toHaveText("ref_id");
+            await expect(fatherElements.nth(1).locator('.jforms-control-input')).toHaveText("2");
+            await expect(fatherElements.nth(2).locator('label')).toHaveText("description");
+            await expect(fatherElements.nth(2).locator('.jforms-control-input')).toHaveText("Father 2");
+
+            childrenElements = popup.locator('.lizmapPopupChildren .lizmapPopupSingleFeature');
+            // first children
+            firstChildRows = childrenElements.nth(0).getByRole('table').locator('tbody tr');
+            await expect(firstChildRows).toHaveCount(3);
+            await expect(firstChildRows.nth(0).locator("td")).toHaveText("4");
+            await expect(firstChildRows.nth(1).locator("td")).toHaveText("2");
+            await expect(firstChildRows.nth(2).locator("td")).toHaveText("Child 4");
+            // second children
+            secondChildRow = childrenElements.nth(1).getByRole('table').locator('tbody tr');
+            await expect(secondChildRow.nth(0).locator("td")).toHaveText("3");
+            await expect(secondChildRow.nth(1).locator("td")).toHaveText("2");
+            await expect(secondChildRow.nth(2).locator("td")).toHaveText("Child 3");
         });
-
-        await getFeatureInfoRequestPromise;
-
-        //time for rendering the popup
-        await page.waitForTimeout(500);
-
-        await expect(page.locator('.lizmapPopupContent > .lizmapPopupSingleFeature .lizmapPopupTitle').first()).toHaveText("father_layer");
-
-        let firstPointElements = page.locator(".container.popup_lizmap_dd .before-tabs p b");
-        await expect(firstPointElements).toHaveCount(3);
-
-        await expect(firstPointElements.nth(0)).toHaveText("fid");
-        await expect(firstPointElements.nth(1)).toHaveText("ref_id");
-        await expect(firstPointElements.nth(2)).toHaveText("description");
-
-
-        let firstElementsValues = page.locator(".container.popup_lizmap_dd .before-tabs div.field");
-        await expect(firstElementsValues).toHaveCount(3);
-        await expect(firstElementsValues.nth(0)).toHaveText("3");
-        await expect(firstElementsValues.nth(1)).toHaveText("1");
-        await expect(firstElementsValues.nth(2)).toHaveText("Father 1");
-
-        //check childrens
-        let firstChildrendElements = page.locator('.lizmapPopupSingleFeature .lizmapPopupChildren .lizmapPopupSingleFeature');
-        await expect(firstChildrendElements).toHaveCount(2);
-
-        let firstElementfirstChildRows = firstChildrendElements.nth(0).getByRole('table').locator('tbody tr');
-        await expect(firstElementfirstChildRows).toHaveCount(3);
-        await expect(firstElementfirstChildRows.nth(0).locator("td")).toHaveText("2");
-        await expect(firstElementfirstChildRows.nth(1).locator("td")).toHaveText("1");
-        await expect(firstElementfirstChildRows.nth(2).locator("td")).toHaveText("Child 2");
-        let firstElementSecondChildRow = firstChildrendElements.nth(1).getByRole('table').locator('tbody tr');
-        await expect(firstElementSecondChildRow.nth(0).locator("td")).toHaveText("1");
-        await expect(firstElementSecondChildRow.nth(1).locator("td")).toHaveText("1");
-        await expect(firstElementSecondChildRow.nth(2).locator("td")).toHaveText("Child 1");
-
-        //clear screen
-        await page.locator('#dock-close').click();
-
-        //second point
-        await page.locator('#newOlMap').click({
-            position: {
-                x: 392,
-                y: 257
-            }
-        });
-        await getFeatureInfoRequestPromise;
-
-        //time for rendering the popup
-        await page.waitForTimeout(500);
-
-        await expect(page.locator('.lizmapPopupContent > .lizmapPopupSingleFeature .lizmapPopupTitle').first()).toHaveText("father_layer");
-
-        let elements = page.locator(".container.popup_lizmap_dd .before-tabs p b");
-        await expect(elements).toHaveCount(3);
-
-        await expect(elements.nth(0)).toHaveText("fid");
-        await expect(elements.nth(1)).toHaveText("ref_id");
-        await expect(elements.nth(2)).toHaveText("description");
-
-
-        let elementsValues = page.locator(".container.popup_lizmap_dd .before-tabs div.field");
-        await expect(elementsValues).toHaveCount(3);
-        await expect(elementsValues.nth(0)).toHaveText("4");
-        await expect(elementsValues.nth(1)).toHaveText("2");
-        await expect(elementsValues.nth(2)).toHaveText("Father 2");
-
-        //check childrens
-        let childrendElements = page.locator('.lizmapPopupSingleFeature .lizmapPopupChildren .lizmapPopupSingleFeature');
-        await expect(childrendElements).toHaveCount(2);
-
-        let firstChildRows = childrendElements.nth(0).getByRole('table').locator('tbody tr');
-        await expect(firstChildRows).toHaveCount(3);
-        await expect(firstChildRows.nth(0).locator("td")).toHaveText("4");
-        await expect(firstChildRows.nth(1).locator("td")).toHaveText("2");
-        await expect(firstChildRows.nth(2).locator("td")).toHaveText("Child 4");
-        let secondChildRow = childrendElements.nth(1).getByRole('table').locator('tbody tr');
-        await expect(secondChildRow.nth(0).locator("td")).toHaveText("3");
-        await expect(secondChildRow.nth(1).locator("td")).toHaveText("2");
-        await expect(secondChildRow.nth(2).locator("td")).toHaveText("Child 3");
     });
-})

--- a/tests/end2end/playwright/n_to_m_relations.spec.js
+++ b/tests/end2end/playwright/n_to_m_relations.spec.js
@@ -1,431 +1,436 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-import { gotoMap } from './globals';
+import {ProjectPage} from "./pages/project";
 
-test.describe('N to M relations', () => {
-    test('Attribute table and popup behavior', async ({ page }) => {
-        /* eslint-disable no-unused-vars */
-        const url = '/index.php/view/map/?repository=testsrepository&project=n_to_m_relations';
-        await gotoMap(url, page);
+test.describe('N to M relations',
+    {
+        tag:['@write'],
+    },
+    () => {
+        test('Attribute table and popup behavior', async ({ page }) => {
+            const project = new ProjectPage(page, 'n_to_m_relations');
+            await project.open();
 
-        // open attribute table panel
-        await page.locator('#button-attributeLayers').click();
+            // open attribute table panel
+            await page.locator('#button-attributeLayers').click();
 
-        // maximize panel
-        await page.getByRole('button', { name: 'Maximize' }).click();
+            // maximize panel
+            await page.getByRole('button', { name: 'Maximize' }).click();
 
-        let getFeatureRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeature') === true);
+            let getFeatureRequestPromise = page.waitForRequest(
+                request => request.method() === 'POST'
+                && request.postData()?.includes('GetFeature') === true
+            );
 
-        // open main layer attribute table panel
-        await page.locator('#attribute-layer-list button[value="natural_areas"]').click();
-        await getFeatureRequestPromise;
+            // open main layer attribute table panel
+            await page.locator('#attribute-layer-list button[value="natural_areas"]').click();
+            await getFeatureRequestPromise;
 
-        // open birds spots attribute table panel
-        let birdSpotRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeature') === true);
-        await page.locator('#nav-tab-attribute-summary').click();
-        await page.locator('#attribute-layer-list button[value="birds_spots"]').click();
-        await getFeatureRequestPromise;
+            // open birds spots attribute table panel
+            await page.locator('#nav-tab-attribute-summary').click();
+            await page.locator('#attribute-layer-list button[value="birds_spots"]').click();
+            await getFeatureRequestPromise;
 
-        // open birds attribute table panel
-        let birdsRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeature') === true);
-        await page.locator('#nav-tab-attribute-summary').click();
-        await page.locator('#attribute-layer-list button[value="birds"]').click();
-        await getFeatureRequestPromise;
+            // open birds attribute table panel
+            await page.locator('#nav-tab-attribute-summary').click();
+            await page.locator('#attribute-layer-list button[value="birds"]').click();
+            await getFeatureRequestPromise;
 
-        //back to natural areas panel
-        await page.locator('#nav-tab-attribute-layer-natural_areas').click();
+            //back to natural areas panel
+            await page.locator('#nav-tab-attribute-layer-natural_areas').click();
 
-        let attrTable = page.locator("#attribute-layer-table-natural_areas");
-        await expect(attrTable).toHaveCount(1);
+            let attrTable = page.locator("#attribute-layer-table-natural_areas");
+            await expect(attrTable).toHaveCount(1);
 
-        // inspect main table
-        await expect(attrTable.locator("tbody tr")).toHaveCount(3);
-        await expect(attrTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
-        await expect(attrTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Étang du Galabert");
-        await expect(attrTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("2");
-        await expect(attrTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("Étang de la Vignalie");
-        await expect(attrTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("3");
-        await expect(attrTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("Étang Saint Anne");
+            // inspect main table
+            await expect(attrTable.locator("tbody tr")).toHaveCount(3);
+            await expect(attrTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
+            await expect(attrTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Étang du Galabert");
+            await expect(attrTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("2");
+            await expect(attrTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("Étang de la Vignalie");
+            await expect(attrTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("3");
+            await expect(attrTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("Étang Saint Anne");
 
-        // inspect feature toolbar of main table
-        let naturalAreasTableFeatureToolbar = attrTable.locator("tbody tr").all();
-        for (const tr of await naturalAreasTableFeatureToolbar) {
-            const featToolbar = tr.locator("td").nth(0).locator("lizmap-feature-toolbar");
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Select']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Filter']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Zoom']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Center']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Edit']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Delete']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Unlink child']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Create feature']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar .feature-create-child ul li a")).toHaveText("Bird sposts");
-        }
-
-        // check child layer html divs
-        await expect(page.locator("#nav-tab-attribute-child-tab-natural_areas-birds")).toHaveCount(1);
-        await expect(page.locator("#nav-tab-attribute-child-tab-natural_areas-birds_spots")).toHaveCount(1);
-
-        // click on first row of main table and open "m" layer attribute table
-        let firstChildRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeature') === true);
-        await attrTable.locator("tbody tr").nth(0).click();
-        await getFeatureRequestPromise;
-
-        let nRelatedAttrTable = page.locator("#attribute-layer-table-natural_areas-birds");
-        await expect(attrTable).toHaveCount(1);
-
-        // inspect "m" layer related table
-        await expect(nRelatedAttrTable.locator("tbody tr")).toHaveCount(4);
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Greater flamingo");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("2");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("Black-winged stilt");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("6");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("Common tern");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(3).locator("td").nth(1)).toHaveText("8");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(3).locator("td").nth(2)).toHaveText("Little grebe");
-
-        // inspect feature toolbar of "m" related layer
-        let mTableFeatureToolbarFirst = nRelatedAttrTable.locator("tbody tr").all();
-        for (const tr of await mTableFeatureToolbarFirst) {
-            const featToolbar = tr.locator("td").nth(0).locator("lizmap-feature-toolbar");
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Select']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Filter']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Zoom']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Center']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Edit']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Delete']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Unlink child']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Create feature']")).toBeHidden();
-        }
-
-        // change main record
-        let secondChildRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeature') === true);
-        await attrTable.locator("tbody tr").nth(1).click();
-        await getFeatureRequestPromise;
-
-        // inspect new list of birds
-        await expect(nRelatedAttrTable.locator("tbody tr")).toHaveCount(3);
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Greater flamingo");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("3");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("Purple heron");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("5");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("Eurasian teal");
-
-        let mTableFeatureToolbarSecond = nRelatedAttrTable.locator("tbody tr").all();
-        for (const tr of await mTableFeatureToolbarSecond) {
-            const featToolbar = tr.locator("td").nth(0).locator("lizmap-feature-toolbar");
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Select']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Filter']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Zoom']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Center']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Edit']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Delete']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Unlink child']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Create feature']")).toBeHidden();
-        }
-
-        // back to first record
-        //let backToFirstChildRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeature') === true);
-        //await attrTable.locator("tbody tr").nth(0).click();
-        //await getFeatureRequestPromise;
-
-        // change tab to inspect bird spots (1:n control)
-        await page.locator("#nav-tab-attribute-child-tab-natural_areas-birds_spots").click();
-
-        // inspect 1:n layer related table
-        let oneToNAttrTable = page.locator("#attribute-layer-table-natural_areas-birds_spots");
-        await expect(oneToNAttrTable).toHaveCount(1);
-
-        // inspect 1:n layer table
-        await expect(oneToNAttrTable.locator("tbody tr")).toHaveCount(2);
-        await expect(oneToNAttrTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("3");
-        await expect(oneToNAttrTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Étang de la Vignalie");
-        await expect(oneToNAttrTable.locator("tbody tr").nth(0).locator("td").nth(3)).toHaveText("East tower");
-        await expect(oneToNAttrTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("4");
-        await expect(oneToNAttrTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("Étang de la Vignalie");
-        await expect(oneToNAttrTable.locator("tbody tr").nth(1).locator("td").nth(3)).toHaveText("Vignalie tower");
-
-        // inspect feature toolbar of 1:n layer table
-        let oneToNTableFeatureToolbar = oneToNAttrTable.locator("tbody tr").all();
-        for (const tr of await oneToNTableFeatureToolbar) {
-            const featToolbar = tr.locator("td").nth(0).locator("lizmap-feature-toolbar");
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Select']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Filter']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Zoom']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Center']")).toBeHidden();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Edit']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Delete']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Unlink child']")).toBeVisible();
-            await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Create feature']")).toBeHidden();
-        }
-
-        // unlink bird spot from second natural area record
-        let unlinkOneToN = page.waitForRequest(request => request.method() === 'POST' && request.url().includes('unlinkChild'));
-
-        await oneToNAttrTable.locator("tbody tr").nth(0).locator("td").nth(0).locator("lizmap-feature-toolbar").locator(".feature-toolbar button[data-bs-title='Unlink child']").click();
-        await unlinkOneToN;
-
-        // wait for UI to reload properly
-        await page.waitForTimeout(300);
-
-        await expect(page.locator("#lizmap-edition-message")).toBeVisible();
-        await expect(page.locator("#lizmap-edition-message li.jelix-msg-item-success")).toHaveText("The child feature has correctly been unlinked.");
-        await page.locator("#lizmap-edition-message .btn-close").click();
-
-
-        // check 1:n table
-        await expect(oneToNAttrTable.locator("tbody tr")).toHaveCount(1);
-        await expect(oneToNAttrTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("4");
-        await expect(oneToNAttrTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Étang de la Vignalie");
-        await expect(oneToNAttrTable.locator("tbody tr").nth(0).locator("td").nth(3)).toHaveText("Vignalie tower");
-
-        // go to birds spots tab and check the unlinked record
-        await page.locator('#nav-tab-attribute-layer-birds_spots').click();
-        let birdsSpotsTable = page.locator("#attribute-layer-table-birds_spots");
-
-        await expect(birdsSpotsTable.locator("tbody tr")).toHaveCount(5);
-        await expect(birdsSpotsTable.getByRole('row', { name: '3 East tower' }).getByRole('cell').nth(2)).toHaveText("");
-
-
-        // insert new bird associated with first area
-
-        //back to natural areas panel first
-        await page.locator('#nav-tab-attribute-layer-natural_areas').click();
-
-        let addBirdsRequestPromise = page.waitForResponse(response => response.url().includes('editFeature'));
-        await page.locator("#attribute-layer-main-natural_areas .edition-children-add-buttons button[value='birds']").click();
-        await addBirdsRequestPromise;
-
-        // check info message for link pivot
-        await expect(page.locator("#edition-link-pivot")).toHaveText("The new record will be linked to the feature ID \"2\" of \"Natural areas\" layer")
-
-        // fill the form and submit
-        await page.locator("#jforms_view_edition").getByLabel('Name', { exact: true }).fill("Northern pintail");
-        await page.locator("#jforms_view_edition").getByLabel('Scientific name', { exact: true }).fill("Anas acuta");
-
-        await page.locator('#jforms_view_edition__submit_submit').click();
-
-        await addBirdsRequestPromise;
-
-        await expect(page.locator("#lizmap-edition-message")).toBeVisible();
-        await expect(page.locator("#lizmap-edition-message ul.jelix-msg").nth(0)).toHaveText("Data has been saved.");
-        await expect(page.locator("#lizmap-edition-message ul.jelix-msg").nth(1)).toHaveText('The new feature of layer "Birds" was successfully linked to the layer "Natural areas"');
-
-        // check birds child table
-        await page.locator("#nav-tab-attribute-child-tab-natural_areas-birds").click();
-
-        await expect(nRelatedAttrTable.locator("tbody tr")).toHaveCount(4);
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Greater flamingo");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("3");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("Purple heron");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("5");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("Eurasian teal");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(3).locator("td").nth(1)).toHaveText("9");
-        await expect(nRelatedAttrTable.locator("tbody tr").nth(3).locator("td").nth(2)).toHaveText("Northern pintail");
-
-        // go to birds panel and look for the new inserted record
-        await page.locator('#nav-tab-attribute-layer-birds').click();
-
-        let birdsTable = page.locator("#attribute-layer-table-birds");
-        await expect(birdsTable.locator("tbody tr")).toHaveCount(9);
-        await expect(birdsTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
-        await expect(birdsTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Greater flamingo");
-        await expect(birdsTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("2");
-        await expect(birdsTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("Black-winged stilt");
-        await expect(birdsTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("3");
-        await expect(birdsTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("Purple heron");
-        await expect(birdsTable.locator("tbody tr").nth(3).locator("td").nth(1)).toHaveText("4");
-        await expect(birdsTable.locator("tbody tr").nth(3).locator("td").nth(2)).toHaveText("Kingfisher");
-        await expect(birdsTable.locator("tbody tr").nth(4).locator("td").nth(1)).toHaveText("5");
-        await expect(birdsTable.locator("tbody tr").nth(4).locator("td").nth(2)).toHaveText("Eurasian teal");
-        await expect(birdsTable.locator("tbody tr").nth(5).locator("td").nth(1)).toHaveText("6");
-        await expect(birdsTable.locator("tbody tr").nth(5).locator("td").nth(2)).toHaveText("Common tern");
-        await expect(birdsTable.locator("tbody tr").nth(6).locator("td").nth(1)).toHaveText("7");
-        await expect(birdsTable.locator("tbody tr").nth(6).locator("td").nth(2)).toHaveText("Black-headed gull");
-        await expect(birdsTable.locator("tbody tr").nth(7).locator("td").nth(1)).toHaveText("8");
-        await expect(birdsTable.locator("tbody tr").nth(7).locator("td").nth(2)).toHaveText("Little grebe");
-        await expect(birdsTable.locator("tbody tr").nth(8).locator("td").nth(1)).toHaveText("9");
-        await expect(birdsTable.locator("tbody tr").nth(8).locator("td").nth(2)).toHaveText("Northern pintail");
-
-        // click on last inserted record and check child attribute table
-        let naturalAreaChildPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeature') === true);
-        await birdsTable.locator("tbody tr").nth(8).click();
-        await getFeatureRequestPromise;
-
-        let childNaturalAreasTable = page.locator("#attribute-layer-table-birds-natural_areas");
-        await expect(childNaturalAreasTable.locator("tbody tr")).toHaveCount(1);
-        await expect(childNaturalAreasTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("2");
-        await expect(childNaturalAreasTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Étang de la Vignalie");
-
-        // unlink area from birds, this should delete the pivot record
-        page.once('dialog', dialog => {
-            expect(dialog.message()).toBe("Are you sure you want to unlink the selected feature from \"Birds\" layer?");
-            return dialog.accept();
-        });
-
-        let unlinkPivotFeature = page.waitForResponse(response => response.request().method() === 'POST' && response.request().postData()?.includes('%22bird_id%22+%3D+%279%27') === true)
-        await childNaturalAreasTable.locator("tbody tr").nth(0).locator("td").nth(0).locator("lizmap-feature-toolbar").locator(".feature-toolbar button[data-bs-title='Unlink child']").click();
-        await unlinkPivotFeature;
-
-
-        await page.waitForTimeout(300);
-
-        await expect(childNaturalAreasTable.locator("tbody tr")).toHaveCount(1)
-        await expect(childNaturalAreasTable.locator("tbody tr").nth(0).locator("td").nth(0)).toHaveText("No data available in table");
-
-        // delete a bird record, this should remove pivot records too
-        page.once('dialog', dialog => {
-            expect(dialog.message()).toBe("Are you sure you want to delete the selected feature? \n\nThe related links with the following layers:\n \nNatural areas \n\nwill be also deleted");
-            return dialog.accept();
-        });
-
-        let deleteBirdFeature = page.waitForResponse(response => response.request().method() === 'POST'
-            && response.request().postData()?.includes('GetFeature') === true
-            && response.request().postData()?.includes('birds') === true
-            && response.request().postData()?.includes('extent') === true)
-        await expect(birdsTable.locator("tbody tr").nth(6).locator("td").nth(0).locator("lizmap-feature-toolbar").locator(".feature-toolbar button[data-bs-title='Delete']")).toHaveCount(1);
-        await birdsTable.locator("tbody tr").nth(6).locator("td").nth(0).locator("lizmap-feature-toolbar").locator(".feature-toolbar button[data-bs-title='Delete']").click();
-        await deleteBirdFeature;
-
-        await expect(birdsTable.locator("tbody tr")).toHaveCount(8);
-
-        // popup behavior
-        await page.locator("#bottom-dock-window-buttons button.btn-bottomdock-clear").click()
-
-        // click on map to get popup list
-        let getFeatureInfoRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeatureInfo') === true);
-        await page.locator('#newOlMap').click({
-            position: {
-                x: 413,
-                y: 232
+            // inspect feature toolbar of main table
+            let naturalAreasTableFeatureToolbar = attrTable.locator("tbody tr").all();
+            for (const tr of await naturalAreasTableFeatureToolbar) {
+                const featToolbar = tr.locator("td").nth(0).locator("lizmap-feature-toolbar");
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Select']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Filter']")).toBeHidden();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Zoom']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Center']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Edit']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Delete']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Unlink child']")).toBeHidden();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Create feature']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar .feature-create-child ul li a")).toHaveText("Bird sposts");
             }
+
+            // check child layer html divs
+            await expect(page.locator("#nav-tab-attribute-child-tab-natural_areas-birds")).toHaveCount(1);
+            await expect(page.locator("#nav-tab-attribute-child-tab-natural_areas-birds_spots")).toHaveCount(1);
+
+            // click on first row of main table and open "m" layer attribute table
+            await attrTable.locator("tbody tr").nth(0).click();
+            await getFeatureRequestPromise;
+
+            let nRelatedAttrTable = page.locator("#attribute-layer-table-natural_areas-birds");
+            await expect(attrTable).toHaveCount(1);
+
+            // inspect "m" layer related table
+            await expect(nRelatedAttrTable.locator("tbody tr")).toHaveCount(4);
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Greater flamingo");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("2");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("Black-winged stilt");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("6");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("Common tern");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(3).locator("td").nth(1)).toHaveText("8");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(3).locator("td").nth(2)).toHaveText("Little grebe");
+
+            // inspect feature toolbar of "m" related layer
+            let mTableFeatureToolbarFirst = nRelatedAttrTable.locator("tbody tr").all();
+            for (const tr of await mTableFeatureToolbarFirst) {
+                const featToolbar = tr.locator("td").nth(0).locator("lizmap-feature-toolbar");
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Select']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Filter']")).toBeHidden();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Zoom']")).toBeHidden();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Center']")).toBeHidden();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Edit']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Delete']")).toBeHidden();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Unlink child']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Create feature']")).toBeHidden();
+            }
+
+            // change main record
+            await attrTable.locator("tbody tr").nth(1).click();
+            await getFeatureRequestPromise;
+
+            // inspect new list of birds
+            await expect(nRelatedAttrTable.locator("tbody tr")).toHaveCount(3);
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Greater flamingo");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("3");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("Purple heron");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("5");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("Eurasian teal");
+
+            let mTableFeatureToolbarSecond = nRelatedAttrTable.locator("tbody tr").all();
+            for (const tr of await mTableFeatureToolbarSecond) {
+                const featToolbar = tr.locator("td").nth(0).locator("lizmap-feature-toolbar");
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Select']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Filter']")).toBeHidden();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Zoom']")).toBeHidden();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Center']")).toBeHidden();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Edit']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Delete']")).toBeHidden();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Unlink child']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Create feature']")).toBeHidden();
+            }
+
+            // change tab to inspect bird spots (1:n control)
+            await page.locator("#nav-tab-attribute-child-tab-natural_areas-birds_spots").click();
+
+            // inspect 1:n layer related table
+            let oneToNAttrTable = page.locator("#attribute-layer-table-natural_areas-birds_spots");
+            await expect(oneToNAttrTable).toHaveCount(1);
+
+            // inspect 1:n layer table
+            await expect(oneToNAttrTable.locator("tbody tr")).toHaveCount(2);
+            await expect(oneToNAttrTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("3");
+            await expect(oneToNAttrTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Étang de la Vignalie");
+            await expect(oneToNAttrTable.locator("tbody tr").nth(0).locator("td").nth(3)).toHaveText("East tower");
+            await expect(oneToNAttrTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("4");
+            await expect(oneToNAttrTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("Étang de la Vignalie");
+            await expect(oneToNAttrTable.locator("tbody tr").nth(1).locator("td").nth(3)).toHaveText("Vignalie tower");
+
+            // inspect feature toolbar of 1:n layer table
+            let oneToNTableFeatureToolbar = oneToNAttrTable.locator("tbody tr").all();
+            for (const tr of await oneToNTableFeatureToolbar) {
+                const featToolbar = tr.locator("td").nth(0).locator("lizmap-feature-toolbar");
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Select']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Filter']")).toBeHidden();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Zoom']")).toBeHidden();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Center']")).toBeHidden();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Edit']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Delete']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Unlink child']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Create feature']")).toBeHidden();
+            }
+
+            // unlink bird spot from second natural area record
+            let unlinkOneToN = page.waitForRequest(request => request.method() === 'POST' && request.url().includes('unlinkChild'));
+
+            await oneToNAttrTable.locator("tbody tr").nth(0).locator("td").nth(0).locator("lizmap-feature-toolbar")
+                .locator(".feature-toolbar button[data-bs-title='Unlink child']").click();
+            await unlinkOneToN;
+
+            // wait for UI to reload properly
+            await page.waitForTimeout(300);
+
+            await expect(page.locator("#lizmap-edition-message")).toBeVisible();
+            await expect(page.locator("#lizmap-edition-message li.jelix-msg-item-success"))
+                .toHaveText("The child feature has correctly been unlinked.");
+            await page.locator("#lizmap-edition-message .btn-close").click();
+
+            // check 1:n table
+            await expect(oneToNAttrTable.locator("tbody tr")).toHaveCount(1);
+            await expect(oneToNAttrTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("4");
+            await expect(oneToNAttrTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Étang de la Vignalie");
+            await expect(oneToNAttrTable.locator("tbody tr").nth(0).locator("td").nth(3)).toHaveText("Vignalie tower");
+
+            // go to birds spots tab and check the unlinked record
+            await page.locator('#nav-tab-attribute-layer-birds_spots').click();
+            let birdsSpotsTable = page.locator("#attribute-layer-table-birds_spots");
+
+            await expect(birdsSpotsTable.locator("tbody tr")).toHaveCount(5);
+            await expect(birdsSpotsTable.getByRole('row', { name: '3 East tower' }).getByRole('cell').nth(2)).toHaveText("");
+
+            // insert new bird associated with first area
+
+            //back to natural areas panel first
+            await page.locator('#nav-tab-attribute-layer-natural_areas').click();
+
+            let addBirdsRequestPromise = page.waitForResponse(response => response.url().includes('editFeature'));
+            await page.locator("#attribute-layer-main-natural_areas .edition-children-add-buttons button[value='birds']").click();
+            await addBirdsRequestPromise;
+
+            // check info message for link pivot
+            await expect(project.editionForm.locator("#edition-link-pivot"))
+                .toHaveText("The new record will be linked to the feature ID \"2\" of \"Natural areas\" layer");
+
+            // fill the form and submit
+            await project.fillEditionFormTextInput('bird_name', 'Northern pintail');
+            await project.fillEditionFormTextInput('bird_scientific_name', 'Anas acuta');
+
+            await project.editingSubmitForm();
+
+            await addBirdsRequestPromise;
+            await expect(page.locator("#lizmap-edition-message ul.jelix-msg").nth(0)).toHaveText("Data has been saved.");
+            await expect(page.locator("#lizmap-edition-message ul.jelix-msg").nth(1))
+                .toHaveText('The new feature of layer "Birds" was successfully linked to the layer "Natural areas"');
+
+            // check birds child table
+            await page.locator("#nav-tab-attribute-child-tab-natural_areas-birds").click();
+
+            await expect(nRelatedAttrTable.locator("tbody tr")).toHaveCount(4);
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Greater flamingo");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("3");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("Purple heron");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("5");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("Eurasian teal");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(3).locator("td").nth(1)).toHaveText("9");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(3).locator("td").nth(2)).toHaveText("Northern pintail");
+
+            // go to birds panel and look for the new inserted record
+            await page.locator('#nav-tab-attribute-layer-birds').click();
+
+            let birdsTable = page.locator("#attribute-layer-table-birds");
+            await expect(birdsTable.locator("tbody tr")).toHaveCount(9);
+            await expect(birdsTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
+            await expect(birdsTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Greater flamingo");
+            await expect(birdsTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("2");
+            await expect(birdsTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("Black-winged stilt");
+            await expect(birdsTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("3");
+            await expect(birdsTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("Purple heron");
+            await expect(birdsTable.locator("tbody tr").nth(3).locator("td").nth(1)).toHaveText("4");
+            await expect(birdsTable.locator("tbody tr").nth(3).locator("td").nth(2)).toHaveText("Kingfisher");
+            await expect(birdsTable.locator("tbody tr").nth(4).locator("td").nth(1)).toHaveText("5");
+            await expect(birdsTable.locator("tbody tr").nth(4).locator("td").nth(2)).toHaveText("Eurasian teal");
+            await expect(birdsTable.locator("tbody tr").nth(5).locator("td").nth(1)).toHaveText("6");
+            await expect(birdsTable.locator("tbody tr").nth(5).locator("td").nth(2)).toHaveText("Common tern");
+            await expect(birdsTable.locator("tbody tr").nth(6).locator("td").nth(1)).toHaveText("7");
+            await expect(birdsTable.locator("tbody tr").nth(6).locator("td").nth(2)).toHaveText("Black-headed gull");
+            await expect(birdsTable.locator("tbody tr").nth(7).locator("td").nth(1)).toHaveText("8");
+            await expect(birdsTable.locator("tbody tr").nth(7).locator("td").nth(2)).toHaveText("Little grebe");
+            await expect(birdsTable.locator("tbody tr").nth(8).locator("td").nth(1)).toHaveText("9");
+            await expect(birdsTable.locator("tbody tr").nth(8).locator("td").nth(2)).toHaveText("Northern pintail");
+
+            // click on last inserted record and check child attribute table
+            await birdsTable.locator("tbody tr").nth(8).click();
+            await getFeatureRequestPromise;
+
+            let childNaturalAreasTable = page.locator("#attribute-layer-table-birds-natural_areas");
+            await expect(childNaturalAreasTable.locator("tbody tr")).toHaveCount(1);
+            await expect(childNaturalAreasTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("2");
+            await expect(childNaturalAreasTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Étang de la Vignalie");
+
+            // unlink area from birds, this should delete the pivot record
+            page.once('dialog', dialog => {
+                expect(dialog.message()).toBe("Are you sure you want to unlink the selected feature from \"Birds\" layer?");
+                return dialog.accept();
+            });
+
+            let unlinkPivotFeature = page.waitForResponse(response =>
+                response.request().method() === 'POST'
+                && response.request().postData()?.includes('%22bird_id%22+%3D+%279%27') === true
+            );
+            await childNaturalAreasTable.locator("tbody tr").nth(0).locator("td").nth(0).locator("lizmap-feature-toolbar")
+                .locator(".feature-toolbar button[data-bs-title='Unlink child']").click();
+            await unlinkPivotFeature;
+
+            await page.waitForTimeout(300);
+
+            await expect(childNaturalAreasTable.locator("tbody tr")).toHaveCount(1)
+            await expect(childNaturalAreasTable.locator("tbody tr").nth(0).locator("td").nth(0)).toHaveText("No data available in table");
+
+            // delete a bird record, this should remove pivot records too
+            page.once('dialog', dialog => {
+                expect(dialog.message()).toBe("Are you sure you want to delete the selected feature? \n\nThe related links with the following layers:\n \nNatural areas \n\nwill be also deleted");
+                return dialog.accept();
+            });
+
+            let deleteBirdFeature = page.waitForResponse(response => response.request().method() === 'POST'
+                && response.request().postData()?.includes('GetFeature') === true
+                && response.request().postData()?.includes('birds') === true
+                && response.request().postData()?.includes('extent') === true
+            );
+
+            await expect(birdsTable.locator("tbody tr").nth(6).locator("td").nth(0).locator("lizmap-feature-toolbar").locator(".feature-toolbar button[data-bs-title='Delete']")).toHaveCount(1);
+            await birdsTable.locator("tbody tr").nth(6).locator("td").nth(0).locator("lizmap-feature-toolbar").locator(".feature-toolbar button[data-bs-title='Delete']").click();
+            await deleteBirdFeature;
+
+            await expect(birdsTable.locator("tbody tr")).toHaveCount(8);
+
+            // popup behavior
+            await page.locator("#bottom-dock-window-buttons button.btn-bottomdock-clear").click()
+
+            // click on map to get popup list
+            let getFeatureInfoRequestPromise = page.waitForRequest(request =>
+                request.method() === 'POST'
+                && request.postData()?.includes('GetFeatureInfo') === true
+            );
+
+            await project.clickOnMap(413, 232);
+
+            await getFeatureInfoRequestPromise;
+
+            //time for rendering the popup
+            await page.waitForTimeout(500);
+            let popup = await project.identifyContentLocator(
+                '1',
+                'natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813'
+            );
+            await expect(popup.locator('.lizmapPopupTitle').first()).toHaveText('Natural areas');
+
+            let natAreaElements = popup.locator(".container.popup_lizmap_dd").first().locator(".before-tabs .control-group");
+            await expect(natAreaElements).toHaveCount(2);
+            await expect(natAreaElements.nth(0).locator('.jforms-control-input')).toHaveText("1");
+            await expect(natAreaElements.nth(1).locator('.jforms-control-input')).toHaveText("Étang du Galabert");
+
+            // inspect popup children
+            let childrenBirds = popup.locator('.lizmapPopupChildren.birds .lizmapPopupSingleFeature');
+            await expect(childrenBirds).toHaveCount(4);
+
+            // unlink a bird from popup
+            page.once('dialog', dialog => {
+                expect(dialog.message()).toBe("Are you sure you want to unlink the selected feature from \"Natural areas\" layer?");
+                return dialog.accept();
+            });
+
+            let unlinkPopupPivotFeature = page.waitForResponse(response =>
+                response.request().method() === 'GET'
+                && response.request().url().includes('deleteFeature')
+            );
+            await childrenBirds.nth(0).locator("lizmap-feature-toolbar button.feature-unlink").click();
+            await unlinkPopupPivotFeature;
+
+            await expect(childrenBirds.nth(0).locator(".lizmapPopupDiv")).toHaveCount(0);
+
+            // add a new bird from natural areas popup
+            let editFeatureRequestPromise = page.waitForResponse(response => response.url().includes('editFeature'));
+            await popup.locator("lizmap-feature-toolbar").first().locator('.feature-toolbar button.feature-edit').click();
+            await editFeatureRequestPromise;
+
+            await expect(page.locator("#edition-child-tab-natural_areas-birds")).toHaveCount(1);
+
+            // click on the add feature button
+            await page.locator("#edition-child-tab-natural_areas-birds .attribute-layer-feature-create").nth(0).click();
+            await editFeatureRequestPromise;
+
+            await expect(page.locator("#edition-link-pivot")).toHaveText("The new record will be linked to the feature ID \"1\" of \"Natural areas\" layer")
+
+            // fill the form and submit
+            await project.fillEditionFormTextInput('bird_name', 'Common snipe');
+            await project.fillEditionFormTextInput('bird_scientific_name', 'Gallinago gallinago');
+
+            await project.editingSubmitForm();
+            await editFeatureRequestPromise;
+
+            await page.waitForTimeout(500);
+
+            // inspect birds table in edition form
+            let editionFormBirdsTable = page.locator("#edition-table-natural_areas-birds");
+
+            await expect(editionFormBirdsTable).toHaveCount(1);
+            await expect(editionFormBirdsTable.locator("tbody tr")).toHaveCount(4);
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Greater flamingo");
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("2");
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("Black-winged stilt");
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("6");
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("Common tern");
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(3).locator("td").nth(1)).toHaveText("10");
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(3).locator("td").nth(2)).toHaveText("Common snipe");
+
+            // insert new bird with "create new feature" submit option, this should create the pivot record again
+            // click on the add feature button
+            await page.locator("#edition-child-tab-natural_areas-birds .attribute-layer-feature-create").nth(0).click()
+            await editFeatureRequestPromise;
+
+            await expect(page.locator("#edition-link-pivot")).toHaveText("The new record will be linked to the feature ID \"1\" of \"Natural areas\" layer")
+
+            //await project.editionForm.locator('#jforms_view_edition_liz_future_action').selectOption('create');
+            // fill the form and submit
+            await project.fillEditionFormTextInput('bird_name', 'Mute swan');
+            await project.fillEditionFormTextInput('bird_scientific_name', 'Cygnus olor');
+            await project.editingSubmitForm('create');
+
+            await editFeatureRequestPromise;
+
+            await page.waitForTimeout(500);
+            await expect(page.locator(".alert-linkaddedfeature p")).toHaveText('The new feature of layer "Birds" was successfully linked to the layer "Natural areas"');
+            await expect(page.locator("#edition-link-pivot")).toHaveText("The new record will be linked to the feature ID \"1\" of \"Natural areas\" layer")
+
+            // insert new bird with option "reopen form", this should not add the pivot record in order to avoid duplication
+            // fill the form and submit
+            await project.fillEditionFormTextInput('bird_name', 'Common shelduck');
+            await project.fillEditionFormTextInput('bird_scientific_name', 'Tadorna tadorna');
+            await project.editingSubmitForm('edit');
+
+            await editFeatureRequestPromise;
+            await expect(page.locator(".alert-linkaddedfeature p")).toHaveText('The new feature of layer "Birds" was successfully linked to the layer "Natural areas"');
+            await expect(page.locator("#edition-link-pivot")).toHaveCount(0);
+
+            // submit again to update
+            await project.editingSubmitForm('edit');
+
+            await editFeatureRequestPromise;
+
+            await expect(page.locator(".alert-linkaddedfeature")).toHaveCount(0);
+            await expect(page.locator("#edition-link-pivot")).toHaveCount(0);
+
+            // cancel edition and inspect new child attribute table
+            page.once('dialog', dialog => {
+                return dialog.accept();
+            });
+            await page.locator('#jforms_view_edition__submit_cancel').click();
+            await editFeatureRequestPromise;
+
+            await expect(editionFormBirdsTable).toHaveCount(1);
+            await expect(editionFormBirdsTable.locator("tbody tr")).toHaveCount(6);
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Greater flamingo");
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("2");
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("Black-winged stilt");
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("6");
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("Common tern");
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(3).locator("td").nth(1)).toHaveText("10");
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(3).locator("td").nth(2)).toHaveText("Common snipe");
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(4).locator("td").nth(1)).toHaveText("11");
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(4).locator("td").nth(2)).toHaveText("Mute swan");
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(5).locator("td").nth(1)).toHaveText("12");
+            await expect(editionFormBirdsTable.locator("tbody tr").nth(5).locator("td").nth(2)).toHaveText("Common shelduck");
         });
-        await getFeatureInfoRequestPromise;
-
-        //time for rendering the popup
-        await page.waitForTimeout(500);
-
-        await expect(page.locator('.lizmapPopupContent > .lizmapPopupSingleFeature .lizmapPopupTitle').first()).toHaveText("Natural areas");
-        await expect(page.locator(".container.popup_lizmap_dd").nth(0).locator(".before-tabs div.field")).toHaveCount(2);
-        await expect(page.locator(".container.popup_lizmap_dd").nth(0).locator(".before-tabs div.field").nth(0)).toHaveText("1");
-        await expect(page.locator(".container.popup_lizmap_dd").nth(0).locator(".before-tabs div.field").nth(1)).toHaveText("Étang du Galabert");
-
-        // inspect popup children
-        await expect(page.locator(".lizmapPopupContent .lizmapPopupChildren")).toHaveCount(2);
-        await expect(page.locator(".lizmapPopupContent .lizmapPopupChildren").nth(0).locator(".lizmapPopupSingleFeature")).toHaveCount(4);
-
-        // unlink a bird from popup
-
-        page.once('dialog', dialog => {
-            expect(dialog.message()).toBe("Are you sure you want to unlink the selected feature from \"Natural areas\" layer?");
-            return dialog.accept();
-        });
-
-        let unlinkPopupPivotFeature = page.waitForResponse(response => response.request().method() === 'GET' && response.request().url().includes('deleteFeature'));
-        await page.locator(".lizmapPopupContent .lizmapPopupChildren").nth(0).locator(".lizmapPopupSingleFeature").nth(0).locator(".lizmapPopupDiv lizmap-feature-toolbar .feature-toolbar button[data-bs-title='Unlink child']").click();
-        await unlinkPopupPivotFeature;
-
-        await expect(page.locator(".lizmapPopupContent .lizmapPopupChildren").nth(0).locator(".lizmapPopupSingleFeature").nth(0).locator(".lizmapPopupDiv")).toHaveCount(0)
-
-        // add a new bird from natural areas popup
-        let editFeatureRequestPromise = page.waitForResponse(response => response.url().includes('editFeature'));
-        await page.locator('.lizmapPopupContent > .lizmapPopupSingleFeature').nth(0).locator("lizmap-feature-toolbar").first().locator(".feature-toolbar button[data-bs-title='Edit']").click()
-        await editFeatureRequestPromise;
-
-        await expect(page.locator("#edition-child-tab-natural_areas-birds")).toHaveCount(1);
-
-        // click on the add feature button
-        await page.locator("#edition-child-tab-natural_areas-birds .attribute-layer-feature-create").nth(0).click()
-        await editFeatureRequestPromise;
-
-        await expect(page.locator("#edition-link-pivot")).toHaveText("The new record will be linked to the feature ID \"1\" of \"Natural areas\" layer")
-
-        // fill the form and submit
-        await page.locator("#jforms_view_edition").getByLabel('Name', { exact: true }).fill("Common snipe");
-        await page.locator("#jforms_view_edition").getByLabel('Scientific name', { exact: true }).fill("Gallinago gallinago");
-
-        await page.locator('#jforms_view_edition__submit_submit').click();
-        await editFeatureRequestPromise;
-
-        await page.waitForTimeout(500);
-
-        // inspect birds table in edition form
-        let editionFormBirdsTable = page.locator("#edition-table-natural_areas-birds");
-
-        await expect(editionFormBirdsTable).toHaveCount(1);
-        await expect(editionFormBirdsTable.locator("tbody tr")).toHaveCount(4);
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Greater flamingo");
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("2");
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("Black-winged stilt");
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("6");
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("Common tern");
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(3).locator("td").nth(1)).toHaveText("10");
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(3).locator("td").nth(2)).toHaveText("Common snipe");
-
-        // insert new bird with "create new feature" submit option, this should create the pivot record again
-        // click on the add feature button
-        await page.locator("#edition-child-tab-natural_areas-birds .attribute-layer-feature-create").nth(0).click()
-        await editFeatureRequestPromise;
-
-        await expect(page.locator("#edition-link-pivot")).toHaveText("The new record will be linked to the feature ID \"1\" of \"Natural areas\" layer")
-
-        await page.locator('#jforms_view_edition_liz_future_action').selectOption("create");
-        // fill the form and submit
-        await page.locator("#jforms_view_edition").getByLabel('Name', { exact: true }).fill("Mute swan");
-        await page.locator("#jforms_view_edition").getByLabel('Scientific name', { exact: true }).fill("Cygnus olor");
-
-        await page.locator('#jforms_view_edition__submit_submit').click();
-        await editFeatureRequestPromise;
-
-        await page.waitForTimeout(500);
-        await expect(page.locator(".alert-linkaddedfeature p")).toHaveText('The new feature of layer "Birds" was successfully linked to the layer "Natural areas"');
-        await expect(page.locator("#edition-link-pivot")).toHaveText("The new record will be linked to the feature ID \"1\" of \"Natural areas\" layer")
-
-        // insert new bird with option "reopen form", this should not add the pivot record in order to avoid duplication
-
-        await page.locator('#jforms_view_edition_liz_future_action').selectOption("edit");
-
-        // fill the form and submit
-        await page.locator("#jforms_view_edition").getByLabel('Name', { exact: true }).fill("Common shelduck");
-        await page.locator("#jforms_view_edition").getByLabel('Scientific name', { exact: true }).fill("Tadorna tadorna");
-
-        await page.locator('#jforms_view_edition__submit_submit').click();
-        await editFeatureRequestPromise;
-        await expect(page.locator(".alert-linkaddedfeature p")).toHaveText('The new feature of layer "Birds" was successfully linked to the layer "Natural areas"');
-        await expect(page.locator("#edition-link-pivot")).toHaveCount(0);
-
-        // submit again to update
-        await page.locator('#jforms_view_edition__submit_submit').click();
-        await editFeatureRequestPromise;
-
-        await expect(page.locator(".alert-linkaddedfeature")).toHaveCount(0);
-        await expect(page.locator("#edition-link-pivot")).toHaveCount(0);
-
-        // cancel edition and inspect new child attribute table
-        page.once('dialog', dialog => {
-            return dialog.accept();
-        });
-        await page.locator('#jforms_view_edition__submit_cancel').click();
-        await editFeatureRequestPromise;
-
-        await expect(editionFormBirdsTable).toHaveCount(1);
-        await expect(editionFormBirdsTable.locator("tbody tr")).toHaveCount(6);
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Greater flamingo");
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("2");
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("Black-winged stilt");
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("6");
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("Common tern");
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(3).locator("td").nth(1)).toHaveText("10");
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(3).locator("td").nth(2)).toHaveText("Common snipe");
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(4).locator("td").nth(1)).toHaveText("11");
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(4).locator("td").nth(2)).toHaveText("Mute swan");
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(5).locator("td").nth(1)).toHaveText("12");
-        await expect(editionFormBirdsTable.locator("tbody tr").nth(5).locator("td").nth(2)).toHaveText("Common shelduck");
-        /* eslint-enable no-unused-vars */
-    })
-})
+    });

--- a/tests/end2end/playwright/pages/project.js
+++ b/tests/end2end/playwright/pages/project.js
@@ -97,6 +97,13 @@ export class ProjectPage extends BasePage {
      */
     search;
 
+    // form
+    /**
+     * Edition form
+     * @type {Locator}
+     */
+    editionForm;
+
     // Messages
     /**
      * Foreground message bar
@@ -148,6 +155,7 @@ export class ProjectPage extends BasePage {
         this.switcher = page.locator('#button-switcher');
         this.baseLayerSelect = page.locator('#switcher-baselayer').getByRole('combobox')
         this.buttonEditing = page.locator('#button-edition');
+        this.editionForm = page.locator('#jforms_view_edition');
     }
 
     /**
@@ -239,7 +247,43 @@ export class ProjectPage extends BasePage {
         } else {
             await expect(this.page.locator('#edition-form-container')).toBeVisible();
         }
-        await expect(this.page.locator('#lizmap-edition-message')).toBeVisible();
+        if(futureAction == 'close') {
+            await expect(this.page.locator('#lizmap-edition-message')).toBeVisible();
+        }
+    }
+
+    /**
+     * checkEditionFormTextField function
+     * check the given text input or text widget value
+     * @param {string} fieldName The name of the input/text widget field
+     * @param {string} fieldValue The expected field/text widget value
+     * @param {null|string} labelText The label text, optional if only input value should be checked
+     * @param {boolean} trim trim the text widget value (only for text widget checks)
+     */
+    async checkEditionFormTextField(fieldName, fieldValue, labelText = null, trim = false){
+        if (labelText !== null) {
+            await expect(this.editionForm.locator(`label[id='jforms_view_edition_${fieldName}_label']`))
+                .toHaveText(labelText);
+        }
+        const input = this.editionForm.locator(`input[id='jforms_view_edition_${fieldName}']`);
+        let value;
+        if (trim) {
+            value = (await input.inputValue()).replace(/\s+/g,' ').trim();
+        } else {
+            value = await input.inputValue();
+        }
+
+        expect(value).toBe(fieldValue);
+    }
+
+    /**
+     * fillEditionFormTextInput function
+     * fills the given text input with the given text value
+     * @param {string} inputName The name of the input field
+     * @param {string} value The value to be filled
+     */
+    async fillEditionFormTextInput(inputName ,value){
+        await this.editionForm.locator(`input[id='jforms_view_edition_${inputName}']`).fill(value);
     }
 
     /**

--- a/tests/end2end/playwright/webdav-upload.spec.js
+++ b/tests/end2end/playwright/webdav-upload.spec.js
@@ -1,393 +1,442 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-import { gotoMap, playwrightTestFile } from './globals';
+import { playwrightTestFile } from './globals';
+import {ProjectPage} from "./pages/project";
 
-test.describe('WebDAV Server', () => {
-    test.beforeEach(async ({ page }) => {
-        const url = '/index.php/view/map/?repository=testsrepository&project=form_upload_webdav';
-        await gotoMap(url, page);
-        await page.locator('#dock-close').click();
+test.describe('WebDAV Server',
+    {
+        tag:['@write'],
+    }, () =>
+    {
+
+        test('Upload new file to remote server, inspect attribute table', async ({ page }) => {
+            const project = new ProjectPage(page, 'form_upload_webdav');
+            await project.open();
+            await project.closeLeftDock();
+
+            let editFeatureRequestPromise = page.waitForResponse(response => response.url().includes('editFeature'));
+            await project.openEditingFormWithLayer('form_edition_upload_webdav');
+            await page.locator('#jforms_view_edition_remote_path_jf_action_new').click();
+
+            await page.locator('#jforms_view_edition_remote_path').setInputFiles(playwrightTestFile('test_upload_file', 'test_upload_attribute_table.txt'));
+            // submit the form
+
+            await project.editingSubmitForm('edit');
+            await editFeatureRequestPromise;
+
+            // Wait a bit for the UI to refresh
+            await page.waitForTimeout(300);
+
+            await expect(page.locator("div.alert.alert-success")).toBeVisible();
+
+            let id = await page.locator('#jforms_view_edition_id').inputValue();
+
+            let getFeatureRequestPromise = page.waitForRequest(request =>
+                request.method() === 'POST'
+                && request.postData()?.includes('GetFeature') === true
+            );
+            await page.locator("#button-attributeLayers").click();
+            await page.locator("button[value='form_edition_upload_webdav']").click();
+            await getFeatureRequestPromise;
+
+            let attrTable = page.locator("#attribute-layer-table-form_edition_upload_webdav");
+            await expect(attrTable).toHaveCount(1);
+
+            await expect(attrTable.locator("tr[id='" + id + "']")).toHaveCount(1);
+
+            await expect(attrTable.locator("tr[id='" + id + "']").locator("td")).toHaveCount(4);
+
+            await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(1)).toHaveText(id);
+            await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2)).toHaveText("remote");
+            await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/remoteData/test_upload_attribute_table.txt");
+
+        });
+
+        test('Keep same file after reopen form, inspect attribute table', async ({ page }) => {
+            const project = new ProjectPage(page, 'form_upload_webdav');
+            await project.open();
+            await project.closeLeftDock();
+
+            let getFeatureRequestPromise = page.waitForRequest(request =>
+                request.method() === 'POST'
+                && request.postData()?.includes('GetFeature') === true
+            );
+            await page.locator("#button-attributeLayers").click();
+            await page.locator("button[value='form_edition_upload_webdav_geom']").click();
+            await getFeatureRequestPromise;
+
+            let attrTable = page.locator("#attribute-layer-table-form_edition_upload_webdav_geom");
+            await expect(attrTable).toHaveCount(1);
+            await expect(attrTable.locator("tr").nth(1).locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/logo.png");
+            let editFeatureRequestPromise = page.waitForResponse(response => response.url().includes('editFeature'));
+            await attrTable.locator("tr").nth(1).locator("td").nth(0).locator("button[data-bs-title='Edit']").click();
+            await editFeatureRequestPromise;
+            await page.waitForTimeout(300);
+
+            await expect(page.locator("#jforms_view_edition_remote_path_jf_action_keep")).toBeChecked()
+
+            let getNewFeatureRequestPromise = page.waitForRequest(request =>
+                request.method() === 'POST'
+                && request.postData()?.includes('GetFeature') === true
+            );
+
+            await project.editingSubmitForm('close');
+
+            await getNewFeatureRequestPromise;
+
+            await page.waitForTimeout(300);
+
+            await expect(attrTable.locator("tr").nth(1).locator("td").nth(2).locator("a")).toHaveText("remote");
+            await expect(attrTable.locator("tr").nth(1).locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/logo.png");
+
+        });
+
+        test('Change file after reopen form, inspect attribute table', async ({ page }) => {
+            const project = new ProjectPage(page, 'form_upload_webdav');
+            await project.open();
+            await project.closeLeftDock();
+
+            let editFeatureRequestPromise = page.waitForResponse(response => response.url().includes('editFeature'));
+            await project.openEditingFormWithLayer('form_edition_upload_webdav');
+
+            await page.locator('#jforms_view_edition_remote_path_jf_action_new').click();
+            await page.locator('#jforms_view_edition_remote_path').setInputFiles(playwrightTestFile('test_upload_file','test_upload_attribute_table_keep.txt'));
+
+            // submit the form
+            await project.editingSubmitForm('edit');
+
+            await editFeatureRequestPromise;
+
+            await page.waitForTimeout(300);
+
+            await expect(page.locator("div.alert.alert-success")).toBeVisible();
+
+            let id = await page.locator('#jforms_view_edition_id').inputValue();
+
+            let getFeatureRequestPromise = page.waitForRequest(request =>
+                request.method() === 'POST'
+                && request.postData()?.includes('GetFeature') === true
+            );
+
+            await page.locator("#button-attributeLayers").click();
+            await page.locator("button[value='form_edition_upload_webdav']").click();
+            await getFeatureRequestPromise;
+
+            let attrTable = page.locator("#attribute-layer-table-form_edition_upload_webdav");
+            await expect(attrTable).toHaveCount(1);
+
+            await expect(attrTable.locator("tr[id='" + id + "']")).toHaveCount(1);
+
+            await expect(attrTable.locator("tr[id='" + id + "']").locator("td")).toHaveCount(4);
+
+            await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(1)).toHaveText(id);
+            await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2)).toHaveText("remote");
+            await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/remoteData/test_upload_attribute_table_keep.txt");
+
+            await page.locator("#jforms_view_edition_remote_path_jf_action_new").click();
+            await expect(page.locator("#jforms_view_edition_remote_path_jf_action_new")).toBeChecked();
+
+            await page.locator('#jforms_view_edition_remote_path').setInputFiles(playwrightTestFile('test_upload_file','test_upload_replace.txt'));
+
+            await project.editingSubmitForm('close');
+
+            await editFeatureRequestPromise;
+
+            await getFeatureRequestPromise;
+
+            await page.waitForTimeout(300);
+
+            await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(1)).toHaveText(id);
+            await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2)).toHaveText("remote");
+            await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/remoteData/test_upload_replace.txt");
+
+        });
+
+        test('Delete file, inspect attribute table', async ({ page }) => {
+            const project = new ProjectPage(page, 'form_upload_webdav');
+            await project.open();
+            await project.closeLeftDock();
+
+            let editFeatureRequestPromise = page.waitForResponse(response => response.url().includes('editFeature'));
+            await project.openEditingFormWithLayer('form_edition_upload_webdav');
+            await page.locator('#jforms_view_edition_remote_path_jf_action_new').click();
+
+            await page.locator('#jforms_view_edition_remote_path').setInputFiles(playwrightTestFile('test_upload_file','test_upload_delete.txt'));
+            // submit the form
+            await project.editingSubmitForm('edit');
+            await editFeatureRequestPromise;
+
+            await page.waitForTimeout(300);
+
+            await expect(page.locator("div.alert.alert-success")).toBeVisible();
+
+            let id = await page.locator('#jforms_view_edition_id').inputValue();
+
+            let getFeatureRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeature') === true);
+            await page.locator("#button-attributeLayers").click();
+            await page.locator("button[value='form_edition_upload_webdav']").click();
+            await getFeatureRequestPromise;
+
+            let attrTable = page.locator("#attribute-layer-table-form_edition_upload_webdav");
+            await expect(attrTable).toHaveCount(1);
+
+            await expect(attrTable.locator("tr[id='" + id + "']")).toHaveCount(1);
+
+            await expect(attrTable.locator("tr[id='" + id + "']").locator("td")).toHaveCount(4);
+
+            await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(1)).toHaveText(id);
+            await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2)).toHaveText("remote");
+            await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/remoteData/test_upload_delete.txt");
+
+            await page.locator("#jforms_view_edition_remote_path_jf_action_del").click();
+            await expect(page.locator("#jforms_view_edition_remote_path_jf_action_del")).toBeChecked();
+
+            await project.editingSubmitForm('close');
+
+            await editFeatureRequestPromise;
+
+            await getFeatureRequestPromise;
+
+            await page.waitForTimeout(300);
+
+            await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(1)).toHaveText(id);
+            await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2)).toHaveText("");
+            await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2).locator("a")).toHaveCount(0);
+
+        });
+
+        test("Inspect popups and attribute table for postgre layers", async ({ page }) => {
+            const project = new ProjectPage(page, 'form_upload_webdav');
+            await project.open();
+            await project.closeLeftDock();
+
+            let getFeatureInfoRequestPromise = page.waitForRequest(
+                request => request.method() === 'POST'
+                && request.postData()?.includes('GetFeatureInfo') === true
+            );
+            await project.clickOnMap(644, 282);
+
+            await getFeatureInfoRequestPromise;
+
+            //time for rendering the popup
+            await page.waitForTimeout(500);
+
+            const popup = await project.identifyContentLocator(
+                '1',
+                'form_edition_upload_webdav_geom_c71ec5ff_dc88_451f_98e1_ccf41e34ddd7'
+            );
+
+            await expect(popup.locator('.lizmapPopupTitle')).toHaveText("form_edition_upload_webdav_geom");
+            let uploadFields = popup.locator(".container.popup_lizmap_dd").locator(".before-tabs .control-group");
+            await expect(uploadFields).toHaveCount(3);
+            const resourceUrl = await popup.locator('#dd_jforms_view_edition_remote_path a').getAttribute("href");
+            expect(resourceUrl).toContain("index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav%2Flogo.png");
+            // no image preview
+            await expect(popup.locator('#dd_jforms_view_edition_remote_path a').locator('img')).toHaveCount(0);
+
+            //clear screen
+            await page.locator('#dock-close').click();
+
+            let getFeatureRequestPromise = page.waitForRequest(request =>
+                request.method() === 'POST'
+                && request.postData()?.includes('GetFeature') === true
+            );
+
+            await page.locator("#button-attributeLayers").click();
+            await page.locator("button[value='form_edition_upload_webdav_geom']").click();
+            await getFeatureRequestPromise;
+
+            let attrTable = page.locator("#attribute-layer-table-form_edition_upload_webdav_geom");
+            await expect(attrTable).toHaveCount(1);
+            await expect(attrTable.locator("tr").nth(1).locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/logo.png");
+            await expect(attrTable.locator("tr").nth(2).locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/test_upload.conf");
+            await expect(attrTable.locator("tr").nth(3).locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/test_upload.txt");
+        });
+
+        test("Inspect popups and attribute table for non-postgre layers", async ({ page }) => {
+            const project = new ProjectPage(page, 'form_upload_webdav');
+            await project.open();
+            await project.closeLeftDock();
+
+            let getFeatureInfoRequestPromise = page.waitForRequest(request =>
+                request.method() === 'POST'
+                && request.postData()?.includes('GetFeatureInfo') === true
+            );
+            await project.clickOnMap(397, 180);
+
+            await getFeatureInfoRequestPromise;
+
+            //time for rendering the popup
+            await page.waitForTimeout(500);
+
+            const popup = await project.identifyContentLocator(
+                '1',
+                'for_edition_upload_webdav_shape_caf087fb_dfd0_40c5_93a4_ac1ae5648e96'
+            );
+
+            await expect(popup.locator('.lizmapPopupTitle')).toHaveText("form_edition_upload_webdav_shape");
+            const popupTable = popup.locator('.lizmapPopupTable');
+            await expect(popupTable).toHaveCount(1);
+            await expect(popupTable.locator('tbody tr')).toHaveCount(3);
+
+            await expect(popupTable.locator("tbody tr").nth(1).locator("td").locator("a")).toHaveCount(1);
+            const resourceUrl = await popupTable.locator("tbody tr").nth(1).locator("td").locator("a").getAttribute("href");
+            expect(resourceUrl).toContain("index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav%2Flogo.png");
+
+            // image preview
+            const imageUrl = await popupTable.locator("tbody tr").nth(1).locator("td").locator("a img").getAttribute("src");
+            expect(imageUrl).toContain("index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav%2Flogo.png");
+
+            //clear screen
+            await page.locator('#dock-close').click();
+
+            let getFeatureRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeature') === true);
+            await page.locator("#button-attributeLayers").click();
+            await page.locator("button[value='form_edition_upload_webdav_shape']").click();
+            await getFeatureRequestPromise;
+
+            let attrTable = page.locator("#attribute-layer-table-form_edition_upload_webdav_shape");
+            await expect(attrTable).toHaveCount(1);
+            await expect(attrTable.locator("tr").nth(1).locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/test_upload.conf");
+            await expect(attrTable.locator("tr").nth(2).locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/logo.png");
+
+        });
+
+        test('GetMedia, different file type from webdav storage', async ({ page, request }) => {
+            const project = new ProjectPage(page, 'form_upload_webdav');
+            await project.open();
+            await project.closeLeftDock();
+
+            let getFeatureRequestPromise = page.waitForRequest(request =>
+                request.method() === 'POST'
+                && request.postData()?.includes('GetFeature') === true
+            );
+
+            await page.locator("#button-attributeLayers").click();
+            await page.locator("button[value='form_edition_upload_webdav_geom']").click();
+            await getFeatureRequestPromise;
+
+            let attrTable = page.locator("#attribute-layer-table-form_edition_upload_webdav_geom");
+
+            await expect(attrTable).toHaveCount(1);
+
+            // file.png
+            await expect(attrTable.locator("tr[id='1']").locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/logo.png");
+
+            const getLogo = await attrTable.locator("tr[id='1']").locator("td").nth(2).locator("a").getAttribute("href") || "";
+
+            const logoReq = await request.get(getLogo);
+            expect(logoReq.status()).toBe(200);
+            expect(logoReq.headers()["content-type"]).toBe("image/png");
+
+            // file .conf
+            await expect(attrTable.locator("tr[id='2']").locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/test_upload.conf");
+
+            const downloadPromise = page.waitForEvent('download');
+            await attrTable.locator("tr[id='2']").locator("td").nth(2).locator("a").click();
+            const download = await downloadPromise;
+
+            expect(download.suggestedFilename()).toBe("test_upload.conf");
+
+            const getConfFile = await attrTable.locator("tr[id='2']").locator("td").nth(2).locator("a").getAttribute("href") || "";
+
+            const confReq = await request.get(getConfFile);
+            expect(confReq.status()).toBe(200);
+            expect(confReq.headers()["content-type"]).toBe("application/octet-stream");
+
+            // file .txt
+            await expect(attrTable.locator("tr[id='3']").locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/test_upload.txt");
+
+            const getTxtFile = await attrTable.locator("tr[id='3']").locator("td").nth(2).locator("a").getAttribute("href") || "";
+
+            const txtFileReq = await request.get(getTxtFile);
+            expect(txtFileReq.status()).toBe(200);
+            expect(txtFileReq.headers()["content-type"]).toContain("text/plain");
+
+        });
+
+        test('Inspect popupAllFeaturesCompact data table in popup', async ({ page }) => {
+            const project = new ProjectPage(page, 'form_upload_webdav');
+            await project.open();
+            await project.closeLeftDock();
+
+            let getFeatureInfoRequestPromise = page.waitForRequest(request =>
+                request.method() === 'POST'
+                && request.postData()?.includes('GetFeatureInfo') === true
+            );
+
+            await project.clickOnMap(484, 377);
+
+            await getFeatureInfoRequestPromise;
+
+            //time for rendering the popup
+            await page.waitForTimeout(500);
+
+            const popup = await project.identifyContentLocator(
+                '1',
+                'form_edition_upload_webdav_parent_geom_8c26e78b_f73b_4b2a_9c0e_d7a9e185346e'
+            );
+            await expect(popup.locator('.lizmapPopupTitle').first()).toHaveText("form_edition_upload_webdav_parent_geom");
+
+            let children = popup.locator('.lizmapPopupChildren');
+            await expect(children).toHaveCount(1);
+
+            // inspect distinct children tables
+            await expect(children.locator(".lizmapPopupSingleFeature")).toHaveCount(2);
+
+            // first table
+            let firstChild = children.locator(".lizmapPopupSingleFeature").nth(0);
+            let popupTable = firstChild.locator('.lizmapPopupTable');
+            await expect(popupTable).toHaveCount(1);
+
+            await expect(popupTable.locator('tbody tr').nth(0).locator('th')).toHaveText('Id');
+            await expect(popupTable.locator('tbody tr').nth(0).locator('td')).toHaveText('2');
+            await expect(popupTable.locator('tbody tr').nth(1).locator('th')).toHaveText('Id parent');
+            await expect(popupTable.locator('tbody tr').nth(1).locator('td')).toHaveText('1');
+            await expect(popupTable.locator('tbody tr').nth(2).locator('th')).toHaveText('remote_path');
+            const firstChildresourceUrl = await popupTable.locator('tbody tr').nth(2).locator("td a").getAttribute("href");
+            expect(firstChildresourceUrl).toContain("index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav%2Ftest_upload.conf");
+
+            // second table
+            let secondChild = children.locator(".lizmapPopupSingleFeature").nth(1);
+            popupTable = secondChild.locator('.lizmapPopupTable');
+            await expect(popupTable).toHaveCount(1);
+
+            await expect(popupTable.locator('tbody tr').nth(0).locator('th')).toHaveText('Id');
+            await expect(popupTable.locator('tbody tr').nth(0).locator('td')).toHaveText('1');
+            await expect(popupTable.locator('tbody tr').nth(1).locator('th')).toHaveText('Id parent');
+            await expect(popupTable.locator('tbody tr').nth(1).locator('td')).toHaveText('1');
+            await expect(popupTable.locator('tbody tr').nth(2).locator('th')).toHaveText('remote_path');
+
+            const secondChildresourceUrl = await popupTable.locator('tbody tr').nth(2).locator("td a").getAttribute("href");
+            expect(secondChildresourceUrl).toContain("index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav%2Flogo.png");
+            await expect(popupTable.locator('tbody tr').nth(2).locator("td a").locator("img")).toHaveCount(1)
+            const secondChildImageSrc = await popupTable.locator('tbody tr').nth(2).locator("td a").locator("img").getAttribute("src");
+            expect(secondChildImageSrc).toContain("index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav%2Flogo.png");
+
+            // inspect popupAllFeaturesCompact table
+            await expect(children.locator(".popupAllFeaturesCompact")).toHaveCount(1);
+            await expect(children.locator(".popupAllFeaturesCompact")).not.toBeVisible();
+            await expect(children.locator('.compact-tables')).toHaveCount(1);
+
+            //click on the compact table button
+            await children.locator('.compact-tables').click();
+            await expect(children.locator('.popupAllFeaturesCompact')).toBeVisible();
+            const allFeatureDataTable = children.locator('.popupAllFeaturesCompact table');
+            await expect(allFeatureDataTable).toHaveCount(1);
+
+            // first row
+            await expect(allFeatureDataTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
+            await expect(allFeatureDataTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("1");
+            const firstRowFilePath = await allFeatureDataTable.locator("tbody tr").nth(0).locator("td").nth(3).locator("a").getAttribute("href");
+            expect(firstRowFilePath).toContain("index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav%2Flogo.png");
+            const firstRowSrc = await allFeatureDataTable.locator("tbody tr").nth(0).locator("td").nth(3).locator("a").locator("img").getAttribute("src");
+            expect(firstRowSrc).toContain("index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav%2Flogo.png")
+
+            // second row
+            await expect(allFeatureDataTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("2");
+            await expect(allFeatureDataTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("1");
+            const secondRowFilePath = await allFeatureDataTable.locator("tbody tr").nth(1).locator("td").nth(3).locator("a").getAttribute("href");
+            expect(secondRowFilePath).toContain("index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav%2Ftest_upload.conf");
+        });
     });
-
-    test('Upload new file to remote server, inspect attribute table', async ({ page }) => {
-
-        let editFeatureRequestPromise = page.waitForResponse(response => response.url().includes('editFeature'));
-        await page.locator('#button-edition').click();
-        await page.locator('a#edition-draw').click();
-        await page.locator('#jforms_view_edition_remote_path_jf_action_new').click();
-
-        await page.locator('#jforms_view_edition_liz_future_action').selectOption("edit");
-
-        await page.locator('#jforms_view_edition_remote_path').setInputFiles(playwrightTestFile("test_upload_file", "test_upload_attribute_table.txt"));
-        // submit the form
-        await page.locator('#jforms_view_edition__submit_submit').click();
-
-        await editFeatureRequestPromise;
-
-        // Wait a bit for the UI to refresh
-        await page.waitForTimeout(300);
-
-        await expect(page.locator("div.alert.alert-success")).toBeVisible();
-
-        let id = await page.locator('#jforms_view_edition_id').inputValue();
-
-        let getFeatureRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeature') === true);
-        await page.locator("#button-attributeLayers").click();
-        await page.locator("button[value='form_edition_upload_webdav']").click();
-        await getFeatureRequestPromise;
-
-        let attrTable = page.locator("#attribute-layer-table-form_edition_upload_webdav");
-        await expect(attrTable).toHaveCount(1);
-
-        await expect(attrTable.locator("tr[id='" + id + "']")).toHaveCount(1);
-
-        await expect(attrTable.locator("tr[id='" + id + "']").locator("td")).toHaveCount(4);
-
-        await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(1)).toHaveText(id);
-        await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2)).toHaveText("remote");
-        await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/remoteData/test_upload_attribute_table.txt");
-
-    })
-
-    test('Keep same file after reopen form, inspect attribute table', async ({ page }) => {
-
-        let getFeatureRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeature') === true);
-        await page.locator("#button-attributeLayers").click();
-        await page.locator("button[value='form_edition_upload_webdav_geom']").click();
-        await getFeatureRequestPromise;
-
-        let attrTable = page.locator("#attribute-layer-table-form_edition_upload_webdav_geom");
-        await expect(attrTable).toHaveCount(1);
-        await expect(attrTable.locator("tr").nth(1).locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/logo.png");
-        let editFeatureRequestPromise = page.waitForResponse(response => response.url().includes('editFeature'));
-        await attrTable.locator("tr").nth(1).locator("td").nth(0).locator("button[data-bs-title='Edit']").click();
-        await editFeatureRequestPromise;
-        await page.waitForTimeout(300);
-
-        await expect(page.locator("#jforms_view_edition_remote_path_jf_action_keep")).toBeChecked()
-
-        await page.locator('#jforms_view_edition_liz_future_action').selectOption("close");
-        let getNewFeatureRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeature') === true);
-        await page.locator('#jforms_view_edition__submit_submit').click();
-
-        await getNewFeatureRequestPromise;
-
-        await page.waitForTimeout(300);
-
-        await expect(attrTable.locator("tr").nth(1).locator("td").nth(2).locator("a")).toHaveText("remote");
-        await expect(attrTable.locator("tr").nth(1).locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/logo.png");
-
-    })
-
-    test('Change file after reopen form, inspect attribute table', async ({ page }) => {
-
-        let editFeatureRequestPromise = page.waitForResponse(response => response.url().includes('editFeature'));
-        await page.locator('#button-edition').click();
-        await page.locator('a#edition-draw').click();
-        await page.locator('#jforms_view_edition_remote_path_jf_action_new').click();
-
-        await page.locator('#jforms_view_edition_liz_future_action').selectOption("edit");
-
-        await page.locator('#jforms_view_edition_remote_path').setInputFiles("./playwright/test_upload_file/test_upload_attribute_table_keep.txt");
-        // submit the form
-        await page.locator('#jforms_view_edition__submit_submit').click();
-
-        await editFeatureRequestPromise;
-
-        await page.waitForTimeout(300);
-
-        await expect(page.locator("div.alert.alert-success")).toBeVisible();
-
-        let id = await page.locator('#jforms_view_edition_id').inputValue();
-
-        let getFeatureRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeature') === true);
-        await page.locator("#button-attributeLayers").click();
-        await page.locator("button[value='form_edition_upload_webdav']").click();
-        await getFeatureRequestPromise;
-
-        let attrTable = page.locator("#attribute-layer-table-form_edition_upload_webdav");
-        await expect(attrTable).toHaveCount(1);
-
-        await expect(attrTable.locator("tr[id='" + id + "']")).toHaveCount(1);
-
-        await expect(attrTable.locator("tr[id='" + id + "']").locator("td")).toHaveCount(4);
-
-        await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(1)).toHaveText(id);
-        await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2)).toHaveText("remote");
-        await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/remoteData/test_upload_attribute_table_keep.txt");
-
-        await page.locator("#jforms_view_edition_remote_path_jf_action_new").click();
-        await expect(page.locator("#jforms_view_edition_remote_path_jf_action_new")).toBeChecked();
-
-        await page.locator('#jforms_view_edition_remote_path').setInputFiles("./playwright/test_upload_file/test_upload_replace.txt");
-
-        await page.locator('#jforms_view_edition_liz_future_action').selectOption("close");
-
-        await page.locator('#jforms_view_edition__submit_submit').click();
-
-        await editFeatureRequestPromise;
-
-        await getFeatureRequestPromise;
-
-        await page.waitForTimeout(300);
-
-        await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(1)).toHaveText(id);
-        await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2)).toHaveText("remote");
-        await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/remoteData/test_upload_replace.txt");
-
-    })
-
-    test('Delete file, inspect attribute table', async ({ page }) => {
-
-        let editFeatureRequestPromise = page.waitForResponse(response => response.url().includes('editFeature'));
-        await page.locator('#button-edition').click();
-        await page.locator('a#edition-draw').click();
-        await page.locator('#jforms_view_edition_remote_path_jf_action_new').click();
-
-        await page.locator('#jforms_view_edition_liz_future_action').selectOption("edit");
-
-        await page.locator('#jforms_view_edition_remote_path').setInputFiles("./playwright/test_upload_file/test_upload_delete.txt");
-        // submit the form
-        await page.locator('#jforms_view_edition__submit_submit').click();
-
-        await editFeatureRequestPromise;
-
-        await page.waitForTimeout(300);
-
-        await expect(page.locator("div.alert.alert-success")).toBeVisible();
-
-        let id = await page.locator('#jforms_view_edition_id').inputValue();
-
-        let getFeatureRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeature') === true);
-        await page.locator("#button-attributeLayers").click();
-        await page.locator("button[value='form_edition_upload_webdav']").click();
-        await getFeatureRequestPromise;
-
-        let attrTable = page.locator("#attribute-layer-table-form_edition_upload_webdav");
-        await expect(attrTable).toHaveCount(1);
-
-        await expect(attrTable.locator("tr[id='" + id + "']")).toHaveCount(1);
-
-        await expect(attrTable.locator("tr[id='" + id + "']").locator("td")).toHaveCount(4);
-
-        await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(1)).toHaveText(id);
-        await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2)).toHaveText("remote");
-        await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/remoteData/test_upload_delete.txt");
-
-        await page.locator("#jforms_view_edition_remote_path_jf_action_del").click();
-        await expect(page.locator("#jforms_view_edition_remote_path_jf_action_del")).toBeChecked();
-
-        await page.locator('#jforms_view_edition_liz_future_action').selectOption("close");
-
-        //let getNewFeatureRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeature') === true);
-        await page.locator('#jforms_view_edition__submit_submit').click();
-
-        await editFeatureRequestPromise;
-
-        await getFeatureRequestPromise;
-
-        await page.waitForTimeout(300);
-
-        await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(1)).toHaveText(id);
-        await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2)).toHaveText("");
-        await expect(attrTable.locator("tr[id='" + id + "']").locator("td").nth(2).locator("a")).toHaveCount(0);
-
-    })
-
-    test("Inspect popups and attribute table for postgre layers", async ({ page }) => {
-
-        let getFeatureInfoRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeatureInfo') === true);
-
-        await page.locator('#newOlMap').click({
-            position: {
-                x: 644,
-                y: 282
-            }
-        });
-        await getFeatureInfoRequestPromise;
-
-        //time for rendering the popup
-        await page.waitForTimeout(500);
-
-        await expect(page.locator('.lizmapPopupContent > .lizmapPopupSingleFeature .lizmapPopupTitle').first()).toHaveText("form_edition_upload_webdav_geom");
-        await expect(page.locator(".container.popup_lizmap_dd .before-tabs div.field")).toHaveCount(2);
-        const resourceUrl = await page.locator(".container.popup_lizmap_dd .before-tabs div.field").nth(1).locator("a").getAttribute("href");
-        expect(resourceUrl).toContain("index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav%2Flogo.png");
-        // no image preview
-        await expect(page.locator(".container.popup_lizmap_dd .before-tabs div.field").nth(1).locator("img")).toHaveCount(0);
-
-        //clear screen
-        await page.locator('#dock-close').click();
-
-        let getFeatureRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeature') === true);
-        await page.locator("#button-attributeLayers").click();
-        await page.locator("button[value='form_edition_upload_webdav_geom']").click();
-        await getFeatureRequestPromise;
-
-        let attrTable = page.locator("#attribute-layer-table-form_edition_upload_webdav_geom");
-        await expect(attrTable).toHaveCount(1);
-        await expect(attrTable.locator("tr").nth(1).locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/logo.png");
-        await expect(attrTable.locator("tr").nth(2).locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/test_upload.conf");
-        await expect(attrTable.locator("tr").nth(3).locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/test_upload.txt");
-    })
-
-    test("Inspect popups and attribute table for non-postgre layers", async ({ page }) => {
-
-        let getFeatureInfoRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeatureInfo') === true);
-
-        await page.locator('#newOlMap').click({
-            position: {
-                x: 397,
-                y: 180
-            }
-        });
-        await getFeatureInfoRequestPromise;
-
-        //time for rendering the popup
-        await page.waitForTimeout(500);
-
-        await expect(page.locator('.lizmapPopupContent > .lizmapPopupSingleFeature .lizmapPopupTitle').first()).toHaveText("form_edition_upload_webdav_shape");
-        await expect(page.locator(".lizmapPopupContent > .lizmapPopupSingleFeature .lizmapPopupTable").locator("tbody tr")).toHaveCount(3);
-
-        await expect(page.locator(".lizmapPopupContent > .lizmapPopupSingleFeature .lizmapPopupTable").locator("tbody tr").nth(1).locator("td").locator("a")).toHaveCount(1);
-        const resourceUrl = await page.locator(".lizmapPopupContent > .lizmapPopupSingleFeature .lizmapPopupTable").locator("tbody tr").nth(1).locator("td").locator("a").getAttribute("href");
-        expect(resourceUrl).toContain("index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav%2Flogo.png");
-
-        // image preview
-        const imageUrl = await page.locator(".lizmapPopupContent > .lizmapPopupSingleFeature .lizmapPopupTable").locator("tbody tr").nth(1).locator("td").locator("a img").getAttribute("src");
-        expect(imageUrl).toContain("index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav%2Flogo.png");
-
-        //clear screen
-        await page.locator('#dock-close').click();
-
-        let getFeatureRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeature') === true);
-        await page.locator("#button-attributeLayers").click();
-        await page.locator("button[value='form_edition_upload_webdav_shape']").click();
-        await getFeatureRequestPromise;
-
-        let attrTable = page.locator("#attribute-layer-table-form_edition_upload_webdav_shape");
-        await expect(attrTable).toHaveCount(1);
-        await expect(attrTable.locator("tr").nth(1).locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/test_upload.conf");
-        await expect(attrTable.locator("tr").nth(2).locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/logo.png");
-
-    })
-
-    test('GetMedia, different file type from webdav storage', async ({ page, request }) => {
-        let getFeatureRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeature') === true);
-
-        await page.locator("#button-attributeLayers").click();
-        await page.locator("button[value='form_edition_upload_webdav_geom']").click();
-        await getFeatureRequestPromise;
-
-        let attrTable = page.locator("#attribute-layer-table-form_edition_upload_webdav_geom");
-
-        await expect(attrTable).toHaveCount(1);
-
-        // file.png
-        await expect(attrTable.locator("tr[id='1']").locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/logo.png");
-
-        const getLogo = await attrTable.locator("tr[id='1']").locator("td").nth(2).locator("a").getAttribute("href") || "";
-
-        const logoReq = await request.get(getLogo);
-        expect(logoReq.status()).toBe(200);
-        expect(logoReq.headers()["content-type"]).toBe("image/png");
-
-        // file .conf
-        await expect(attrTable.locator("tr[id='2']").locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/test_upload.conf");
-
-        const downloadPromise = page.waitForEvent('download');
-        await attrTable.locator("tr[id='2']").locator("td").nth(2).locator("a").click();
-        const download = await downloadPromise;
-
-        expect(download.suggestedFilename()).toBe("test_upload.conf");
-
-        const getConfFile = await attrTable.locator("tr[id='2']").locator("td").nth(2).locator("a").getAttribute("href") || "";
-
-        const confReq = await request.get(getConfFile);
-        expect(confReq.status()).toBe(200);
-        expect(confReq.headers()["content-type"]).toBe("application/octet-stream");
-
-        // file .txt
-        await expect(attrTable.locator("tr[id='3']").locator("td").nth(2).locator("a")).toHaveAttribute("href", "/index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav/test_upload.txt");
-
-        const getTxtFile = await attrTable.locator("tr[id='3']").locator("td").nth(2).locator("a").getAttribute("href") || "";
-
-        const txtFileReq = await request.get(getTxtFile);
-        expect(txtFileReq.status()).toBe(200);
-        expect(txtFileReq.headers()["content-type"]).toContain("text/plain");
-
-    })
-
-    test('Inspect popupAllFeaturesCompact data table in popup', async ({ page }) => {
-        let getFeatureInfoRequestPromise = page.waitForRequest(request => request.method() === 'POST' && request.postData()?.includes('GetFeatureInfo') === true);
-
-        await page.locator('#newOlMap').click({
-            position: {
-                x: 484,
-                y: 377
-            }
-        });
-        await getFeatureInfoRequestPromise;
-
-        //time for rendering the popup
-        await page.waitForTimeout(500);
-        await expect(page.locator('.lizmapPopupContent > .lizmapPopupSingleFeature .lizmapPopupTitle').first()).toHaveText("form_edition_upload_webdav_parent_geom");
-        let children = page.locator('.lizmapPopupContent .lizmapPopupChildren');
-        await expect(children).toHaveCount(1);
-
-        // inspect distinct children tables
-        await expect(children.locator(".lizmapPopupSingleFeature")).toHaveCount(2);
-
-        // first table
-        let firstChild = children.locator(".lizmapPopupSingleFeature").nth(0);
-        await expect(firstChild.locator(".lizmapPopupTable")).toHaveCount(1);
-
-        await expect(firstChild.locator(".lizmapPopupTable tbody tr").nth(0).locator("th")).toHaveText("Id");
-        await expect(firstChild.locator(".lizmapPopupTable tbody tr").nth(0).locator("td")).toHaveText("2");
-        await expect(firstChild.locator(".lizmapPopupTable tbody tr").nth(1).locator("th")).toHaveText("Id parent");
-        await expect(firstChild.locator(".lizmapPopupTable tbody tr").nth(1).locator("td")).toHaveText("1");
-        await expect(firstChild.locator(".lizmapPopupTable tbody tr").nth(2).locator("th")).toHaveText("remote_path");
-        const firstChildresourceUrl = await firstChild.locator(".lizmapPopupTable tbody tr").nth(2).locator("td a").getAttribute("href");
-        expect(firstChildresourceUrl).toContain("index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav%2Ftest_upload.conf");
-
-        // second table
-        let secondChild = children.locator(".lizmapPopupSingleFeature").nth(1);
-        await expect(secondChild.locator(".lizmapPopupTable tbody tr").nth(0).locator("th")).toHaveText("Id");
-        await expect(secondChild.locator(".lizmapPopupTable tbody tr").nth(0).locator("td")).toHaveText("1");
-        await expect(secondChild.locator(".lizmapPopupTable tbody tr").nth(1).locator("th")).toHaveText("Id parent");
-        await expect(secondChild.locator(".lizmapPopupTable tbody tr").nth(1).locator("td")).toHaveText("1");
-        await expect(secondChild.locator(".lizmapPopupTable tbody tr").nth(2).locator("th")).toHaveText("remote_path");
-        const secondChildresourceUrl = await secondChild.locator(".lizmapPopupTable tbody tr").nth(2).locator("td a").getAttribute("href");
-        expect(secondChildresourceUrl).toContain("index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav%2Flogo.png");
-        await expect(secondChild.locator(".lizmapPopupTable tbody tr").nth(2).locator("td a").locator("img")).toHaveCount(1)
-        const secondChildImageSrc = await secondChild.locator(".lizmapPopupTable tbody tr").nth(2).locator("td a").locator("img").getAttribute("src");
-        expect(secondChildImageSrc).toContain("index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav%2Flogo.png");
-
-        // inspect popupAllFeaturesCompact table
-        await expect(children.locator(".popupAllFeaturesCompact")).toHaveCount(1);
-        await expect(children.locator(".popupAllFeaturesCompact")).not.toBeVisible();
-        await expect(children.locator('.compact-tables')).toHaveCount(1);
-
-        //click on the compact table button
-        await children.locator('.compact-tables').click();
-        await expect(children.locator(".popupAllFeaturesCompact")).toBeVisible();
-
-        await expect(children.locator(".popupAllFeaturesCompact table")).toHaveCount(1);
-
-        let allFeatureDataTable = children.locator(".popupAllFeaturesCompact table");
-
-        // first row
-        await expect(allFeatureDataTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
-        await expect(allFeatureDataTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("1");
-        const firstRowFilePath = await allFeatureDataTable.locator("tbody tr").nth(0).locator("td").nth(3).locator("a").getAttribute("href");
-        expect(firstRowFilePath).toContain("index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav%2Flogo.png");
-        const firstRowSrc = await allFeatureDataTable.locator("tbody tr").nth(0).locator("td").nth(3).locator("a").locator("img").getAttribute("src");
-        expect(firstRowSrc).toContain("index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav%2Flogo.png")
-
-        // second row
-        await expect(allFeatureDataTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("2");
-        await expect(allFeatureDataTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("1");
-        const secondRowFilePath = await allFeatureDataTable.locator("tbody tr").nth(1).locator("td").nth(3).locator("a").getAttribute("href");
-        expect(secondRowFilePath).toContain("index.php/view/media/getMedia?repository=testsrepository&project=form_upload_webdav&path=dav%2Ftest_upload.conf");
-    })
-})


### PR DESCRIPTION
Updates some e2e tests following  https://github.com/3liz/qgis-lizmap-server-plugin/commit/1b4a14c63f8ac3c5f51bee23678e8dafa820f9ae

- `edition-form.spec.js` and `embedded-relations.spec.js` have been refactored to be POM compliant
- `n_to_m_relations_spec.js` and `webdav-upload.spec.js` have been partially refactored. These two tests requires a lot of effort to be completely refactored so for now I've just made some changes in locators to make them work properly with the new HTML template.
- 



Funded by Faunalia
