### PR TITLE
Deprecate `run-docker`

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -99,7 +99,9 @@ jobs:
           make show-qgis-server-versions
 
       - name: Run docker compose
-        run: ./run-docker
+        run: |
+          make env
+          docker compose up -d 
 
       - name: Wait and check about QGIS Server status
         run: |

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -48,13 +48,12 @@ env:
 	SWAGGER_PORT=$(SWAGGER_UI_PORT)
 	EOF
 
-
 build-plugins:
 	docker run \
 	    -u $(LIZMAP_USER_ID):$(LIZMAP_GROUP_ID) \
 	    --rm -i \
 	    -e QGSRV_SERVER_PLUGINPATH=/srv/plugins \
-	    -e QGIS_PLUGIN_MANAGER_SOURCES_FILE=/tmp/sources-plugin-manager.list \
+	    -e QGIS_PLUGIN_MANAGER_SOURCES_FILE=/src/docker-conf/unstable-plugin-sources.list \
 	    -e QGIS_PLUGIN_MANAGER_CACHE_DIR=/tmp/cache-plugin-manager \
 	    -v $(shell pwd)/qgis-server-plugins:/srv/plugins \
 	    -v $(shell pwd)/:/src \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -90,9 +90,29 @@ upgrade-projects:
 up: env
 	docker compose up  -V --force-recreate -d
 
+# Alias for 'up'
+run: up
+
 stop:
 	docker compose stop
 
 reset:
 	docker compose down -v --remove-orphans
 	./lizmap-ctl clean
+
+# install or update base images, to be sure we have the latest images
+build:: env
+	docker compose pull
+
+# install or update plugins, to be sure we have the latest plugins
+build:: build-plugins
+
+clean:
+	./lizmap-ctl clean
+
+# run docker
+# prepare lizmap
+# populate PostgreSQL database with testing data
+install: run
+	./lizmap-ctl install
+	./qgis-projects/tests/load_sql.sh

--- a/tests/README.md
+++ b/tests/README.md
@@ -34,22 +34,19 @@ git pull
 
 ### With Linux
 
-You must install Docker on your machine first. Then you should execute
-the `run-docker` script.
+You must install Docker on your machine first. Then execute `make run`
 
 To launch containers for the first time, with your current user:
 
 ```bash
-./lizmap-ctl clean
-./run-docker build
+make clean
+make build
 ```
 
 Then:
 
 ```bash
-./run-docker
-./lizmap-ctl install
-./qgis-projects/tests/load_sql.sh # to populate PostgreSQL database with testing data
+make install
 ```
 
 Then, in your browser, go to `http://localhost:8130/`. (see below to change the port)
