### PR TITLE
Fix version count

### DIFF
--- a/lizmap/modules/admin/templates/project_list_help.tpl
+++ b/lizmap/modules/admin/templates/project_list_help.tpl
@@ -15,7 +15,7 @@
                     <li>{@admin.project.rules.list.blocking.html@}</li>
                     <ul class="rules">
                         <li class="blocker">{jlocale "admin.project.rules.list.blocking.target.html",
-                            array($minimumLizmapTargetVersionRequired - 0.1)}</li>
+                            array($blockingLizmapTargetVersion)}</li>
                     </ul>
 
                     <li>{@admin.project.rules.list.warnings.html@}</li>

--- a/lizmap/modules/admin/zones/project_list.zone.php
+++ b/lizmap/modules/admin/zones/project_list.zone.php
@@ -82,20 +82,17 @@ class project_listZone extends jZone
             }
             $maps[$r] = $lizmapViewItem;
         }
-        // Fixme, to move in VersionTools
         $lizmapTargetVersionInt = jApp::config()->minimumRequiredVersion['lizmapWebClientTargetVersion'];
-        $humanLizmapTargetVersion = substr($lizmapTargetVersionInt, 0, 1);  // Major
-        $humanLizmapTargetVersion .= '.'.ltrim(substr($lizmapTargetVersionInt, 2, 1), ''); // Minor
+        $blockingLizmapVersionInt = ($lizmapTargetVersionInt - 100);
+        $humanLizmapTargetVersion = VersionTools::intVersionToHumanString($lizmapTargetVersionInt, true);
+        $humanBlockingLizmapTargetVersion = VersionTools::intVersionToHumanString($blockingLizmapVersionInt, true);
 
-        // Fixme, to move in VersionTools
         $lizmapDesktopInt = jApp::config()->minimumRequiredVersion['lizmapDesktopPlugin'];
-        $lizmapDesktopRecommended = substr($lizmapDesktopInt, 0, 1);  // Major
-        $lizmapDesktopRecommended .= '.'.ltrim(substr($lizmapDesktopInt, 2, 1), '');  // Minor
-        $lizmapDesktopRecommended .= '.'.ltrim(substr($lizmapDesktopInt, 3, 2), '');  // Bugfix
-
+        $lizmapDesktopRecommended = VersionTools::intVersionToHumanString($lizmapDesktopInt);
         $this->_tpl->assign('mapItems', $maps);
         $this->_tpl->assign('hasInspectionData', $hasInspectionData);
         $this->_tpl->assign('minimumLizmapTargetVersionRequired', $humanLizmapTargetVersion);
+        $this->_tpl->assign('blockingLizmapTargetVersion', $humanBlockingLizmapTargetVersion);
 
         // Add an warning message when some projects cannot be displayed in LWC
         if ($hasSomeProjectsNotDisplayed) {
@@ -222,8 +219,7 @@ class project_listZone extends jZone
         $projectItem['qgis_version_int'] = (int) substr($qgisVersionInt, 0, 3);
 
         // Target Lizmap Web Client version
-        $targetVersion = substr($projectItem['lizmap_web_client_target_version'], 0, 1);
-        $targetVersion .= '.'.ltrim(substr($projectItem['lizmap_web_client_target_version'], 2, 1), '');
+        $targetVersion = VersionTools::intVersionToSortableString($projectItem['lizmap_web_client_target_version']);
         $projectItem['lizmap_web_client_target_version_display'] = $targetVersion;
         $projectItem['needs_update_error'] = $projectMetadata->needsUpdateError();
         $projectItem['needs_update_warning'] = $projectMetadata->needsUpdateWarning();

--- a/lizmap/modules/admin/zones/project_list.zone.php
+++ b/lizmap/modules/admin/zones/project_list.zone.php
@@ -83,6 +83,7 @@ class project_listZone extends jZone
             $maps[$r] = $lizmapViewItem;
         }
         $lizmapTargetVersionInt = jApp::config()->minimumRequiredVersion['lizmapWebClientTargetVersion'];
