### PR TITLE
Fix Digitizing module: deactivate it when draw is closed

### DIFF
--- a/assets/src/modules/Digitizing.js
+++ b/assets/src/modules/Digitizing.js
@@ -391,10 +391,16 @@ export class Digitizing {
         this._lizmap3.events.on({
             minidockopened: (e) => {
                 if (e.id == 'measure') {
-                    this.toolSelected = this._tools[0];
+                    this.toolSelected = this._tools[0]; // DigitizingTools.Deactivate
                 } else if (['draw', 'print'].includes(e.id)) {
                     // Display draw for print redlining
                     this.context = e.id === 'print' ? 'draw' : e.id;
+                    this.toggleVisibility(true);
+                }
+            },
+            minidockclosed: (e) => {
+                if (e.id == 'draw') {
+                    this.toolSelected = this._tools[0]; // DigitizingTools.Deactivate
                 }
             }
         });


### PR DESCRIPTION
When closing draw dock, the digitizing is still active. The user can continue drawing even if the interface is not available.

Funded By WPD Onshore France
