### PR TITLE
Update lizmapFts.class.php - upgrade item_filter to accept comma-seperated list

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapFts.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapFts.class.php
@@ -66,12 +66,12 @@ class lizmapFts
             $appContext = $project->getAppContext();
             $userGroups = $appContext->aclUserPublicGroupsId();
             foreach ($userGroups as $g) {
-                $sql .= " OR item_filter = '".$g."'";
+                $sql .= " OR '".$g."' = ANY ( string_to_array(item_filter, ',', ' ') )";
             }
             // Ok if user matches
             $user = jAuth::getUserSession();
             $login = $user->login;
-            $sql .= " OR item_filter = '".$login."'";
+            $sql .= " OR '".$login."' = ANY ( string_to_array(item_filter, ',', ' ') )";
         }
         $sql .= ' )';
         $sql .= '


### PR DESCRIPTION
Just like item_projects in the lizmap_search view was accepting a comma sperated list of items, this enables the filter to be supplied with a list of users/groups