### PR TITLE
Remove BBOX and proj name from the landing page

### DIFF
--- a/lizmap/modules/view/templates/view.tpl
+++ b/lizmap/modules/view/templates/view.tpl
@@ -16,6 +16,7 @@
       <div id="liz-project-{$mi->id}-{$p->id}" class="liz-project"
         data-lizmap-repository="{$mi->id}"
         data-lizmap-project="{$p->id}"
+        data-lizmap-keywords="{$p->keywordList}"
         data-lizmap-bbox="{$p->bbox}"
         data-lizmap-proj="{$p->proj}">
         <a class="liz-project-view" href="{$p->url}{if $hide_header}&h=0{/if}">
@@ -26,9 +27,6 @@
             <br/><b>{@default.project.abstract.label@}</b>&nbsp;: <span class="abstract">{$p->abstract|strip_tags|truncate:100}</span>
             <br/>
             <br/><b>{@default.project.keywordList.label@}</b>&nbsp;: <span class="keywordList">{$p->keywordList}</span>
-            <br/>
-            <br/><b>{@default.project.projection.label@}</b>&nbsp;: <span class="proj">{$p->proj}</span>
-            <br/><b>{@default.project.bbox.label@}</b>&nbsp;: <span class="bbox">{$p->bbox}</span>
           </p>
         </a>
       </div>

--- a/tests/end2end/playwright/project-homepage.spec.js
+++ b/tests/end2end/playwright/project-homepage.spec.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
 
