### PR TITLE
Force QGIS Server to use Py-QGIS-Server

### DIFF
--- a/lizmap/app/system/mainconfig.ini.php
+++ b/lizmap/app/system/mainconfig.ini.php
@@ -50,6 +50,13 @@ lizmapDesktopPluginDate="2025-02-14"
 ; 3 versions behind the current version of LWC
 lizmapWebClientTargetVersion=30600
 
+[qgisWrapper]
+; If off, FCGI is not allowed, only Py-QGIS-Server or QJazz
+; https://docs.lizmap.com/current/en/install/py-qgis-server.html
+; https://docs.3liz.org/py-qgis-server/
+; https://github.com/3liz/qjazz
+allowFcgi=off
+
 [lizmap]
 ; CSP header for the map interface
 ; Exemple value: "default-src 'self' http: https:;connect-src 'self' http: https:;script-src http: https: 'unsafe-inline' 'unsafe-eval'; style-src http: https: 'unsafe-inline';object-src 'none';font-src https:;base-uri 'self';form-action 'self' http: https:;img-src http: https: data: blob:;frame-ancestors http: https:"

--- a/lizmap/modules/admin/controllers/server_information.classic.php
+++ b/lizmap/modules/admin/controllers/server_information.classic.php
@@ -41,6 +41,13 @@ class server_informationCtrl extends jController
         $currentQgisVersion = $server->getQgisServerVersion();
         $currentLizmapVersion = $server->getLizmapPluginServerVersion();
 
+        // Check QGIS server wrapper
+        $checkQgisServerWrapper = $server->checkQgisServerWrapper();
+        $qgisServerWrapperLabel = jLocale::get('admin.server.information.qgis.wrapper.force.html');
+        if (!$checkQgisServerWrapper) {
+            jLog::log($qgisServerWrapperLabel, 'lizmapadmin');
+        }
+
         // Check their status
         if (is_null($currentQgisVersion) || is_null($currentLizmapVersion)) {
             // Either QGIS server or Lizmap QGIS server were not found
@@ -84,6 +91,8 @@ class server_informationCtrl extends jController
             'installationComplete' => $modules->compareLizmapCoreModulesVersions($data['info']['version']),
             'qgisServerNeedsUpdate' => $qgisServerNeedsUpdate,
             'updateQgisServer' => $updateQgisServer,
+            'checkQgisServerWrapper' => $checkQgisServerWrapper,
+            'qgisServerWrapperLabel' => $qgisServerWrapperLabel,
             'lizmapQgisServerNeedsUpdate' => $lizmapQgisServerNeedsUpdate,
             'lizmapPluginUpdate' => $updateLizmapPlugin,
             'minimumQgisVersion' => $qgisMinimumVersionRequired,

--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -307,6 +307,8 @@ You might need to increase debug level.
 server.information.qgis.error.fetching.information.detail.NO_ACCESS=You don't have access to information about QGIS Server
 server.information.qgis.error.fetching.information.detail.HTTP_ERROR=QGIS Server returns an HTTP error about the Lizmap plugin:
 server.information.qgis.update=QGIS Server needs to be updated at least to version %s for this version of Lizmap Web Client.
+server.information.qgis.wrapper.force.html=This installation does not allow QGIS with FCGI, either Py-QGIS-Server or QJazz must be used. \
+This check about the QGIS wrapper can be disabled in <code>lizmap/var/config/localconfig.ini.php.dist</code>.
 server.information.plugin.update=The plugin must be updated.
 server.information.qgis.unknown=QGIS server minimum %s and Lizmap QGIS server plugin minimum %s need to be installed and configured correctly. \
 Your QGIS server couldn't be reached correctly with the given URL "%s".

--- a/lizmap/modules/admin/templates/server_information.tpl
+++ b/lizmap/modules/admin/templates/server_information.tpl
@@ -13,6 +13,11 @@
           {@admin.server.information.installation.not.complete.html@}
       </div>
     {/if}
+    {if !$checkQgisServerWrapper}
+      <div class="alert alert-danger" role="alert">
+          {$qgisServerWrapperLabel}
+      </div>
+    {/if}
     <table class="table table-striped table-bordered table-server-info table-lizmap-web-client">
         <tr>
             <th>{@admin.server.information.lizmap.info.version@}</th>

--- a/lizmap/modules/lizmap/lib/Server/Server.php
+++ b/lizmap/modules/lizmap/lib/Server/Server.php
@@ -75,6 +75,35 @@ class Server
         return $this->metadata['qgis_server_info']['metadata']['version'];
     }
 
