### PR TITLE
[Bugfix] Tile WMS layer has no loading status updated

### DIFF
--- a/assets/src/modules/map.js
+++ b/assets/src/modules/map.js
@@ -674,7 +674,7 @@ export default class map extends olMap {
                     const mapLayer = rootMapGroup.getMapLayerByName(event.target.get('name'))
                     mapLayer.loadStatus = MapLayerLoadStatus.Error;
                 });
-            } else if (source instanceof WMTS) {
+            } else if (source instanceof TileWMS || source instanceof WMTS) {
                 source.on('tileloadstart', event => {
                     const mapLayer = rootMapGroup.getMapLayerByName(event.target.get('name'))
                     mapLayer.loadStatus = MapLayerLoadStatus.Loading;


### PR DESCRIPTION
In the map Module, the loading status of TileWMS was not listen by Lizmap, so the load status was not updated.