### PR TITLE
Add User-Agent in Log and check when QGIS performs authentification 

### DIFF
--- a/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
+++ b/lizmap/modules/admin/locales/en_US/admin.UTF-8.properties
@@ -231,6 +231,7 @@ logs.content=Content
 logs.repository=Repository
 logs.project=Project
 logs.ip=IP
+logs.user_agent=User-agent
 
 logs.first_page=First
 logs.previous_page=Previous

--- a/lizmap/modules/admin/templates/logs_detail.tpl
+++ b/lizmap/modules/admin/templates/logs_detail.tpl
@@ -11,6 +11,7 @@
           <th>{@admin~admin.logs.repository@}</th>
           <th>{@admin~admin.logs.project@}</th>
           <th>{@admin~admin.logs.ip@}</th>
+          <th>{@admin~admin.logs.user_agent@}</th>
         </tr>
       </thead>
       <tbody>
@@ -23,6 +24,7 @@
           <td>{$item->repository}</td>
           <td>{$item->project}</td>
           <td>{$item->ip}</td>
+          <td>{$item->user_agent}</td>
         </tr>
         {/foreach}
       </tbody>

--- a/lizmap/modules/lizmap/classes/lizmapLog.listener.php
+++ b/lizmap/modules/lizmap/classes/lizmapLog.listener.php
@@ -20,11 +20,13 @@ class lizmapLogListener extends jEventListener
     public function onAuthCanLogin($event)
     {
         $key = 'login';
+        $userAgent = $_SERVER['HTTP_USER_AGENT'];
         $data = array(
             'key' => $key,
             'user' => $event->getParam('login'),
             'repository' => null,
             'project' => null,
+            'user_agent' => (preg_match('#QGIS/\d+/#', $userAgent) ? 'QGIS' : ''),
         );
 
         $this->addLog($key, $data);

--- a/lizmap/modules/lizmap/daos/logDetail.dao.xml
+++ b/lizmap/modules/lizmap/daos/logDetail.dao.xml
@@ -12,6 +12,7 @@
         <property name="repository" fieldname="log_repository" datatype="string"/>
         <property name="project" fieldname="log_project" datatype="string"/>
         <property name="ip" fieldname="log_ip" datatype="string"/>
+        <property name="user_agent" fieldname="user_agent" datatype="string"/>
         <!--<property name="" fieldname="" datatype="string/int/float/date"
         required="yes" maxlength="" minlength="" regexp="" sequence=""
         updatepattern="" insertpattern="" selectpattern=""/>-->

--- a/lizmap/modules/lizmap/install/sql/adduseragent.mysql.sql
+++ b/lizmap/modules/lizmap/install/sql/adduseragent.mysql.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `log_detail` ADD COLUMN `user_agent` VARCHAR(40);

--- a/lizmap/modules/lizmap/install/sql/adduseragent.pgsql.sql
+++ b/lizmap/modules/lizmap/install/sql/adduseragent.pgsql.sql
@@ -1,0 +1,1 @@
+ALTER TABLE log_detail ADD COLUMN user_agent character varying(40)

--- a/lizmap/modules/lizmap/install/sql/adduseragent.sqlite.sql
+++ b/lizmap/modules/lizmap/install/sql/adduseragent.sqlite.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "log_detail" ADD COLUMN "user_agent" VARCHAR;

--- a/lizmap/modules/lizmap/install/sql/lizlog.mysql.sql
+++ b/lizmap/modules/lizmap/install/sql/lizlog.mysql.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS `log_detail` (
     `log_repository` VARCHAR(100),
     `log_project` VARCHAR(100),
     `log_ip` VARCHAR(40),
+    `user_agent` VARCHAR(40),
     PRIMARY KEY (`id`)
 );
 

--- a/lizmap/modules/lizmap/install/sql/lizlog.pgsql.sql
+++ b/lizmap/modules/lizmap/install/sql/lizlog.pgsql.sql
@@ -6,7 +6,8 @@ CREATE TABLE IF NOT EXISTS log_detail (
     log_content TEXT,
     log_repository character varying(100),
     log_project character varying(100),
-    log_ip character varying(40)
+    log_ip character varying(40),
+    user_agent character varying(40)
 );
 
 CREATE TABLE IF NOT EXISTS log_counter (

--- a/lizmap/modules/lizmap/install/sql/lizlog.sqlite.sql
+++ b/lizmap/modules/lizmap/install/sql/lizlog.sqlite.sql
@@ -6,7 +6,8 @@ CREATE TABLE IF NOT EXISTS "log_detail" (
     "log_content" TEXT,
     "log_repository" VARCHAR,
     "log_project" VARCHAR,
-    "log_ip" VARCHAR);
+    "log_ip" VARCHAR,
+    "user_agent" VARCHAR);
 
 CREATE TABLE IF NOT EXISTS "log_counter" (
     "id" INTEGER PRIMARY KEY  AUTOINCREMENT  NOT NULL ,

--- a/lizmap/modules/lizmap/install/upgrade_uainlog.php
+++ b/lizmap/modules/lizmap/install/upgrade_uainlog.php
@@ -1,0 +1,19 @@
+<?php
+
+use Jelix\Installer\Module\API\InstallHelpers;
+use Jelix\Installer\Module\Installer;
+
+class lizmapModuleUpgrader_uainlog extends Installer
+{
+    public $targetVersions = array(
+        '3.10.0-pre.1', '3.9.0-rc.4'
+    );
+    public $date = '2025-06-17';
+
+    public function install(InstallHelpers $helpers)
+    {
+        // Add user agent colum to lizlog table
+        $helpers->database()->useDbProfile('lizlog');
+        $helpers->database()->execSQLScript('sql/adduseragent');
+    }
+}

--- a/lizmap/modules/lizmap/lib/Logger/Item.php
+++ b/lizmap/modules/lizmap/lib/Logger/Item.php
@@ -40,6 +40,7 @@ class Item
         'project',
         'ip',
         'email',
+        'user_agent',
     );
 
     protected $appContext;


### PR DESCRIPTION
Add `user_agent` column on log table to check if the login event was perfomed by QGIS

I add a column User-Agent on the page 
 
 
![Screenshot 2025-06-17 at 15-37-45 Administration](https://github.com/user-attachments/assets/1d821bc0-62f9-4150-ac57-577a1df96880)

But another solution can be to add a badge

![Screenshot 2025-06-17 at 15-40-05 Administration](https://github.com/user-attachments/assets/5222e9ee-fc2a-49b0-ab0f-36c9b59b2d45)

I assum the next release will be named `3.9.0-rc.4` (3.9.x) and `3.10.0-pre.1` (3.10.x)
Ticket : #

Funded by 3Liz
