### PR TITLE
Fix WMS GetLegendGraphic to perform request with get method with single layer

### DIFF
--- a/assets/src/modules/Errors.js
+++ b/assets/src/modules/Errors.js
@@ -7,6 +7,28 @@
  */
 
 /**
+ * Representing a request error with message and parameters before fetching
+ * @class
+ * @augments Error
+ * @property {string} name       - Error name: RequestError
+ * @property {string} message    - Error message
+ * @property {object} parameters - The request parameters
+ */
+export class RequestError extends Error {
+
+    /**
+     * Creating a request error with message and parameters before fetching
+     * @param {string} message    - Error message
+     * @param {object} params     - The request parameters
+     */
+    constructor(message, params) {
+        super(message);
+        this.name = "RequestError";
+        this.parameters = params;
+    }
+}
+
+/**
  * Representing a network error with message, resource and options fetched
  * @class
  * @augments Error

--- a/assets/src/modules/Errors.js
+++ b/assets/src/modules/Errors.js
@@ -10,11 +10,15 @@
  * Representing a network error with message, resource and options fetched
  * @class
  * @augments Error
+ * @property {string} name - Error name: NetworkError
+ * @property {string} message - Error message
+ * @property {string} resource - The resource has been fetched
+ * @property {string} options - The resource options
  */
