### PR TITLE
[Bugfix] The WMS Capability root layer has no bounding boxes

### DIFF
--- a/assets/src/modules/Lizmap.js
+++ b/assets/src/modules/Lizmap.js
@@ -77,7 +77,7 @@ export default class Lizmap {
                 proj4.defs("CRS:84","+proj=longlat +datum=WGS84 +no_defs +type=crs");
                 register(proj4);
                 // Update project projection if its axis orientation is not ENU
-                if (configProj.ref !== "") {
+                if (configProj.ref !== "" && Array.isArray(wmsCapabilities.Capability.Layer.BoundingBox)) {
                     // loop through bounding boxes of the project provided by WMS capabilities
                     for (const bbox of wmsCapabilities.Capability.Layer.BoundingBox) {
                         // If the BBOX CRS is not the same of the project projection, continue.


### PR DESCRIPTION
The WMS Capability XML file sometimes does not contain `BoundingBox` elements in the root `layer` element. So the `wmsCapabilities.Capability.Layer.BoundingBox` is not an array.

Fixed #5730
Fixed #5617