@@ -67,7 +64,7 @@ Then, in your browser, go to `http://lizmap.local:8130/`. (see below to change t
 To stop containers:
 
 ```bash
-./run-docker stop
+make stop
 ```
 
 You may have to close connections to the postgresql database if you are using
@@ -142,7 +139,7 @@ If you want to update this page, you can modify the [./api/openapi.yaml](./api/o
 ## Admin User Account Setup
 
 Default admin credentials are `admin`/`admin`, to modify it, set these variables in your environment,
-default values are provided in `run-docker` :
+default values provided:
 - `LIZMAP_ADMIN_LOGIN`: Login of the admin user
 - `LIZMAP_ADMIN_EMAIL`: Email address of the admin user, it will be used by the password reset process.
 - `LIZMAP_ADMIN_DEFAULT_PASSWORD_SOURCE`: The password source to user for the admin user, it can either be:
@@ -165,7 +162,7 @@ export LZMWEBPORT=8151
 export LZMQGSRVPORT=8152
 export QGSRVAPIPORT=8134
 
-./run-docker up -d
+make up
 
 # you can then open browser at :
 # http://localhost:8151/ for Lizmap Web Client
@@ -189,7 +186,7 @@ You must set these (optional) environment variables, **before** building the sta
 export PHP_VERSION=8.3
 export LZMQGSRVVERSION=3.42
 export LZMPOSTGISVERSION=17-3
-./run-docker build
+make build
 ```
 
 ## Running different docker stack for each branch
@@ -197,15 +194,14 @@ export LZMPOSTGISVERSION=17-3
 By default, name of containers are different for each branch, so you can build
 and run a docker stack for each branch of the repository. Name of containers
 are made with the name of the current branch. You set a different name by creating
-an environment variable `LZMBRANCH` before running `run-docker` or `lizmap-ctl`.
+an environment variable `LZMBRANCH` before running `make run` or `lizmap-ctl`.
 
 Example:
 
 ```bash
 export LZMBRANCH=another-name
 
-./run-docker build
-./run-docker up -d
+make build up
 ./lizmap-ctl reset
 # etc...
 

--- a/tests/add_server_plugins.sh
+++ b/tests/add_server_plugins.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+if [[ ! -f "$QGIS_PLUGIN_MANAGER_SOURCES_FILE" ]]; then
+    echo "Please set QGIS_PLUGIN_MANAGER_SOURCES_FILE to a valid file (found \"$QGIS_PLUGIN_MANAGER_SOURCES_FILE\")"
+    exit 1
+fi
+
 # Remove legacy folders about qgis-plugin-manager
 if [ -d /srv/plugins/.cache_qgis_plugin_manager ]; then
   rm -rf /srv/plugins/.cache_qgis_plugin_manager
@@ -11,9 +16,7 @@ if [ -f /srv/plugins/sources.list ]; then
 fi
 
 echo "QGIS Server Lizmap and WfsOutputExtension plugins"
-echo "Unstable from https://packages.3liz.org"
-# qgis-plugin-manager init
-echo "https://packages.3liz.org/pub/server-plugins-repository/unstable/plugins.[VERSION].xml" > /tmp/sources-plugin-manager.list
+echo "Loading from $(cat $QGIS_PLUGIN_MANAGER_SOURCES_FILE)"
 qgis-plugin-manager update
 qgis-plugin-manager install -f "Lizmap server"
 qgis-plugin-manager install -f wfsOutputExtension

--- a/tests/docker-conf/unstable-plugin-sources.list
+++ b/tests/docker-conf/unstable-plugin-sources.list
@@ -1,0 +1,1 @@
+https://packages.3liz.org/pub/server-plugins-repository/unstable/plugins.[VERSION].xml

--- a/tests/lizmap-ctl
+++ b/tests/lizmap-ctl
@@ -130,7 +130,7 @@ case $COMMAND in
        docker exec -it --user postgres -e PGPASSWORD="lizmap1234!" lizmap${LZMBRANCH}_test_pgsql /bin/bash  -l
        ;;
     dump-pgsql)
-       docker exec -i -e PGPASSWORD="lizmap1234!" lizmap${LZMBRANCH}_test_pgsql pg_dump -U lizmap --no-owner --no-acl -n tests_projects -f /srv/lzm/tests/qgis-projects/tests/tests_dataset.sql
+       docker exec -i -e PGPASSWORD="lizmap1234!" lizmap${LZMBRANCH}_test_pgsql pg_dump -U lizmap --no-owner --no-acl --restrict-key=lizmap_test -n tests_projects -f /srv/lzm/tests/qgis-projects/tests/tests_dataset.sql
        docker exec -i -e PGPASSWORD="lizmap1234!" lizmap${LZMBRANCH}_test_pgsql sed -i '/^-- Dumped/ d' /srv/lzm/tests/qgis-projects/tests/tests_dataset.sql
        docker exec -i -e PGPASSWORD="lizmap1234!" lizmap${LZMBRANCH}_test_pgsql sed -i '/^SET idle_in_transaction_session_timeout/ d' /srv/lzm/tests/qgis-projects/tests/tests_dataset.sql
        docker exec -i -e PGPASSWORD="lizmap1234!" lizmap${LZMBRANCH}_test_pgsql sed -i '/^SET transaction_timeout/ d' /srv/lzm/tests/qgis-projects/tests/tests_dataset.sql


### PR DESCRIPTION
Simplify commands for local and CI tests.

### Changes

Deprecate `./run-docker` which is only a pass-through to make without really value-added and allows more fine grained  command execution.