-class NetworkError extends Error {
+export class NetworkError extends Error {
 
     /**
-     * Creating an HTTP error with message and status code
+     * Creating an HTTP error with message, resource and options fetched
      * @param {string} message    - Error message
      * @param {string} resource   - The resource has been fetched
      * @param {string} options    - The resource options
@@ -30,9 +34,14 @@ class NetworkError extends Error {
 /**
  * Representing an HTTP error with message, status code, resource and options fetched
  * @class
- * @augments Error
+ * @augments NetworkError
+ * @property {string} name - Error name: HttpError
+ * @property {string} message - Error message
+ * @property {string} resource - The resource has been fetched
+ * @property {string} options - The resource options
+ * @property {number} statusCode - HTTP Error status code
  */
-class HttpError extends NetworkError {
+export class HttpError extends NetworkError {
 
     /**
      * Creating an HTTP error with message and status code
@@ -42,34 +51,36 @@ class HttpError extends NetworkError {
      * @param {string} options    - The resource options
      */
     constructor(message, statusCode, resource, options) {
-        super(message);
+        super(message, resource, options);
         this.name = "HttpError";
         this.statusCode = statusCode;
-        this.resource = resource;
-        this.options = options;
     }
 }
 
 /**
- * Representing an HTTP error with message, response, resource and options fetched
+ * Representing an response error with message, response, resource and options fetched
  * @class
- * @augments Error
+ * @augments HttpError
+ * @property {string} name - Error name: ResponseError
+ * @property {string} message - Error message
+ * @property {string} resource - The resource has been fetched
+ * @property {string} options - The resource options
+ * @property {number} statusCode - HTTP Error status code
+ * @property {Response} response - Response object from fetch
  */
-class ResponseError extends NetworkError {
+export class ResponseError extends HttpError {
 
     /**
      * Creating an HTTP error with message and status code
      * @param {string}   message    - Error message
-     * @param {Response} response - HTTP Error status code
+     * @param {Response} response   - Response object from fetch
      * @param {string}   resource   - The resource has been fetched
      * @param {string}   options    - The resource options
      */
     constructor(message, response, resource, options) {
-        super(message);
+        super(message, response.status, resource, options);
         this.name = "ResponseError";
         this.response = response;
-        this.resource = resource;
-        this.options = options;
     }
 }
 
@@ -78,7 +89,7 @@ class ResponseError extends NetworkError {
  * @class
  * @augments Error
  */
-class ConversionError extends Error {
+export class ConversionError extends Error {
 
     /**
      * Creating a conversion error
@@ -96,7 +107,7 @@ class ConversionError extends Error {
  * @class
  * @augments Error
  */
-class ValidationError extends Error {
+export class ValidationError extends Error {
 
     /**
      * Creating a validation error
@@ -114,7 +125,7 @@ class ValidationError extends Error {
  * @class
  * @augments ValidationError
  */
-class PropertyRequiredError extends ValidationError {
+export class PropertyRequiredError extends ValidationError {
 
     /**
      * Creating a property required error
@@ -126,5 +137,3 @@ class PropertyRequiredError extends ValidationError {
     }
 
 }
-
-export { NetworkError, HttpError, ResponseError, ConversionError, ValidationError, PropertyRequiredError };

--- a/assets/src/modules/WMS.js
+++ b/assets/src/modules/WMS.js
@@ -6,6 +6,7 @@
  */
 
 import { Utils } from './Utils.js';
+import { RequestError } from './Errors.js';
 
 /**
  * @class
@@ -54,15 +55,35 @@ export default class WMS {
      * Get legend graphic from WMS
      * @param {object} options - optional parameters which can override this._defaultGetLegendGraphicsParameters
      * @returns {Promise} Promise object represents data
+     * @throws {HttpError} In case of not successful response (status not in the range 200 – 299)
+     * @throws {NetworkError} In case of catch exceptions
      * @memberof WMS
      */
     async getLegendGraphic(options) {
+        const layers = options['LAYERS'] ?? options['LAYER'];
+        // Check if layer is specified
+        if (!layers) {
+            return Promise.reject(
+                new RequestError(
+                    'LAYERS or LAYER parameter is required for getLegendGraphic request',
+                    options,
+                )
+            );
+        }
+        const params = new URLSearchParams({
+            ...this._defaultGetLegendGraphicParameters,
+            ...options
+        });
+        // Check if multiple layers are specified
+        if ((Array.isArray(layers) && layers.length == 1) ||
+            (!Array.isArray(layers) && layers.split(',').length == 1)) {
+            // Use GET request for single layer
+            return Utils.fetchJSON(`${globalThis['lizUrls'].wms}?${params}`);
+        }
+        // Use POST request for multiple layers
         return Utils.fetchJSON(globalThis['lizUrls'].wms, {
             method: "POST",
-            body: new URLSearchParams({
-                ...this._defaultGetLegendGraphicParameters,
-                ...options
-            })
+            body: params,
         });
     }
 }

--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -671,11 +671,24 @@ class serviceCtrl extends jController
      */
     protected function GetLegendGraphics($wmsRequest)
     {
-        $result = $wmsRequest->process();
-
         /** @var jResponseBinary $rep */
         $rep = $this->getResponse('binary');
+        // Etag header and cache control
+        $etag = $this->buildEtag('GetLegendGraphic');
+        $respCanBeCached = $this->canBeCached();
+        if ($respCanBeCached && $rep->isValidCache(null, $etag)) {
+            $this->setACAOHeader($rep);
+
+            return $rep;
+        }
+
+        $result = $wmsRequest->process();
         $this->setupBinaryResponse($rep, $result, 'qgis_server_legend');
+
+        if ($respCanBeCached) {
+            $this->setEtagCacheHeaders($rep, $etag);
+            $this->setACAOHeader($rep);
+        }
 
         return $rep;
     }

--- a/tests/end2end/playwright/globals.js
+++ b/tests/end2end/playwright/globals.js
@@ -122,7 +122,7 @@ export async function gotoMap(url, page, mapMustLoad = true, layersInTreeView = 
 
     await expect(async () => {
         const response = await page.goto(url);
-        expect(response.status()).toBeLessThan(400);
+        expect(response?.status()).toBeLessThan(400);
     }).toPass({
         intervals: [1_000, 2_000, 10_000],
         timeout: 60_000
@@ -172,7 +172,7 @@ export async function reloadMap(page, check = true) {
 
     await expect(async () => {
         const response = await page.reload();
-        expect(response.status()).toBeLessThan(400);
+        expect(response?.status()).toBeLessThan(400);
     }).toPass({
         intervals: [1_000, 2_000, 10_000],
         timeout: 60_000

--- a/tests/end2end/playwright/globals.js
+++ b/tests/end2end/playwright/globals.js
@@ -15,6 +15,11 @@ import * as path from 'path';
  */
 
 /**
+ * Playwright APIRequestContext
+ * @typedef {import('@playwright/test').APIRequestContext} APIRequestContext
+ */
+
+/**
  * Integer
  * @typedef {number} int
  */
@@ -254,7 +259,7 @@ export async function expectToHaveLengthCompare(title, parameters, expectedLengt
 
 /**
  * Get the JSON for the given project using the API
- * @param {import("playwright-core/types/types.js").APIRequestContext} request Request to use
+ * @param {APIRequestContext} request Request to use
  * @param {string} project The project name
  * @param {string} repository The repository name, default to "testsrepository".
  * @returns {Promise<any>} The JSON response
@@ -268,9 +273,9 @@ export async function jsonFromProjectApi(request, project, repository = 'testsre
 
 /**
  * Get the version of QGIS written in the project
- * @param {import("playwright-core/types/types.js").APIRequestContext} request Request to use
+ * @param {APIRequestContext} request Request to use
  * @param {string} project The project name
- * @returns {int} The QGIS version, written as "34004" for QGIS 3.40.4, to be easily sortable.
+ * @returns {Promise<int>} The QGIS version, written as "34004" for QGIS 3.40.4, to be easily sortable.
  */
 export async function qgisVersionFromProjectApi(request, project) {
     const response = await jsonFromProjectApi(request, project);
@@ -293,12 +298,11 @@ export async function checkJson(response, status = 200) {
     return await response.json();
 }
 
-/* eslint-disable jsdoc/check-types */
 /**
  * Check parameters against an object containing expected parameters
  * @param {string}                        title Check title, for testing and debug
  * @param {string}                        parameters List of parameters to check
- * @param {Object<string, string|RegExp>} expectedParameters List of expected parameters
+ * @param {{[key: string]: string|RegExp}} expectedParameters List of expected parameters
  * @returns {Promise<URLSearchParams>}    List of promise with parameters
  */
 export async function expectParametersToContain(title, parameters, expectedParameters) {
@@ -341,9 +345,9 @@ const adminPassword = "Basic " + btoa("admin:admin");
 
 /**
  * Create a GET request on a given URL with Basic authentication admin:admin
- * @param {import("playwright-core/types/types.js").APIRequestContext} request Request to use
+ * @param {APIRequestContext} request Request to use
  * @param {string} url URL to do a GET request on
- * @returns {Promise<import("playwright-core/types/types.js").APIResponse>} Response
+ * @returns {Promise<APIResponse>} Response
  */
 export async function requestGETWithAdminBasicAuth(request, url) {
     return await request.get(url,
@@ -356,10 +360,10 @@ export async function requestGETWithAdminBasicAuth(request, url) {
 
 /**
  * Create a POST request on a given URL with Basic authentication admin:admin
- * @param {import("playwright-core/types/types.js").APIRequestContext} request Request to use
+ * @param {APIRequestContext} request Request to use
  * @param {string} url URL to do a POST request on
  * @param {object} data parameters for the request
- * @returns {Promise<import("playwright-core/types/types.js").APIResponse>} Response
+ * @returns {Promise<APIResponse>} Response
  */
 export async function requestPOSTWithAdminBasicAuth(request, url, data) {
     return await request.post(url,
@@ -373,10 +377,10 @@ export async function requestPOSTWithAdminBasicAuth(request, url, data) {
 
 /**
  * Create a DELETE request on a given URL with Basic authentication admin:admin
- * @param {import("playwright-core/types/types.js").APIRequestContext} request Request to use
+ * @param {APIRequestContext} request Request to use
  * @param {string} url URL to do a DELETE request on
  * @param {object} data parameters for the request
- * @returns {Promise<import("playwright-core/types/types.js").APIResponse>} Response
+ * @returns {Promise<APIResponse>} Response
  */
 export async function requestDELETEWithAdminBasicAuth(request, url, data) {
     return await request.delete(url,
@@ -387,4 +391,3 @@ export async function requestDELETEWithAdminBasicAuth(request, url, data) {
             data: data
         });
 }
-/* eslint-enable jsdoc/check-types */

--- a/tests/end2end/playwright/globals.js
+++ b/tests/end2end/playwright/globals.js
@@ -134,9 +134,14 @@ export async function gotoMap(url, page, mapMustLoad = true, layersInTreeView = 
         if (waitForGetLegendGraphic) {
             // Wait for WMS GetLegendGraphic promise
             const getLegendGraphicPromise = page.waitForRequest(
-                request => request.method() === 'POST' &&
+                request => (
+                    request.method() === 'POST' &&
                     request.postData() != null &&
                     request.postData()?.includes('GetLegendGraphic') === true
+                ) || (
+                    request.method() === 'GET' &&
+                    request.url().includes('GetLegendGraphic') === true
+                )
             );
             // Normal check about the map
             // Wait for WMS GetLegendGraphic
@@ -178,10 +183,14 @@ export async function reloadMap(page, check = true) {
     if (check) {
         // Wait for WMS GetLegendGraphic promise
         const getLegendGraphicPromise = page.waitForRequest(
-            request =>
+            request => (
                 request.method() === 'POST' &&
                 request.postData() != null &&
                 request.postData()?.includes('GetLegendGraphic') === true
+            ) || (
+                request.method() === 'GET' &&
+                request.url().includes('GetLegendGraphic') === true
+            )
         );
         // Normal check about the map
         // Wait for WMS GetLegendGraphic

--- a/tests/end2end/playwright/qgis-request.spec.js
+++ b/tests/end2end/playwright/qgis-request.spec.js
@@ -1,19 +1,31 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-import { gotoMap } from './globals';
 
 test.describe('QGIS Requests', () => {
-    test('WMS Get Legend Graphic JSON', async ({ page }) => {
-        const url = '/index.php/view/map?repository=testsrepository&project=layer_legends';
-        await gotoMap(url, page)
-
-        const single = await page.evaluate(async () => {
-            return await fetch(
-                "/index.php/lizmap/service?repository=testsrepository&project=layer_legends&" +
-                "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetLegendGraphic&LAYER=layer_legend_single_symbol&STYLE=&" +
-                "EXCEPTIONS=application/vnd.ogc.se_inimage&FORMAT=application/json&TRANSPARENT=TRUE&DPI=96"
-            ).then(r => r.ok ? r.json() : Promise.reject(r))
-        })
+    test('WMS Get Legend Graphic JSON', async ({ request }) => {
+        // GetLegendGraphic request for a layer with a single symbol
+        let params = new URLSearchParams({
+            repository: 'testsrepository',
+            project: 'layer_legends',
+            SERVICE: 'WMS',
+            VERSION: '1.3.0',
+            REQUEST: 'GetLegendGraphic',
+            LAYER: 'layer_legend_single_symbol',
+            STYLE: '',
+            EXCEPTIONS: 'application/vnd.ogc.se_inimage',
+            FORMAT: 'application/json',
+            TRANSPARENT: 'TRUE',
+            DPI: '96',
+        });
+        let url = `/index.php/lizmap/service?${params}`;
+        let response = await request.get(url, {});
+        // check response
+        expect(response.ok()).toBeTruthy();
+        expect(response.status()).toBe(200);
+        // check content-type header
+        expect(response.headers()['content-type']).toBe('application/json');
+        // check body
+        const single = await response.json()
         // check root
         expect(single.nodes).toHaveLength(1)
         expect(single.title).toBe('')
@@ -25,13 +37,29 @@ test.describe('QGIS Requests', () => {
         expect(singleNode.icon).not.toBeUndefined()
         expect(singleNode.symbols).toBeUndefined()
 
-        const categorized = await page.evaluate(async () => {
-            return await fetch(
-                "/index.php/lizmap/service?repository=testsrepository&project=layer_legends&" +
-                "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetLegendGraphic&LAYER=layer_legend_categorized&STYLE=&" +
-                "EXCEPTIONS=application/vnd.ogc.se_inimage&FORMAT=application/json&TRANSPARENT=TRUE&DPI=96"
-            ).then(r => r.ok ? r.json() : Promise.reject(r))
-        })
+        // GetLegendGraphic request for a layer with categorized symbols
+        params = new URLSearchParams({
+            repository: 'testsrepository',
+            project: 'layer_legends',
+            SERVICE: 'WMS',
+            VERSION: '1.3.0',
+            REQUEST: 'GetLegendGraphic',
+            LAYER: 'layer_legend_categorized',
+            STYLE: '',
+            EXCEPTIONS: 'application/vnd.ogc.se_inimage',
+            FORMAT: 'application/json',
+            TRANSPARENT: 'TRUE',
+            DPI: '96',
+        });
+        url = `/index.php/lizmap/service?${params}`;
+        response = await request.get(url, {});
+        // check response
+        expect(response.ok()).toBeTruthy();
+        expect(response.status()).toBe(200);
+        // check content-type header
+        expect(response.headers()['content-type']).toBe('application/json');
+        // check body
+        const categorized = await response.json();
         // check root
         expect(categorized.nodes).toHaveLength(1)
         expect(categorized.title).toBe('')
@@ -44,13 +72,29 @@ test.describe('QGIS Requests', () => {
         expect(categorizedNode.symbols).not.toBeUndefined()
         expect(categorizedNode.symbols).toHaveLength(2)
 
-        const group = await page.evaluate(async () => {
-            return await fetch(
-                "/index.php/lizmap/service?repository=testsrepository&project=layer_legends&" +
-                "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetLegendGraphic&LAYER=legend_option_test&STYLE=" +
-                "&EXCEPTIONS=application/vnd.ogc.se_inimage&FORMAT=application/json&TRANSPARENT=TRUE&DPI=96"
-            ).then(r => r.ok ? r.json() : Promise.reject(r))
-        })
+        // GetLegendGraphic request for a group
+        params = new URLSearchParams({
+            repository: 'testsrepository',
+            project: 'layer_legends',
+            SERVICE: 'WMS',
+            VERSION: '1.3.0',
+            REQUEST: 'GetLegendGraphic',
+            LAYER: 'legend_option_test',
+            STYLE: '',
+            EXCEPTIONS: 'application/vnd.ogc.se_inimage',
+            FORMAT: 'application/json',
+            TRANSPARENT: 'TRUE',
+            DPI: '96',
+        });
+        url = `/index.php/lizmap/service?${params}`;
+        response = await request.get(url, {});
+        // check response
+        expect(response.ok()).toBeTruthy();
+        expect(response.status()).toBe(200);
+        // check content-type header
+        expect(response.headers()['content-type']).toBe('application/json');
+        // check body
+        const group = await response.json();
         // check root
         expect(group.nodes).toHaveLength(1)
         expect(group.title).toBe('')
@@ -64,16 +108,32 @@ test.describe('QGIS Requests', () => {
         expect(groupNode.nodes).not.toBeUndefined()
         expect(groupNode.nodes).toHaveLength(3)
 
-        const combined = await page.evaluate(async () => {
-            // To get layer_legend_single_symbol first, layer_legend_categorized second and legend_option_test third
-            // LAYER parameter has to be the inverse: legend_option_test,layer_legend_categorized,layer_legend_single_symbol
-            return await fetch(
-                "/index.php/lizmap/service?repository=testsrepository&project=layer_legends&" +
-                "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetLegendGraphic&" +
-                "LAYER=legend_option_test,layer_legend_categorized,layer_legend_single_symbol&STYLE=&" +
-                "EXCEPTIONS=application/vnd.ogc.se_inimage&FORMAT=application/json&TRANSPARENT=TRUE&DPI=96"
-            ).then(r => r.ok ? r.json() : Promise.reject(r))
-        })
+        // GetLegendGraphic request for multiple layers
+        // To get layer_legend_single_symbol first, layer_legend_categorized second and legend_option_test third
+        // LAYER parameter has to be the inverse: legend_option_test,layer_legend_categorized,layer_legend_single_symbol
+        // GetLegendGraphic request for a group
+        params = new URLSearchParams({
+            repository: 'testsrepository',
+            project: 'layer_legends',
+            SERVICE: 'WMS',
+            VERSION: '1.3.0',
+            REQUEST: 'GetLegendGraphic',
+            LAYER: 'legend_option_test,layer_legend_categorized,layer_legend_single_symbol',
+            STYLE: '',
+            EXCEPTIONS: 'application/vnd.ogc.se_inimage',
+            FORMAT: 'application/json',
+            TRANSPARENT: 'TRUE',
+            DPI: '96',
+        });
+        url = `/index.php/lizmap/service?${params}`;
+        response = await request.get(url, {});
+        // check response
+        expect(response.ok()).toBeTruthy();
+        expect(response.status()).toBe(200);
+        // check content-type header
+        expect(response.headers()['content-type']).toBe('application/json');
+        // check body
+        const combined = await response.json();
         // check root
         expect(combined.nodes).toHaveLength(3)
         expect(combined.title).toBe('')
@@ -102,5 +162,34 @@ test.describe('QGIS Requests', () => {
         expect(thirdNode.nodes).not.toBeUndefined()
         expect(thirdNode.nodes).toHaveLength(3)
         expect(thirdNode.nodes).toMatchObject(groupNode.nodes)
+
+        // GetLegendGraphic request for multiple layers as POST
+        params = new URLSearchParams({
+            repository: 'testsrepository',
+            project: 'layer_legends',
+        });
+
+        let formData = {
+            SERVICE: 'WMS',
+            VERSION: '1.3.0',
+            REQUEST: 'GetLegendGraphic',
+            LAYER: 'legend_option_test,layer_legend_categorized,layer_legend_single_symbol',
+            STYLE: '',
+            EXCEPTIONS: 'application/vnd.ogc.se_inimage',
+            FORMAT: 'application/json',
+            TRANSPARENT: 'TRUE',
+            DPI: '96',
+        };
+        url = `/index.php/lizmap/service?${params}`;
+        response = await request.post(url, {form:formData});
+        // check response
+        expect(response.ok()).toBeTruthy();
+        expect(response.status()).toBe(200);
+        // check content-type header
+        expect(response.headers()['content-type']).toBe('application/json');
+        // check body
+        const combinedPost = await response.json();
+        // check root
+        expect(combinedPost.nodes).toHaveLength(3)
     });
 });

--- a/tests/end2end/playwright/qgis-request.spec.js
+++ b/tests/end2end/playwright/qgis-request.spec.js
@@ -24,6 +24,10 @@ test.describe('QGIS Requests', () => {
         expect(response.status()).toBe(200);
         // check content-type header
         expect(response.headers()['content-type']).toBe('application/json');
+        // check headers
+        expect(response.headers()).toHaveProperty('cache-control');
+        expect(response.headers()['cache-control']).toBe('no-cache');
+        expect(response.headers()).toHaveProperty('etag');
         // check body
         const single = await response.json()
         // check root
@@ -58,6 +62,10 @@ test.describe('QGIS Requests', () => {
         expect(response.status()).toBe(200);
         // check content-type header
         expect(response.headers()['content-type']).toBe('application/json');
+        // check headers
+        expect(response.headers()).toHaveProperty('cache-control');
+        expect(response.headers()['cache-control']).toBe('no-cache');
+        expect(response.headers()).toHaveProperty('etag');
         // check body
         const categorized = await response.json();
         // check root
@@ -93,6 +101,10 @@ test.describe('QGIS Requests', () => {
         expect(response.status()).toBe(200);
         // check content-type header
         expect(response.headers()['content-type']).toBe('application/json');
+        // check headers
+        expect(response.headers()).toHaveProperty('cache-control');
+        expect(response.headers()['cache-control']).toBe('no-cache');
+        expect(response.headers()).toHaveProperty('etag');
         // check body
         const group = await response.json();
         // check root
@@ -132,6 +144,10 @@ test.describe('QGIS Requests', () => {
         expect(response.status()).toBe(200);
         // check content-type header
         expect(response.headers()['content-type']).toBe('application/json');
+        // check headers
+        expect(response.headers()).toHaveProperty('cache-control');
+        expect(response.headers()['cache-control']).toBe('no-cache');
+        expect(response.headers()).toHaveProperty('etag');
         // check body
         const combined = await response.json();
         // check root
@@ -187,6 +203,10 @@ test.describe('QGIS Requests', () => {
         expect(response.status()).toBe(200);
         // check content-type header
         expect(response.headers()['content-type']).toBe('application/json');
+        // check headers
+        expect(response.headers()).toHaveProperty('cache-control');
+        expect(response.headers()['cache-control']).toBe('no-store, no-cache, must-revalidate');
+        expect(response.headers()).not.toHaveProperty('etag');
         // check body
         const combinedPost = await response.json();
         // check root

--- a/tests/end2end/playwright/treeview.spec.js
+++ b/tests/end2end/playwright/treeview.spec.js
@@ -205,8 +205,14 @@ test.describe('Treeview mocked', () => {
             await page.route('**/service*', async route => {
                 const request = await route.request();
                 if (request.method() !== 'POST') {
-                    // GetLegendGraphic is a POST request
-                    // Continue the request for non POST requests
+                    // GetLegendGraphic is a GET request for single layer
+                    const searchParams = new URLSearchParams(request.url().split('?')[1]);
+                    if (searchParams.get('SERVICE') === 'WMS' &&
+                        searchParams.has('REQUEST') &&
+                        searchParams.get('REQUEST') === 'GetLegendGraphic') {
+                        GetLegends.push(searchParams);
+                    }
+                    // Continue the request
                     await route.continue();
                     return;
                 }

--- a/tests/js-units/node/wms.test.js
+++ b/tests/js-units/node/wms.test.js
@@ -94,14 +94,14 @@ describe('WMS', function () {
         });
     })
 
-    it('getLegendGraphic', async function () {
+    it('getLegendGraphic POST with multiple layers', async function () {
         client
         .intercept({
             path: /\/index.php\/lizmap\/service/,
             method: 'POST',
         })
         .reply(200, replyPost, {headers: {'content-type': 'application/json'}});
-        const data = await wms.getLegendGraphic({Name:'test'});
+        const data = await wms.getLegendGraphic({LAYER:'test1,test2'});
         expect(data).to.deep.eq({
             "body": {
                 SERVICE: 'WMS',
@@ -110,12 +110,50 @@ describe('WMS', function () {
                 FORMAT: 'application/json',
                 "project": "test",
                 "repository": "test",
-                "Name": "test",
+                LAYER: "test1,test2",
             },
             "method": "POST",
             "origin": "http://localhost:8130",
             "params": {},
             "pathname": "/index.php/lizmap/service",
         });
+    })
+
+    it('getLegendGraphic GET with single layer', async function () {
+        client
+        .intercept({
+            path: /\/index.php\/lizmap\/service/,
+            method: 'GET',
+        })
+        .reply(200, replyGet, {headers: {'content-type': 'application/json'}});
+        const data = await wms.getLegendGraphic({LAYER:'test'});
+        expect(data).to.deep.eq({
+            "method": "GET",
+            "origin": "http://localhost:8130",
+            "params": {
+                SERVICE: 'WMS',
+                REQUEST: 'GetLegendGraphic',
+                VERSION: '1.3.0',
+                FORMAT: 'application/json',
+                "project": "test",
+                "repository": "test",
+                LAYER: "test",
+            },
+            "pathname": "/index.php/lizmap/service",
+        });
+    })
+
+    it('getLegendGraphic Request error', async function () {
+        try {
+            await wms.getLegendGraphic({Name:'test'});
+        } catch (error) {
+            expect(error.name).to.be.eq('RequestError');
+            expect(error.message).to.be.eq(
+                'LAYERS or LAYER parameter is required for getLegendGraphic request'
+            );
+            expect(error.parameters).to.deep.eq({
+                Name:'test',
+            });
+        }
     })
 })


### PR DESCRIPTION
Firstly add Etag to WMS GetLegendGraphic Request, if the WMS GetLegendGraphic is performed with the GET method an Etag is added to get cache.

Then perform WMS GetLegendGraphic with GET method for single layer.