### PR TITLE
[Bugfix] replace getView().fit() by zoomToGeometryOrExtent()

### DIFF
--- a/assets/src/modules/Digitizing.js
+++ b/assets/src/modules/Digitizing.js
@@ -2179,9 +2179,7 @@ export class Digitizing {
                     // And zoom to their bounding extent
                     const featuresGeometry = OL6features.map(feature => feature.getGeometry());
                     const featuresGeometryCollection = new GeometryCollection(featuresGeometry);
-                    const extent = featuresGeometryCollection.getExtent();
-
-                    this._map.getView().fit(extent);
+                    this._map.zoomToGeometryOrExtent(featuresGeometryCollection.getExtent());
                 }
             };
         })(this);

--- a/assets/src/modules/Geolocation.js
+++ b/assets/src/modules/Geolocation.js
@@ -95,7 +95,7 @@ export default class Geolocation {
             // Zoom on accuracy geometry extent when geolocation is activated for the first time
             if (this._firstGeolocation) {
                 const bounds = this._geolocation.getAccuracyGeometry().getExtent();
-                map.getView().fit(bounds, {nearest: true});
+                map.zoomToGeometryOrExtent(bounds, {nearest: true});
                 this.center();
                 this._firstGeolocation = false;
 

--- a/assets/src/modules/Lizmap.js
+++ b/assets/src/modules/Lizmap.js
@@ -385,7 +385,7 @@ export default class Lizmap {
      * @param {Array<number>} bounds - Left, bottom, right, top
      */
     set extent(bounds) {
-        this.map.getView().fit(bounds, {nearest: true});
+        this.map.zoomToGeometryOrExtent(bounds, {nearest: true});
     }
 
     updateOL2MapSize() {

--- a/assets/src/modules/Search.js
+++ b/assets/src/modules/Search.js
@@ -368,7 +368,7 @@ export default class Search {
                         this._map.zoomToWkt(geomWKT, 'EPSG:4326');
                         this._map.setHighlightFeatures(geomWKT, "wkt", "EPSG:4326");
                     } else {
-                        this._map.getView().fit(bbox.toArray());
+                        this._map.zoomToGeometryOrExtent(bbox.toArray());
                     }
 
                     $('#lizmap-search, #lizmap-search-close').removeClass('open');

--- a/assets/src/modules/map.js
+++ b/assets/src/modules/map.js
@@ -1150,7 +1150,7 @@ export default class map extends olMap {
     /**
      * Zoom to given geometry or extent
      * @param {Geometry|Extent} geometryOrExtent The geometry or extent to zoom to. CRS is 4326 by default.
-     * @param {object} [options] Options.
+     * @param {object} [options] OpenLayers View fit options object https://openlayers.org/en/latest/apidoc/module-ol_View-View.html#fit
      */
     zoomToGeometryOrExtent(geometryOrExtent, options) {
         const geometryType = geometryOrExtent.getType?.();
@@ -1179,7 +1179,7 @@ export default class map extends olMap {
     /**
      * Zoom to given feature id
      * @param {string} featureTypeDotId The string as `featureType.fid` to zoom to.
-     * @param {object} [options] Options.
+     * @param {object} [options] OpenLayers View fit options object https://openlayers.org/en/latest/apidoc/module-ol_View-View.html#fit
      */
     zoomToFid(featureTypeDotId, options) {
         const [featureType, fid] = featureTypeDotId.split('.');
@@ -1200,7 +1200,7 @@ export default class map extends olMap {
      * Zomm to given WKT geometry
      * @param {string} wkt The WKT geometry
      * @param {string} projection The projection of the WKT geometry
-     * @param {object} [options] Options.
+     * @param {object} [options] OpenLayers View fit options object https://openlayers.org/en/latest/apidoc/module-ol_View-View.html#fit
      */
     zoomToWkt(wkt, projection, options) {
         const olGeometry = (new WKT()).readGeometry(wkt, {


### PR DESCRIPTION
The `zoomToGeometryOrExtent` method wrapped the OpenLayers View `fit` method and apply the min resolution defined in Lizmap configuration for geometries.