### PR TITLE
[Bugfix] Show feature Count is requested even if it's value is 0

### DIFF
--- a/lizmap/modules/lizmap/lib/Project/Qgis/LayerTreeGroup.php
+++ b/lizmap/modules/lizmap/lib/Project/Qgis/LayerTreeGroup.php
@@ -139,7 +139,13 @@ class LayerTreeGroup extends BaseQgisXmlObject
 
                 continue;
             }
+            if (!$item->customproperties) {
+                continue;
+            }
             if (!array_key_exists('showFeatureCount', $item->customproperties)) {
+                continue;
+            }
+            if (!filter_var($item->customproperties['showFeatureCount'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)) {
                 continue;
             }
             $data[] = $item->name;

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -84,6 +84,8 @@ services:
     environment:
       PGSERVICEFILE: /srv/etc/pg_service.conf
       QGIS_SERVER_LIZMAP_REVEAL_SETTINGS: yes
+      QGIS_SERVER_TRUST_LAYER_METADATA: yes
+      QGIS_SERVER_FORCE_READONLY_LAYERS: yes
       QGSRV_API_ENABLED_LIZMAP: yes
       QGSRV_CACHE_ROOTDIR: /srv/projects
       QGSRV_CACHE_SIZE: '20'

--- a/tests/units/classes/Project/Qgis/LayerTreeRootTest.php
+++ b/tests/units/classes/Project/Qgis/LayerTreeRootTest.php
@@ -465,4 +465,13 @@ class LayerTreeRootTest extends TestCase
         $this->assertCount(1, $layersShowFeatureCount);
         $this->assertEquals('tramway', $layersShowFeatureCount[0]);
     }
+
+    public function testGetLayersShowFeatureCount(): void
+    {
+        $xmlStr = file_get_contents(__DIR__.'/../../Project/Ressources/root-layer-tree-group-no-show-feature-count.xml');
+        $oXml = App\XmlTools::xmlReaderFromString($xmlStr);
+        $root = Qgis\LayerTreeRoot::fromXmlReader($oXml);
+        $layersShowFeatureCount = $root->getLayersShowFeatureCount();
+        $this->assertCount(0, $layersShowFeatureCount);
+    }
 }

