### PR TITLE
Fix digitizing tool to accept decimal values for distance and angle 

### DIFF
--- a/assets/src/components/Digitizing.js
+++ b/assets/src/components/Digitizing.js
@@ -458,6 +458,7 @@ export default class Digitizing extends HTMLElement {
                         placeholder="${lizDict['digitizing.constraint.distance']}"
                         class="distance"
                         min="0"
+                        step="any"
                         @input=${
                             event => mainLizmap.digitizing.distanceConstraint = event.target.value
                         }
@@ -469,6 +470,7 @@ export default class Digitizing extends HTMLElement {
                         type="number"
                         placeholder="${lizDict['digitizing.constraint.angle']}"
                         class="angle"
+                        step="any"
                         @input=${
                             event => mainLizmap.digitizing.angleConstraint = event.target.value
                         }

--- a/assets/src/modules/Digitizing.js
+++ b/assets/src/modules/Digitizing.js
@@ -1295,7 +1295,7 @@ export class Digitizing {
      * @type {number}
      */
     set distanceConstraint(distanceConstraint){
-        this._distanceConstraint = parseInt(distanceConstraint)
+        this._distanceConstraint = parseFloat(distanceConstraint)
     }
 
     /**
@@ -1311,7 +1311,7 @@ export class Digitizing {
      * @type {number}
      */
     set angleConstraint(angleConstraint){
-        this._angleConstraint = parseInt(angleConstraint)
+        this._angleConstraint = parseFloat(angleConstraint)
     }
 
     /**


### PR DESCRIPTION
Changed parseInt() to parseFloat() in the distanceConstraint and angleConstraint setters to allow decimal input. Also added step="any" attribute to the HTML number inputs to enable decimal entry in the UI.

This fixes the issue where users could only enter integer values when using the digitizing measure toggle button.

@rldhont @mdouchin  I hope i do not step your toes with those PRs! I just thought when i see room for improvements, rather then opening endless tickets i try it myself! Please let me know when i'm overstepping or making things more difficult then ease things..! 