### PR TITLE
Fix export layer from sub-dock

### DIFF
--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -2033,7 +2033,8 @@ window.lizMap = function() {
 
         var attributeLayerConfig = getLayerConfigById(config_layer.id, lizMap.config.attributeLayers, 'layerId' );
         // right not set
-        if ( !('export_enabled' in attributeLayerConfig[1]) || attributeLayerConfig[1].export_enabled != 'True' ) {
+        if ( Array.isArray(attributeLayerConfig) && attributeLayerConfig.length == 2 &&
+            (!('export_enabled' in attributeLayerConfig[1]) || attributeLayerConfig[1].export_enabled != 'True') ) {
             mAddMessage(lizDict['layer.export.right.required'], 'danger', true);
             return false;
         }


### PR DESCRIPTION
The export tool from sub-dock is still buggy when the layer has no attribute table config.

Funded by DEAL Martinique