### PR TITLE
[Bugfix] Action: zoom to features using zoomToGeometryOrExtent

### DIFF
--- a/assets/src/modules/Action.js
+++ b/assets/src/modules/Action.js
@@ -279,8 +279,11 @@ export default class Action {
 
             if (callback['method'] == this.CallbackMethods.Zoom && features.length) {
                 // Zoom to the returned features
-                const bounds = this.actionLayer.getSource().getExtent();
-                this._map.getView().fit(bounds, {nearest: true});
+                if (features.length ==1) {
+                    this._map.zoomToGeometryOrExtent(features[0].getGeometry());
+                } else {
+                    this._map.zoomToGeometryOrExtent(this.actionLayer.getSource().getExtent());
+                }
             }
 
             // Check the given layerId is a valid Lizmap layer

--- a/tests/end2end/playwright/feature-toolbar.spec.js
+++ b/tests/end2end/playwright/feature-toolbar.spec.js
@@ -407,7 +407,7 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'STYLES': 'défaut',
             'WIDTH': '958',
             'HEIGHT': '633',
-            'BBOX': /771293.1\d+,6278894.0\d+,772560.5\d+,6279731.4\d+/,
+            'BBOX': /770659.5\d+,6278475.3\d+,773194.2\d+,6280150.1\d+/,
             'SELECTIONTOKEN': /^[a-zA-Z0-9]{32}$/,
         }
         await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);


### PR DESCRIPTION
The Lizmap's `map` module provides a method to zoom to a given geometry or extent: `zoomToGeometryOrExtent`. This method helps to zoom to the right place.

Funded by [TDPA](https://www.terredeprovence-agglo.com/)