### PR TITLE
[Bugfix] Allow same pivot table to be configured multiple timesin drag and drop module

### DIFF
--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -3295,7 +3295,9 @@ var lizAttributeTable = function() {
                         if(refAttributeLayerConf && refAttributeLayerConf[1]?.pivot == 'True'){
                             // check if pivot is in relations for both layers
                             const validRelation = [nlayerId,mLayerId].every((layerId)=>{
-                                return config.relations[layerId] && config.relations[layerId].filter((rlayer)=>{ return rlayer.referencingLayer == pivotId}).length == 1
+                                return config.relations[layerId] && config.relations[layerId].some((rlayer)=>{
+                                    return rlayer.referencingLayer == pivotId
+                                })
                             })
                             if (validRelation)
                                 return pivotId;


### PR DESCRIPTION
Covers a very situational case. It may be possible, in a variety of specific cases, that the same `n_m` relation is defined multiple times in a drag and drop module.

This minor update aims to cover this case by removing the check (perhaps unnecessarily restrictive) that limits the presence of the same `pivot` table to one

Backport 3.8 
Backport 3.9

Funded by Faunalia
