### PR TITLE
[Bugfix] PHP: VectorLayer provider can be null

### DIFF
--- a/lizmap/modules/lizmap/lib/Project/Qgis/Layer/VectorLayer.php
+++ b/lizmap/modules/lizmap/lib/Project/Qgis/Layer/VectorLayer.php
@@ -85,13 +85,13 @@ class VectorLayer extends Qgis\BaseQgisObject
         'layername',
         'srs',
         'datasource',
-        'provider',
         'styleManager',
     );
 
     /** @var array The default values for properties */
     protected $defaultValues = array(
         'layerOpacity' => 1,
+        'provider' => '',
     );
 
     /**


### PR DESCRIPTION
In this case the layer is not valid but can be stored in project.

Funded by [Karum](https://www.karum.fr/)