### PR TITLE
[Backport release_3_8] Fix: `0` integer is transformed to an empty string by `DOMPurify.sanitize()`

### DIFF
--- a/assets/src/legacy/filter.js
+++ b/assets/src/legacy/filter.js
@@ -517,7 +517,7 @@ var lizLayerFilterTool = function () {
                     }
 
                     for (const feat of result) {
-                        globalThis['filterConfig'][field_item.order]['items'][DOMPurify.sanitize(feat['v'])] = feat['c'];
+                        globalThis['filterConfig'][field_item.order]['items'][DOMPurify.sanitize(feat['v'].toString())] = feat['c'];
                     }
 
                     var dhtml = '';

--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -819,7 +819,7 @@ window.lizMap = function() {
         var options = '<option value="-1" label="'+placeHolder+'"></option>';
         for (var fid in features) {
             var feat = features[fid];
-            options += '<option value="' + feat.id + '">' + DOMPurify.sanitize(feat.properties[locate.fieldName]) + '</option>';
+            options += '<option value="' + feat.id + '">' + DOMPurify.sanitize(feat.properties[locate.fieldName].toString()) + '</option>';
         }
         // add option list
         $('#locate-layer-'+cleanName(aName)).html(options);
@@ -1047,7 +1047,7 @@ window.lizMap = function() {
                 var feat = features[i];
                 locate.features[feat.id.toString()] = feat;
                 if ( !('filterFieldName' in locate) )
-                    options += '<option value="' + feat.id + '">' + DOMPurify.sanitize(feat.properties[locate.fieldName]) + '</option>';
+                    options += '<option value="' + feat.id + '">' + DOMPurify.sanitize(feat.properties[locate.fieldName].toString()) + '</option>';
             }
             // listen to select changes
             $('#locate-layer-'+layerName).html(options).change(function() {


### PR DESCRIPTION
Backport #5775
 **Authored by:** @nboisteault