### PR TITLE
lizmap-features-table: Display a message when no features found

### DIFF
--- a/assets/src/components/FeaturesTable.js
+++ b/assets/src/components/FeaturesTable.js
@@ -35,6 +35,7 @@ import GeoJSON from 'ol/format/GeoJSON.js';
  *      (optional) data-center-to-highlighted-feature-geometry="true"
  *      (optional) data-max-features="100"
  *      (optional) data-active-item-feature-id="5"
+ *      (optional) data-empty-message="This table is empty. There are no items to display."
  * >
  *      <lizmap-field
  *          data-alias="District's name"
@@ -607,6 +608,7 @@ export default class FeaturesTable extends HTMLElement {
         this._template = () => html`
             <div class="lizmap-features-table" data-features-count="${this.features.length}">
                 <h4>${this.layerTitle}</h4>
+                ${this.features.length > 0 ? html`
                 <div class="lizmap-features-table-toolbar">
                     <button class="btn btn-mini previous-popup"
                         title="${lizDict['featuresTable.toolbar.previous']}"
@@ -654,6 +656,11 @@ export default class FeaturesTable extends HTMLElement {
                     </tbody>
                 </table>
                 <div class="lizmap-features-table-item-popup"></div>
+                ` : html`
+                <div class="lizmap-features-table-empty">
+                    ${this.dataset.emptyMessage ? this.dataset.emptyMessage : lizDict['featuresTable.empty.message']}
+                </div>
+                `}
             </div>
         `;
 

--- a/lizmap/modules/view/locales/en_US/dictionnary.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/dictionnary.UTF-8.properties
@@ -293,6 +293,7 @@ featuresTable.toolbar.next=Go to the next feature
 featuresTable.toolbar.close=Go back to the list of features
 featuresTable.item.draggable.hover=You can drag and drop the feature to move it above or below
 featuresTable.item.draggable.dropped=You have successfully moved this feature
+featuresTable.empty.message=This table is empty. There are no items to display.
 
 startup.features.error=Zooming to the feature given in the URL parameter is not possible: an error occurred while fetching the feature data.
 startup.features.empty=No features to display


### PR DESCRIPTION
lizmap-features-table always displayed a table even if it is empty. We propose to display a message when the table is empty and an optional attribut has been added to be able to defined a message to display.

Funded by CA Grand Narbonne