### PR TITLE
Fix Edition - External Resource - Default root

### DIFF
--- a/lizmap/modules/lizmap/lib/Project/Qgis/Layer/EditWidget/ExternalResourceConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/Qgis/Layer/EditWidget/ExternalResourceConfig.php
@@ -44,6 +44,7 @@ use Lizmap\Project\Qgis;
  * @property string $StorageAuthConfigId
  * @property int    $StorageMode
  * @property string $StorageType
+ * @property string $DefaultRoot
  */
 class ExternalResourceConfig extends Qgis\BaseQgisObject
 {
@@ -62,6 +63,7 @@ class ExternalResourceConfig extends Qgis\BaseQgisObject
         'StorageAuthConfigId',
         'StorageMode',
         'StorageType',
+        'DefaultRoot',
     );
 
     /** @var array The default values */
@@ -79,6 +81,7 @@ class ExternalResourceConfig extends Qgis\BaseQgisObject
         'StorageAuthConfigId' => '',
         'StorageType' => '',
         'StorageMode' => 0,
+        'DefaultRoot' => '',
     );
 
     protected function set(array $data): void
@@ -166,5 +169,6 @@ class ExternalResourceConfig extends Qgis\BaseQgisObject
                 'StorageAuthConfigId' => 'k6k7lv8',
                 'StorageMode' => 0,
                 'StorageType' => 'WebDAV',
-        );
+                'DefaultRoot' => '',
+           );
 */

--- a/tests/units/classes/Project/Qgis/VectorLayerEditWidgetTest.php
+++ b/tests/units/classes/Project/Qgis/VectorLayerEditWidgetTest.php
@@ -643,6 +643,7 @@ class VectorLayerEditWidgetTest extends TestCase
 
     public function testExternalResourceFromXmlReader(): void
     {
+        // Default
         $xmlStr = '
         <editWidget type="ExternalResource">
           <config>
@@ -691,11 +692,13 @@ class VectorLayerEditWidgetTest extends TestCase
             'StorageAuthConfigId' => '',
             'StorageType' => '',
             'StorageMode' => 0,
+            'DefaultRoot' => '',
         );
         foreach ($config as $prop => $value) {
             $this->assertSame($value, $editWidget->config->{$prop}, $prop);
         }
 
+        // Image
         $xmlStr = '
         <editWidget type="ExternalResource">
           <config>
@@ -732,11 +735,13 @@ class VectorLayerEditWidgetTest extends TestCase
             'StorageAuthConfigId' => '',
             'StorageType' => '',
             'StorageMode' => 0,
+            'DefaultRoot' => '',
         );
         foreach ($config as $prop => $value) {
             $this->assertSame($value, $editWidget->config->{$prop}, $prop);
         }
 
+        // WebDAV
         $xmlStr = '
         <editWidget type="ExternalResource">
           <config>
@@ -786,6 +791,7 @@ class VectorLayerEditWidgetTest extends TestCase
             'StorageAuthConfigId' => 'k6k7lv8',
             'StorageType' => 'WebDAV',
             'StorageMode' => 0,
