### PR TITLE
fix : login key for other entrypoint

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapLog.listener.php
+++ b/lizmap/modules/lizmap/classes/lizmapLog.listener.php
@@ -20,8 +20,9 @@ class lizmapLogListener extends jEventListener
     public function onAuthCanLogin($event)
     {
         $key = 'login';
-        $entrypointFile = jApp::coord()->request->urlScriptName;
+        $entrypointFile = str_replace('/', '', $_SERVER['SCRIPT_NAME']);
         $entrypoint = substr($entrypointFile, 0, -4);
+        // entry point other than admin are provided by other module (webdav, ...), use different log key
         if ($entrypoint != 'admin') {
             $key = $entrypoint.'-login';
         }


### PR DESCRIPTION
 When the [webdav module](https://github.com/3liz/lizmap-webdav-module) is enabled, the Login event should be logged with a specific  key (see https://github.com/3liz/lizmap-web-client/pull/5942 ) 

But #5942 didn't work as expected (request object is not instanciated yet ?) 

<img width="656" height="186" alt="Screenshot 2025-09-16 at 10-48-07 Administration" src="https://github.com/user-attachments/assets/b9fd9118-173d-49c1-8e82-5b1857710db6" />

So the PR use `$_SERVER` vars to find the entrypoint

<img width="950" height="43" alt="Screenshot 2025-09-16 at 10-48-17 Administration" src="https://github.com/user-attachments/assets/6d8dcbd4-7daf-400c-894e-e092d4311c13" />
 
Funded by 3Liz