--- a/tests/units/classes/Project/Ressources/root-layer-tree-group-no-show-feature-count.xml
+++ b/tests/units/classes/Project/Ressources/root-layer-tree-group-no-show-feature-count.xml
@@ -1,0 +1,1692 @@
+
+  <layer-tree-group>
+    <customproperties>
+      <Option/>
+    </customproperties>
+    <layer-tree-layer expanded="1" name="LIMITE_COMMUNE_FRANCE" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id1' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;tdpa&quot;.&quot;LIMITE_COMMUNE_FRANCEB&quot; (geom)" providerKey="postgres" id="LIMITE_COMMUNE_FRANCE_d0f17ef9_be2b_4bcc_bcf5_c01797fcd5e9" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+      <customproperties>
+        <Option type="Map">
+          <Option name="expandedLegendNodes"/>
+        </Option>
+      </customproperties>
+    </layer-tree-layer>
+    <layer-tree-layer expanded="1" name="Limite Terre de Provence" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;tdpa&quot;.&quot;CONTOUR_TDPA&quot; (geom)" providerKey="postgres" id="CONTOUR_TDPA_9644c143_6c36_4c74_91bd_c02e61820da2" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+      <customproperties>
+        <Option type="Map">
+          <Option name="expandedLegendNodes"/>
+        </Option>
+      </customproperties>
+    </layer-tree-layer>
+    <layer-tree-layer expanded="1" name="Communes" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;tdpa&quot;.&quot;LIMITE_COMMUNE_TDPAB&quot; (geom)" providerKey="postgres" id="LIMITE_COMMUNE_TDPA_378a823f_7dc9_434c_ac7f_e9a77070ca15" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+      <customproperties>
+        <Option type="Map">
+          <Option name="expandedLegendNodes"/>
+        </Option>
+      </customproperties>
+    </layer-tree-layer>
+    <layer-tree-layer expanded="0" name="ImpressionParcelles" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;cadastre2025&quot;.&quot;parcelle_info&quot; (geom)" providerKey="postgres" id="Parcelles_61bafacb_a3f4_4fe7_ab5d_8c98ae59d92c" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+      <customproperties>
+        <Option type="Map">
+          <Option name="expandedLegendNodes"/>
+        </Option>
+      </customproperties>
+    </layer-tree-layer>
+    <layer-tree-group expanded="0" name="Observatoire de l'habitat" checked="Qt::Unchecked" groupLayer="">
+      <customproperties>
+        <Option type="Map">
+          <Option name="wmsShortName" type="QString" value="Observatoire_de_l_habitat"/>
+        </Option>
+      </customproperties>
+      <layer-tree-layer expanded="0" name="Arrété Péril et Insalubrité" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID' estimatedmetadata=true srid=3944 type=Point checkPrimaryKeyUnicity='1' table=&quot;habitat&quot;.&quot;HAB_PERIL_INSAL&quot; (geom)" providerKey="postgres" id="Arrété_Péril_et_Insalubrité_b2a1cce6_e496_42e4_8931_1b953373b1e7" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Logements RPLS" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Point checkPrimaryKeyUnicity='1' table=&quot;habitat&quot;.&quot;VUE_RPLS_ACTIF&quot; (geom)" providerKey="postgres" id="Logements_RPLS_16db89be_1ec8_4e82_83a8_90ce54b81eb7" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Logement RPLS Suprimé" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Point checkPrimaryKeyUnicity='1' table=&quot;habitat&quot;.&quot;2018_RPLS&quot; (geom) sql=&quot;DATE_SUPRESSION&quot; is not null" providerKey="postgres" id="Logement_RPLS_Suprimé_ed420987_2837_47cb_ad48_8fbab32bc84b" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Résidence" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID' estimatedmetadata=true srid=3944 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;habitat&quot;.&quot;HAB_RESIDENCE&quot; (geom)" providerKey="postgres" id="Résidence_59cc2cf0_9863_426d_b2bb_4a7481f83b5f" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-group expanded="0" name="Limite Permis de louer" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="Limite_Permis_de_louer"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="Périmètres secteurs renforcés" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID' estimatedmetadata=true srid=3944 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;habitat&quot;.&quot;HAB_PERIM_RENFORCE&quot; (geom)" providerKey="postgres" id="P_rim_tres_secteurs_renforc_s_1dc009fa_491a_4806_96e2_5e942e5c3686" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Limite OPAH-RU (19/06/2017)" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;027_LIMITE_OPAH-RU&quot; (geom)" providerKey="postgres" id="Limite_OPAH_RU__19_06_2017__c8f81907_a4ef_4ba4_b382_a9f94bd2a049" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-layer expanded="1" name="Quartier Politique Ville" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;habitat&quot;.&quot;QUARTIER_POLITIQUE_VILLE&quot; (geom)" providerKey="postgres" id="Quartier_Politique_Ville_5e04a09f_624b_4413_9088_fbb2e6a202bb" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+    </layer-tree-group>
+    <layer-tree-group expanded="0" name="Réseau humide" checked="Qt::Unchecked" groupLayer="">
+      <customproperties>
+        <Option type="Map">
+          <Option name="wmsShortName" type="QString" value="Reseau_humide"/>
+        </Option>
+      </customproperties>
+      <layer-tree-group expanded="1" name="Adduction Eau Potable" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="Adduction_Eau_Potable"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="Hydrant" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID_HYDR' estimatedmetadata=true srid=3944 type=PointZ checkPrimaryKeyUnicity='1' table=&quot;eauass&quot;.&quot;AEP_HYDRANT&quot; (geom)" providerKey="postgres" id="Hydrant_569bb60d_ea45_4f2d_8727_e14e6613d912" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Equipement de Comptage" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID_COMPT' estimatedmetadata=true srid=3944 type=PointZ checkPrimaryKeyUnicity='1' table=&quot;eauass&quot;.&quot;AEP_EQUIP_COMPTAGE&quot; (geom)" providerKey="postgres" id="Equipement_de_Comptage_f20dea57_37fa_408a_90a9_a66571f0dca0" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="Vanne" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID_VANNE' estimatedmetadata=true srid=3944 type=PointZ checkPrimaryKeyUnicity='1' table=&quot;eauass&quot;.&quot;AEP_VANNE&quot; (geom)" providerKey="postgres" id="Vanne_a41e947c_6460_4b84_89b7_c37208fbe554" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="StringList">
+                <Option type="QString" value="{0e424324-88a3-4bc2-bd26-a35b3cb449bb}"/>
+              </Option>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Canalisation AEP" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID_CANA' estimatedmetadata=true srid=3944 type=LineStringZ checkPrimaryKeyUnicity='1' table=&quot;eauass&quot;.&quot;AEP_CANALISATION&quot; (geom)" providerKey="postgres" id="Canalisation_AEP_cf7d777d_53b2_492b_ada8_5d88173a7b66" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="0" name="Assainissement Collectif" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="Assainissement_Collectif"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="Ouvrage AC" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID_OUVRAGE' estimatedmetadata=true srid=3944 type=PointZ checkPrimaryKeyUnicity='1' table=&quot;eauass&quot;.&quot;EU_OUVRAGE&quot; (geom)" providerKey="postgres" id="Ouvrage_AC_282a5048_22a4_4e0e_a844_821238fafd3e" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Regard AC Public" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID_REGARD' estimatedmetadata=true srid=3944 type=PointZ checkPrimaryKeyUnicity='1' table=&quot;eauass&quot;.&quot;EU_REGARD&quot; (geom)" providerKey="postgres" id="Regard_AC_Public_19579f59_50ca_49e4_b50b_5794bf25f046" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Canalisation AC Public" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID_CANA' estimatedmetadata=true srid=3944 type=LineStringZ checkPrimaryKeyUnicity='1' table=&quot;eauass&quot;.&quot;EU_CANALISATION&quot; (geom)" providerKey="postgres" id="Canalisation_AC_Public_e5dfafd8_8bdc_4a99_9106_dd63b890a4cd" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="StringList">
+                <Option type="QString" value="{77ff9fec-96a8-407d-9bf3-bf6ccd7d3bdd}"/>
+              </Option>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="Station Epuration" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID' estimatedmetadata=true srid=3944 type=PolygonZ checkPrimaryKeyUnicity='1' table=&quot;eauass&quot;.&quot;EU_STEP&quot; (geom)" providerKey="postgres" id="Station_Epuration_4a93c540_adb4_4155_bfea_33b1e6768113" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-group expanded="0" name="Réseau privé" checked="Qt::Unchecked" groupLayer="">
+          <customproperties>
+            <Option type="Map">
+              <Option name="wmsShortName" type="QString" value="Reseau_prive"/>
+            </Option>
+          </customproperties>
+          <layer-tree-layer expanded="0" name="Regard AC Privée" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID_REGARD' estimatedmetadata=true srid=3944 type=PointZ checkPrimaryKeyUnicity='1' table=&quot;eauass&quot;.&quot;EU_REGARD&quot; (geom)" providerKey="postgres" id="Regard_AC_Privée_8108eb65_af6a_4933_b79c_a7a6f8349234" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+            <customproperties>
+              <Option type="Map">
+                <Option name="expandedLegendNodes" type="invalid"/>
+              </Option>
+            </customproperties>
+          </layer-tree-layer>
+          <layer-tree-layer expanded="0" name="Canalisation AC Privée" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID_CANA' estimatedmetadata=true srid=3944 type=LineStringZ checkPrimaryKeyUnicity='1' table=&quot;eauass&quot;.&quot;EU_CANALISATION&quot; (geom)" providerKey="postgres" id="Canalisation_AC_Privée_4ad579dc_428b_410a_bc0d_b312bfe70e66" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+            <customproperties>
+              <Option type="Map">
+                <Option name="expandedLegendNodes" type="StringList">
+                  <Option type="QString" value="{77ff9fec-96a8-407d-9bf3-bf6ccd7d3bdd}"/>
+                </Option>
+              </Option>
+            </customproperties>
+          </layer-tree-layer>
+        </layer-tree-group>
+      </layer-tree-group>
+      <layer-tree-group expanded="1" name="Pluvial" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="Pluvial"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="Regard EP" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID_REGARD' estimatedmetadata=true srid=3944 type=PointZ checkPrimaryKeyUnicity='1' table=&quot;eauass&quot;.&quot;EP_REGARD&quot; (geom)" providerKey="postgres" id="Regard_EP_6c8384c0_94b9_4917_8c94_7a8327b5aa25" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="Canalisation EP" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID_CANA' estimatedmetadata=true srid=3944 type=MultiLineStringZ checkPrimaryKeyUnicity='1' table=&quot;eauass&quot;.&quot;EP_CANALISATION&quot; (geom)" providerKey="postgres" id="Canalisation_EP_a1e02ce5_a6f1_440f_b6c8_129bb4be2ae4" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="StringList">
+                <Option type="QString" value="{4d9179f7-6fae-4b63-8937-f26b2c45fd37}"/>
+                <Option type="QString" value="{5812cb7e-68f1-46d1-b0aa-51c9254f4023}"/>
+                <Option type="QString" value="{6a0f73a4-67d9-4d09-bb18-8b46b91205c2}"/>
+              </Option>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Ouvrage EP surfacique" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID' estimatedmetadata=true srid=3944 type=PolygonZ checkPrimaryKeyUnicity='1' table=&quot;eauass&quot;.&quot;EP_OUVRAGE_SURF&quot; (geom)" providerKey="postgres" id="Ouvrage_EP_surfacique_d8242dec_cf7e_4c1e_8681_8a30d4eaa68c" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Périmétre compétence pluvial" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;eauass&quot;.&quot;EP_PERIM_COMPET&quot; (geom)" providerKey="postgres" id="Périmétre_compétence_pluvial__9603fc10_9b79_4749_a440_6f5d9c0a1865" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+    </layer-tree-group>
+    <layer-tree-group expanded="0" name="Réseau sec" checked="Qt::Unchecked" groupLayer="">
+      <customproperties>
+        <Option type="Map">
+          <Option name="wmsShortName" type="QString" value="Reseau_sec"/>
+        </Option>
+      </customproperties>
+      <layer-tree-layer expanded="1" name="GRDF au 16/06/2025" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID' estimatedmetadata=true srid=3944 type=LineString checkPrimaryKeyUnicity='1' table=&quot;tdpa&quot;.&quot;GRDF_RESEAU_EN_SERVICE_20250618&quot; (geom)" providerKey="postgres" id="GRDF_RESEAU_EN_SERVICE_20250618_3a0789a1_74bd_467f_9809_fe284a1f6565" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option/>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-group expanded="1" name="Enedis au 05/09/2024" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="Enedis_au_01_09_2019"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="1" name="Postes Sources Enedis" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Point checkPrimaryKeyUnicity='1' table=&quot;rte&quot;.&quot;POSTES_SOURCES_ENEDIS_20240905&quot; (geom)" providerKey="postgres" id="Postes_Sources_Enedis_4cbf6f45_278c_49f6_b56f_966f3ebfd212" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="Postes Electriques Enedis" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Point checkPrimaryKeyUnicity='1' table=&quot;rte&quot;.&quot;POSTES_ELECTRIQUES_ENEDIS_20240905&quot; (geom)" providerKey="postgres" id="Postes_Electriques_Enedis_1f302fc7_1996_4b5c_ac36_d94caec386d1" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="Lignes souterraines BT" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiLineString checkPrimaryKeyUnicity='1' table=&quot;rte&quot;.&quot;RESEAU_SOUTERRAIN_BT_ENEDIS_20240905&quot; (geom)" providerKey="postgres" id="Lignes_souterraines_BT_ef777866_2fe6_4bbd_adf7_2eaa43959d5b" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="Lignes Aériennes BT" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiLineString checkPrimaryKeyUnicity='1' table=&quot;rte&quot;.&quot;RESEAU_BT_ENEDIS_20240905&quot; (geom)" providerKey="postgres" id="Lignes_Aériennes_BT_44a2369e_bd3a_4b96_8242_d493b5aa1f71" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="Lignes souterraines HTA" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiLineString checkPrimaryKeyUnicity='1' table=&quot;rte&quot;.&quot;RESEAU_SOUTERRAIN_HTA_ENEDIS_20240905&quot; (geom)" providerKey="postgres" id="Lignes_souterraines_HTA_07549393_8b66_4c2f_91c6_07358f8a2dee" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="Lignes aériennes HTA" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiLineString checkPrimaryKeyUnicity='1' table=&quot;rte&quot;.&quot;RESEAU_HTA_ENEDIS_20240905&quot; (geom)" providerKey="postgres" id="Lignes_aériennes_HTA_a81fba9a_cbbd_4a3f_bb7a_e26e0e1009c8" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="POTEAU_ENEDIS_20240905" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Point checkPrimaryKeyUnicity='1' table=&quot;rte&quot;.&quot;POTEAU_ENEDIS_20240905&quot; (geom)" providerKey="postgres" id="POTEAU_ENEDIS_20240905_cf61a8c6_aa09_4433_9c6f_8facc009a4aa" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="1" name="Rte au 10/06/2024" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="Rte_au_06_06_2020"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="1" name="Pylones Rte" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Point checkPrimaryKeyUnicity='1' table=&quot;rte&quot;.&quot;PYLONES_RTE_20240610&quot; (geom)" providerKey="postgres" id="Pylones_Rte_au_06_06_2020_2bd84060_b8c7_46b1_a4e4_9f492e2c2d85" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="Postes Electriques" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Point checkPrimaryKeyUnicity='1' table=&quot;rte&quot;.&quot;POSTES_ELECTRIQUES_RTE_20240610&quot; (geom)" providerKey="postgres" id="Postes_Electriques_au_06_06_2020_1ec2e310_8249_4d6c_b9df_fbf4556cf2b2" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Lignes Souterraines Rte" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiLineString checkPrimaryKeyUnicity='1' table=&quot;rte&quot;.&quot;LIGNES_SOUTERRAINES_RTE_20240610&quot; (geom)" providerKey="postgres" id="Lignes_Souterraines_Rte_au_06_06_2020_e8a7e142_f496_43fa_bd9d_cd558f10d3a3" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+              <Option name="showFeatureCount" type="QString" value="0"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Lignes Aériennes Rte" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=LineString checkPrimaryKeyUnicity='1' table=&quot;rte&quot;.&quot;LIGNES_AERIENNES_RTE_20240610&quot; (geom)" providerKey="postgres" id="Lignes_Aériennes_Rte_au_06_06_2020_93b016f1_22ac_4625_9142_a80b6fd6a56e" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+              <Option name="showFeatureCount" type="QString" value="0"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="Enceintes de Postes" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;rte&quot;.&quot;ENCEINTES_POSTE_RTE_20240610&quot; (geom)" providerKey="postgres" id="Enceintes_de_Postes_au_06_06_2020_dc48a2ea_c5f4_472b_8080_d204a61bcd6c" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+    </layer-tree-group>
+    <layer-tree-group expanded="0" name="Servitudes" checked="Qt::Unchecked" groupLayer="">
+      <customproperties>
+        <Option type="Map">
+          <Option name="wmsShortName" type="QString" value="Servitudes"/>
+        </Option>
+      </customproperties>
+      <layer-tree-layer expanded="0" name="Zone PPRI" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;PPRI&quot; (geom)" providerKey="postgres" id="PPRI_f821d969_9fdf_4da5_8850_00989797871d" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-group expanded="0" name="AC1 - Servitudes de protection des monuments" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="AC1_-_Servitudes_de_protection_des_monuments"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="1" name="Générateur" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;SUP_AC1_GEN_20250226&quot; (geom)" providerKey="postgres" id="SUP_AC1_GEN_5cc723e3_826a_42a9_9947_d98775a8f506" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="Assiette" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;SUP_AC1_ASS_20250226&quot; (geom)" providerKey="postgres" id="SUP_AC1_ASS_a8b14725_a71c_4aea_97e5_4a00a7e9c32e" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-layer expanded="1" name="AC2 - Servitudes relatives aux sites inscrits et classés" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;SUP_AC2_ASS&quot; (geom)" providerKey="postgres" id="SUP_AC2_ASS_1300e33c_0de9_4716_a04c_cd71a9b61b51" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="1" name="SUP_AC4_ASS_20250226" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;SUP_AC4_ASS_20250226&quot; (geom)" providerKey="postgres" id="010_AC4_SPR_488e0ead_8ee9_4630_953a_c82cf06ce90f" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="1" name="AS1 - Protéction des eaux potables et minérales" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;SUP_AS1_ASS_20250822&quot; (geom)" providerKey="postgres" id="SUP_AS1_ASS_8403f1cf_b9c2_4d5a_bfbb_407cc115d3bd" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-group expanded="0" name="INT1 - Servitudes relatives à la protection des cimetières" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="INT1_-_Servitudes_relatives_a_la_protection_des_cimetieres"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="1" name="Générateurs" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;SUP_INT1_GEN&quot; (geom)" providerKey="postgres" id="SUP_INT1_GEN_e5d58aaa_b783_42f8_9688_697d393abbed" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="Assiettes" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;SUP_INT1_ASS&quot; (geom)" providerKey="postgres" id="SUP_INT1_ASS_831fd483_fcba_4a59_be0b_b9116a53acfd" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="0" name="I1 - Servitudes relatives à la maîtrise de l’urbanisation" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="I1_-_Servitudes_relatives_a_la_maitrise_de_l_urbanisation"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="1" name="I1 - Servitudes relatives à l’utilisation de certaines ressources et équipements" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiLineString checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;SUP_I1_GEN&quot; (geom)" providerKey="postgres" id="SUP_I1_GEN_e514dbb4_106e_4d64_a599_38a5651360c3" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="I1 bis - Construction et exploitation de pipeline" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiLineString checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;SUP_I1B_GEN&quot; (geom)" providerKey="postgres" id="SUP_I1B_GEN_340cda0e_a5e3_4d8b_a83a_1391eb7e47dd" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="I1 TMD - Transport de matières dangeureuses" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;SUP_I1_TMD&quot; (geom)" providerKey="postgres" id="SUP_I1_TMD_c1c9bcc9_9634_41ba_81c2_0a1a484e49ab" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-layer expanded="1" name="I2 - Servitudes relatives à l’utilisation de l’énergie hydraulique" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;SUP_I2_GEN&quot; (geom)" providerKey="postgres" id="SUP_I2_GEN_b6a018d8_d43f_4e64_8de0_fc6826703be7" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="1" name="I3 - Servitude relative au transport de gaz naturel" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiLineString checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;SUP_I3_GEN&quot; (geom)" providerKey="postgres" id="SUP_I3_GEN_22c35814_6e69_4f1f_8155_d7a1019a2097" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="1" name="I4 - Servitudes relative au transport d'énérgie éléctrique" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;SUP_I4_ASS_20280821&quot; (geom)" providerKey="postgres" id="SUP_I4_ASS_20280821_f75aaa54_dd83_4e38_a80d_d12f03bf0ae7" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option/>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="1" name="PT3 - Servitudes attachées aux réseaux de télécomunications" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiLineString checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;SUP_PT3_GEN&quot; (geom)" providerKey="postgres" id="SUP_PT3_GEN_644c6055_a592_450d_bfce_e45bdcf70d22" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="1" name="T1 - Servitudes relatives aux voies ferrées" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;SUP_T1_ASS_20230103&quot; (geom)" providerKey="postgres" id="SUP_T1_ASS_080a5432_0086_47b7_bb47_abca09dcc111" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="1" name="T5 - Servitudes Aéronautiques de dégagements" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;SUP_T5_ASS&quot; (geom)" providerKey="postgres" id="SUP_T5_ASS_c3df1da1_9272_43d4_877a_5b4dfcec4f8d" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Servitude zone soumise Fouille" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID' estimatedmetadata=true srid=3944 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;projets&quot;.&quot;SERV_ZONE_FOU&quot; (geom)" providerKey="postgres" id="SERV_ZONE_FOU_c317bdd4_83b8_450b_bd3c_e8307787c612" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+    </layer-tree-group>
+    <layer-tree-group expanded="0" name="Gemapi" checked="Qt::Unchecked" groupLayer="">
+      <customproperties>
+        <Option type="Map">
+          <Option name="wmsShortName" type="QString" value="Gemapi"/>
+        </Option>
+      </customproperties>
+      <layer-tree-layer expanded="0" name="EmpriseMurDiguesChabas" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;projets&quot;.&quot;URB_PRJ_DIGUES_CHABAS&quot; (geom)" providerKey="postgres" id="URB_PRJ_DIGUES_CHABAS_b6157673_33c3_41d4_b008_93668dfd371b" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="EmprisecontournementMurDiguesChabas" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;projets&quot;.&quot;URB_PRJ_CONT_DIGUES_CHABAS&quot; (geom)" providerKey="postgres" id="URB_PRJ_CONT_DIGUES_CHABAS_c1061a2b_3646_4cb0_912b_73b8ba5689fb" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Polygone emprise échangeur LEO" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;gemapi&quot;.&quot;SMA_EMP_POL_LEO&quot; (geom)" providerKey="postgres" id="SMA_EMP_POL_LEO_c391b97e_836f_43e0_b3ac_b7e6000c4858" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+            <Option name="showFeatureCount" type="QString" value="0"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Emprise parcelles LEO intersection ouvrages" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;gemapi&quot;.&quot;SMA_EMP_OUV_LEO&quot; (geom)" providerKey="postgres" id="SMA_EMP_OUV_LEO_89a6b4d3_a63b_42fc_9378_ea90f131dda8" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Polygone emprise Alpines Chateaurenard - rognonas" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygonZ checkPrimaryKeyUnicity='1' table=&quot;gemapi&quot;.&quot;SMA_EMP_POL_ALPINE&quot; (geom)" providerKey="postgres" id="SMA_EMP_POL_ALPINE_ee28f767_04e7_40f4_b389_22a862323c5d" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Emprise parcelles Rognonas intersection ouvrages" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;gemapi&quot;.&quot;SMA_EMP_OUV_ROG&quot; (geom)" providerKey="postgres" id="SMA_EMP_OUV_ROG_e1a48afa_4bbd_4330_89e8_0cd3b98ed48c" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Emprise parcelles Chato intersection ouvrages" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;gemapi&quot;.&quot;SMA_EMP_OUV_CHATO&quot; (geom)" providerKey="postgres" id="SMA_EMP_OUV_CHATO_66348eb8_a88d_4adb_96ac_81a442398df0" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+    </layer-tree-group>
+    <layer-tree-group expanded="0" name="Aléas" checked="Qt::Unchecked" groupLayer="">
+      <customproperties>
+        <Option type="Map">
+          <Option name="wmsShortName" type="QString" value="Aleas"/>
+        </Option>
+      </customproperties>
+      <layer-tree-group expanded="0" name="FeuxForets" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="FeuxForets"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="1" name="Aléa subi faible 2" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;FF_ALEA_SUBI_FAIBLE_2&quot; (geom)" providerKey="postgres" id="FF_ALEA_SUBI_FAIBLE_2_8efb35b6_85f9_4708_a36b_e713935ff293" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="Aléa subi moyen 3" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;FF_ALEA_SUBI_MOYEN_3&quot; (geom)" providerKey="postgres" id="FF_ALEA_SUBI_MOYEN_3_f740a738_2551_4f03_b4b8_bf1205d5a8b0" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="Aléa subi fort 4" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;FF_ALEA_SUBI_FORT_4&quot; (geom)" providerKey="postgres" id="FF_ALEA_SUBI_FORT_4_ede0c3f1_7d3e_4879_a07d_183b75fa2cf1" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="Aléa subi trés fort 5" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;FF_ALEA_SUBI_TRES_FORT_5&quot; (geom)" providerKey="postgres" id="FF_ALEA_SUBI_TRES_FORT_5_5d3e23fd_9aea_45cd_ac08_0265e0e5eec0" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="Aléa subi exeptionnel 6" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;FF_ALEA_SUBI_EXEPTIONNEL_6&quot; (geom)" providerKey="postgres" id="FF_ALEA_SUBI_EXEPTIONNEL_6_0cc2fba5_9f59_4221_896b_57da40c23ea2" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-layer expanded="0" name="Argiles risque aléa" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;ALEA_RISQUE_ARG&quot; (geom)" providerKey="postgres" id="Argiles_risque_aléa_f48a80c7_d38a_44cf_be0c_03d54001e742" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+    </layer-tree-group>
+    <layer-tree-group expanded="0" name="Autres Reglements" checked="Qt::Unchecked" groupLayer="">
+      <customproperties>
+        <Option type="Map">
+          <Option name="wmsShortName" type="QString" value="Autres_Reglements"/>
+        </Option>
+      </customproperties>
+      <layer-tree-layer expanded="0" name="Zone réglementation défrichement" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;L_FORET_REGL_DEFRICH_ZINF_013&quot; (geom)" providerKey="postgres" id="Zone_réglementation_défrichement_a971e4de_0809_4f19_b36a_e8888869158c" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+    </layer-tree-group>
+    <layer-tree-group expanded="1" name="Réglement d'Urbanisme" checked="Qt::Checked" groupLayer="">
+      <customproperties>
+        <Option type="Map">
+          <Option name="wmsShortName" type="QString" value="Reglement_d_Urbanisme"/>
+        </Option>
+      </customproperties>
+      <layer-tree-layer expanded="1" name="Perimetre de droit de preemption urbain" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID' estimatedmetadata=true srid=3944 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;SUL_DPU&quot; (geom)" providerKey="postgres" id="Perimetre_de_droit_de_preemption_urbain_7319296a_d8a1_4744_8f55_ec69c7ff9664" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option/>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-group expanded="0" name="PLU Barbentane 19/08/2024" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="PLU_Barbentane_19_08_2024"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="1" name="010_ALEA_RUISSELLEMENT_2010" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;010-barbentane&quot;.&quot;010_ALEA_RUISSELLEMENT_2010&quot; (geom)" providerKey="postgres" id="010_ALEA_RUISSELLEMENT_2010_d375073c_b9ba_4814_a15f_ae2c5c7846dd" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option/>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="010_PRESCRIPTION_PCT_20240819" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Point checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;010_PRESCRIPTION_PCT_20240819&quot; (geom)" providerKey="postgres" id="010_PRESCRIPTION_PCT_20240819_5b75a038_686f_4f02_80fd_94147ffbe29d" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option/>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="010_PRESCRIPTION_LIN_20240819" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiLineString checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;010_PRESCRIPTION_LIN_20240819&quot; (geom)" providerKey="postgres" id="010_PRESCRIPTION_LIN_20240819_e027d3ab_119a_43b1_ad99_ee54f3b95c80" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option/>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="010_PRESCRIPTION_SURF_20240819" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;010_PRESCRIPTION_SURF_20240819&quot; (geom)" providerKey="postgres" id="010_PRESCRIPTION_SURF_20240819_28f2a0c8_39fc_4431_81ec_41729dcdbfc8" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option/>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="010_INFO_SURF_20240819" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;010_INFO_SURF_20240819&quot; (geom)" providerKey="postgres" id="010_INFO_SURF_20240819_e4e15640_b3af_4926_b13b_b310a305e315" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option/>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Plu Barbentane" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;010_ZONE_URBA_20240819&quot; (geom)" providerKey="postgres" id="Plu_Barbentane_du_19_08_2024_14e03b19_8a69_4446_a294_e98a93775807" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="0" name="PLU Cabannes du 26/02/2020" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="PLU_Cabannes_du_26_02_2020"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="Préscription Surface" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;018_PRESCRIPTION_SURF_20200226&quot; (geom) sql=&quot;typepsc&quot; &lt;>'38'" providerKey="postgres" id="Pr_scription_Surface_1d94a99a_2852_4df8_b066_39a7bf992279" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="StringList">
+                <Option type="QString" value="{eb20c54d-78cb-4cef-b13b-341c19bde1fe}"/>
+              </Option>
+              <Option name="showFeatureCount" type="QString" value="0"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Plu Cabannes du 26/02/2020" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;018_ZONE_URBA_20200226&quot; (geom)" providerKey="postgres" id="Plu_Cabannes_du_26_02_2020_2c479ff4_677d_4015_9a89_34f771c163b3" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="1" name="Chateaurenard du 06/06/2025" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="Chateaurenard_du_03_02_2020"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="1" name="Zones de présomption de prescription archéologique" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;027-chato&quot;.&quot;027_ZPPARCHEO_20211004&quot; (geom)" providerKey="postgres" id="Zones_de_pr_somption_de_prescription_arch_ologique_833ec138_6f18_4292_83f3_e9947abcb8a3" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="DUP-ORI" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID' estimatedmetadata=true srid=3944 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;027-chato&quot;.&quot;027_DUP_ORI&quot; (geom)" providerKey="postgres" id="DUP_ORI_c2607a80_eff0_4e62_b025_d9887bab89bf" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Réglement Local de Publicité (30/01/2020)" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;027-chato&quot;.&quot;027_20200130-RLP&quot; (geom)" providerKey="postgres" id="R_glement_Local_de_Publicit___30_01_2020__fb40dd92_cdbd_4a72_bd99_346280d6b450" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+              <Option name="showFeatureCount" type="QString" value="0"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Information surfaciques" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;027_INFO_SURF_20250606&quot; (geom)" providerKey="postgres" id="Information_surfaciques_4bbfa1b6_a92b_4347_b4b9_5137b5580635" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+              <Option name="showFeatureCount" type="QString" value="0"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Préscription" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;027_PRESCRIPTION_SURF_20250606&quot; (geom)" providerKey="postgres" id="Pr_scription_a38f261a_fa2b_4265_a2bd_eb31d1abace2" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+              <Option name="showFeatureCount" type="int" value="0"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="PLU" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;027_PLU_ZONE_URBA_20250606&quot; (geom)" providerKey="postgres" id="PLU_20e4242b_a0ba_4619_a4a5_bec5d1a60fe8" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="StringList">
+                <Option type="QString" value="{358a00eb-1763-48ee-ab6d-e5b8d6968948}"/>
+                <Option type="QString" value="{e44a8ccd-8f33-471b-8296-905d03c998e7}"/>
+                <Option type="QString" value="{c571a7a9-f4e5-4ee6-9f57-cacd2174807f}"/>
+              </Option>
+              <Option name="showFeatureCount" type="QString" value="0"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="1" name="PLU Eyragues 27/06/2023" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="PLU_Eyragues_27_06_2023"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="036_PRESCRIPTION_LIN_20230627" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiLineString checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;036_PRESCRIPTION_LIN_20230627&quot; (geom)" providerKey="postgres" id="036_PRESCRIPTION_LIN_20230627_06be8ac6_1120_4f67_ab5f_c005d74e7c00" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="036_PRESCRIPTION_SURF_20230627" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;036_PRESCRIPTION_SURF_20230627&quot; (geom)" providerKey="postgres" id="036_PRESCRIPTION_SURF_20230627_07c2fffa_62a6_4581_8b78_fdeb0724af8f" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+              <Option name="showFeatureCount" type="int" value="0"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="036_INFO_SURF_20230627" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;036_INFO_SURF_20230627&quot; (geom) sql=&quot;typeinf&quot; &lt;>'04'" providerKey="postgres" id="036_INFO_SURF_20230627_8bfa25d0_9002_4728_9729_122c31d488d8" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="036_ZONE_URBA_20230627" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;036_ZONE_URBA_20230627&quot; (geom)" providerKey="postgres" id="036_ZONE_URBA_20230627_620bd69e_4031_4e1b_9136_c92aa05e0484" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="1" name="PLU Graveson 21/05/2018" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="PLU_Graveson_21_05_2018"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="Préscription Point" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Point checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;045_PRESCRIPTION_PCT_20180531&quot; (geom)" providerKey="postgres" id="Pr_scription_Point_dd5a6829_63d9_48d5_9609_53d734ec88ea" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Préscription Ligne" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiLineString checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;045_PRESCRIPTION_LIN_20180531&quot; (geom)" providerKey="postgres" id="Pr_scription_Ligne_735d9ff7_c0b8_4590_bfb2_7c72f1b41f48" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Informations surfaciques" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;045_INFO_SURF_20180531&quot; (geom)" providerKey="postgres" id="Informations_surfaciques_921eb5a7_2cb5_4259_ac09_bea57b47cea2" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Préscriptions surfaciques" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;045_PRESCRIPTION_SURF_20180531&quot; (geom)" providerKey="postgres" id="Pr_scriptions_surfaciques_d582e7f8_896f_428a_9afe_35a3277445ed" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="PLU Graveson du 31/05/2018" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;045_PLU_ZONE_URBA&quot; (geom)" providerKey="postgres" id="PLU_Graveson_du_31_05_2018_35369693_cf96_4ed0_b606_e4e64a52c2b1" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="0" name="PLU Maillane 20/10/2022" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="PLU_Maillane_20_10_2022"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="052_INFO_SURF_DPU" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;052_INFO_SURF_20221020&quot; (geom)" providerKey="postgres" id="052_INFO_SURF_DPU_a97ab28d_6c14_4c82_b399_e56af0da0be5" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="QString" value="{49e4ec68-03d2-4f90-900d-2ef49192ad2c}"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="052_INFO_SURF_PPRI" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;052_INFO_SURF_20221020&quot; (geom)" providerKey="postgres" id="052_INFO_SURF_PPRI_aae0615d_14e8_4e36_9ee0_0a02c05267bd" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="QString" value="{49e4ec68-03d2-4f90-900d-2ef49192ad2c}"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="052_PRESCRIPTION_LIN_20221020" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true type=MultiLineString checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;052_PRESCRIPTION_LIN_20221020&quot; (geom)" providerKey="postgres" id="052_PRESCRIPTION_LIN_20221020_5c77a347_6ac6_4a43_aa0f_3a271db18732" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="052_PRESCRIPTION_PCT_20221020" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true type=Point checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;052_PRESCRIPTION_PCT_20221020&quot; (geom)" providerKey="postgres" id="052_PRESCRIPTION_PCT_20221020_76cb0e99_e334_4891_a2ac_dca2b335e34d" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="052_PRESCRIPTION_SURF_20221020" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;052_PRESCRIPTION_SURF_20221020&quot; (geom)" providerKey="postgres" id="052_PRESCRIPTION_SURF_20221020_dbc4136d_273a_4354_a0a0_5b4b727cf854" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+              <Option name="showFeatureCount" type="QString" value="0"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="052_PLU_ZONE_URBA_20221020" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;052_PLU_ZONE_URBA_20221020&quot; (geom)" providerKey="postgres" id="052_PLU_ZONE_URBA_20221020_a7f116b4_ad5e_47e9_aa5e_8a4cd745cdc8" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="0" name="PLU Mollégès 18/12/2024" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="PLU_Molleges_13_01_2020"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="064_INFO_SURF_20241218" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;064_INFO_SURF_20241218&quot; (geom)" providerKey="postgres" id="064_INFO_SURF_20241218_39e77401_85a8_4837_9869_05c0b280c108" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option/>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="064_PRESCRIPTION_SURF_20241218" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;064_PRESCRIPTION_SURF_20241218&quot; (geom)" providerKey="postgres" id="064_PRESCRIPTION_SURF_20241218_2cff5d6a_99d8_461d_b2db_a09b24a116f9" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option/>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="PLU Molleges 18/12/2024" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;064_PLU_ZONE_URBA_20241218&quot; (geom)" providerKey="postgres" id="PLU_Molleges_18_12_2024_c6dff659_e76d_4fba_82cd_8caf5e0f22f3" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="0" name="PLU Noves 03/07/2024" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="PLU_Noves_03_07_2024"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="Préscriptions Linéaires" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiLineString checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;066_PRESCRIPTION_LIN_20240703&quot; (geom)" providerKey="postgres" id="Pr_scriptions_Lin_aires_d4b35b35_28a0_45b6_8c21_e2ea7101c144" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Informations Surfaciques" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;066_INFO_SURF_20240703&quot; (geom)" providerKey="postgres" id="Informations_Surfaciques_31bf3350_4bd8_4198_8536_a1a34366bc31" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Préscriptions Surfaciques" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;066_PRESCRIPTION_SURF_20240703&quot; (geom)" providerKey="postgres" id="Pr_scriptions_Surfaciques_4fa108c3_583b_46dd_a9a4_d7da21be9835" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+              <Option name="showFeatureCount" type="QString" value="0"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="PLU Noves 3/7/2024" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;066_ZONE_URBA_20240703&quot; (geom)" providerKey="postgres" id="PLU_Noves_3_7_2024_23cfc6e4_504f_4d0e_9051_553de8bce51c" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="0" name="RNU Orgon" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="Orgon"/>
+          </Option>
+        </customproperties>
+        <layer-tree-group expanded="0" name="Etude Ruissellement 2019" checked="Qt::Unchecked" groupLayer="">
+          <customproperties>
+            <Option type="Map">
+              <Option name="wmsShortName" type="QString" value="Etude_Ruissellement_2019"/>
+            </Option>
+          </customproperties>
+          <layer-tree-layer expanded="1" name="Aléa ruissellement" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=2154 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;067_ALEA_RUISSELEMENT_2019&quot; (geom)" providerKey="postgres" id="Aléa_ruissellement_1924be26_d20d_45cd_8f75_e54b1418e579" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+            <customproperties>
+              <Option type="Map">
+                <Option name="expandedLegendNodes" type="invalid"/>
+                <Option name="showFeatureCount" type="int" value="0"/>
+              </Option>
+            </customproperties>
+          </layer-tree-layer>
+          <layer-tree-layer expanded="1" name="Aléa ruissellement residuel" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=2154 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;067_ALEA_RESIDUEL_RUISSELEMENT_2019&quot; (geom)" providerKey="postgres" id="Aléa_ruissellement_residuel_f9ff51ee_509d_40c0_84ff_960cee1a538f" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+            <customproperties>
+              <Option type="Map">
+                <Option name="expandedLegendNodes" type="invalid"/>
+              </Option>
+            </customproperties>
+          </layer-tree-layer>
+          <layer-tree-layer expanded="1" name="Zonage ruissellement" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=2154 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;067_ZONAGE_RUISSELLEMENT_2019&quot; (geom)" providerKey="postgres" id="Zonage_ruissellement_424199c0_3dc2_4ecf_85c1_0f813be7987c" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+            <customproperties>
+              <Option type="Map">
+                <Option name="expandedLegendNodes" type="invalid"/>
+              </Option>
+            </customproperties>
+          </layer-tree-layer>
+        </layer-tree-group>
+        <layer-tree-group expanded="0" name="Directive Paysagére" checked="Qt::Unchecked" groupLayer="">
+          <customproperties>
+            <Option type="Map">
+              <Option name="wmsShortName" type="QString" value="Directive_Paysagere"/>
+            </Option>
+          </customproperties>
+          <layer-tree-layer expanded="1" name="067_DPA_SecteursAEnjeuxPaysagers" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;067_DPA_SecteursAEnjeuxPaysagers&quot; (geom)" providerKey="postgres" id="067_DPA_SecteursAEnjeuxPaysagers_821536c5_f2b1_450c_b6a6_e76c6301fe93" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+            <customproperties>
+              <Option type="Map">
+                <Option name="expandedLegendNodes" type="invalid"/>
+              </Option>
+            </customproperties>
+          </layer-tree-layer>
+          <layer-tree-layer expanded="1" name="067_DPA_PaysagesNaturelsRemarquables" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;067_DPA_PaysagesNaturelsRemarquables&quot; (geom)" providerKey="postgres" id="067_DPA_PaysagesNaturelsRemarquables_dded9097_1ef6_4f8c_af94_3281c3e777fe" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+            <customproperties>
+              <Option type="Map">
+                <Option name="expandedLegendNodes" type="invalid"/>
+              </Option>
+            </customproperties>
+          </layer-tree-layer>
+          <layer-tree-layer expanded="1" name="067_DPA_PaysagesNaturelsConstruits" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;067_DPA_PaysagesNaturelsConstruits&quot; (geom)" providerKey="postgres" id="067_DPA_PaysagesNaturelsConstruits_7632ac7a_c066_4163_b6ff_ef1ceaa5b4d6" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+            <customproperties>
+              <Option type="Map">
+                <Option name="expandedLegendNodes" type="invalid"/>
+              </Option>
+            </customproperties>
+          </layer-tree-layer>
+          <layer-tree-layer expanded="1" name="067_DPA_PaysagesConstruits" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;067_DPA_PaysagesConstruits&quot; (geom)" providerKey="postgres" id="067_DPA_PaysagesConstruits_f5f90090_939b_42a5_9d2b_d72d1d0d3158" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+            <customproperties>
+              <Option type="Map">
+                <Option name="expandedLegendNodes" type="invalid"/>
+              </Option>
+            </customproperties>
+          </layer-tree-layer>
+          <layer-tree-layer expanded="1" name="067_DPA_ConstructionsEnPNRem" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;067_DPA_ConstructionsEnPNRem&quot; (geom)" providerKey="postgres" id="067_DPA_ConstructionsEnPNRem_f737fd22_68f6_40ef_84a6_bd0f4c6a520a" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+            <customproperties>
+              <Option type="Map">
+                <Option name="expandedLegendNodes" type="invalid"/>
+              </Option>
+            </customproperties>
+          </layer-tree-layer>
+        </layer-tree-group>
+        <layer-tree-layer expanded="1" name="RNU" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;067-RNU&quot; (geom)" providerKey="postgres" id="067_RNU_7ad5b187_4bf8_4ea9_9b9e_2b97dcef8be5" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="0" name="PLU Plan d'Orgon 09/11/2021" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="PLU_Plan_d_Orgon_09_11_2021"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="Préscription Ligne PLU" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiLineString checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;076_PRESCRIPTION_LIN_20211129&quot; (geom)" providerKey="postgres" id="Pr_scription_Ligne_PLU_eb3272a7_7468_452b_b44b_78d6a137fd9a" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="076_INFO_SURF_20211129" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;076_INFO_SURF_20211129&quot; (geom)" providerKey="postgres" id="076_INFO_SURF_20211129_4554bac5_b055_464b_b918_fa1d43bb8cd2" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Préscription surface PLU" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;076_PRESCRIPTION_SURF_20211129&quot; (geom)" providerKey="postgres" id="Pr_scription_surface_PLU_54de6c0a_95cc_4879_b615_2e6362b95c8b" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="PLU Plan d'orgon 29/11/2021" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;076_ZONE_URBA_20211129&quot; (geom)" providerKey="postgres" id="PLU_Plan_d_orgon_29_11_2021_5d1dd8c4_64ef_4685_a67e_2d5cdf1f0496" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="0" name="PLU Rognonas 06/09/2023" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="PLU_Rognonas_06_06_2018_1"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="1" name="083_INFO_SURF_20230906" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;083_INFO_SURF_20230906&quot; (geom)" providerKey="postgres" id="083_INFO_SURF_20230906_0adddf76_bd49_45cf_9aa9_81f138312ef5" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Préscrition Surfacique" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;083_PRESCRIPTION_SURF_20230906&quot; (geom)" providerKey="postgres" id="Pr_scrition_Surfacique_b5f6fc30_fdc1_4659_a933_d2de103fa3a3" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+              <Option name="showFeatureCount" type="QString" value="0"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="1" name="Préscription point" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Point checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;083_PRESCRIPTION_PCT_20230906&quot; (geom)" providerKey="postgres" id="Pr_scription_point_b72f295b_795c_49ce_a318_b8dd6bd607e8" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Préscription Linéaire" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiLineString checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;083_PRESCRIPTION_LIN_20230906&quot; (geom)" providerKey="postgres" id="Pr_scription_Lin_aire_66906e42_3fce_49d5_ad50_d57d7fb34b3e" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="083_PLU_ZONE_URBA_20230906" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;083_PLU_ZONE_URBA_20230906&quot; (geom)" providerKey="postgres" id="PLU_Rognonas_06_09_2023_fe900cf2_785b_4e23_9613_45d7c55e88d2" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="StringList">
+                <Option type="QString" value="{358a00eb-1763-48ee-ab6d-e5b8d6968948}"/>
+                <Option type="QString" value="{e44a8ccd-8f33-471b-8296-905d03c998e7}"/>
+                <Option type="QString" value="{c571a7a9-f4e5-4ee6-9f57-cacd2174807f}"/>
+              </Option>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="0" name="PLU Saint-Andiol" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="Plu_Saint-Andiol_09_02_2017"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="089_PRESCRIPTION_PCT_20170209" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Point checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;089_PRESCRIPTION_PCT_20170209&quot; (geom)" providerKey="postgres" id="089_PRESCRIPTION_PCT_20170209_15d9f599_4c40_4b66_8cc5_66adb92fb1f6" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="089_PRESCRIPTION_SURF_20170209" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;089_PRESCRIPTION_SURF_20170209&quot; (geom)" providerKey="postgres" id="089_PRESCRIPTION_SURF_20170209_ba124aae_0928_4f4b_8c82_47b42302e6e5" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="089_PRESCRIPTION_LIN_20170209" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=LineString checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;089_PRESCRIPTION_LIN_20170209&quot; (geom)" providerKey="postgres" id="089_PRESCRIPTION_LIN_20170209_d34b53d9_7972_4ef4_bac9_f86f4b098fd2" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="PLU Saint-Andiol 09/02/2017" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;089_PLU_ZONE_URBA&quot; (geom)" providerKey="postgres" id="PLU_Saint_Andiol_09_02_2017_c73024d4_8a91_40f4_ae0c_15c97d9d6d05" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="0" name="PLU Verquières 27/06/2023" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="PLU_Verquieres_27_06_2023"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="116_INFO_SURF_20240301" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;116_INFO_SURF_20240301&quot; (geom)" providerKey="postgres" id="116_INFO_SURF_20240301_7c9973ea_10ce_4a81_a518_8329c98b3e23" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="116_PRESCRIPTION_PCT_20230627" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Point checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;116_PRESCRIPTION_PCT_20230627&quot; (geom)" providerKey="postgres" id="116_PRESCRIPTION_PCT_20230627_b08a45a2_ba1a_4e18_8b22_868b694698c8" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="cached_name" type="QString" value="116_PRESCRIPTION_PCT_20230627"/>
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="116_PRESCRIPTION_SURF_20230627" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;116_PRESCRIPTION_SURF_20230627&quot; (geom)" providerKey="postgres" id="116_PRESCRIPTION_SURF_20230627_f30fcbe1_567a_49d8_aab1_49dbbc887b48" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="cached_name" type="QString" value="116_PRESCRIPTION_SURF_20230627"/>
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="116_ZONE_URBA_20230627" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;116_ZONE_URBA_20230627&quot; (geom)" providerKey="postgres" id="116_ZONE_URBA_20230627_d17f0f77_cccc_440b_8fc6_46654b966f87" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="-1,-1">
+          <customproperties>
+            <Option type="Map">
+              <Option name="cached_name" type="QString" value="116_ZONE_URBA_20230627"/>
+              <Option name="expandedLegendNodes"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+    </layer-tree-group>
+    <layer-tree-layer expanded="0" name="20230828_ANTENNE_RELAIS_GSM" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Point checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;20230828_ANTENNE_RELAIS_GSM&quot; (geom)" providerKey="postgres" id="20230828_ANTENNE_RELAIS_GSM_0818dc79_5ad7_480f_ab8b_8a4307d213ad" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+      <customproperties>
+        <Option type="Map">
+          <Option name="expandedLegendNodes" type="invalid"/>
+        </Option>
+      </customproperties>
+    </layer-tree-layer>
+    <layer-tree-layer expanded="0" name="Lotissements" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;LOTISSEMENTS&quot; (geom)" providerKey="postgres" id="LOTISSEMENTS_81db0824_acd4_4da6_b5dc_ea4f39a7224b" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+      <customproperties>
+        <Option type="Map">
+          <Option name="expandedLegendNodes" type="invalid"/>
+        </Option>
+      </customproperties>
+    </layer-tree-layer>
+    <layer-tree-layer expanded="0" name="Lot ZAE" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID' estimatedmetadata=true srid=3944 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;espacepublic&quot;.&quot;ZAE_LOT&quot; (geom)" providerKey="postgres" id="ZAE_LOT_5767f38f_5289_4b9b_b4ac_cb03756c900d" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+      <customproperties>
+        <Option type="Map">
+          <Option name="expandedLegendNodes" type="invalid"/>
+        </Option>
+      </customproperties>
+    </layer-tree-layer>
+    <layer-tree-layer expanded="0" name="Zone Activité TPA" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='IDZA' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;espacepublic&quot;.&quot;ZAE_ZONE_ACTIVITE&quot; (geom) sql=&quot;type_zone&quot; in ('ZAE INTERCOMMUNALE','DECHETERIE','CHEMIN COMMUNAUTAIRE')" providerKey="postgres" id="ZAE_ZONE_ACTIVITE_2a747cea_d779_47c2_8d72_267ab7251f9d" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+      <customproperties>
+        <Option type="Map">
+          <Option name="expandedLegendNodes"/>
+        </Option>
+      </customproperties>
+    </layer-tree-layer>
+    <layer-tree-layer expanded="0" name="Périmetre ZAE AUPA" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id1' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;Import&quot;.&quot;20230322_PERIMETRE_ZAE_TPA_AUPA&quot; (geom)" providerKey="postgres" id="20230322_PERIMETRE_ZAE_TPA_AUPA_c4f69e0a_953a_4a0f_8c9d_2ad09ce26364" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+      <customproperties>
+        <Option/>
+      </customproperties>
+    </layer-tree-layer>
+    <layer-tree-group expanded="0" name="Adresses" checked="Qt::Unchecked" groupLayer="">
+      <customproperties>
+        <Option type="Map">
+          <Option name="wmsShortName" type="QString" value="Adresses"/>
+        </Option>
+      </customproperties>
+      <layer-tree-layer expanded="0" name="point_adresse" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id_point' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;adresse&quot;.&quot;point_adresse&quot; (geom)" providerKey="postgres" id="point_adresse_7d883433_a5cd_42ef_9f3f_9bd65aa28464" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="voie" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id_voie' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;adresse&quot;.&quot;voie&quot; (geom)" providerKey="postgres" id="voie_afef52c3_bb3b_4b6f_8ae0_d8257927ac48" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+    </layer-tree-group>
+    <layer-tree-layer expanded="1" name="Parcelle prop Etat emprise Léo" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;projets&quot;.&quot;20250718_PARCELLE_ETAT_LEO&quot; (geom)" providerKey="postgres" id="20250718_PARCELLE_ETAT_LEO_0fbf0a69_bf7f_4534_9861_d9b880b5d2db" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+      <customproperties>
+        <Option/>
+      </customproperties>
+    </layer-tree-layer>
+    <layer-tree-layer expanded="0" name="Parcelle mutation 3 derniéres années" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='geo_parcelle' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;cadastre&quot;.&quot;vue_parcinfo_parcelle2025&quot; (geom)" providerKey="postgres" id="Parcelle_mutation_3_derni_res_ann_es_9065c5fc_c328_46ba_9367_d5ec87da1393" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+      <customproperties>
+        <Option/>
+      </customproperties>
+    </layer-tree-layer>
+    <layer-tree-layer expanded="0" name="Parcelle Publique" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;cadastre2025&quot;.&quot;parcelle_info&quot; (geom)" providerKey="postgres" id="Parcelle_Publique_16e1e892_6c26_4e1c_91cf_4fce28150d3a" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+      <customproperties>
+        <Option type="Map">
+          <Option name="cached_name" type="QString" value="Parcelle Publique"/>
+          <Option name="expandedLegendNodes" type="invalid"/>
+          <Option name="showFeatureCount" type="int" value="0"/>
+        </Option>
+      </customproperties>
+    </layer-tree-layer>
+    <layer-tree-group expanded="0" name="OCCSE GE" checked="Qt::Unchecked" groupLayer="">
+      <customproperties>
+        <Option type="Map">
+          <Option name="wmsShortName" type="QString" value="OCCSE_GE"/>
+        </Option>
+      </customproperties>
+      <layer-tree-layer expanded="1" name="UF sup 2500 zone U" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;(with ocge_u as ( &#x9;with plu_u as&#x9; &#x9;( &#x9;&#x9;select plu.libelle plu_libelle,plu.geom geom_plu  &#x9;&#x9;from urbanisme.\&quot;010_ZONE_URBA_20200225\&quot; plu &#x9;&#x9;where plu.typezone ='U' &#x9;union &#x9;&#x9;select plu.libelle plu_libelle,plu.geom geom_plu  &#x9;&#x9;from \&quot;urbanisme\&quot;.\&quot;018_ZONE_URBA_20201118\&quot; plu &#x9;&#x9;where plu.typezone ='U' &#x9;union &#x9;&#x9;select plu.libelle plu_libelle,plu.geom geom_plu  &#x9;&#x9;from \&quot;urbanisme\&quot;.\&quot;027_PLU_ZONE_URBA_20230607\&quot; plu &#x9;&#x9;where plu.typezone ='U' &#x9;union &#x9;&#x9;select plu.libelle plu_libelle,plu.geom geom_plu  &#x9;&#x9;from \&quot;urbanisme\&quot;.\&quot;036_ZONE_URBA_20230627\&quot; plu &#x9;&#x9;where plu.typezone ='U' &#x9;union &#x9;&#x9;select plu.libelle plu_libelle,plu.geom geom_plu  &#x9;&#x9;from \&quot;urbanisme\&quot;.\&quot;045_PLU_ZONE_URBA\&quot; plu &#x9;&#x9;where plu.typezone ='U' &#x9;union &#x9;&#x9;select plu.libelle plu_libelle,plu.geom geom_plu  &#x9;&#x9;from \&quot;urbanisme\&quot;.\&quot;052_PLU_ZONE_URBA_20221020\&quot; plu &#x9;&#x9;where plu.typezone ='U' &#x9;union &#x9;&#x9;select plu.libelle plu_libelle,plu.geom geom_plu  &#x9;&#x9;from \&quot;urbanisme\&quot;.\&quot;064_PLU_ZONE_URBA_20241218\&quot; plu &#x9;&#x9;where plu.typezone ='U' &#x9;union &#x9;&#x9;select plu.libelle plu_libelle,plu.geom geom_plu  &#x9;&#x9;from \&quot;urbanisme\&quot;.\&quot;066_ZONE_URBA_20240703\&quot; plu &#x9;&#x9;where plu.typezone ='U' &#x9;union &#x9;&#x9;select plu.libelle plu_libelle,plu.geom geom_plu  &#x9;&#x9;from \&quot;urbanisme\&quot;.\&quot;076_ZONE_URBA_20211129\&quot; plu &#x9;&#x9;where plu.typezone ='U' &#x9;union &#x9;&#x9;select plu.libelle plu_libelle,plu.geom geom_plu  &#x9;&#x9;from \&quot;urbanisme\&quot;.\&quot;083_PLU_ZONE_URBA_20230906\&quot; plu &#x9;&#x9;where plu.typezone ='U' &#x9;union &#x9;&#x9;select plu.zone_gen3 plu_libelle,plu.geom geom_plu  &#x9;&#x9;from \&quot;urbanisme\&quot;.\&quot;089_PLU_ZONE_URBA\&quot; plu &#x9;&#x9;where plu.zone_gen2 ='U' &#x9;union &#x9;&#x9;select plu.libelle plu_libelle,plu.geom geom_plu  &#x9;&#x9;from \&quot;urbanisme\&quot;.\&quot;116_ZONE_URBA_20230627\&quot; plu &#x9;&#x9;where plu.typezone ='U' &#x9;) &#x9;select  ocge.code_cs, &#x9;&#x9;&#x9;ST_Intersection(plu_u.geom_plu, ocge.geom) geom &#x9;from &#x9;\&quot;Import\&quot;.\&quot;20250617-OCCUPATION_SOL\&quot; ocge, &#x9;&#x9;&#x9;plu_u &#x9;where ST_Intersects(geom_plu, ocge.geom) &#x9;and round((st_area(ST_Intersection(ocge.geom, plu_u.geom_plu))/st_area(ocge.geom))::numeric,2)*100 > 1 &#x9;and not (( \&quot;code_cs\&quot; in ( 'CS1.1.1.1' , 'CS1.1.1.2' , 'CS1.1.2.2' )) OR  (\&quot;code_cs\&quot; =  'CS1.1.2.1' and  \&quot;code_us\&quot; !=  'US1.3') OR ( \&quot;code_cs\&quot; = 'CS2.2.1' and  \&quot;code_us\&quot; in ( 'US2' , 'US235' , 'US3' , 'US4.1.1' , 'US4.1.2' , 'US4.1.3' , 'US4.1.5' , 'US4.2' , 'US4.3' , 'US5' , 'US6.1' ))) ) select &#x9;row_number() OVER ()::integer AS id, &#x9;&#x9;string_agg(ocge_u.code_cs,',') , &#x9;&#x9;p.comptecommunal, &#x9;&#x9;p.proprietaire, &#x9;&#x9;p.proprietaire_info, &#x9;&#x9;p.\&quot;SURFACE_UF\&quot;, &#x9;&#x9;sum(round(st_area(ST_Intersection(p.geom, ocge_u.geom))::numeric,2)) surf_emprise, &#x9;&#x9;sum(round((st_area(ST_Intersection(p.geom, ocge_u.geom))/st_area(p.geom))::numeric,2)*100) pourc, &#x9;&#x9;p.geom from &#x9;ocge_u, &#x9;&#x9;urbanisme.\&quot;2025_UNITE_FONCIERE\&quot; p where ST_Intersects(p.geom , ocge_u.geom) and round((st_area(ST_Intersection(p.geom, ocge_u.geom))/st_area(p.geom))::numeric,2)*100 > 1 and \&quot;SURFACE_UF\&quot; >= 2500 group by&#x9;p.comptecommunal, &#x9;&#x9;&#x9;p.proprietaire, &#x9;&#x9;&#x9;p.proprietaire_info, &#x9;&#x9;&#x9;p.\&quot;SURFACE_UF\&quot;, &#x9;&#x9;&#x9;p.geom &#xa;)&quot; (geom)" providerKey="postgres" id="UF_retenue_8ec3422c_13ec_4495_a7ec_ca1b475f7b63" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option/>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="1" name="20250617_SCOT_PETR_PROJETS" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID' estimatedmetadata=true type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;20250617_SCOT_PETR_PROJETS&quot; (geom)" providerKey="postgres" id="20250617_SCOT_PETR_PROJETS_6cb777bd_858f_4642_8631_d7ce2963c9e8" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option/>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="20250617-OCCUPATION_SOL" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID' estimatedmetadata=true srid=3944 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;Import&quot;.&quot;20250617-OCCUPATION_SOL&quot; (geom)" providerKey="postgres" id="20250617_OCCUPATION_SOL_fde2f742_f988_4a20_a4cd_acf5bd156f20" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option/>
+        </customproperties>
+      </layer-tree-layer>
+    </layer-tree-group>
+    <layer-tree-group expanded="1" name="Cadastre" checked="Qt::Checked" groupLayer="">
+      <customproperties>
+        <Option type="Map">
+          <Option name="wmsShortName" type="QString" value="Cadastre"/>
+        </Option>
+      </customproperties>
+      <layer-tree-layer expanded="0" name="VUE_PARCELLE_CATEG_2023" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Point checkPrimaryKeyUnicity='1' table=&quot;cadastre&quot;.&quot;VUE_PARCELLE_CATEG_2025&quot; (geom) sql=&quot;nat_loc&quot; in ('MA','AP')" providerKey="postgres" id="VUE_PARCELLE_CATEG_2022_418060e0_f987_41bf_9485_608a80edeac6" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+            <Option name="showFeatureCount" type="int" value="0"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="1" name="Etiquettes Propriétaire" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;cadastre2025&quot;.&quot;parcelle_info&quot; (geom)" providerKey="postgres" id="Parcelles_ccec544b_598c_48ec_99b4_daf469cf0127" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="CommunesCad" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;cadastre2025&quot;.&quot;geo_commune&quot; (geom)" providerKey="postgres" id="Communes_b117633d_43bc_42e9_a4e9_940dd02a2cec" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Sections" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;cadastre2025&quot;.&quot;geo_section&quot; (geom)" providerKey="postgres" id="Sections_66d67950_b37b_4fa8_b861_13b1d70088da" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Bâti" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;cadastre2025&quot;.&quot;geo_batiment&quot; (geom)" providerKey="postgres" id="Bâti_0f134d74_21a1_4f87_9604_7450cc4d920e" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Parcelles" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;cadastre2025&quot;.&quot;parcelle_info&quot; (geom)" providerKey="postgres" id="Parcelles_877182fb_cb74_4f94_aebc_d32512503e18" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="1" name="UnitéFoncière" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;2025_UNITE_FONCIERE&quot; (geom)" providerKey="postgres" id="2022_UNITE_FONCIERE_1ae7a241_e793_4155_92fc_58bec2ced02b" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option/>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Cours d'eau" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='geo_tronfluv' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;cadastre2025&quot;.&quot;geo_tronfluv&quot; (geom)" providerKey="postgres" id="Cours_d_eau_ba81a829_f2f6_469e_98c9_bf10aeb2384d" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Surfaces" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='geo_tsurf' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;cadastre2025&quot;.&quot;geo_tsurf&quot; (geom)" providerKey="postgres" id="Surfaces_585ce3ee_1f9f_43bd_84c6_0d340d2b67a5" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Subdivisions fiscales" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='geo_subdfisc' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;cadastre2025&quot;.&quot;geo_subdfisc&quot; (geom)" providerKey="postgres" id="Subdivisions_fiscales_7600d013_24cb_4b5c_8c32_1ccca787b3cc" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Lieux-dits" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='geo_lieudit' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;cadastre2025&quot;.&quot;geo_lieudit&quot; (geom)" providerKey="postgres" id="Lieux_dits_3ec5cbd8_205d_4f2f_b8a2_3f0e628e32e8" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-group expanded="0" name="FondCadastre" checked="Qt::Checked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="FondCadastre"/>
+          </Option>
+        </customproperties>
+        <layer-tree-group expanded="1" name="Étiquettes cadastre" checked="Qt::Checked" groupLayer="">
+          <customproperties>
+            <Option type="Map">
+              <Option name="wmsShortName" type="QString" value="Etiquettes_cadastre"/>
+            </Option>
+          </customproperties>
+          <layer-tree-layer expanded="0" name="Numéros de voie" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;cadastre2025&quot;.&quot;geo_label&quot; (geom) sql=&quot;ogr_obj_lnk_layer&quot; = 'NUMVOIE_id'" providerKey="postgres" id="Numéros_de_voie_97412aec_636b_4241_ac89_b5f167de79dc" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+            <customproperties>
+              <Option type="Map">
+                <Option name="expandedLegendNodes"/>
+              </Option>
+            </customproperties>
+          </layer-tree-layer>
+          <layer-tree-layer expanded="0" name="Cours d'eau (étiquettes)" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;cadastre2025&quot;.&quot;geo_label&quot; (geom) sql=&quot;ogr_obj_lnk_layer&quot; = 'TRONFLUV_id'" providerKey="postgres" id="Cours_d_eau__étiquettes__66bcba62_8754_4cc0_957e_b344df84ad46" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+            <customproperties>
+              <Option type="Map">
+                <Option name="expandedLegendNodes"/>
+              </Option>
+            </customproperties>
+          </layer-tree-layer>
+          <layer-tree-layer expanded="0" name="Parcelles (étiquettes)" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;cadastre2025&quot;.&quot;geo_label&quot; (geom) sql=&quot;ogr_obj_lnk_layer&quot; = 'PARCELLE_id'" providerKey="postgres" id="Parcelles__étiquettes__3b8adeeb_c113_4cf1_a84b_969e8feabfc2" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+            <customproperties>
+              <Option type="Map">
+                <Option name="expandedLegendNodes"/>
+              </Option>
+            </customproperties>
+          </layer-tree-layer>
+          <layer-tree-layer expanded="0" name="Subdivisions fiscales (étiquette)" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;cadastre2025&quot;.&quot;geo_label&quot; (geom) sql=&quot;ogr_obj_lnk_layer&quot; = 'SUBDFISC_id'" providerKey="postgres" id="Subdivisions_fiscales__étiquette__2230efe1_8ed1_45b7_a294_a9823e467802" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+            <customproperties>
+              <Option type="Map">
+                <Option name="expandedLegendNodes"/>
+              </Option>
+            </customproperties>
+          </layer-tree-layer>
+          <layer-tree-layer expanded="0" name="Noms de voies" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;cadastre2025&quot;.&quot;geo_label&quot; (geom) sql=&quot;ogr_obj_lnk_layer&quot; IN ( 'ZONCOMMUNI_id') " providerKey="postgres" id="Noms_de_voies_d62898e0_b0a6_4c4e_877b_9feea6c434f5" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+            <customproperties>
+              <Option type="Map">
+                <Option name="expandedLegendNodes"/>
+              </Option>
+            </customproperties>
+          </layer-tree-layer>
+        </layer-tree-group>
+        <layer-tree-group expanded="1" name="Données cadastre" checked="Qt::Checked" groupLayer="">
+          <customproperties>
+            <Option type="Map">
+              <Option name="wmsShortName" type="QString" value="Donnees_cadastre"/>
+            </Option>
+          </customproperties>
+          <layer-tree-layer expanded="0" name="Murs, fossés, clotûres" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='geo_symblim' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;cadastre2025&quot;.&quot;geo_symblim&quot; (geom)" providerKey="postgres" id="Murs__fossés__clotûres_8f9deef4_7f3d_4b52_a135_29db05006329" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+            <customproperties>
+              <Option type="Map">
+                <Option name="expandedLegendNodes"/>
+              </Option>
+            </customproperties>
+          </layer-tree-layer>
+        </layer-tree-group>
+      </layer-tree-group>
+    </layer-tree-group>
+    <layer-tree-layer expanded="1" name="Panoramax" source="styleUrl=https://panoramax.openstreetmap.fr/api/map/style.json&amp;type=xyz&amp;url=https://panoramax.openstreetmap.fr/api/map/%7Bz%7D/%7Bx%7D/%7By%7D.mvt&amp;zmax=15&amp;zmin=0&amp;http-header:referer=" providerKey="xyzvectortiles" id="Panoramax_7ce33c8b_8221_414a_8f16_df2c70e13d4b" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+      <customproperties>
+        <Option/>
+      </customproperties>
+    </layer-tree-layer>
+    <layer-tree-layer expanded="0" name="PCRS Ouest 13 5cm 2023" source="crs=EPSG:2154&amp;dpiMode=7&amp;format=image/png&amp;layers=pcrs_ouest13&amp;styles&amp;url=https://geoservices2.crige-paca.org/geoserver/pcrs23_ouest13/wms" providerKey="wms" id="PCRS_Ouest_13_5cm_2023_bb5c918d_0592_4c44_802d_75f342070255" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+      <customproperties>
+        <Option/>
+      </customproperties>
+    </layer-tree-layer>
+    <layer-tree-group expanded="0" name="baselayers" mutually-exclusive-child="1" mutually-exclusive="1" checked="Qt::Unchecked" groupLayer="">
+      <customproperties>
+        <Option type="Map">
+          <Option name="wmsShortName" type="QString" value="Fond"/>
+        </Option>
+      </customproperties>
+      <layer-tree-group expanded="1" name="project-background-color" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="project-background-color"/>
+          </Option>
+        </customproperties>
+      </layer-tree-group>
+      <layer-tree-layer expanded="1" name="OpenStreetMap" source="crs=EPSG:3857&amp;format&amp;type=xyz&amp;url=http://a.tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&amp;zmax=19&amp;zmin=0" providerKey="wms" id="OpenStreetMap_eb2548f8_68ba_49e5_b11e_bd1d482622f0" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Crige_Ortho_2023_20Cm" source="crs=EPSG:4326&amp;dpiMode=7&amp;format=image/png&amp;layers=BD_ORTHO_DEPT13_2023&amp;styles&amp;url=https://geoservices2.crige-paca.org/geoserver/crige_ortho/wms&amp;http-header:referer=" providerKey="wms" id="Crige_Ortho_2023_20Cm_f0e746e2_6c33_427a_ae62_81381402575f" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option/>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Crige_Ortho_2020_20Cm" source="crs=EPSG:4326&amp;dpiMode=7&amp;format=image/png&amp;layers=ortho_hr_rvb20_dept13_2020_5871337&amp;styles&amp;url=https://mapserver.crige-paca.org/maps/ign&amp;username=fseissontdp&amp;password=!Eyragues13630" providerKey="wms" id="Crige_Ortho_2020_20Cm_4f144a63_1fcf_4310_91a4_473de6f8aff1" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Crige_Ortho_2014_15Cm" source="crs=EPSG:4326&amp;dpiMode=7&amp;format=image/png&amp;layers=ORTHO_RVB15_DEPT13_2014&amp;styles&amp;url=https://geoservices2.crige-paca.org/geoserver/crige_ortho/wms" providerKey="wms" id="Crige_Ortho_2014_15Cm_6c7f33d7_94f7_4b37_a851_c3246c0fd72e" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option/>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Crige_Ortho_2009_15cm" source="crs=EPSG:4326&amp;dpiMode=7&amp;format=image/png&amp;layers=ORTHO_RVB15_DEPT13_2009&amp;styles&amp;url=https://geoservices2.crige-paca.org/geoserver/crige_ortho/wms" providerKey="wms" id="Crige_Ortho_2009_15cm_54431df6_876c_4792_8f1a_b65e07cd9d34" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option/>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Scan 25 topographique 2019" source="crs=EPSG:3944&amp;dpiMode=7&amp;format=image/png&amp;layers=sc25_topo_l93_3185fba&amp;styles&amp;url=https://mapserver.crige-paca.org/maps/ign&amp;username=fseissontdp&amp;password=!Eyragues13630" providerKey="wms" id="Scan_25_topographique_2019_42d05cc3_4407_497f_a88e_17cd1d9b0e20" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-group expanded="0" name="Cadastre 2022" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="Cadastre_2022"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="Batiment 2022" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;cadastre2022&quot;.&quot;geo_batiment&quot; (geom)" providerKey="postgres" id="Batiment_2020_aef1cf63_ebe8_4a12_868b_07e9b047b5ef" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="parcelle 2022" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;cadastre2022&quot;.&quot;parcelle_info&quot; (geom)" providerKey="postgres" id="parcelle_2020_cfcefc3c_2deb_4f29_bac7_134bab661b81" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="0" name="Cadastre 2018" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="Cadastre_2018"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="Batiment 2018" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;cadastre2018&quot;.&quot;geo_batiment&quot; (geom)" providerKey="postgres" id="Batiment_2018_3bb95a96_8e24_47cc_9dad_f911eb137a21" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+              <Option name="showFeatureCount" type="QString" value="0"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="parcelle 2018" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;cadastre2018&quot;.&quot;parcelle_info&quot; (geom)" providerKey="postgres" id="parcelle_2018_74baf06a_f373_412e_9731_540af1492ab2" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="0" name="Cadastre 2015" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="Cadastre_2015"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="Batiment 2015" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='tid' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;cadastre2015&quot;.&quot;geo_batiment&quot; (geom)" providerKey="postgres" id="Batiment_2015_eabfeecf_0dc1_4a41_9502_0adffa224690" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+              <Option name="showFeatureCount" type="QString" value="0"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="parcelle 2015" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;cadastre2015&quot;.&quot;parcelle_info&quot; (geom)" providerKey="postgres" id="parcelle_2015_df20ff39_e0c1_4dba_9884_d20f1e395fcf" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+              <Option name="showFeatureCount" type="QString" value="0"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="0" name="Cadastre 2011" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="Cadastre_2011"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="Batiment 2011" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='tid' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;cadastre2011&quot;.&quot;geo_batiment&quot; (geom)" providerKey="postgres" id="Batiment_2011_d415a937_e376_446d_a39a_d28c51f215c9" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+              <Option name="showFeatureCount" type="QString" value="0"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="parcelle 2011" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;cadastre2011&quot;.&quot;parcelle_info&quot; (geom)" providerKey="postgres" id="parcelle_2011_5c6b42e4_9ae6_439f_9a91_40045a97d6cb" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="0" name="Cadastre 2009" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="Cadastre_2009"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="parcelle 2009" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;cadastre2009&quot;.&quot;parcelle_info&quot; (geom)" providerKey="postgres" id="parcelle_2009_b364b5be_b3f2_44df_acbc_f201ec74e8aa" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+              <Option name="showFeatureCount" type="QString" value="0"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="Batiment 2009" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='tid' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;cadastre2009&quot;.&quot;geo_batiment&quot; (geom)" providerKey="postgres" id="Batiment_2009_95598cc2_0d73_4229_9df0_1d7b7730d7bc" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+      <layer-tree-group expanded="0" name="Cadastre 2007" checked="Qt::Unchecked" groupLayer="">
+        <customproperties>
+          <Option type="Map">
+            <Option name="wmsShortName" type="QString" value="Cadastre_2007"/>
+          </Option>
+        </customproperties>
+        <layer-tree-layer expanded="0" name="Batiment 2007" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='tid' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;cadastre2007&quot;.&quot;geo_batiment&quot; (geom)" providerKey="postgres" id="Batiment_2007_2f90c1de_aa18_4965_8da0_ec883e38c6c5" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+              <Option name="showFeatureCount" type="QString" value="0"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+        <layer-tree-layer expanded="0" name="parcelle 2007" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ogc_fid' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;cadastre2007&quot;.&quot;parcelle_info&quot; (geom)" providerKey="postgres" id="parcelle_2007_1403d0a0_ccdf_4203_8f57_9db7f56af9b3" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+          <customproperties>
+            <Option type="Map">
+              <Option name="expandedLegendNodes" type="invalid"/>
+              <Option name="showFeatureCount" type="QString" value="0"/>
+            </Option>
+          </customproperties>
+        </layer-tree-layer>
+      </layer-tree-group>
+    </layer-tree-group>
+    <layer-tree-group expanded="1" name="hidden" checked="Qt::Unchecked" groupLayer="">
+      <customproperties>
+        <Option type="Map">
+          <Option name="wmsShortName" type="QString" value="hidden"/>
+        </Option>
+      </customproperties>
+      <layer-tree-layer expanded="0" name="VOI_SIGN_VERT_PANNEAU" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id_panneau' checkPrimaryKeyUnicity='1' table=&quot;espacepublic&quot;.&quot;VOI_SIGN_VERT_PANNEAU&quot;" providerKey="postgres" id="VOI_SIGN_VERT_PANNEAU_05fef897_ada7_4a58_b7f3_e1293a5681e9" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="1" name="HIST_PARCELLE" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID' checkPrimaryKeyUnicity='1' table=&quot;cadastre&quot;.&quot;HIST_PARCELLE&quot;" providerKey="postgres" id="HIST_PARCELLE_c8e2af11_4279_4abd_8ad6_057ac56ef96e" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option/>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="Historique Lotissement" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID_HISTO' checkPrimaryKeyUnicity='1' table=&quot;urbanisme&quot;.&quot;LOTI_HIST_DOC&quot;" providerKey="postgres" id="LOTI_HIST_DOC_e7b46cd7_24d3_42eb_b70e_f8706e67bfd4" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="-1,-1">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="1" name="parcelle_info_plu" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID' checkPrimaryKeyUnicity='1' table=&quot;cadastre2025&quot;.&quot;parcelle_info_plu&quot;" providerKey="postgres" id="parcelle_info_plu_5ec940e0_a405_4130_a0a3_e544b4a14107" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="1" name="CONFIG_CHAM" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID_CONF' checkPrimaryKeyUnicity='1' table=&quot;tdpa&quot;.&quot;CONFIG_CHAM&quot;" providerKey="postgres" id="CONFIG_CHAM_90be8aab_c376_4305_99fc_9912511d7725" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="0" name="ZAE_LOT_HIST" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID' checkPrimaryKeyUnicity='1' table=&quot;espacepublic&quot;.&quot;ZAE_LOT_HIST&quot;" providerKey="postgres" id="ZAE_LOT_HIST_8bb22535_b801_423b_b556_57bf64cce3a6" legend_split_behavior="0" checked="Qt::Unchecked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes" type="invalid"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer expanded="1" name="HIST_VOIE_ADR" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='ID_HISTO' checkPrimaryKeyUnicity='1' table=&quot;adresse&quot;.&quot;HIST_VOIE_ADR&quot;" providerKey="postgres" id="HIST_VOIE_ADR_949e35e1_4cb8_4a39_904b_4315ad6d7beb" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+    </layer-tree-group>
+    <layer-tree-group expanded="0" name="Overview" checked="Qt::Checked" groupLayer="">
+      <customproperties>
+        <Option type="Map">
+          <Option name="wmsShortName" type="QString" value="Overview"/>
+        </Option>
+      </customproperties>
+      <layer-tree-layer expanded="1" name="Com" source="dbname='lizmap_terredeprovence_sig' host=qgisdb-tdpa.lizmap.com port=5432 user='fseisson@terredeprovenceagglo' key='id' estimatedmetadata=true srid=3944 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;tdpa&quot;.&quot;LIMITE_COMMUNE_TDPAB&quot; (geom)" providerKey="postgres" id="Communes_32a91df6_a5a9_44f2_aa1a_a8b0fa555177" legend_split_behavior="0" checked="Qt::Checked" legend_exp="" patch_size="0,0">
+        <customproperties>
+          <Option type="Map">
+            <Option name="expandedLegendNodes"/>
+          </Option>
+        </customproperties>
+      </layer-tree-layer>
+    </layer-tree-group>


### PR DESCRIPTION
The custom property `showfeatureCount` is not removed by QIS when it is false, so it is necessary to cast the value.

Funded by Terre de Provence Agglomération
