### PR TITLE
Remove BBOX and proj name from project info

### DIFF
--- a/lizmap/modules/view/locales/en_US/default.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/default.UTF-8.properties
@@ -14,8 +14,6 @@ project.access.denied=Access denied for this project.
 project.title.label=Title
 project.abstract.label=Abstract
 project.keywordList.label=Keyword list
-project.projection.label=Projection
-project.bbox.label=Bounding Box
 
 project.open.map=Load the map
 project.open.map.metadata=View metadata

--- a/lizmap/modules/view/templates/view.tpl
+++ b/lizmap/modules/view/templates/view.tpl
@@ -72,22 +72,6 @@
                             <dd>{$p->abstract|nl2br}&nbsp;</dd>
                         </div>
                     </dl>
-                    <dl class="row">
-                        <div class="col text-end">
-                            <dt>{@default.project.projection.label@}</dt>
-                        </div>
-                        <div class="col-8">
-                            <dd><span class="proj">{$p->proj}</span>&nbsp;</dd>
-                        </div>
-                    </dl>
-                    <dl class="row">
-                        <div class="col text-end">
-                            <dt>{@default.project.bbox.label@}</dt>
-                        </div>
-                        <div class="col-8">
-                            <dd><span class="bbox">{$p->bbox}</span></dd>
-                        </div>
-                    </dl>
                     {if $p->wmsGetCapabilitiesUrl}
                     <dl class="row">
                         <div class="col text-end">


### PR DESCRIPTION
Same as #5635

Extents are not human readable. Lizmap is used by non GIS end users. If some people want to display these extents, they can still do it with some Javascript with these data-attributes `data-lizmap-bbox`, `data-lizmap-proj`

Keen to have feedback, it will be merged after #5635

Fix #3558 cc @gioman