### PR TITLE
Media - Improve HTTP error codes when the user is not authenticated

### DIFF
--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -2,6 +2,7 @@
 
 use GuzzleHttp\Psr7\Utils as Psr7Utils;
 use Lizmap\App\Checker;
+use Lizmap\App\ControllerTools;
 use Lizmap\Project\Project;
 
 use Lizmap\Project\UnknownLizmapProjectException;
@@ -292,23 +293,9 @@ class serviceCtrl extends jController
 
                 // Add WWW-Authenticate header only for external clients
                 // To avoid web browser to ask for login/password when session expires
-                // In browser, Lizmap UI sends full service URL in referer
-                $addwww = false;
-                $referer = isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '';
-                if (!empty($referer)) {
-                    $referer_parse = parse_url($referer);
-                    if (array_key_exists('host', $referer_parse)) {
-                        $referer_domain = $referer_parse['host'];
-                        $domain = jApp::coord()->request->getDomainName();
-                        if (!empty($domain) and $referer_domain != $domain) {
-                            $addwww = true;
-                        }
-                    }
-                } else {
-                    $addwww = true;
-                }
+                $addHeader = !ControllerTools::clientIsABrowser();
                 // Add WWW-Authenticate header
-                if ($addwww) {
+                if ($addHeader) {
                     $rep->addHttpHeader('WWW-Authenticate', 'Basic realm="LizmapWebClient", charset="UTF-8"');
                 }
             } elseif ($code == 'Forbidden') {

--- a/lizmap/modules/lizmap/lib/App/ControllerTools.php
+++ b/lizmap/modules/lizmap/lib/App/ControllerTools.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Controlers tools for Lizmap.
+ *
+ * @author    3liz
+ * @copyright 2024 3liz
+ *
+ * @see      https://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+namespace Lizmap\App;
+
+class ControllerTools
+{
+    /**
+     * Check if we are in a browser or an external client.
+     */
+    public static function clientIsABrowser(): bool
+    {
+        // In browser, Lizmap UI sends full service URL in referer
+        $inBrowser = true;
+        $referer = isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '';
+        if (!empty($referer)) {
+            $referer_parse = parse_url($referer);
+            if (array_key_exists('host', $referer_parse)) {
+                $referer_domain = $referer_parse['host'];
+                $domain = \jApp::coord()->request->getDomainName();
+                if (!empty($domain) && $referer_domain != $domain) {
+                    $inBrowser = false;
+                }
+            }
+        } else {
+            $inBrowser = false;
+        }
+
+        return $inBrowser;
+    }
+}

--- a/lizmap/modules/view/locales/en_US/default.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/default.UTF-8.properties
@@ -11,6 +11,7 @@ service.access.denied=Access denied to the service.
 service.access.forbidden=Access forbidden to the service.
 service.access.wrong_credentials.title=Wrong credentials
 service.access.wrong_credentials.detail=The given login and password are incorrect. Cannot authenticate.
+service.access.unauthorized=Access needs a valid authentication credentials
 
 project.access.denied=Access denied for this project.
 project.title.label=Title

--- a/tests/end2end/playwright/media.spec.js
+++ b/tests/end2end/playwright/media.spec.js
@@ -215,6 +215,20 @@ test.describe('Media', () => {
         expect(body['error']).toBe('404 not found (wrong action)');
         expect(body).toHaveProperty('message');
 
+        // Parameters to a media file but from a projec requiring auth
+        params = new URLSearchParams({
+            repository: 'testsrepository',
+            project: 'project_acl',
+            path: 'media/raster.asc',
+        });
+        url = `/index.php/view/media/getMedia?${params}`;
+        response = await request.head(url, {});
+        await expect(response).not.toBeOK();
+        expect(response.status()).toBe(401);
+        // We do not check the www-authenticate header
+        // since we are in the browser
+        // expect(response.headers()['www-authenticate']).toBe('Basic realm="LizmapWebClient", charset="UTF-8"');
+
         // Parameters without any error
         params = new URLSearchParams({
             repository: 'testsrepository',


### PR DESCRIPTION
When the user is not authenticated and media must be accessed with specific rights, return a `401` instead of a `403` and add the header `WWW-Authenticate`

Funded by Valabre