+        // 31500 - 100 → 31400 → 3.14
         $blockingLizmapVersionInt = ($lizmapTargetVersionInt - 100);
         $humanLizmapTargetVersion = VersionTools::intVersionToHumanString($lizmapTargetVersionInt, true);
         $humanBlockingLizmapTargetVersion = VersionTools::intVersionToHumanString($blockingLizmapVersionInt, true);

--- a/lizmap/modules/lizmap/lib/App/VersionTools.php
+++ b/lizmap/modules/lizmap/lib/App/VersionTools.php
@@ -92,7 +92,7 @@ class VersionTools
     }
 
     /**
-     * Transform int formatted version to a human readable string (remove useless 0),
+     * Transform int formatted version to a human readable string (remove useless 0 if needed),
      * optionnaly remove patch version.
      * ! short version (342 for 3.42) are not handled.
      *

--- a/lizmap/modules/lizmap/lib/App/VersionTools.php
+++ b/lizmap/modules/lizmap/lib/App/VersionTools.php
@@ -93,15 +93,18 @@ class VersionTools
 
     /**
      * Transform int formatted version to a human readable string (remove useless 0),
-     * (remove patch version if 00).
+     * optionnaly remove patch version.
+     * ! short version (342 for 3.42) are not handled.
      *
-     * Transform "101" into "1.1"
-     * Transform "0590" into "5.90"
-     * Transform "250208 into 25.2.8
-     * Transform "031400 into 3.14
+     * Transform "59000" into "5.90.00"
+     * Transform "059000" into "5.90.00"
+     * Transform "250208" into "25.2.8"
+     * Transform "250208" into "25.2" (strip patch set to true)
+     * Transform "031400" into "3.14" (strip patch set to true)
      *
      * @param string $intVersion a version number as int
      *                           (major version on 1 or 2 digit, min and patch version on 2 digit)
+     * @param bool   $stripPatch remove the patch version (default false)
      *
      * @return string the version as human readable string
      */

--- a/lizmap/modules/lizmap/lib/App/VersionTools.php
+++ b/lizmap/modules/lizmap/lib/App/VersionTools.php
@@ -90,4 +90,27 @@ class VersionTools
 
         return intval(intval($version[0]) * 10000 + intval($version[1]) * 100 + intval($version[2]));
     }
+
+    /**
+     * Transform int formatted version to a human readable string (remove useless 0),
+     * (remove patch version if 00).
+     *
+     * Transform "101" into "1.1"
+     * Transform "0590" into "5.90"
+     * Transform "250208 into 25.2.8
+     * Transform "031400 into 3.14
+     *
+     * @param string $intVersion a version number as int
+     *                           (major version on 1 or 2 digit, min and patch version on 2 digit)
+     *
+     * @return string the version as human readable string
+     */
+    public static function intVersionToHumanString(string $intVersion, bool $stripPatch = false): string
+    {
+        $intVersion6Digit = (strlen($intVersion) == 6 ? $intVersion : '0'.$intVersion);
+        list($majorVersion, $minorVersion, $patchVersion) = str_split($intVersion6Digit, 2);
+        $patchSuffix = ($stripPatch ? '' : '.'.intval($patchVersion));
+
+        return intval($majorVersion).'.'.intval($minorVersion).$patchSuffix;
+    }
 }

