### PR TITLE
Editing - Avoid checking valuerelation & relationreference fields as valid WFS typenames

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/WFSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WFSRequest.php
@@ -364,10 +364,16 @@ class WFSRequest extends OGCRequest
             return $this->getfeatureQgis();
         }
 
-        // Checking Typename which is mandatory for DescribeFeatureType
-        $typenameCheckingCode = $this->checkingTypename();
-        if ($typenameCheckingCode !== 200) {
-            return $this->serviceException($typenameCheckingCode);
+        // Checking Typename which is mandatory for GetFeature
+        // Check only if we are not in the editing context
+        // To let editors not publish some vector layers in WFS/OAPIF
+        // to fill in the value relation or relation references
+        // of some form fields
+        if (!$this->editingContext) {
+            $typenameCheckingCode = $this->checkingTypename();
+            if ($typenameCheckingCode !== 200) {
+                return $this->serviceException($typenameCheckingCode);
+            }
         }
 
         // Get type name


### PR DESCRIPTION
In the context of editing features, Lizmap Web Client backend should access data with WFS getfeature request even if the publisher has not checked them as published in the QGIS project properties. This allows to fill the combo boxes (or multiple checkboxes) based on "value relation" or "relation reference" edit types.

Funded by 3liz
