### PR TITLE
[Backport release_3_8] Fix: When using quick search menu you can't zoom back to a feature after moving the map

### DIFF
--- a/assets/src/modules/Search.js
+++ b/assets/src/modules/Search.js
@@ -351,9 +351,9 @@ export default class Search {
                     evt.preventDefault();
                     const linkClicked = evt.currentTarget;
                     var bbox = linkClicked.getAttribute('href').replace('#', '');
-                    var bbox = OpenLayers.Bounds.fromString(bbox);
+                    bbox = OpenLayers.Bounds.fromString(bbox);
                     bbox.transform(wgs84, this._map.getProjectionObject());
-                    this._map.zoomToExtent(bbox);
+                    lizMap.mainLizmap.map.getView().fit(bbox.toArray());
 
                     var feat = new OpenLayers.Feature.Vector(bbox.toGeometry().getCentroid());
                     var geomWKT = linkClicked.dataset.wkt;


### PR DESCRIPTION
Backport #5653
 **Authored by:** @nboisteault