### PR TITLE
add opengraph tags for map page

### DIFF
--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -257,11 +257,20 @@ class lizMapCtrl extends jController
         if ($wmsInfo['WMSServiceTitle'] != '') {
             $title = $wmsInfo['WMSServiceTitle'];
         }
+        $openGraphTitle = $title;
 
         $title .= ' - '.$lrep->getLabel();
         $title .= ' - '.$lser->appName;
         $rep->title = $title;
 
+        // use addHeadContent to prevent url html escaping
+        $rep->addHeadContent('<meta property="og:image" content="'.jUrl::getFull('view~media:illustration', array('repository' => $this->param('repository'), 'project' => $this->param('project'))).'">');
+        $rep->addMeta(array('property' => 'og:title', 'content' => $openGraphTitle));
+        $rep->addMeta(array('property' => 'og:image:width', 'content' => '250'));
+        $rep->addMeta(array('property' => 'og:image:height', 'content' => '250'));
+        if (!empty($wmsInfo['WMSServiceAbstract'])) {
+            $rep->addMeta(array('property' => 'og:description', 'content' => $wmsInfo['WMSServiceAbstract']));
+        }
         // Add moment.js for timemanager
         if ($lproj->hasTimemanagerLayers()) {
             $rep->addJSLink($bp.'assets/js/moment.js', array('defer' => ''));


### PR DESCRIPTION
Add open graph tags in map page html header

It will allow various apps/social networks to propose an enriched content (image, title) when a link is posted .
It use the same values as the repository page : title , abstract, illustration image

See the result with firefox extension "open graph preview" for "montepellier" demo project
![Capture d'écran 2025-06-20 160209](https://github.com/user-attachments/assets/c855aba3-c5ed-4b42-904b-80d8b4dfa896)

More info  : https://ogp.me/

Funded by 3Liz
