### PR TITLE
UX - Add tooltips on buttons in the maps management page (and remove this 1/0 about user defined themes)

### DIFF
--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -47,8 +47,11 @@ Please contact the application administrator.
 
 configuration.button.modify.service.label=Modify
 configuration.button.view.repository.label=View
+configuration.button.view.repository.tooltip=Open the landing page with only this repository
 configuration.button.modify.repository.label=Modify
+configuration.button.modify.repository.tooltip=Change the settings of this repository
 configuration.button.remove.repository.label=Remove
+configuration.button.remove.repository.tooltip=Remove this repository (it will not delete the files from the server)
 configuration.button.remove.repository.confirm.label=Would you like to remove this repository?
 configuration.button.add.repository.label=Create a repository
 
@@ -205,6 +208,7 @@ cache.repository.removed=The cache for the repository %s has been successfully e
 cache.layer.removed=The cache for the layer %s has been successfully emptied.
 cache.button.remove.repository.cache.confirm.label=Would you like to empty the cache for this repository?
 cache.button.remove.repository.cache.label=Empty cache
+cache.button.remove.repository.cache.tooltip=Remove the cache related to the layers tiles
 
 logs.counter.title=Log count
 logs.detail.title=Log detail

--- a/lizmap/modules/admin/templates/maps.tpl
+++ b/lizmap/modules/admin/templates/maps.tpl
@@ -35,8 +35,16 @@
                                         <th>{@admin~admin.form.admin_section.repository.$prop.label@}</th><td>{$d}</td>
                                     {/if}
                                 {else}
-                                    <!-- FIXME don't use getData() which is deprecated -->
-                                    <th>{@admin~admin.form.admin_section.repository.$prop.label@}</th><td>{$repo->getData($prop)}</td>
+                                    {* FIXME don't use getData() which is deprecated *}
+                                    {assign $value = $repo->getData($prop)}
+                                    {if $prop == 'allowUserDefinedThemes'}
+                                        {if $value == 1}
+                                            {assign $value = '✔️'}
+                                        {else}
+                                            {assign $value = '-'}
+                                        {/if}
+                                    {/if}
+                                <th>{@admin~admin.form.admin_section.repository.$prop.label@}</th><td>{$value}</td>
                                 {/if}
                             </tr>
                         {/foreach}
@@ -61,18 +69,37 @@
             <div class="form-actions">
                 <!-- View repository page -->
                 {ifacl2 'lizmap.repositories.view', $repo->getKey()}
-                    <a class="btn" href="{jurl 'view~default:index', array('repository'=>$repo->getKey())}" target="_blank">{@admin~admin.configuration.button.view.repository.label@}</a>
+                    <a
+                        class="btn"
+                        href="{jurl 'view~default:index', array('repository'=>$repo->getKey())}"
+                        target="_blank"
+                        title="{@admin~admin.configuration.button.view.repository.tooltip@}"
+                    >{@admin~admin.configuration.button.view.repository.label@}</a>
                 {/ifacl2}
                 <!-- Modify -->
                 {ifacl2 'lizmap.admin.repositories.update'}
-                    <a class="btn" href="{jurl 'admin~maps:modifySection', array('repository'=>$repo->getKey())}">{@admin~admin.configuration.button.modify.repository.label@}</a>
+                    <a
+                        class="btn"
+                        href="{jurl 'admin~maps:modifySection', array('repository'=>$repo->getKey())}"
+                        title="{@admin~admin.configuration.button.modify.repository.tooltip@}"
+                    >{@admin~admin.configuration.button.modify.repository.label@}</a>
                 {/ifacl2}
                 <!-- Remove -->
                 {ifacl2 'lizmap.admin.repositories.delete'}
-                    <a class="btn" href="{jurl 'admin~maps:removeSection', array('repository'=>$repo->getKey())}" onclick="return confirm(`{@admin~admin.configuration.button.remove.repository.confirm.label@}`)">{@admin~admin.configuration.button.remove.repository.label@}</a>
+                    <a
+                        class="btn"
+                        href="{jurl 'admin~maps:removeSection', array('repository'=>$repo->getKey())}"
+                        onclick="return confirm(`{@admin~admin.configuration.button.remove.repository.confirm.label@}`)"
+                        title="{@admin~admin.configuration.button.remove.repository.tooltip@}"
+                    >{@admin~admin.configuration.button.remove.repository.label@}</a>
                 {/ifacl2}
                 {ifacl2 'lizmap.admin.repositories.delete'}
-                    <a class="btn" href="{jurl 'admin~maps:removeCache', array('repository'=>$repo->getKey())}" onclick="return confirm(`{@admin~admin.cache.button.remove.repository.cache.confirm.label@}`)">{@admin~admin.cache.button.remove.repository.cache.label@}</a>
+                    <a
+                        class="btn"
+                        href="{jurl 'admin~maps:removeCache', array('repository'=>$repo->getKey())}"
+                        onclick="return confirm(`{@admin~admin.cache.button.remove.repository.cache.confirm.label@}`)"
+                        title="{@admin~admin.cache.button.remove.repository.cache.tooltip@}"
+                    >{@admin~admin.cache.button.remove.repository.cache.label@}</a>
                 {/ifacl2}
             </div>
         </div>


### PR DESCRIPTION
* Remove this legacy `1` or `0` about "allow user defined themes"
* Add tooltips on buttons, ref https://github.com/3liz/lizmap-web-client/issues/5607#issuecomment-2792511447