### PR TITLE
JS: Remove import from legacy

### DIFF
--- a/assets/src/index.js
+++ b/assets/src/index.js
@@ -32,6 +32,7 @@ import executeJSFromServer from './modules/ExecuteJSFromServer.js';
 
 import olDep from './dependencies/ol.js';
 import litHTMLDep from './dependencies/lit-html.js';
+import DOMPurify from 'dompurify';
 import proj4 from 'proj4';
 
 /**
@@ -86,6 +87,7 @@ const definedCustomElements = () => {
 const initLizmapApp = () => {
     lizMap.ol = olDep;
     lizMap.litHTML = litHTMLDep;
+    lizMap.DOMPurify = DOMPurify;
     lizMap.proj4 = proj4;
 
     lizMap.events.on({

--- a/assets/src/legacy/atlas.js
+++ b/assets/src/legacy/atlas.js
@@ -5,9 +5,6 @@
  * @license MPL-2.0
  */
 
-import DOMPurify from 'dompurify';
-import { getCenter } from 'ol/extent.js';
-
 (function () {
 
     lizMap.events.on({
@@ -204,7 +201,7 @@ import { getCenter } from 'ol/extent.js';
                             }
                         }
 
-                        $('#liz-atlas-select').html(DOMPurify.sanitize(options));
+                        $('#liz-atlas-select').html(lizMap.DOMPurify.sanitize(options));
                         // reset val
                         $('#liz-atlas-select').val(val);
                         // get popup
@@ -403,7 +400,7 @@ import { getCenter } from 'ol/extent.js';
                 // Get Atlas home
                 var home = getAtlasHome(lizAtlasConfig);
 
-                $("#atlas-content").html(DOMPurify.sanitize(home));
+                $("#atlas-content").html(lizMap.DOMPurify.sanitize(home));
 
                 // Add events
                 activateAtlasTrigger(lizAtlasConfig);
@@ -566,7 +563,7 @@ import { getCenter } from 'ol/extent.js';
                 if (lizAtlasConfig['zoom']) {
                     if (lizAtlasConfig['zoom'].toLowerCase() == 'center') {
                         // center
-                        const center = getCenter(olFeature.getGeometry().getExtent());
+                        const center = lizMap.ol.extent.getCenter(olFeature.getGeometry().getExtent());
                         lizMap.map.setCenter(center);
                     }
                     else {

--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -5,8 +5,6 @@
  * @license MPL-2.0
  */
 
-import DOMPurify from 'dompurify';
-
 var lizAttributeTable = function() {
 
     const intRegex = /^[0-9]+$/;
@@ -1927,7 +1925,7 @@ var lizAttributeTable = function() {
                                     continue;
                                 var prop = feat.properties[idx];
                                 if (typeof prop == 'string') {
-                                    prop = DOMPurify.sanitize(prop, {
+                                    prop = lizMap.DOMPurify.sanitize(prop, {
                                         ADD_ATTR: ['target']
                                     });
                                 }

--- a/assets/src/legacy/filter.js
+++ b/assets/src/legacy/filter.js
@@ -5,8 +5,6 @@
  * @license MPL-2.0
  */
 
-import DOMPurify from 'dompurify';
-
 var lizLayerFilterTool = function () {
 
     lizMap.events.on({
@@ -528,7 +526,7 @@ var lizLayerFilterTool = function () {
                     }
 
                     for (const feat of result) {
-                        globalThis['filterConfig'][field_item.order]['items'][DOMPurify.sanitize(feat['v'].toString())] = feat['c'];
+                        globalThis['filterConfig'][field_item.order]['items'][lizMap.DOMPurify.sanitize(feat['v'].toString())] = feat['c'];
                     }
 
                     var dhtml = '';

--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -8,12 +8,6 @@
  * @license MPL-2.0
  */
 
-import { extend } from 'ol/extent.js';
-
-import WFS from '../modules/WFS.js';
-import WMS from '../modules/WMS.js';
-import { Utils } from '../modules/Utils.js';
-
 window.lizMap = function() {
     /**
      * PRIVATE Property: config
@@ -2082,7 +2076,7 @@ window.lizMap = function() {
         // Download file
         document.querySelectorAll('.exportLayer').forEach(el => el.disabled = true);
         mAddMessage(lizDict['layer.export.started'], 'info', true).addClass('export-in-progress');
-        Utils.downloadFile(getFeatureUrlData['url'], getFeatureUrlData['options'], () => {
+        lizMap.mainLizmap.utils.downloadFile(getFeatureUrlData['url'], getFeatureUrlData['options'], () => {
             document.querySelectorAll('.exportLayer').forEach(el => el.disabled = false);
             document.querySelector('#message .export-in-progress button').click();
         });
@@ -2301,8 +2295,8 @@ window.lizMap = function() {
             types: aConfig['types']
         };
 
-        const wfs = new WFS();
-        wfs.getFeature(getFeatureUrlData['options']).then(data => {
+        // get the data
+        lizMap.mainLizmap.wfs.getFeature(getFeatureUrlData['options']).then(data => {
             aConfig['featureCrs'] = 'EPSG:4326';
 
             if (aConfig?.['alias'] && aConfig?.['types']) {
@@ -2522,7 +2516,7 @@ window.lizMap = function() {
 
         // Query the server
         $.post(globalThis['lizUrls'].service, wmsOptions, function(data) {
-            aCallback(Utils.sanitizeGFIContent(data));
+            aCallback(lizMap.mainLizmap.utils.sanitizeGFIContent(data));
         });
     }
 
@@ -2596,7 +2590,7 @@ window.lizMap = function() {
         // Query the server
         $.post(globalThis['lizUrls'].service, wmsOptions, function(data) {
             if (aCallback) {
-                aCallback(globalThis['lizUrls'].service, wmsOptions, Utils.sanitizeGFIContent(data));
+                aCallback(globalThis['lizUrls'].service, wmsOptions, lizMap.mainLizmap.utils.sanitizeGFIContent(data));
             }
         });
     }
@@ -3249,17 +3243,15 @@ window.lizMap = function() {
             if(layerName && filter){
 
                 // Feature extent
-                const wfs = new WFS();
                 const wfsParams = {
                     TYPENAME: layerName,
                     EXP_FILTER: filter
                 };
 
-                featureExtentRequest = wfs.getFeature(wfsParams);
+                featureExtentRequest = lizMap.mainLizmap.wfs.getFeature(wfsParams);
 
                 // Feature info
                 if(urlParameters.get('popup') === 'true'){
-                    const wms = new WMS();
                     const wmsParams = {
                         QUERY_LAYERS: layerName,
                         LAYERS: layerName,
@@ -3267,7 +3259,7 @@ window.lizMap = function() {
                         FILTER: `${layerName}:${filter}`,
                     };
 
-                    getFeatureInfoRequest = wms.getFeatureInfo(wmsParams);
+                    getFeatureInfoRequest = lizMap.mainLizmap.wms.getFeatureInfo(wmsParams);
                 }
             }
 
@@ -3302,7 +3294,7 @@ window.lizMap = function() {
 
                 if(featuresExtent){
                     for (const feature of startupFeatures) {
-                        featuresExtent = extend(featuresExtent, feature.bbox);
+                        featuresExtent = lizMap.ol.extent.extend(featuresExtent, feature.bbox);
                     }
                 }
 


### PR DESCRIPTION
The legacy JS code does not have to contain `import` like modules.

If we need some methods or classes in the legacy JS code, they have o be exposed.