### PR TITLE
Fix setting projection axis orientation with a simple way

### DIFF
--- a/assets/src/modules/Lizmap.js
+++ b/assets/src/modules/Lizmap.js
@@ -31,7 +31,7 @@ import WMSCapabilities from 'ol/format/WMSCapabilities.js';
 import WFSCapabilities from 'ol-wfs-capabilities';
 import { Coordinate as olCoordinate } from 'ol/coordinate.js'
 import { Extent as olExtent, intersects as olExtentIntersects} from 'ol/extent.js';
-import { transform as olTransform, transformExtent as olTransformExtent, get as getProjection, clearAllProjections, addCommon } from 'ol/proj.js';
+import { transform as olTransform, transformExtent as olTransformExtent, get as getProjection } from 'ol/proj.js';
 import { register } from 'ol/proj/proj4.js';
 
 import proj4 from 'proj4';
@@ -116,15 +116,7 @@ export default class Lizmap {
                             && Math.abs(extent[2] - bbox.extent[3]) < Math.abs(extent[2] - bbox.extent[2])
                             && Math.abs(extent[3] - bbox.extent[2]) < Math.abs(extent[3] - bbox.extent[3])) {
                             // If inverted axis are closest, we have to update the projection definition
-                            proj4.defs(configProj.ref, configProj.proj4+' +axis=neu');
-                            // Clear all cached projections and transforms.
-                            clearAllProjections();
-                            // Add transforms to and from EPSG:4326 and EPSG:3857.  This function should
-                            // need to be called again after `clearAllProjections()`
-                            // @see ol/proj.js#L731
-                            addCommon();
-                            // Need to register projections again
-                            register(proj4);
+                            projectProj.axisOrientation_ = 'neu';
                             break;
                         }
                         // Transform extent from project projection to CRS:84
@@ -132,14 +124,7 @@ export default class Lizmap {
                         // Check intersects between transform extent and provided extent by WMS Capapbilities
                         if (!olExtentIntersects(geoExtent, wmsLayer.EX_GeographicBoundingBox)) {
                             // if extents do not intersect, we have to update the projection definition
-                            proj4.defs(configProj.ref, configProj.proj4+' +axis=neu');
-                            clearAllProjections();
-                            // Add transforms to and from EPSG:4326 and EPSG:3857. This function should
-                            // need to be called again after `clearAllProjections()`
-                            // @see ol/proj.js#L731
-                            addCommon();
-                            // Need to re register projections again
-                            register(proj4);
+                            projectProj.axisOrientation_ = 'neu';
                             break;
                         }
                     }


### PR DESCRIPTION
By working on using Proj4rs instead of Proj4js #5799, we found a simple way to set axis orientation of some projection.
