### PR TITLE
Fix GetLegendGraphic Etag by adding layer

### DIFF
--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -674,7 +674,8 @@ class serviceCtrl extends jController
         /** @var jResponseBinary $rep */
         $rep = $this->getResponse('binary');
         // Etag header and cache control
-        $etag = $this->buildEtag('GetLegendGraphic');
+        $etag = 'GetLegendGraphic-'.$wmsRequest->param('layer', $wmsRequest->param('layers', ''));
+        $etag = $this->buildEtag($etag);
         $respCanBeCached = $this->canBeCached();
         if ($respCanBeCached && $rep->isValidCache(null, $etag)) {
             $this->setACAOHeader($rep);

--- a/tests/end2end/playwright/qgis-request.spec.js
+++ b/tests/end2end/playwright/qgis-request.spec.js
@@ -28,6 +28,9 @@ test.describe('QGIS Requests', () => {
         expect(response.headers()).toHaveProperty('cache-control');
         expect(response.headers()['cache-control']).toBe('no-cache');
         expect(response.headers()).toHaveProperty('etag');
+        const etag = response.headers()['etag'];
+        expect(etag).not.toBe('');
+        expect(etag).toHaveLength(43);
         // check body
         const single = await response.json()
         // check root
@@ -66,6 +69,9 @@ test.describe('QGIS Requests', () => {
         expect(response.headers()).toHaveProperty('cache-control');
         expect(response.headers()['cache-control']).toBe('no-cache');
         expect(response.headers()).toHaveProperty('etag');
+        expect(response.headers()['etag']).not.toBe('');
+        expect(response.headers()['etag']).toHaveLength(43);
+        expect(response.headers()['etag']).not.toBe(etag);
         // check body
         const categorized = await response.json();
         // check root
@@ -105,6 +111,9 @@ test.describe('QGIS Requests', () => {
         expect(response.headers()).toHaveProperty('cache-control');
         expect(response.headers()['cache-control']).toBe('no-cache');
         expect(response.headers()).toHaveProperty('etag');
+        expect(response.headers()['etag']).not.toBe('');
+        expect(response.headers()['etag']).toHaveLength(43);
+        expect(response.headers()['etag']).not.toBe(etag);
         // check body
         const group = await response.json();
         // check root
@@ -148,6 +157,9 @@ test.describe('QGIS Requests', () => {
         expect(response.headers()).toHaveProperty('cache-control');
         expect(response.headers()['cache-control']).toBe('no-cache');
         expect(response.headers()).toHaveProperty('etag');
+        expect(response.headers()['etag']).not.toBe('');
+        expect(response.headers()['etag']).toHaveLength(43);
+        expect(response.headers()['etag']).not.toBe(etag);
         // check body
         const combined = await response.json();
         // check root


### PR DESCRIPTION
The GetLegendGraphic Etag was not enough specific. I was the same for a project.

Linked to https://github.com/3liz/lizmap-web-client/pull/5792

Funded by SMAVD