### PR TITLE
[Bugfix] Filter unique values list is empty if one is null

### DIFF
--- a/assets/src/legacy/filter.js
+++ b/assets/src/legacy/filter.js
@@ -528,7 +528,11 @@ var lizLayerFilterTool = function () {
                     }
 
                     for (const feat of result) {
-                        globalThis['filterConfig'][field_item.order]['items'][DOMPurify.sanitize(feat['v'].toString())] = feat['c'];
+                        if (feat['v'] !== null) {
+                            globalThis['filterConfig'][field_item.order]['items'][DOMPurify.sanitize(feat['v'].toString())] = feat['c'];
+                        } else {
+                            globalThis['filterConfig'][field_item.order]['items'][feat['v']+''] = feat['c']; // 'null' for null value
+                        }
                     }
 
                     var dhtml = '';


### PR DESCRIPTION
The display of unique values in filter form is empty if one value is null.

Funded by [TDPA](https://www.terredeprovence-agglo.com/)