+    /** Check if QGIS Server wrapper FCGI is allowed.
+     * According to the setting "qgisWrapper/allowFcgi",
+     * if 'off' then Py-QGIS-Server or QJazz are checked and must be used.
+     *
+     * @return bool boolean If Py-QGIS-Server or QJazz must be used
+     */
+    public function checkQgisServerWrapper()
+    {
+        if (\jApp::config()->qgisWrapper['allowFcgi'] == 'on') {
+            // FCGI is allowed, we do not check further the installation.
+            // QGIS Server must be OK. There is another check about the state of QGIS with its Lizmap plugin.
+            return true;
+        }
+
+        // FCGI is not allowed, we check if Py-QGIS-Server or QJazz is correctly installed.
+
+        // As of 05/05/2025, with QJazz, it is also included inside the "py_qgis_server" JSON section.
+        // Maybe it will be changed soon.
+        if (!array_key_exists('py_qgis_server', $this->metadata['qgis_server_info'])) {
+            return false;
+        }
+
+        if (!array_key_exists('found', $this->metadata['qgis_server_info']['py_qgis_server'])) {
+            return false;
+        }
+
+        return $this->metadata['qgis_server_info']['py_qgis_server']['found'];
+    }
+
     /** Check if a QGIS server plugin needs to be updated.
      *
      * @param string $currentVersion  The current version to check

--- a/lizmap/modules/view/controllers/default.classic.php
+++ b/lizmap/modules/view/controllers/default.classic.php
@@ -124,6 +124,12 @@ class defaultCtrl extends jController
             $requiredQgisVersion = jApp::config()->minimumRequiredVersion['qgisServer'];
             $currentQgisVersion = $server->getQgisServerVersion();
 
+            // Check QGIS server wrapper
+            $isQgisWrapperOk = $server->checkQgisServerWrapper();
+            if (!$isQgisWrapperOk) {
+                $checkServerInformation = true;
+            }
+
             // Check Lizmap server status
             $requiredLizmapVersion = jApp::config()->minimumRequiredVersion['lizmapServerPlugin'];
             $currentLizmapVersion = $server->getLizmapPluginServerVersion();

--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -7,7 +7,7 @@ use Lizmap\Request\RemoteStorageRequest;
 use Lizmap\Server\Server;
 
 /**
- * Displays a full featured map based on one Qgis project.
+ * Displays a full featured map based on one QGIS project.
  *
  * @author    3liz
  * @copyright 2011 3liz
@@ -83,6 +83,13 @@ class lizMapCtrl extends jController
         // Check if they are found and also their versions
         if ($server->versionCompare($currentQgisVersion, $requiredQgisVersion)
             || $server->pluginServerNeedsUpdate($currentLizmapVersion, $requiredLizmapVersion)) {
+            jMessage::add(jLocale::get('view~default.server.information.error'), 'error');
+
+            return $rep;
+        }
+
+        // Check QGIS Server wrapper
+        if (!$server->checkQgisServerWrapper()) {
             jMessage::add(jLocale::get('view~default.server.information.error'), 'error');
 
             return $rep;

--- a/lizmap/var/config/localconfig.ini.php.dist
+++ b/lizmap/var/config/localconfig.ini.php.dist
@@ -15,6 +15,12 @@
 ;; see documentation to complete the ldap configuration
 ;ldapdao.enable=on
 
+[qgisWrapper]
+; If off, FCGI is not allowed, only Py-QGIS-Server or QJazz
+; https://docs.lizmap.com/current/en/install/py-qgis-server.html
+; https://docs.3liz.org/py-qgis-server/
+; https://github.com/3liz/qjazz
+; allowFcgi=off
 
 [coordplugin_auth]
 ;; uncomment it if you want to use ldap for authentication


### PR DESCRIPTION
Given the discussion in #5567 and that many "Lizmap" developers haven't used or tried QGIS FCGI for many years, I'm adding a setting to force or not Py-QGIS-Server.

By default, Py-QGIS-Server must be used according to the default value in the settings file. This can be changed of course.

Linked to https://github.com/3liz/lizmap-documentation/pull/272
