### PR TITLE
Return correct HTTP code if the lizmap_search has failed

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapFts.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapFts.class.php
@@ -15,7 +15,14 @@ class lizmapFts
 {
     protected $sql;
 
-    protected function generateSql($project)
+    /**
+     * Generate the SQL for lizmap_search according to the given project.
+     *
+     * @param Project $project The QGIS project
+     *
+     * @return string The SQL query
+     */
+    protected static function generateSql($project)
     {
 
         // Build search query.
@@ -78,12 +85,20 @@ class lizmapFts
         ORDER BY sim DESC, item_label
         LIMIT :lim;
         ';
-        $this->sql = $sql;
+
+        return $sql;
     }
 
+    /**
+     * Get SQL for the given project.
+     *
+     * @param Project $project The QGIS project
+     *
+     * @return string The SQL query
+     */
     protected function getSql($project)
     {
-        $this->generateSql($project);
+        $this->sql = $this->generateSql($project);
 
         return $this->sql;
     }
@@ -97,7 +112,7 @@ class lizmapFts
      *
      * @return array<object> as an array
      */
-    protected function query($sql, $filterParams, $profile = null)
+    protected static function query($sql, $filterParams, $profile = null)
     {
         if (!$profile) {
             $profile = 'search';
@@ -111,16 +126,11 @@ class lizmapFts
             $profile = null;
         }
 
-        try {
-            $cnx = jDb::getConnection($profile);
-            $resultset = $cnx->prepare($sql);
-            $resultset->execute($filterParams);
-            $result = $resultset->fetchAll();
-        } catch (Exception $e) {
-            $result = array();
-        }
+        $cnx = jDb::getConnection($profile);
+        $resultSet = $cnx->prepare($sql);
+        $resultSet->execute($filterParams);
 
-        return $result;
+        return $resultSet->fetchAll();
     }
 
     /**
@@ -192,6 +202,11 @@ class lizmapFts
             }
         } catch (Exception $e) {
             $data = array();
+            jLog::log(
+                'An error has been raised when executing lizmap_search on "'.$project->getKey().'":'.$e->getMessage(),
+                'lizmapadmin'
+            );
+            jLog::logEx($e, 'error');
         }
 
         return $data;

--- a/lizmap/modules/lizmap/controllers/searchFts.classic.php
+++ b/lizmap/modules/lizmap/controllers/searchFts.classic.php
@@ -1,6 +1,7 @@
 <?php
 
 use Lizmap\Project\UnknownLizmapProjectException;
+use Lizmap\Request\Proxy;
 
 /**
  * Php proxy to access database search.
@@ -31,19 +32,24 @@ class searchFtsCtrl extends jController
         // Parameters
         $pquery = htmlspecialchars(strip_tags($this->param('query')), ENT_NOQUOTES);
         if (!$pquery) {
+            jLog::log('Invalid "query" parameter in lizmap_search', 'lizmapadmin');
+            $rep->setHttpStatus(400, Proxy::getHttpStatusMsg(400));
+
             return $rep;
         }
 
         $repository = $this->param('repository');
         if (!$repository) {
-            // The parameter repository is mandatory !
+            jLog::log('Invalid "repository" parameter in lizmap_search', 'lizmapadmin');
+            $rep->setHttpStatus(400, Proxy::getHttpStatusMsg(400));
 
             return $rep;
         }
 
         $project = $this->param('project');
         if (!$project) {
-            // The parameter project is mandatory !
+            jLog::log('Invalid "project" parameter in lizmap_search', 'lizmapadmin');
+            $rep->setHttpStatus(400, Proxy::getHttpStatusMsg(400));
 
             return $rep;
         }
@@ -51,7 +57,8 @@ class searchFtsCtrl extends jController
         // Check repository
         $lrep = lizmap::getRepository($repository);
         if ($lrep == null) {
-            jLog::log('The repository '.$repository.' does not exist !', 'lizmapadmin');
+            jLog::log('The repository "'.$repository.'"" does not exist.', 'lizmapadmin');
+            $rep->setHttpStatus(400, Proxy::getHttpStatusMsg(400));
 
             return $rep;
         }
@@ -62,13 +69,15 @@ class searchFtsCtrl extends jController
         try {
             $lproj = lizmap::getProject($repository.'~'.$project);
             if ($lproj == null) {
-                jLog::log('The lizmap project '.$project.' does not exist !', 'lizmapadmin');
+                jLog::log('The lizmap project "'.$project.'" does not exist.', 'lizmapadmin');
+                $rep->setHttpStatus(400, Proxy::getHttpStatusMsg(400));
 
                 return $rep;
             }
         } catch (UnknownLizmapProjectException $e) {
             jLog::logEx($e, 'error');
-            jLog::log('The lizmap project '.$project.' does not exist !', 'lizmapadmin');
+            jLog::log('The lizmap project "'.$project.'" does not exist.', 'lizmapadmin');
+            $rep->setHttpStatus(400, Proxy::getHttpStatusMsg(400));
 
             return $rep;
         }
@@ -76,6 +85,7 @@ class searchFtsCtrl extends jController
         // Redirect if no rights to access this repository
         if (!$lproj->checkAcl()) {
             // jMessage::add(jLocale::get('view~default.repository.access.denied'), 'AuthorizationRequired');
+            $rep->setHttpStatus(403, Proxy::getHttpStatusMsg(403));
 
             return $rep;
         }

--- a/lizmap/modules/lizmap/controllers/searchFts.classic.php
+++ b/lizmap/modules/lizmap/controllers/searchFts.classic.php
@@ -69,7 +69,7 @@ class searchFtsCtrl extends jController
         try {
             $lproj = lizmap::getProject($repository.'~'.$project);
             if ($lproj == null) {
-                jLog::log('The lizmap project "'.$project.'" does not exist.', 'lizmapadmin');
+                jLog::log('Error while loading "'.$project.'" project', 'lizmapadmin');
                 $rep->setHttpStatus(400, Proxy::getHttpStatusMsg(400));
 
                 return $rep;
@@ -92,7 +92,7 @@ class searchFtsCtrl extends jController
 
         // Run query
         $fts = jClasses::getService('lizmap~lizmapFts');
-        $data = $fts->getData($lproj, $pquery, $this->boolParam('debug'));
+        $data = $fts::getData($lproj, $pquery, $this->boolParam('debug'));
 
         $rep->data = $data;
 

--- a/tests/end2end/playwright/globals.js
+++ b/tests/end2end/playwright/globals.js
@@ -10,6 +10,11 @@ import * as path from 'path';
  */
 
 /**
+ * Playwright Page
+ * @typedef {import('@playwright/test').APIResponse} APIResponse
+ */
+
+/**
  * Integer
  * @typedef {number} int
  */
@@ -236,6 +241,21 @@ export async function expectToHaveLengthCompare(title, parameters, expectedLengt
             Debug  : ${expectedParameters.join(', ')}\n
             Debug count : ${expectedParameters.length} items`
     ).toHaveLength(expectedLength);
+}
+
+/**
+ * Check for a JSON response
+ * @param {APIResponse} response The response object
+ * @param {int} status The expected HTTP status code
+ * @returns {Promise<any>} The JSON response
+ */
+export async function checkJson(response, status = 200) {
+    if (status < 400){
+        expect(response.ok()).toBeTruthy();
+    }
+    expect(response.status()).toBe(status);
+    expect(response.headers()['content-type']).toBe('application/json');
+    return await response.json();
 }
 
 /* eslint-disable jsdoc/check-types */

--- a/tests/end2end/playwright/location_search.spec.js
+++ b/tests/end2end/playwright/location_search.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-import { gotoMap } from './globals';
+import { checkJson, gotoMap } from './globals';
 
 test.describe('Location search', () => {
 
@@ -104,3 +104,40 @@ test.describe('Location search', () => {
     });
 
 });
+
+
+test.describe('Lizmap Search HTTP code',
+    {
+        tag: ['@requests', '@readonly'],
+    }, () => {
+
+        test('Check wrong requests', async ({request}) => {
+            let params = {
+                'repository': 'testsrepository',
+                'project': 'location_search',
+                'query': 'Montpellier',
+            }
+            let response = await request.get('/index.php/lizmap/searchFts/get?',{params});
+            await checkJson(response);
+
+            params['query'] = 'Tokyo';
+            response = await request.get('/index.php/lizmap/searchFts/get?',{params});
+            await checkJson(response, 200);
+
+            params['query'] = '';
+            response = await request.get('/index.php/lizmap/searchFts/get?',{params});
+            await checkJson(response, 400);
+
+            params['query'] = 'Montpellier';
+            params['project'] = 'does_not_exist';
+            response = await request.get('/index.php/lizmap/searchFts/get?',{params});
+            await checkJson(response, 400);
+
+            params['query'] = 'Montpellier';
+            params['project'] = 'location_search';
+            params['repository'] = null;
+            response = await request.get('/index.php/lizmap/searchFts/get?',{params});
+            await checkJson(response, 400);
+        });
+    }
+);

--- a/tests/end2end/playwright/requests-api.spec.js
+++ b/tests/end2end/playwright/requests-api.spec.js
@@ -1,25 +1,8 @@
 // @ts-check
 import {expect, test} from '@playwright/test';
-import { requestWithAdminBasicAuth } from './globals';
-
-/**
- * Playwright Page
- * @typedef {import('@playwright/test').APIResponse} APIResponse
- */
+import { checkJson, requestWithAdminBasicAuth } from './globals';
 
 const url = 'api.php/admin';
-
-/**
- * Check for a JSON response about the metadata
- * @param {APIResponse} response The response object
- * @returns {Promise<any>} The JSON response
- */
-export async function checkJson(response) {
-    expect(response.ok()).toBeTruthy();
-    expect(response.status()).toBe(200);
-    expect(response.headers()['content-type']).toBe('application/json');
-    return await response.json();
-}
 
 test.describe('Not connected',
     {

--- a/tests/end2end/playwright/requests-metadata.spec.js
+++ b/tests/end2end/playwright/requests-metadata.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-import { requestWithAdminBasicAuth, getAuthStorageStatePath } from './globals';
+import { checkJson as coreCheckJson, requestWithAdminBasicAuth, getAuthStorageStatePath } from './globals';
 
 /**
  * Playwright Page
@@ -15,10 +15,7 @@ const url = 'index.php/view/app/metadata';
  * @returns {Promise<any>} The JSON response
  */
 export async function checkJson(response) {
-    expect(response.ok()).toBeTruthy();
-    expect(response.status()).toBe(200);
-    expect(response.headers()['content-type']).toBe('application/json');
-    const json = await response.json();
+    const json = await coreCheckJson(response);
 
     // LWC metadata are always accessible...
     expect(json.info.version).toBeDefined();


### PR DESCRIPTION
Lizmap search was always return HTTP code 200 even if the query has failed.

It returns now correct HTTP code, and logging in the admin panel at the same time in case of an exception.

Follow up from previous PR #5619
