### PR TITLE
Media - Allow to use media links with BASIC authentication

### DIFF
--- a/lizmap/modules/view/controllers/media.classic.php
+++ b/lizmap/modules/view/controllers/media.classic.php
@@ -162,6 +162,14 @@ class mediaCtrl extends jController
             return $rep;
         }
 
+        // Optional BASIC authentication
+        if (isset($_SERVER['PHP_AUTH_USER'])) {
+            $ok = jAuth::login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
+            if (!$ok) {
+                return $this->error403(jLocale::get('view~default.repository.access.denied'));
+            }
+        }
+
         // Get repository data
         $repository = $this->param('repository');
 


### PR DESCRIPTION
Allow to use a Lizmap media link with BASIC authentication.

Funded by Valabre https://www.valabre.com/
