### PR TITLE
Minor updates on docstring PHP in the project API

### DIFF
--- a/lizmap/modules/admin_api/controllers/project_rest.classic.php
+++ b/lizmap/modules/admin_api/controllers/project_rest.classic.php
@@ -95,7 +95,7 @@ class project_restCtrl extends RestApiCtrl
 
         $response = array(
             'id' => $proj->getKey(),
-            'projectname' => $projInfos['projectname'],
+            'projectName' => $projInfos['projectName'],
             'title' => $proj->getTitle(),
             'abstract' => $proj->getAbstract(),
             'keywordList' => $proj->getKeywordsList(),

--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -1705,9 +1705,9 @@ class QgisProject
     }
 
     /**
-     * Retrieve the first QGIS config line as array.
+     * Retrieve the first QGIS config line as an array.
      *
-     * @return array Array filled with version, projectname, saveDateTime, saveUser and saveUserFull
+     * @return array Array filled with "version", "projectName", "saveDateTime", "saveUser" and "saveUserFull"
      *
      * @throws \Exception
      *
@@ -1716,7 +1716,7 @@ class QgisProject
      *   saveUserFull="Chandler Bing" version="3.34.12-Prizren"
      * >
      */
-    public function getFirstQgisConfigLine()
+    public function getFirstQgisConfigLine(): array
     {
         $xmlReader = App\XmlTools::xmlReaderFromFile($this->path);
 
@@ -1732,7 +1732,7 @@ class QgisProject
                 && $xmlReader->localName == 'qgis') {
                 $data = array(
                     'version' => $xmlReader->getAttribute('version'),
-                    'projectname' => $xmlReader->getAttribute('projectname'),
+                    'projectName' => $xmlReader->getAttribute('projectname'),
                     'saveDateTime' => $xmlReader->getAttribute('saveDateTime'),
                     'saveUser' => $xmlReader->getAttribute('saveUser'),
                     'saveUserFull' => $xmlReader->getAttribute('saveUserFull'),

--- a/tests/end2end/playwright/requests-api.spec.js
+++ b/tests/end2end/playwright/requests-api.spec.js
@@ -75,7 +75,7 @@ test.describe('Connected',
             const json = await checkJson(response);
 
             expect(json.id).toBe("attribute_table");
-            expect(json.projectname).toBeDefined();
+            expect(json.projectName).toBeDefined();
             expect(json.title).toBe("attribute_table");
             expect(json.abstract).toBe("");
             expect(json.keywordList).toBe("");


### PR DESCRIPTION
Follow up from #5596 

All variables were using camelCase convention. So I have changed in the API, despite the value in the XML which is `projectname`.