### PR TITLE
Fix e2e playwright tests popup: default buffer length

### DIFF
--- a/tests/end2end/playwright/popup.spec.js
+++ b/tests/end2end/playwright/popup.spec.js
@@ -462,8 +462,8 @@ test.describe('Popup Geometry',
             // Get default buffer with one point
             let buffer = await page.screenshot({clip:{x:425, y:325, width:100, height:100}});
             const defaultByteLength = buffer.byteLength;
-            expect(defaultByteLength).toBeGreaterThan(800); // 851
-            expect(defaultByteLength).toBeLessThan(900) // 851
+            await expect(defaultByteLength).toBeGreaterThan(800); // 851 or 906
+            await expect(defaultByteLength).toBeLessThan(1000) // 851 or 906
 
             // Click on a point
             let getFeatureInfoPromise = project.waitForGetFeatureInfoRequest();
@@ -497,8 +497,8 @@ test.describe('Popup Geometry',
             // Get default buffer with one point
             let buffer = await page.screenshot({clip:{x:425, y:325, width:100, height:100}});
             const defaultByteLength = buffer.byteLength;
-            expect(defaultByteLength).toBeGreaterThan(800); // 851
-            expect(defaultByteLength).toBeLessThan(900) // 851
+            await expect(defaultByteLength).toBeGreaterThan(800); // 851 or 906
+            await expect(defaultByteLength).toBeLessThan(1000) // 851 or 906
 
             // Click on a point
             let getFeatureInfoPromise = project.waitForGetFeatureInfoRequest();


### PR DESCRIPTION
After 4f47864a1c53788cf1e7bbf628025c548c911b3e homogenize end2end Playwright popup tests about default buffer length.