### PR TITLE
Detect entry point when login event and adapt event key

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapLog.listener.php
+++ b/lizmap/modules/lizmap/classes/lizmapLog.listener.php
@@ -20,6 +20,11 @@ class lizmapLogListener extends jEventListener
     public function onAuthCanLogin($event)
     {
         $key = 'login';
+        $entrypointFile = jApp::coord()->request->urlScriptName;
+        $entrypoint = substr($entrypointFile, 0, -4);
+        if ($entrypoint != 'admin') {
+            $key = $entrypoint.'-login';
+        }
         // if user-agent is QGIS, change event key
         if (preg_match('#QGIS/\d+/#', $_SERVER['HTTP_USER_AGENT'])) {
             $key = 'qgis-login';

--- a/lizmap/modules/lizmap/daos/logDetail.dao.xml
+++ b/lizmap/modules/lizmap/daos/logDetail.dao.xml
@@ -22,7 +22,7 @@
             <parameter name="offset"/>
             <parameter name="limit"/>
             <conditions >
-                <neq property="key" value="qgis-login" />
+                <notlike property="key" value="%-login" />
             </conditions>
             <order>
                 <orderitem property="id" way="desc" />


### PR DESCRIPTION
When anoter entry point (installed by an external lizmap module) is performing an authentication process, the "login" event will now  be `<entry-point>-login` and will be filtered from log pages (as QGIS plugin login see https://github.com/3liz/lizmap-web-client/pull/5845)

Ticket : #

Funded by 3Liz