+            'DefaultRoot' => '',
         );
         foreach ($config as $prop => $value) {
             $this->assertSame($value, $editWidget->config->{$prop}, $prop);
@@ -798,6 +804,142 @@ class VectorLayerEditWidgetTest extends TestCase
                 'storageUrl' => array(
                     'active' => true,
                     'expression' => '\'http://webdav/shapeData/\'||file_name(@selected_file_path)',
+                    'type' => 3,
+                ),
+            ),
+            'type' => 'collection',
+        );
+        foreach ($propertyCollection as $prop => $value) {
+            $this->assertSame($value, $editWidget->config->PropertyCollection[$prop], $prop);
+        }
+
+        // DefaultRoot
+        $xmlStr = '
+          <editWidget type="ExternalResource">
+            <config>
+              <Option type="Map">
+                <Option name="DefaultRoot" type="QString" value="../media/specific_media_folder"></Option>
+                <Option name="DocumentViewer" type="int" value="1"></Option>
+                <Option name="DocumentViewerHeight" type="int" value="0"></Option>
+                <Option name="DocumentViewerWidth" type="int" value="0"></Option>
+                <Option name="FileWidget" type="bool" value="true"></Option>
+                <Option name="FileWidgetButton" type="bool" value="true"></Option>
+                <Option name="FileWidgetFilter" type="QString" value=""></Option>
+                <Option name="PropertyCollection" type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties" type="invalid"></Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+                <Option name="RelativeStorage" type="int" value="1"></Option>
+                <Option name="StorageAuthConfigId" type="QString" value=""></Option>
+                <Option name="StorageMode" type="int" value="0"></Option>
+                <Option name="StorageType" type="QString" value=""></Option>
+              </Option>
+            </config>
+          </editWidget>
+        ';
+        $oXml = App\XmlTools::xmlReaderFromString($xmlStr);
+        $editWidget = VectorLayerEditWidget::fromXmlReader($oXml);
+
+        $this->assertEquals('ExternalResource', $editWidget->type);
+        $this->assertNotNull($editWidget->config);
+        $this->assertInstanceOf(EditWidget\ExternalResourceConfig::class, $editWidget->config);
+
+        $config = array(
+            'DocumentViewer' => 1,
+            'DocumentViewerHeight' => 0,
+            'DocumentViewerWidth' => 0,
+            'FileWidget' => true,
+            'FileWidgetButton' => true,
+            'FileWidgetFilter' => '',
+            'UseLink' => false,
+            'FullUrl' => false,
+            'PropertyCollection' => array(
+                'name' => '',
+                'properties' => null,
+                'type' => 'collection',
+            ),
+            'RelativeStorage' => 1,
+            'StorageAuthConfigId' => '',
+            'StorageType' => '',
+            'StorageMode' => 0,
+            'DefaultRoot' => '../media/specific_media_folder',
+        );
+        foreach ($config as $prop => $value) {
+            $this->assertSame($value, $editWidget->config->{$prop}, $prop);
+        }
+
+        // Expression root path
+        $xmlStr = '
+          <editWidget type="ExternalResource">
+            <config>
+              <Option type="Map">
+                <Option name="DocumentViewer" type="int" value="1"></Option>
+                <Option name="DocumentViewerHeight" type="int" value="0"></Option>
+                <Option name="DocumentViewerWidth" type="int" value="0"></Option>
+                <Option name="FileWidget" type="bool" value="true"></Option>
+                <Option name="FileWidgetButton" type="bool" value="true"></Option>
+                <Option name="FileWidgetFilter" type="QString" value=""></Option>
+                <Option name="PropertyCollection" type="Map">
+                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="properties" type="Map">
+                    <Option name="propertyRootPath" type="Map">
+                      <Option name="active" type="bool" value="true"></Option>
+                      <Option name="expression" type="QString" value="concat(&#xA;&#x9;\'media/expression_root_folder/\',&#xA;&#x9;CASE&#xA;&#x9;&#x9;WHEN lower(trim(to_string(current_value(\'feature_code\')))) IN (\'\', \'null\') OR current_value(\'feature_code\') IS NULL &#xA;&#x9;&#x9;&#x9;THEN \'0\'&#xA;&#x9;&#x9;ELSE trim(to_string(current_value(\'feature_code\')))&#xA;&#x9;END,&#xA;&#x9;\'/\'&#xA;)"></Option>
+                      <Option name="type" type="int" value="3"></Option>
+                    </Option>
+                  </Option>
+                  <Option name="type" type="QString" value="collection"></Option>
+                </Option>
+                <Option name="RelativeStorage" type="int" value="1"></Option>
+                <Option name="StorageAuthConfigId" type="QString" value=""></Option>
+                <Option name="StorageMode" type="int" value="0"></Option>
+                <Option name="StorageType" type="QString" value=""></Option>
+              </Option>
+            </config>
+          </editWidget>
+        ';
+        $oXml = App\XmlTools::xmlReaderFromString($xmlStr);
+        $editWidget = VectorLayerEditWidget::fromXmlReader($oXml);
+
+        $this->assertEquals('ExternalResource', $editWidget->type);
+        $this->assertNotNull($editWidget->config);
+        $this->assertInstanceOf(EditWidget\ExternalResourceConfig::class, $editWidget->config);
+
+        $config = array(
+            'DocumentViewer' => 1,
+            'DocumentViewerHeight' => 0,
+            'DocumentViewerWidth' => 0,
+            'FileWidget' => true,
+            'FileWidgetButton' => true,
+            'FileWidgetFilter' => '',
+            'UseLink' => false,
+            'FullUrl' => false,
+            'RelativeStorage' => 1,
+            'StorageAuthConfigId' => '',
+            'StorageType' => '',
+            'StorageMode' => 0,
+            'DefaultRoot' => '',
+        );
+        foreach ($config as $prop => $value) {
+            $this->assertSame($value, $editWidget->config->{$prop}, $prop);
+        }
+
+        $this->assertNotNull($editWidget->config->PropertyCollection);
+        $propertyCollection = array(
+            'name' => '',
+            'properties' => array(
+                'propertyRootPath' => array(
+                    'active' => true,
+                    'expression' => 'concat(
+	\'media/expression_root_folder/\',
+	CASE
+		WHEN lower(trim(to_string(current_value(\'feature_code\')))) IN (\'\', \'null\') OR current_value(\'feature_code\') IS NULL '.'
+			THEN \'0\'
+		ELSE trim(to_string(current_value(\'feature_code\')))
+	END,
+	\'/\'
+)',
                     'type' => 3,
                 ),
             ),


### PR DESCRIPTION
With the QGIS project parser refactoring, the external resource default root was lost. Fix with unit tests

Funded by Cedegis
