### PR TITLE
Fix: set alphanumeric order in form filter

### DIFF
--- a/assets/src/legacy/filter.js
+++ b/assets/src/legacy/filter.js
@@ -536,10 +536,8 @@ var lizLayerFilterTool = function () {
                         globalThis['filterConfig'][field_item.order]['items']
                     );
 
-                    // Order fkeys alphabetically (which means sort checkboxes for each field)
-                    fkeys.sort(function (a, b) {
-                        return a.localeCompare(b);
-                    });
+                    // Order fkeys alphanumerically (which means sort checkboxes for each field)
+                    fkeys.sort(new Intl.Collator(undefined, { numeric: true }).compare);
 
                     for (const f_val of fkeys) {
                         // Replace key by value if defined


### PR DESCRIPTION
```js
// Before
["1", "10", "2"].sort(function (a, b) {
                        return a.localeCompare(b);
                    });
Array(3) [ "1", "10", "2" ]

// After
["1", "10", "2"].sort(new Intl.Collator(undefined,{numeric:true}).compare);
Array(3) [ "1", "2", "10" ]
```

Ticket : paid support ticket 3561

Funded by CD 48 support