--- a/lizmap/www/assets/js/admin/activate_datatable.js
+++ b/lizmap/www/assets/js/admin/activate_datatable.js
@@ -12,10 +12,11 @@ $(document).ready(function () {
         var columnDefs = [
             // Change lizmap plugin version display
             {
-                "targets": 'lizmap_plugin_version',
+                "targets": 5,
                 "render": function (data, type, row, meta) {
                     if (type == 'display') {
-                        return data.replace(/\.0/g, '.').replace(/^0/, '');
+                        // 03.09.00 => 3.9
+                        return data.substr(0, 5).replace(/\.0/g, '.').replace(/^0/, '');
                     }
                     return data;
                 }

--- a/tests/units/classes/App/VersionToolsTest.php
+++ b/tests/units/classes/App/VersionToolsTest.php
@@ -34,14 +34,43 @@ class VersionToolsTest extends TestCase
         $this->assertEquals(33412, VersionTools::qgisVersionWithNameToInt('03.34.12'));
     }
 
-    public function testIntVersionToSortableString(): void
+    public static function intVersionToSortableProvider() {
+        return [
+            'string version with starting 0' => ['01.01.02' , '01.01.02'],
+            'string version without starting 0' => ['1.01.02' , '01.01.02'],
+            'string version only 1 digit' => ['1.1.2' , '01.01.02'],
+            'int version (5char)' => ['10102' , '01.01.02'],
+            'int version (6 char)' => ['050912', '05.09.12'],
+            'master' =>['master', '00.00.00'],
+            'dev' =>['dev', '00.00.00'],
+        ];
+    }
+
+    /**
+     * @dataProvider intVersionToSortableProvider
+     */
+    public function testIntVersionToSortableString(string $intVersion, string $expected): void
     {
-        $this->assertEquals('01.01.02', VersionTools::intVersionToSortableString('01.01.02'));
-        $this->assertEquals('01.01.02', VersionTools::intVersionToSortableString('1.01.02'));
-        $this->assertEquals('01.01.02', VersionTools::intVersionToSortableString('1.1.2'));
-        $this->assertEquals('01.01.02', VersionTools::intVersionToSortableString('10102'));
-        $this->assertEquals('05.09.12', VersionTools::intVersionToSortableString('050912'));
-        $this->assertEquals('00.00.00', VersionTools::intVersionToSortableString('master'));
-        $this->assertEquals('00.00.00', VersionTools::intVersionToSortableString('dev'));
+        $this->assertEquals($expected, VersionTools::intVersionToSortableString($intVersion));
+    }
+
+    public static function intVersionToHumanProvider() {
+        return [
+            '1 digit (5char)' => ['10102' , '1.1.2', false],
+            '1 digit (6 char)' => ['050912', '5.9.12', false],
+            '2 digit' =>  ['311225' , '31.12.25', false],
+            '2 digit no patch' =>  ['031415' , '3.14', true],
+            'no patch version' => ['056000' , '5.60', true],
+            'only maj version' => ['600000' , '60.0.0', false],
+            'only maj version no patch' => ['600000' , '60.0', true],
+        ];
+    }
+
+    /**
+     * @dataProvider intVersionToHumanProvider
+     */
+    public function testIntVersionToHumanString(string $intVersion, string $expected, bool $stripPatch): void
+    {
+        $this->assertEquals($expected, VersionTools::intVersionToHumanString($intVersion, $stripPatch));
     }
 }

--- a/tests/units/classes/App/VersionToolsTest.php
+++ b/tests/units/classes/App/VersionToolsTest.php
@@ -2,6 +2,7 @@
 
 use Lizmap\App\VersionTools;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @internal
@@ -49,6 +50,7 @@ class VersionToolsTest extends TestCase
     /**
      * @dataProvider intVersionToSortableProvider
      */
+    #[DataProvider('intVersionToSortableProvider')]
     public function testIntVersionToSortableString(string $intVersion, string $expected): void
     {
         $this->assertEquals($expected, VersionTools::intVersionToSortableString($intVersion));
@@ -69,6 +71,7 @@ class VersionToolsTest extends TestCase
     /**
      * @dataProvider intVersionToHumanProvider
      */
+    #[DataProvider('intVersionToHumanProvider')]
     public function testIntVersionToHumanString(string $intVersion, string $expected, bool $stripPatch): void
     {
         $this->assertEquals($expected, VersionTools::intVersionToHumanString($intVersion, $stripPatch));


### PR DESCRIPTION
add `VersionTools:intVersionToHumanString`  method  to convert int version to human readable string
 example : `030506 `means `3.5.6`, 

keep the `intVersionToSortableString` to allow sortable string ( "03.10.XX" > "03.09.YY" but 3.10 < 3.9), so update js to convert "sortable" string to a human string 

Ticket : #5855 

Funded by 3Liz
