### PR TITLE
Fix: When using quick search menu you can't zoom back to a feature after moving the map

### DIFF
--- a/assets/src/modules/Search.js
+++ b/assets/src/modules/Search.js
@@ -361,7 +361,7 @@ export default class Search {
                     var bbox = linkClicked.getAttribute('href').replace('#', '');
                     bbox = OpenLayers.Bounds.fromString(bbox);
                     bbox.transform(wgs84, this._lizmap3.map.getProjectionObject());
-                    this._lizmap3.map.zoomToExtent(bbox);
+                    lizMap.mainLizmap.map.getView().fit(bbox.toArray());
 
                     var feat = new OpenLayers.Feature.Vector(bbox.toGeometry().getCentroid());
                     var geomWKT = linkClicked.dataset.wkt;


### PR DESCRIPTION
Fix: When using quick search menu you can't zoom back to a feature after moving the map

Fix #5564

Funded by 3liz
