### PR TITLE
Update Lizmap.js

### DIFF
--- a/assets/src/modules/Lizmap.js
+++ b/assets/src/modules/Lizmap.js
@@ -82,7 +82,11 @@ export default class Lizmap {
                 // child which could be a layer or a group.
                 let wmsLayer = wmsCapabilities.Capability.Layer;
                 while (wmsLayer.BoundingBox === undefined) {
-                    for (const wmsChildLayer of wmsLayer.Layer || {}) {
+                    // breaking while before the loop because wmsLayer.Layer is not iterable
+                    if (wmsLayer.Layer === undefined) {
+                        break;
+                    }
+                    for (const wmsChildLayer of wmsLayer.Layer) {
                         if (Array.isArray(wmsChildLayer.BoundingBox)) {
                             wmsLayer = wmsChildLayer;
                             break;

--- a/assets/src/modules/Lizmap.js
+++ b/assets/src/modules/Lizmap.js
@@ -97,7 +97,7 @@ export default class Lizmap {
                 // Update project projection if its axis orientation is not ENU
                 if (configProj.ref !== "" && Array.isArray(wmsLayer.BoundingBox)) {
                     // loop through bounding boxes of the project provided by WMS capabilities
-                    for (const bbox of wmsLayer.BoundingBox || {}) {
+                    for (const bbox of wmsLayer.BoundingBox) {
                         // If the BBOX CRS is not the same of the project projection, continue.
                         if (bbox.crs !== configProj.ref) {
                             continue;

--- a/assets/src/modules/Lizmap.js
+++ b/assets/src/modules/Lizmap.js
@@ -62,7 +62,7 @@ export default class Lizmap {
                 this._utils = Utils;
 
                 // Register projections if unknown
-                for (const [ref, def] of Object.entries(globalThis['lizProj4'])) {
+                for (const [ref, def] of Object.entries(globalThis['lizProj4'] || {})) {
                     if (ref !== "" && !proj4.defs(ref)) {
                         proj4.defs(ref, def);
                     }
@@ -82,7 +82,7 @@ export default class Lizmap {
                 // child which could be a layer or a group.
                 let wmsLayer = wmsCapabilities.Capability.Layer;
                 while (wmsLayer.BoundingBox === undefined) {
-                    for (const wmsChildLayer of wmsLayer.Layer) {
+                    for (const wmsChildLayer of wmsLayer.Layer || {}) {
                         if (Array.isArray(wmsChildLayer.BoundingBox)) {
                             wmsLayer = wmsChildLayer;
                             break;
@@ -93,7 +93,7 @@ export default class Lizmap {
                 // Update project projection if its axis orientation is not ENU
                 if (configProj.ref !== "" && Array.isArray(wmsLayer.BoundingBox)) {
                     // loop through bounding boxes of the project provided by WMS capabilities
-                    for (const bbox of wmsLayer.BoundingBox) {
+                    for (const bbox of wmsLayer.BoundingBox || {}) {
                         // If the BBOX CRS is not the same of the project projection, continue.
                         if (bbox.crs !== configProj.ref) {
                             continue;


### PR DESCRIPTION
to fix map.js:3556

TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator)) at _createForOfIteratorHelper (Lizmap.js:33:86) at Object.configsloaded (Lizmap.js:80:60) at initialize.triggerEvent (OpenLayers.js?_r=250519080505:497:145) at eval (map.js:3323:33) at _callee$ (map.js:3313:53) at s (map.js:2:1) at Generator.eval (map.js:2:1) at Generator.eval [as next] (map.js:2:1) at asyncGeneratorStep (map.js:2:1) at _next (map.js:2:1)

eval@map.js:3556Promise.catchinit@map.js:3555eval@map.js:3645e@jquery-3.5.1.min.js?_r=250519080505:2t@jquery-3.5.1.min.js?_r=250519080505:2setTimeout(anonymous)@jquery-3.5.1.min.js?_r=250519080505:2c@jquery-3.5.1.min.js?_r=250519080505:2add@jquery-3.5.1.min.js?_r=250519080505:2(anonymous)@jquery-3.5.1.min.js?_r=250519080505:2s.Deferred@jquery-migrate-3.3.1…s?_r=250519080505:2then@jquery-3.5.1.min.js?_r=250519080505:2S.fn.ready@jquery-3.5.1.min.js?_r=250519080505:2eval@map.js:3628./assets/src/legacy/map.js@map.js?_r=250519080505:19__webpack_require__@map.js?_r=250519080505:272(anonymous)@map.js?_r=250519080505:1438(anonymous)@map.js?_r=250519080505:1441  for wmsLayer.BoundingBox and wmsLayer.Layer also

<!--
Add the word "fix" in front of "#" if it fixes the ticket
or do nothing to only mention it.

funded by NAME
If funded by someone else than 3Liz, please add label "sponsored development"

Please mention if the PR should be backported and to which versions.

Please add new tests if possible (JS, PHP, End2End…)
-->

Ticket : #

Funded by
