### PR TITLE
[Bugfix] Selection buttons tooltip position

### DIFF
--- a/assets/src/components/SelectionTool.js
+++ b/assets/src/components/SelectionTool.js
@@ -208,7 +208,8 @@ export default class SelectionTool extends HTMLElement {
         // Add tooltip on buttons
         // TODO allow tooltip on disabled buttons : https://stackoverflow.com/a/19938049/2000654
         $('.menu-content button, .menu-content .selectiontool-export, .selectiontool-geom-operator', this).tooltip({
-            placement: 'top'
+            placement: 'top',
+            container: this,
         });
 
         // Export


### PR DESCRIPTION
The way tooltip is inserted in the DOM causes trouble in the way button is display. The insert breaks some style rule.

Fixed #5841 [Bug]: selection tool - new, add & remove selection buttons shift vertically on hover

Funded by [Terre de Provence Agglomération](https://www.terredeprovence-agglo.com/)
