### PR TITLE
CI: create a docker compose`dev` profile

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -128,6 +128,12 @@ password=lizmap1234!
 
 ## Accessing to Swagger for admin API
 
+Swagger is not launched by default so you need to start the stack this way:
+
+```bash
+docker compose --profile dev up -d
+```
+
 If you want to test or learn about the API, after having set up the stack, you can access
 to http://localhost:8133/ and find the Swagger page.
 
@@ -329,6 +335,12 @@ composer rector:fix
 ```
 
 ## Using LDAP
+
+LDAP is not launched by default so you need to start the stack this way:
+
+```bash
+docker compose --profile dev up -d
+```
 
 Into `lizmap/var/config/localconfig.ini.php`:
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       SLAPD_DOMAIN: "tests.lizmap"
     volumes:
       - { type: bind, source: ./docker-conf/openldap/ldif, target: /customldif }
+    profiles: ["dev"]
   lizmap:
     build:
       context: ./docker-conf/phpfpm
@@ -50,7 +51,6 @@ services:
     depends_on:
       - pgsql
       - redis
-      - openldap
   web:
     image: nginx:alpine
     container_name: "lizmap${LZMBRANCH}_test_nginx"
@@ -113,6 +113,7 @@ services:
       - { type: bind, source: ./api, target: /api }
     ports:
       - ${SWAGGER_PORT}:8080
+    profiles: ["dev"]
 volumes:
   pg_data:
     name: "lizmap${LZMBRANCH}_pg_data"


### PR DESCRIPTION
This way, `openldap` and `swagger` are not used for e2e tests