-test.describe('Projects homepage', function () {
+test.describe('Projects homepage @readonly', function () {
 
     test.beforeEach(async ({ page }) => {
         const url = '/index.php/view/';
@@ -10,56 +10,66 @@ test.describe('Projects homepage', function () {
 
     test('should display project metadata (cold cache)', async function ({ page }) {
 
-        const allmetadata = page.locator('.liz-project-desc').filter({ hasText: 'Test tags: nature, flower' });
-        await expect(allmetadata).not.toBeVisible();
+        let project = page.locator('.liz-project').filter({ hasText: 'Test tags: nature, flower' });
+        await expect(project).toHaveAttribute(
+            "data-lizmap-proj",'EPSG:4326');
+        await expect(project).toHaveAttribute(
+            "data-lizmap-bbox", '-1.2459627329192546, -1.0, 1.2459627329192546, 1.0');
 
-        await page.getByRole('link').filter({ has: allmetadata }).hover();
-        await expect(allmetadata).toBeVisible();
-        await expect(allmetadata.locator('.title')).toContainText('Test tags: nature, flower');
-        await expect(allmetadata.locator('.abstract')).toContainText('This is an abstract');
-        await expect(allmetadata.locator('.keywordList')).toContainText('nature, flower');
-        await expect(allmetadata.locator('.proj')).toContainText('EPSG:4326');
-        await expect(allmetadata.locator('.bbox')).toContainText('-1.2459627329192546, -1.0, 1.2459627329192546, 1.0');
+        const allMetadata = await project.locator('.liz-project-desc');
+        await expect(allMetadata).not.toBeVisible();
+
+        await project.hover();
+        await expect(allMetadata).toBeVisible();
+        await expect(allMetadata.locator('.title')).toContainText('Test tags: nature, flower');
+        await expect(allMetadata.locator('.abstract')).toContainText('This is an abstract');
+        await expect(allMetadata.locator('.keywordList')).toContainText('nature, flower');
 
         // hover on header
         await page.locator('#headermenu').hover();
-        await expect(allmetadata).not.toBeVisible();
+        await expect(allMetadata).not.toBeVisible();
 
         // another project
-        const allmetadataTree = page.locator('.liz-project-desc').filter({ hasText: 'Tests tags: nature, tree' });
-        await expect(allmetadataTree).not.toBeVisible();
+        project = page.locator('.liz-project').filter({ hasText: 'Tests tags: nature, tree' });
+        await expect(project).toHaveAttribute(
+            "data-lizmap-proj",'EPSG:4326');
+        await expect(project).toHaveAttribute(
+            "data-lizmap-bbox", '-1.2459627329192546, -1.0, 1.2459627329192546, 1.0');
 
-        await page.getByRole('link').filter({ has: allmetadataTree }).hover();
-        await expect(allmetadataTree).toBeVisible();
-        await expect(allmetadataTree.locator('.title')).toContainText('Tests tags: nature, tree');
-        await expect(allmetadataTree.locator('.abstract')).toContainText('Tags: nature, tree');
-        await expect(allmetadataTree.locator('.keywordList')).toContainText('nature, tree');
-        await expect(allmetadataTree.locator('.proj')).toContainText('EPSG:4326');
-        await expect(allmetadataTree.locator('.bbox')).toContainText('-1.2459627329192546, -1.0, 1.2459627329192546, 1.0');
+        const allMetadataTree = project.locator('.liz-project-desc');
+        await expect(allMetadataTree).not.toBeVisible();
+
+        await project.hover();
+        await expect(allMetadataTree).toBeVisible();
+        await expect(allMetadataTree.locator('.title')).toContainText('Tests tags: nature, tree');
+        await expect(allMetadataTree.locator('.abstract')).toContainText('Tags: nature, tree');
+        await expect(allMetadataTree.locator('.keywordList')).toContainText('nature, tree');
 
         // hover on header
         await page.locator('#headermenu').hover();
-        await expect(allmetadataTree).not.toBeVisible();
+        await expect(allMetadataTree).not.toBeVisible();
 
     });
 
     test('should display project metadata (hot cache)', async function ({ page }) {
 
+        const project = page.locator('.liz-project').filter({ hasText: 'Test tags: nature, flower' });
+        await expect(project).toHaveAttribute(
+            "data-lizmap-proj",'EPSG:4326');
+        await expect(project).toHaveAttribute(
+            "data-lizmap-bbox", '-1.2459627329192546, -1.0, 1.2459627329192546, 1.0');
+        const allMetadata = project.locator('.liz-project-desc');
+        await expect(allMetadata).not.toBeVisible();
 
-        const allmetadata = page.locator('.liz-project-desc').filter({ hasText: 'Test tags: nature, flower' });
-        await expect(allmetadata).not.toBeVisible();
-
-        await page.getByRole('link').filter({ has: allmetadata }).hover();
-        await expect(allmetadata).toBeVisible();
-        await expect(allmetadata.locator('.title')).toContainText('Test tags: nature, flower');
-        await expect(allmetadata.locator('.abstract')).toContainText('This is an abstract');
-        await expect(allmetadata.locator('.keywordList')).toContainText('nature, flower');
-        await expect(allmetadata.locator('.proj')).toContainText('EPSG:4326');
-        await expect(allmetadata.locator('.bbox')).toContainText('-1.2459627329192546, -1.0, 1.2459627329192546, 1.0');
+        await project.hover();
+        await expect(allMetadata).toBeVisible();
+        await expect(allMetadata.locator('.title')).toContainText('Test tags: nature, flower');
+        await expect(allMetadata.locator('.abstract')).toContainText('This is an abstract');
+        await expect(allMetadata.locator('.keywordList')).toContainText('nature, flower');
 
         // hover on header
         await page.locator('#headermenu').hover();
-        await expect(allmetadata).not.toBeVisible();
+        await expect(allMetadata).not.toBeVisible();
 
     });
 });


### PR DESCRIPTION
Read my comment https://github.com/3liz/lizmap-web-client/pull/4032#issuecomment-2056588757 exactly one year ago, I'm keen to have feedbacks.

These extents are not human-readable and are not designed to be shown like this IMHO. (especially on a landing page, for end users)

~I'm even thinking to backport to 3.8.~

The next step is to remove totally this hover div I think, but first removing these numbers.

Linked to #3558 cc @gioman 