### PR TITLE
Update Lizmap.js

### DIFF
--- a/assets/src/modules/Lizmap.js
+++ b/assets/src/modules/Lizmap.js
@@ -62,7 +62,7 @@ export default class Lizmap {
                 this._utils = Utils;
 
                 // Register projections if unknown
-                for (const [ref, def] of Object.entries(globalThis['lizProj4'])) {
+                for (const [ref, def] of Object.entries(globalThis['lizProj4'] || {})) {
                     if (ref !== "" && !proj4.defs(ref)) {
                         proj4.defs(ref, def);
                     }


### PR DESCRIPTION
fix https://github.com/3liz/lizmap-web-client/pull/5736#issuecomment-2887080213

```
TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at _createForOfIteratorHelper (Lizmap.js:33:86)
    at Object.configsloaded (Lizmap.js:80:60)
    at initialize.triggerEvent (OpenLayers.js?_r=250515115803:497:145)
    at eval (map.js:3323:33)
    at _callee$ (map.js:3313:53)
    at s (map.js:2:1)
    at Generator.eval (map.js:2:1)
    at Generator.eval [as next] (map.js:2:1)
    at asyncGeneratorStep (map.js:2:1)
    at _next (map.js:2:1)
```


