### PR TITLE
Fix regression: exporter disappear from layer information sub dock

### DIFF
--- a/assets/src/legacy/switcher-layers-actions.js
+++ b/assets/src/legacy/switcher-layers-actions.js
@@ -176,15 +176,32 @@ var lizLayerActionButtons = function() {
             if ( 'exportLayers' in lizMap.config.options
                 && lizMap.config.options.exportLayers == 'True'
                 && featureTypes != null
-                && featureTypes.length != 0 ) {
+                && featureTypes.length != 0
+                && layerConfig.typename != undefined) {
                 var exportFormats = lizMap.mainLizmap.initialConfig.vectorLayerResultFormat;
                 var options = '';
                 for ( const format of exportFormats ) {
                     options += '<option value="'+format+'">'+format+'</option>';
                 }
+                // Check export enabled
+                // By default, export is enabled for all layers with typename
+                let exportEnabled = true;
+                // If attribute layers is defined, we have to check if the publisher
+                // has disabled export in attribute table config
+                const attrLayersConfig = lizMap.mainLizmap.initialConfig.attributeLayers;
+                if (attrLayersConfig !== null) {
+                    const attrLayerConfigsLen = attrLayersConfig.layerConfigs.length;
+                    const exportLayersLen = attrLayersConfig.layerConfigs.filter(attr => attr.exportEnabled).length;
+                    // If some layers have export disabled, we have to check if the current layer is in the list
+                    if (attrLayerConfigsLen != exportLayersLen) {
+                        const attrLayerConfig = attrLayersConfig.layerConfigs.find(layer => layer.id === layerConfig.id);
+                        // If the layer is not in the list, export is disabled
+                        // else export is available as definde in attribute layer config
+                        exportEnabled = (attrLayerConfig !== undefined && attrLayerConfig.exportEnabled);
+                    }
+                }
                 // Export layer
-                // Only if layer is in attribute table
-                if( options != '' && layerConfig.typename != undefined) {
+                if( options != '' && exportEnabled) {
                     html+= '        <dt>'+lizDict['layer.metadata.export.title']+'</dt>';
                     html+= '<dd>';
                     html+= '<select class="exportLayer '+isBaselayer+'">';

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -1999,6 +1999,10 @@ class Project
             }
         }
 
+        // Add export layer right
+        if ($this->appContext->aclCheck('lizmap.tools.layer.export', $this->repository->getKey())) {
+            $configJson->options->exportLayers = 'True';
+        }
         // Set layers export permissions
         $this->setLayersExportPermissions($configJson, $userGroups);
 

--- a/tests/end2end/playwright/sub-dock-metadata.spec.js
+++ b/tests/end2end/playwright/sub-dock-metadata.spec.js
@@ -1,0 +1,174 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+import { ProjectPage } from "./pages/project";
+
+test.describe('Sub dock', () => {
+
+    test('Metadata layer in attribute table project', async ({ page }) => {
+        const project = new ProjectPage(page, 'attribute_table');
+        await project.open();
+
+        // Display info button
+        await expect(page.getByTestId('Les quartiers à Montpellier').locator('.icon-info-sign')).toBeHidden();
+        await page.getByTestId('Les quartiers à Montpellier').hover();
+        await expect(page.getByTestId('Les quartiers à Montpellier').locator('.icon-info-sign')).toBeVisible();
+
+        // Display sub dock metadata
+        await expect(page.locator('#sub-dock')).toBeHidden();
+        await page.getByTestId('Les quartiers à Montpellier').locator('.icon-info-sign').click();
+        await expect(page.locator('#sub-dock')).toBeVisible();
+
+        // Check sub dock metadata content
+        await expect(page.locator('#sub-dock .sub-metadata h3 .text')).toHaveText('Information');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt')).toHaveCount(5);
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(0)).toHaveText('Name');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(1)).toHaveText('Type');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(2)).toHaveText('Zoom to the layer extent');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(3)).toHaveText('Opacity');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(4)).toHaveText('Export');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dd')).toHaveCount(5);
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dd').nth(0)).toHaveText('Les quartiers à Montpellier');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dd').nth(1)).toHaveText('Layer');
+
+        //close sub dock
+        await expect(page.locator('#hide-sub-dock')).toBeVisible();
+        await page.locator('#hide-sub-dock').click();
+        await expect(page.locator('#sub-dock')).toBeHidden();
+
+        // Display sub dock metadata for group
+        await page.getByTestId('relation').locator('> div.group > div.node').hover();
+        await expect(page.getByTestId('relation').locator('> div.group > div.node .icon-info-sign')).toBeVisible();
+        await page.getByTestId('relation').locator('> div.group > div.node .icon-info-sign').click();
+        await expect(page.locator('#hide-sub-dock')).toBeVisible();
+
+        // Check sub dock metadata content
+        await expect(page.locator('#sub-dock .sub-metadata h3 .text')).toHaveText('Information');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt')).toHaveCount(4);
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(0)).toHaveText('Name');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(1)).toHaveText('Type');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(2)).toHaveText('Zoom to the layer extent');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(3)).toHaveText('Opacity');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dd')).toHaveCount(4);
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dd').nth(0)).toHaveText('relation');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dd').nth(1)).toHaveText('Group');
+
+        //close sub dock
+        await expect(page.locator('#hide-sub-dock')).toBeVisible();
+        await page.locator('#hide-sub-dock').click();
+        await expect(page.locator('#sub-dock')).toBeHidden();
+    });
+
+    test('Metadata one on two layers in WFS with attribute table', async ({ page }) => {
+        const project = new ProjectPage(page, 'permalink');
+        await project.open();
+
+        // Display sub dock metadata for layer in WFS with multiple styles
+        await page.getByTestId('sousquartiers').hover();
+        await page.getByTestId('sousquartiers').locator('.icon-info-sign').click();
+        await expect(page.locator('#sub-dock')).toBeVisible();
+
+        // Check sub dock metadata content
+        await expect(page.locator('#sub-dock .sub-metadata h3 .text')).toHaveText('Information');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt')).toHaveCount(6);
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(0)).toHaveText('Name');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(1)).toHaveText('Type');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(2)).toHaveText('Zoom to the layer extent');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(3)).toHaveText('Change layer style');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(4)).toHaveText('Opacity');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(5)).toHaveText('Export');
+
+        // Display sub dock metadata for layer not in WFS and no multiple styles
+        await page.getByTestId('Les quartiers à Montpellier').hover();
+        await page.getByTestId('Les quartiers à Montpellier').locator('.icon-info-sign').click();
+        await expect(page.locator('#sub-dock')).toBeVisible();
+
+        // Check sub dock metadata content
+        await expect(page.locator('#sub-dock .sub-metadata h3 .text')).toHaveText('Information');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt')).toHaveCount(4);
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(0)).toHaveText('Name');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(1)).toHaveText('Type');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(2)).toHaveText('Zoom to the layer extent');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(3)).toHaveText('Opacity');
+    });
+
+    test('Metadata one on two layers in WFS without attribute table', async ({ page }) => {
+        // Remove attribute table config
+        await page.route('**/service/getProjectConfig*', async route => {
+            const response = await route.fetch();
+            const json = await response.json();
+            json.attributeLayers = {};
+            await route.fulfill({ response, json });
+        });
+
+        const project = new ProjectPage(page, 'permalink');
+        await project.open();
+
+        // Display sub dock metadata for layer in WFS with multiple styles
+        await page.getByTestId('sousquartiers').hover();
+        await page.getByTestId('sousquartiers').locator('.icon-info-sign').click();
+        await expect(page.locator('#sub-dock')).toBeVisible();
+
+        // Check sub dock metadata content
+        await expect(page.locator('#sub-dock .sub-metadata h3 .text')).toHaveText('Information');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt')).toHaveCount(6);
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(0)).toHaveText('Name');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(1)).toHaveText('Type');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(2)).toHaveText('Zoom to the layer extent');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(3)).toHaveText('Change layer style');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(4)).toHaveText('Opacity');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(5)).toHaveText('Export');
+
+        // Display sub dock metadata for layer not in WFS and no multiple styles
+        await page.getByTestId('Les quartiers à Montpellier').hover();
+        await page.getByTestId('Les quartiers à Montpellier').locator('.icon-info-sign').click();
+        await expect(page.locator('#sub-dock')).toBeVisible();
+
+        // Check sub dock metadata content
+        await expect(page.locator('#sub-dock .sub-metadata h3 .text')).toHaveText('Information');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt')).toHaveCount(4);
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(0)).toHaveText('Name');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(1)).toHaveText('Type');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(2)).toHaveText('Zoom to the layer extent');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(3)).toHaveText('Opacity');
+    });
+
+    test('Metadata one on two layers in WFS with export disable in attribute table', async ({ page }) => {
+        // Remove attribute table config
+        await page.route('**/service/getProjectConfig*', async route => {
+            const response = await route.fetch();
+            const json = await response.json();
+            json.attributeLayers.sousquartiers.export_enabled = 'False';
+            await route.fulfill({ response, json });
+        });
+
+        const project = new ProjectPage(page, 'permalink');
+        await project.open();
+
+        // Display sub dock metadata for layer in WFS with multiple styles
+        await page.getByTestId('sousquartiers').hover();
+        await page.getByTestId('sousquartiers').locator('.icon-info-sign').click();
+        await expect(page.locator('#sub-dock')).toBeVisible();
+
+        // Check sub dock metadata content
+        await expect(page.locator('#sub-dock .sub-metadata h3 .text')).toHaveText('Information');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt')).toHaveCount(5);
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(0)).toHaveText('Name');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(1)).toHaveText('Type');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(2)).toHaveText('Zoom to the layer extent');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(3)).toHaveText('Change layer style');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(4)).toHaveText('Opacity');
+
+        // Display sub dock metadata for layer not in WFS and no multiple styles
+        await page.getByTestId('Les quartiers à Montpellier').hover();
+        await page.getByTestId('Les quartiers à Montpellier').locator('.icon-info-sign').click();
+        await expect(page.locator('#sub-dock')).toBeVisible();
+
+        // Check sub dock metadata content
+        await expect(page.locator('#sub-dock .sub-metadata h3 .text')).toHaveText('Information');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt')).toHaveCount(4);
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(0)).toHaveText('Name');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(1)).toHaveText('Type');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(2)).toHaveText('Zoom to the layer extent');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(3)).toHaveText('Opacity');
+    });
+});


### PR DESCRIPTION
An exporter tool was available in the layer information sub dock up to version 3.8. It has desappear with the ability to disable the export of layer in attribute layer.

To get back this feature, the exporter is available for all layer publshed in WFS if no attribute table config is defined or if export in attribute table is not disabled for any layer in attribute table.

The exporter is disable if at least it has been disabled for one layer in attribute table config and it is not enabled for this layer.

Fixes #5857