### PR TITLE
Tests: PHP-Unit 11 for local like in Github workflows

### DIFF
--- a/tests/units/composer.json
+++ b/tests/units/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": ">=8.2.0",
-        "phpunit/phpunit": "^10.5.29",
+        "phpunit/phpunit": "^11.5.2",
         "phpstan/phpstan": "1.11.11",
         "rector/rector": "1.2.*",
         "symfony/console": "*"


### PR DESCRIPTION
In the Github wrokflows, the PHP-Unit version is 11.5.2 and 10 for local.

The default PHP version for tests is 8.2.