### PR TITLE
[Backport release_3_8] Fix: incorrect replacement in `<a href="media/"><img src="media/"></a>`

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -668,7 +668,7 @@ class WMSRequest extends OGCRequest
                 $templateConfigured = true;
                 // first replace all "media/bla/bla/media.ext" by full url
                 $popupTemplate = preg_replace_callback(
-                    '#(["\']){1}((\.\./)?media/.+\.\w{3,10})(["\']){1}#',
+                    '#(["\']){1}((\.\./)?media/.+\.\w{3,10})(["\']){1}#U',
                     array($this, 'replaceMediaPathByMediaUrl'),
                     $popupTemplate
                 );
@@ -747,7 +747,7 @@ class WMSRequest extends OGCRequest
                 if ($attribute['name'] == 'maptip') {
                     // first replace all "media/bla/bla/media.ext" by full url
                     $maptipValue = preg_replace_callback(
-                        '#(["\']){1}((\.\./)?media/.+\.\w{3,10})(["\']){1}#',
+                        '#(["\']){1}((\.\./)?media/.+\.\w{3,10})(["\']){1}#U',
                         array($this, 'replaceMediaPathByMediaUrl'),
                         $attribute['value']
                     );

--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -21,7 +21,7 @@ class WMSRequest extends OGCRequest
 {
     protected $tplExceptions = 'lizmap~wms_exception';
 
-    protected static $regexp_media_urls = '#["\']((\.\./)?media/.+?\.\w{3,10})["\']{1}#';
+    protected static $regexp_media_urls = '#["\']((\.\./)?media/.+?\.\w{2,10})["\']{1}#';
 
     private $forceRequest = false;
 

--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -21,6 +21,8 @@ class WMSRequest extends OGCRequest
 {
     protected $tplExceptions = 'lizmap~wms_exception';
 
+    protected static $regexp_media_urls = '#["\']((\.\./)?media/.+?\.\w{3,10})["\']{1}#';
+
     private $forceRequest = false;
 
     public function getForceRequest()
@@ -668,7 +670,7 @@ class WMSRequest extends OGCRequest
                 $templateConfigured = true;
                 // first replace all "media/bla/bla/media.ext" by full url
                 $popupTemplate = preg_replace_callback(
-                    '#(["\']){1}((\.\./)?media/.+\.\w{3,10})(["\']){1}#U',
+                    self::$regexp_media_urls,
                     array($this, 'replaceMediaPathByMediaUrl'),
                     $popupTemplate
                 );
@@ -747,7 +749,7 @@ class WMSRequest extends OGCRequest
                 if ($attribute['name'] == 'maptip') {
                     // first replace all "media/bla/bla/media.ext" by full url
                     $maptipValue = preg_replace_callback(
-                        '#(["\']){1}((\.\./)?media/.+\.\w{3,10})(["\']){1}#U',
+                        self::$regexp_media_urls,
                         array($this, 'replaceMediaPathByMediaUrl'),
                         $attribute['value']
                     );
@@ -874,14 +876,13 @@ class WMSRequest extends OGCRequest
     protected function replaceMediaPathByMediaUrl($matches)
     {
         $appContext = $this->appContext;
-        $req = $appContext->getCoord()->request;
         $return = '"';
         $return .= $appContext->getFullUrl(
             'view~media:getMedia',
             array(
                 'repository' => $this->repository->getKey(),
                 'project' => $this->project->getKey(),
-                'path' => $matches[2],
+                'path' => $matches[1],
             )
         );
         $return .= '"';

--- a/tests/end2end/playwright/popup.spec.js
+++ b/tests/end2end/playwright/popup.spec.js
@@ -263,6 +263,11 @@ test.describe('Popup',
         await expect(project.map.locator('#liz_layer_popup')).toBeVisible();
         await expect(project.map.locator('#liz_layer_popup_contentDiv > div > div > div > ul > li.active > a')).toBeVisible();
         await expect(project.map.locator('#liz_layer_popup_contentDiv > div > div > div > ul > li:nth-child(2) > a')).toBeVisible();
+
+        // Assert media links are replaced by the lizmap media service
+        const mediaLink = 'http://localhost:8130/index.php/view/media/getMedia?repository=testsrepository&project=popup&path=media%2Fimages%2Fmontpellier.qgs.webp';
+        await expect(page.locator('#popup_dd_1_tab1 a')).toHaveAttribute('href', mediaLink);
+        await expect(page.locator('#popup_dd_1_tab1 a img')).toHaveAttribute('src', mediaLink);
     });
 
     test('changes popup tab', async ({ page }) => {

--- a/tests/qgis-projects/tests/popup.qgs
+++ b/tests/qgis-projects/tests/popup.qgs
@@ -42,8 +42,8 @@
   </layer-tree-group>
   <snapping-settings enabled="0" intersection-snapping="0" maxScale="0" minScale="0" mode="2" scaleDependencyMode="0" self-snapping="0" tolerance="12" type="1" unit="1">
     <individual-layer-settings>
-      <layer-setting enabled="0" id="dnd_popup_3b9d335a_5491_45fa_8a8b_8dca1ca7ff3b" maxScale="0" minScale="0" tolerance="12" type="1" units="1"></layer-setting>
       <layer-setting enabled="0" id="townhalls_pg_6c85c4bf_fe76_46b1_8445_0041d55d6e76" maxScale="0" minScale="0" tolerance="12" type="1" units="1"></layer-setting>
+      <layer-setting enabled="0" id="dnd_popup_3b9d335a_5491_45fa_8a8b_8dca1ca7ff3b" maxScale="0" minScale="0" tolerance="12" type="1" units="1"></layer-setting>
     </individual-layer-settings>
   </snapping-settings>
   <relations>
@@ -971,6 +971,7 @@ def my_form_open(dialog, layer, feature):
                         )
                         ELSE ''
                     END %]
+	&lt;a href="media/images/montpellier.qgs.webp" target="_blank"&gt;&lt;img src="media/images/montpellier.qgs.webp"&gt;&lt;/a&gt;
   &lt;/div&gt;
 
   &lt;div id="popup_dd_[% $id %]_tab2" class="tab-pane "&gt;

--- a/tests/units/classes/Request/WMSRequestTest.php
+++ b/tests/units/classes/Request/WMSRequestTest.php
@@ -284,6 +284,18 @@ class WMSRequestTest extends TestCase
             $maptipValue,
         );
 
+        // Accepted extensions with 2 characters
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'src="media/foobar.7z"',
+            $matches,
+        );
+        $this->assertCount(2, $matches);
+        $this->assertEquals(
+            'media/foobar.7z',
+            $matches[1],
+        );
+
         // does not match directory
         preg_match(
             $wms->getRegexpMediaUrlsForTests(),
@@ -308,6 +320,13 @@ class WMSRequestTest extends TestCase
         preg_match(
             $wms->getRegexpMediaUrlsForTests(),
             'src="media/.bar"',
+            $matches,
+        );
+        $this->assertCount(0, $matches);
+        // does not match extension with 1 character
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'src="media/foobar.z"',
             $matches,
         );
         $this->assertCount(0, $matches);

--- a/tests/units/classes/Request/WMSRequestTest.php
+++ b/tests/units/classes/Request/WMSRequestTest.php
@@ -220,4 +220,96 @@ class WMSRequestTest extends TestCase
         $this->assertEquals($expectedUseCache, $useCache);
         $this->assertEquals($expectedWmsClient, $wmsClient);
     }
+
+    public function testRegexpMediaUrls(): void
+    {
+        $testContext = new ContextForTests();
+        $wms = new WMSRequestForTests(new ProjectForOGCForTests($testContext), array(), null);
+
+        // src attribute for media directory
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'src="media/foo.bar"',
+            $matches,
+        );
+        $this->assertCount(2, $matches);
+        $this->assertEquals(
+            'media/foo.bar',
+            $matches[1],
+        );
+        // href attribute for media directory
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'href="media/foo.bar"',
+            $matches,
+        );
+        $this->assertCount(2, $matches);
+        $this->assertEquals(
+            'media/foo.bar',
+            $matches[1],
+        );
+
+        // src attribute for parent media directory
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'src="../media/foo.bar"',
+            $matches,
+        );
+        $this->assertCount(3, $matches);
+        $this->assertEquals(
+            '../media/foo.bar',
+            $matches[1],
+        );
+
+        // href attribute for parent media directory
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'href="../media/foo.bar"',
+            $matches,
+        );
+        $this->assertCount(3, $matches);
+        $this->assertEquals(
+            '../media/foo.bar',
+            $matches[1],
+        );
+
+        // multiple attributes like in a maptip
+        $maptipValue = preg_replace_callback(
+            $wms->getRegexpMediaUrlsForTests(),
+            array($wms, 'replaceMediaPathByMediaUrlForTests'),
+            '<a href="media/foo.bar"><img src="media/foo.bar"></a>',
+        );
+        $this->assertEquals(
+            '<a href="getMedia?path=media/foo.bar"><img src="getMedia?path=media/foo.bar"></a>',
+            $maptipValue,
+        );
+
+        // does not match directory
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'src="media/"',
+            $matches,
+        );
+        $this->assertCount(0, $matches);
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'src="media/foo/bar/"',
+            $matches,
+        );
+        $this->assertCount(0, $matches);
+        // does not match no extension
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'src="media/foo/bar"',
+            $matches,
+        );
+        $this->assertCount(0, $matches);
+        // does not match only extension
+        preg_match(
+            $wms->getRegexpMediaUrlsForTests(),
+            'src="media/.bar"',
+            $matches,
+        );
+        $this->assertCount(0, $matches);
+    }
 }

--- a/tests/units/testslib/WMSRequestForTests.php
+++ b/tests/units/testslib/WMSRequestForTests.php
@@ -19,4 +19,14 @@ class WMSRequestForTests extends WMSRequest
     {
         return $this->useCache($configLayer, $params, $profile);
     }
+
+    public function getRegexpMediaUrlsForTests()
+    {
+        return self::$regexp_media_urls;
+    }
+
+    public function replaceMediaPathByMediaUrlForTests($matches)
+    {
+        return '"getMedia?path='.$matches[1].'"';
+    }
 }


### PR DESCRIPTION
Backport #5251
 **Authored by:** @nboisteault 