### PR TITLE
Fix #5934: Display legend for external WMS layers

### DIFF
--- a/assets/src/modules/WMS.js
+++ b/assets/src/modules/WMS.js
@@ -86,4 +86,29 @@ export default class WMS {
             body: params,
         });
     }
+    
+    /**
+     * Get legend graphic as PNG image URL from WMS
+     * @param {object} options - optional parameters which can override this._defaultGetLegendGraphicsParameters
+     * @returns {string} PNG image URL
+     * @memberof WMS
+     */
+    getLegendGraphicPNG(options) {
+        const layers = options['LAYERS'] ?? options['LAYER'];
+        // Check if layer is specified
+        if (!layers) {
+            throw new RequestError(
+                'LAYERS or LAYER parameter is required for getLegendGraphic request',
+                options,
+            );
+        }
+
+        const params = new URLSearchParams({
+            ...this._defaultGetLegendGraphicParameters,
+            ...options,
+            FORMAT: 'image/png' // Force PNG format for external WMS layers
+        });
+
+        return `${globalThis['lizUrls'].wms}?${params}`;
+    }
 }

--- a/assets/src/modules/action/Symbology.js
+++ b/assets/src/modules/action/Symbology.js
@@ -51,9 +51,9 @@ export async function updateLayerTreeLayersSymbology(treeLayers, method=HttpRequ
                         name: treeLayer.wmsName,
                         title: treeLayer.name,
                         symbols: [{
-                            icon: pngUrl,
-                            ruleKey: '',
-                            title: treeLayer.name
+                            type: 'image',
+                            url: pngUrl,
+                            title: treeLayer.name,
                         }]
                     };
                 } catch (error) {

--- a/assets/src/modules/action/Symbology.js
+++ b/assets/src/modules/action/Symbology.js
@@ -32,11 +32,42 @@ export async function updateLayerTreeLayersSymbology(treeLayers, method=HttpRequ
 
     if (method.toUpperCase() == HttpRequestMethods.GET) {
         for (const treeLayer of treeLayers) {
+            // Check if this is an external WMS layer using the backend flag
+            const isExternalWMS = treeLayer.layerConfig?.externalWmsToggle;
+
+            if (isExternalWMS) {
+                // For external WMS layers, use GetLegendGraphic URL directly as DOM element src
+                const wmsParams = {
+                    LAYER: treeLayer.wmsName,
+                    STYLES: treeLayer.wmsSelectedStyleName,
+                    LAYERTITLE: 'FALSE',
+                };
+                try {
+                    const pngUrl = wms.getLegendGraphicPNG(wmsParams);
+                    // Wrap in LayerSymbolsSymbology structure to make it expandable/hideable
+                    // This creates a single-item legend that can be collapsed
+                    treeLayer.symbology = {
+                        type: 'layer',
+                        name: treeLayer.wmsName,
+                        title: treeLayer.name,
+                        symbols: [{
+                            icon: pngUrl,
+                            ruleKey: '',
+                            title: treeLayer.name
+                        }]
+                    };
+                } catch (error) {
+                    console.error('Error loading external WMS legend:', error);
+                    // Fallback to default icon will be handled by symbology state
+                }
+                continue;
+            }
+
+            // Request JSON only for non external WMS
             const wmsParams = {
                 LAYER: treeLayer.wmsName,
                 STYLES: treeLayer.wmsSelectedStyleName,
             };
-
             await wms.getLegendGraphic(wmsParams).then((response) => {
                 for (const node of response.nodes) {
                     // If the layer has no symbology, there is no type property

--- a/assets/src/modules/state/Symbology.js
+++ b/assets/src/modules/state/Symbology.js
@@ -154,6 +154,18 @@ export class BaseIconSymbology extends BaseObjectSymbology {
      * @type {string}
      */
     get icon() {
+        // Check if _icon exists and is a string
+        if (!this._icon || typeof this._icon !== 'string') {
+            return base64png + base64pngNullData;
+        }
+
+        // If it's already a URL (absolute or relative) or data URI, return as-is
+        // This allows external WMS legends to be served directly from their source
+        if (this._icon.startsWith('http://') || this._icon.startsWith('https://') || this._icon.startsWith('/') || this._icon.startsWith('data:')) {
+            return this._icon;
+        }
+
+        // Otherwise, it's base64 data that needs the prefix
         return base64png + this._icon;
     }
 }
@@ -174,12 +186,11 @@ export class LayerIconSymbology extends BaseIconSymbology {
      * Create a layer icon symbology instance based on a node object provided by QGIS Server
      * @param {object}  node      - the QGIS node symbology
      * @param {string}  node.type  - the node type: layer
-     * @param {string}  node.icon  - the png image in base64
+     * @param {string}  node.icon  - the png image in base64 or URL
      * @param {string}  node.name  - the layer name
      * @param {string}  node.title - the node title
      */
     constructor(node) {
-
         if (!node.hasOwnProperty('type') || node.type != 'layer') {
             throw new ValidationError('The layer icon symbology is only available for layer type!');
         }

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -2045,13 +2045,14 @@ class Project
                                 && !array_key_exists('crs', $layerDatasource)) {
                                 $layerDatasource['crs'] = 'EPSG:3857';
                             }
-                            // if the layer datasource contains type and crs EPSG:3857
-                            // external access can be provided
-                            if (array_key_exists('type', $layerDatasource)
-                                && $layerDatasource['crs'] == 'EPSG:3857') {
+                            // Set externalWmsToggle for:
+                            // 1. WMS layers (no 'type' field or type='wms')
+                            // 2. xyz/wmts layers with EPSG:3857 CRS (preserves original functionality)
+                            if ((!array_key_exists('type', $layerDatasource) || $layerDatasource['type'] == 'wms')
+                                || (array_key_exists('type', $layerDatasource) && $layerDatasource['crs'] == 'EPSG:3857')) {
                                 $obj->externalWmsToggle = 'True';
-                                $obj->externalAccess = $layerDatasource;
                             }
+                            $obj->externalAccess = $layerDatasource;
                         }
                     }
                 }

--- a/tests/js-units/node/state/symbology.test.js
+++ b/tests/js-units/node/state/symbology.test.js
@@ -344,7 +344,7 @@ describe('SymbolRuleSymbology', function () {
 })
 
 describe('BaseSymbolsSymbology', function () {
-    it('Valid', function () {
+    it('Valid with icons', function () {
         const symbols = new BaseSymbolsSymbology({
             "symbols":[{
                 "icon":"iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAAU0lEQVQ4jWNgGAV0A4z4JJWVlf8j8+\/evYtTPQs+Q9YelkMRC7Zl+I\/LMKyC2AxBGPYIq8uYcLmIVDBEDLp79y5jsO0jkgwiKfphlpBkwyigPgAATTcaN5pMVDUAAAAASUVORK5CYII=",
@@ -370,6 +370,64 @@ describe('BaseSymbolsSymbology', function () {
         const symbolsGetChildren = symbols.getChildren()
         expect(symbolsGetChildren.next().value).to.be.instanceOf(BaseIconSymbology).that.be.eq(symbolsChildren[0])
         expect(symbolsGetChildren.next().value).to.be.instanceOf(BaseIconSymbology).that.be.eq(symbolsChildren[1])
+    })
+
+    it('Valid with image', function () {
+        const symbols = new BaseSymbolsSymbology({
+            "symbols":[{
+                "url":"http://localhost:8130/index.php/lizmap/service/?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetLegendGraphic&LAYER=legend&FORMAT=image/png&STYLE=default",
+                "title":"legend",
+                "type":"image",
+            }],
+            "title":"hide_at_startup",
+            "type":"layer"
+        })
+        expect(symbols).to.be.instanceOf(BaseSymbolsSymbology)
+        expect(symbols.title).to.be.eq('hide_at_startup')
+        expect(symbols.type).to.be.eq('layer')
+        expect(symbols.expanded).to.be.false
+        expect(symbols.childrenCount).to.be.eq(1)
+        expect(symbols.children).to.be.an('array').that.have.lengthOf(1)
+
+        const symbolsChildren = symbols.children
+        expect(symbolsChildren[0]).to.be.instanceOf(SymbolImageSymbology)
+
+        const symbolsGetChildren = symbols.getChildren()
+        expect(symbolsGetChildren.next().value).to.be.instanceOf(SymbolImageSymbology).that.be.eq(symbolsChildren[0])
+    })
+
+    it('Valid with icons and image', function () {
+        const symbols = new BaseSymbolsSymbology({
+            "symbols":[{
+                "icon":"iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAAU0lEQVQ4jWNgGAV0A4z4JJWVlf8j8+\/evYtTPQs+Q9YelkMRC7Zl+I\/LMKyC2AxBGPYIq8uYcLmIVDBEDLp79y5jsO0jkgwiKfphlpBkwyigPgAATTcaN5pMVDUAAAAASUVORK5CYII=",
+                "title":"category 1"
+            },{
+                "icon":"iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAAU0lEQVQ4jWNgGAV0A4z4JJWVlf8j8+\/evYtTPQs+Q4Q2HkUV9Lf+j8swrIJYDYGCd\/7WWF3GhMtFpIIhYtDdu3cZ3\/lbk2QQSdEPs4QkG0YB9QEAMC8aMZ0a06cAAAAASUVORK5CYII=",
+                "title":"category 2"
+            },{
+                "url":"http://localhost:8130/index.php/lizmap/service/?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetLegendGraphic&LAYER=legend&FORMAT=image/png&STYLE=default",
+                "title":"legend",
+                "type":"image",
+            }],
+            "title":"hide_at_startup",
+            "type":"layer"
+        })
+        expect(symbols).to.be.instanceOf(BaseSymbolsSymbology)
+        expect(symbols.title).to.be.eq('hide_at_startup')
+        expect(symbols.type).to.be.eq('layer')
+        expect(symbols.expanded).to.be.false
+        expect(symbols.childrenCount).to.be.eq(3)
+        expect(symbols.children).to.be.an('array').that.have.lengthOf(3)
+
+        const symbolsChildren = symbols.children
+        expect(symbolsChildren[0]).to.be.instanceOf(BaseIconSymbology)
+        expect(symbolsChildren[1]).to.be.instanceOf(BaseIconSymbology)
+        expect(symbolsChildren[2]).to.be.instanceOf(SymbolImageSymbology)
+
+        const symbolsGetChildren = symbols.getChildren()
+        expect(symbolsGetChildren.next().value).to.be.instanceOf(BaseIconSymbology).that.be.eq(symbolsChildren[0])
+        expect(symbolsGetChildren.next().value).to.be.instanceOf(BaseIconSymbology).that.be.eq(symbolsChildren[1])
+        expect(symbolsGetChildren.next().value).to.be.instanceOf(SymbolImageSymbology).that.be.eq(symbolsChildren[2])
     })
 
     it('Event', function () {
@@ -747,6 +805,117 @@ describe('LayerSymbolsSymbology', function () {
         expect(symbology._icons[1].title).to.be.eq('')
         expect(symbology._icons[1].parentRuleKey).to.be.eq('')
         expect(symbology._icons[1].parentRule).to.be.null
+    })
+
+    it('image', function () {
+        const symbology = new LayerSymbolsSymbology({
+            "symbols":[{
+                "url":"http://localhost:8130/index.php/lizmap/service/?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetLegendGraphic&LAYER=legend&FORMAT=image/png&STYLE=default",
+                "title":"legend",
+                "type":"image",
+            }],
+            "title":"layer_legend_categorized",
+            "type":"layer",
+            "name":"layer_legend_categorized"
+        })
+        expect(symbology).to.be.instanceOf(BaseSymbolsSymbology)
+        expect(symbology).to.be.instanceOf(LayerSymbolsSymbology)
+        expect(symbology.title).to.be.eq('layer_legend_categorized')
+        expect(symbology.name).to.be.eq('layer_legend_categorized')
+        expect(symbology.type).to.be.eq('layer')
+        expect(symbology.expanded).to.be.false
+        expect(symbology.legendOn).to.be.true
+        expect(symbology.childrenCount).to.be.eq(1)
+        expect(symbology.children).to.be.an('array').that.have.lengthOf(1)
+
+        const symbologyChildren = symbology.children
+        expect(symbologyChildren[0])
+            .to.be.instanceOf(BaseIconSymbology)
+            .that.be.instanceOf(SymbolImageSymbology)
+            .that.not.be.instanceOf(SymbolIconSymbology)
+            .that.not.be.instanceOf(SymbolRuleSymbology)
+
+        const symbologyGetChildren = symbology.getChildren()
+        expect(symbologyGetChildren.next().value).to.be.instanceOf(SymbolImageSymbology).that.be.eq(symbologyChildren[0])
+        expect(symbologyGetChildren.next().value).to.be.undefined
+
+        expect(symbology.wmsParameters('layer_legend_categorized')).to.be.an('object').that.be.deep.eq({})
+    })
+
+    it('categorizedSymbol with image', function () {
+        const symbology = new LayerSymbolsSymbology({
+            "symbols":[{
+                "icon":"iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAAU0lEQVQ4jWNgGAV0A4z4JJWVlf8j8+\/evYtTPQs+Q9YelkMRC7Zl+I\/LMKyC2AxBGPYIq8uYcLmIVDBEDLp79y5jsO0jkgwiKfphlpBkwyigPgAATTcaN5pMVDUAAAAASUVORK5CYII=",
+                "title":"category 1",
+                "ruleKey":"0",
+                "checked":true
+            },{
+                "icon":"iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAAU0lEQVQ4jWNgGAV0A4z4JJWVlf8j8+\/evYtTPQs+Q4Q2HkUV9Lf+j8swrIJYDYGCd\/7WWF3GhMtFpIIhYtDdu3cZ3\/lbk2QQSdEPs4QkG0YB9QEAMC8aMZ0a06cAAAAASUVORK5CYII=",
+                "title":"category 2",
+                "ruleKey":"1",
+                "checked":true
+            },{
+                "url":"http://localhost:8130/index.php/lizmap/service/?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetLegendGraphic&LAYER=legend&FORMAT=image/png&STYLE=default",
+                "title":"legend",
+                "type":"image",
+            }],
+            "title":"layer_legend_categorized",
+            "type":"layer",
+            "name":"layer_legend_categorized"
+        })
+        expect(symbology).to.be.instanceOf(BaseSymbolsSymbology)
+        expect(symbology).to.be.instanceOf(LayerSymbolsSymbology)
+        expect(symbology.title).to.be.eq('layer_legend_categorized')
+        expect(symbology.name).to.be.eq('layer_legend_categorized')
+        expect(symbology.type).to.be.eq('layer')
+        expect(symbology.expanded).to.be.false
+        expect(symbology.legendOn).to.be.true
+        expect(symbology.childrenCount).to.be.eq(3)
+        expect(symbology.children).to.be.an('array').that.have.lengthOf(3)
+
+        const symbologyChildren = symbology.children
+        expect(symbologyChildren[0])
+            .to.be.instanceOf(BaseIconSymbology)
+            .that.be.instanceOf(SymbolIconSymbology)
+            .that.not.be.instanceOf(SymbolRuleSymbology)
+        expect(symbologyChildren[1])
+            .to.be.instanceOf(BaseIconSymbology)
+            .that.be.instanceOf(SymbolIconSymbology)
+            .that.not.be.instanceOf(SymbolRuleSymbology)
+        expect(symbologyChildren[2])
+            .to.be.instanceOf(BaseIconSymbology)
+            .that.be.instanceOf(SymbolImageSymbology)
+            .that.not.be.instanceOf(SymbolIconSymbology)
+            .that.not.be.instanceOf(SymbolRuleSymbology)
+
+        const symbologyGetChildren = symbology.getChildren()
+        expect(symbologyGetChildren.next().value).to.be.instanceOf(SymbolIconSymbology).that.be.eq(symbologyChildren[0])
+        expect(symbologyGetChildren.next().value).to.be.instanceOf(SymbolIconSymbology).that.be.eq(symbologyChildren[1])
+        expect(symbologyGetChildren.next().value).to.be.instanceOf(SymbolImageSymbology).that.be.eq(symbologyChildren[2])
+        expect(symbologyGetChildren.next().value).to.be.undefined
+
+        expect(symbology.wmsParameters('layer_legend_categorized')).to.be.an('object').that.be.deep.eq({})
+        symbologyChildren[0].checked = false
+        expect(symbology.legendOn).to.be.true
+        expect(symbology.wmsParameters('layer_legend_categorized')).to.be.an('object').that.be.deep.eq({
+            "LEGEND_ON": "layer_legend_categorized:1",
+            "LEGEND_OFF": "layer_legend_categorized:0"
+        })
+        symbologyChildren[1].checked = false
+        expect(symbology.legendOn).to.be.false
+        expect(symbology.wmsParameters('layer_legend_categorized')).to.be.an('object').that.be.deep.eq({
+            "LEGEND_ON": "layer_legend_categorized:",
+            "LEGEND_OFF": "layer_legend_categorized:0,1"
+        })
+        symbologyChildren[0].checked = true
+        expect(symbology.legendOn).to.be.true
+        expect(symbology.wmsParameters('layer_legend_categorized')).to.be.an('object').that.be.deep.eq({
+            "LEGEND_ON": "layer_legend_categorized:0",
+            "LEGEND_OFF": "layer_legend_categorized:1"
+        })
+        symbologyChildren[1].checked = true
+        expect(symbology.legendOn).to.be.true
+        expect(symbology.wmsParameters('layer_legend_categorized')).to.be.an('object').that.be.deep.eq({})
     })
 
     it('Failing required properties', function () {


### PR DESCRIPTION
I hope to help and fix the missing legends for external WMS services:

https://github.com/3liz/lizmap-web-client/issues/5934

External WMS layers were showing empty legend icons because QGIS Server
   returns empty icon fields in JSON GetLegendGraphic responses.

   - Added getLegendGraphicPNG() method to WMS class
   - Modified updateLayerTreeLayersSymbology() to detect external WMS layers
   - External WMS layers now fetch PNG legend and convert to base64
   - Normal layers continue using JSON format (no breaking changes)


I'm not sure if that is enough to get a proper legend from the WMS, i was not able to run proper tests, i just wanted to lay the groundwork to get WMS legends working (i hope it does not interfere with the recent changes which sped up the loading time so much! :smiley: )