### PR TITLE
[Bugfix] jAcl2Db cache clear when user is added to or removed from a group

### DIFF
--- a/lizmap/modules/admin/controllers/acl.classic.php
+++ b/lizmap/modules/admin/controllers/acl.classic.php
@@ -51,6 +51,7 @@ class aclCtrl extends jController
         } else {
             $rep->action = 'jauthdb_admin~default:index';
         }
+        jAcl2::clearCache();
 
         return $rep;
     }
@@ -83,6 +84,7 @@ class aclCtrl extends jController
         } catch (jAcl2DbAdminUIException $e) {
             $this->checkException($e, 'addusertogroup');
         }
+        jAcl2::clearCache();
 
         return $rep;
     }


### PR DESCRIPTION
The jAcl2Db cache was not clear when the user's groups are managed by Lizmap.

Funded By [TDPA](https://www.terredeprovence-agglo.com/)