### PR TITLE
Fix CORS allow methods when OPTIONS Request

### DIFF
--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -164,7 +164,7 @@ class serviceCtrl extends jController
         /** @var jResponseText $resp */
         $resp = $this->getResponse('text');
         if ($this->request->header('Origin')) {
-            $resp->addHttpHeader('Access-Control-Allow-Methods', 'GET,POST');
+            $resp->addHttpHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
             $resp->addHttpHeader('Access-Control-Request-Headers', $this->request->header('Access-Control-Request-Headers'));
             $resp->addHttpHeader('Access-Control-Allow-Credentials', 'true');
             $resp->addHttpHeader('Access-Control-Max-Age', '3600');


### PR DESCRIPTION
For OPTIONS request, the OPTIONS method was not explicit in the Access-Control-Allow-Methods instead of the other methods.

Funded by SMICA