### PR TITLE
Editing - Allow to create a feature on a layer with login based attribute filter

### DIFF
--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -751,16 +751,21 @@ class QgisForm implements QgisFormControlsInterface
 
         // Get filter by login
         $expByUserLoginKey = 'filterByLogin';
-        $expByUserLoginObj = $project->getLoginFilter($this->layer->getName(), true);
-        $expByUserLogin = '';
-        if (!empty($expByUserLoginObj) && array_key_exists('filter', $expByUserLoginObj)) {
-            $expByUserLogin = $expByUserLoginObj['filter'];
-        }
-        if ($expByUserLogin !== '') {
-            while (array_key_exists($expByUserLoginKey, $constraintExpressions)) {
-                $expByUserLoginKey .= '@';
+        // Only if the user has no right to override the filter
+        // And only for UPDATE. For INSERT, the value might be empty in the form
+        // since it can be filled by a database trigger based on localisation (ex: city code)
+        if (!$this->loginFilteredOverride && $feature) {
+            $expByUserLoginObj = $project->getLoginFilter($this->layer->getName(), true);
+            $expByUserLogin = '';
+            if (!empty($expByUserLoginObj) && array_key_exists('filter', $expByUserLoginObj)) {
+                $expByUserLogin = $expByUserLoginObj['filter'];
             }
-            $constraintExpressions[$expByUserLoginKey] = $expByUserLogin;
+            if ($expByUserLogin !== '') {
+                while (array_key_exists($expByUserLoginKey, $constraintExpressions)) {
+                    $expByUserLoginKey .= '@';
+                }
+                $constraintExpressions[$expByUserLoginKey] = $expByUserLogin;
+            }
         }
 
         // Evaluate constraint expressions
@@ -796,12 +801,7 @@ class QgisForm implements QgisFormControlsInterface
                     continue;
                 }
                 if ($fieldName === $expByUserLoginKey) {
-                    // Do not check if the authenticated user has "loginFilterOverride"
-                    if ($this->loginFilteredOverride) {
-                        continue;
-                    }
-
-                    // If not, set an error
+                    // Set an error, as the result should be 1 and is not
                     $loginFilterConfig = $project->getLoginFilteredConfig($this->layer->getName());
                     $form->setErrorOn($loginFilterConfig->filterAttribute, \jLocale::get('view~edition.message.error.feature.editable'));
 


### PR DESCRIPTION
Some editable layers are also filtered based on the authenticated user groups (attribute filter).

In the case of a feature creation, the field used by the filter might be empty (not available in the form)
but will be calculated automatically by a database trigger (based on the position of the object).

We should not prevent the user from creating a feature in this context. At worse, the feature will only be visible by the admin user.

Funded by Destination Bretagne Sud Golfe du Morbihan https://destination-bretagnesud.bzh/
