### PR TITLE
Tests: fix restrict key for dumping database

### DIFF
--- a/tests/lizmap-ctl
+++ b/tests/lizmap-ctl
@@ -130,7 +130,7 @@ case $COMMAND in
        docker exec -it --user postgres -e PGPASSWORD="lizmap1234!" lizmap${LZMBRANCH}_test_pgsql /bin/bash  -l
        ;;
     dump-pgsql)
-       docker exec -i -e PGPASSWORD="lizmap1234!" lizmap${LZMBRANCH}_test_pgsql pg_dump -U lizmap --no-owner --no-acl --restrict-key=lizmap_test -n tests_projects -f /srv/lzm/tests/qgis-projects/tests/tests_dataset.sql
+       docker exec -i -e PGPASSWORD="lizmap1234!" lizmap${LZMBRANCH}_test_pgsql pg_dump -U lizmap --no-owner --no-acl --restrict-key=testse2elizmap -n tests_projects -f /srv/lzm/tests/qgis-projects/tests/tests_dataset.sql
        docker exec -i -e PGPASSWORD="lizmap1234!" lizmap${LZMBRANCH}_test_pgsql sed -i '/^-- Dumped/ d' /srv/lzm/tests/qgis-projects/tests/tests_dataset.sql
        docker exec -i -e PGPASSWORD="lizmap1234!" lizmap${LZMBRANCH}_test_pgsql sed -i '/^SET idle_in_transaction_session_timeout/ d' /srv/lzm/tests/qgis-projects/tests/tests_dataset.sql
        docker exec -i -e PGPASSWORD="lizmap1234!" lizmap${LZMBRANCH}_test_pgsql sed -i '/^SET transaction_timeout/ d' /srv/lzm/tests/qgis-projects/tests/tests_dataset.sql

--- a/tests/qgis-projects/tests/tests_dataset.sql
+++ b/tests/qgis-projects/tests/tests_dataset.sql
@@ -2,6 +2,8 @@
 -- PostgreSQL database dump
 --
 
+\restrict testse2elizmap
+
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -5049,3 +5051,5 @@ ALTER TABLE ONLY tests_projects.tramway_pivot
 --
 -- PostgreSQL database dump complete
 --
+
+\unrestrict testse2elizmap


### PR DESCRIPTION
To check if database is not changed by readonly end2end tests, the database is dumped. pg_dump will generate a random one as needed. Keys may contain only alphanumeric characters.