### PR TITLE
JS: OpenLayers v10.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "jsts": "^2.11.x",
         "lit-html": "^3.3.x",
         "mocha": "^11.7.x",
-        "ol": "^10.6.x",
+        "ol": "^10.7.x",
         "ol-ext": "^4.0.x",
         "ol-wfs-capabilities": "^2.0.x",
         "playwright-ctrf-json-reporter": "^0.0.x",
@@ -8404,9 +8404,9 @@
       "license": "MIT"
     },
     "node_modules/ol": {
-      "version": "10.6.1",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-10.6.1.tgz",
-      "integrity": "sha512-xp174YOwPeLj7c7/8TCIEHQ4d41tgTDDhdv6SqNdySsql5/MaFJEJkjlsYcvOPt7xA6vrum/QG4UdJ0iCGT1cg==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-10.7.0.tgz",
+      "integrity": "sha512-122U5gamPqNgLpLOkogFJhgpywvd/5en2kETIDW+Ubfi9lPnZ0G9HWRdG+CX0oP8od2d6u6ky3eewIYYlrVczw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jsts": "^2.11.x",
     "lit-html": "^3.3.x",
     "mocha": "^11.7.x",
-    "ol": "^10.6.x",
+    "ol": "^10.7.x",
     "ol-ext": "^4.0.x",
     "ol-wfs-capabilities": "^2.0.x",
     "playwright-ctrf-json-reporter": "^0.0.x",


### PR DESCRIPTION
Update OpenLayers to version [v10.7.0](https://github.com/openlayers/openlayers/releases/tag/v10.7.0) with:

* Several WebGL renderer bug fixes, along with improved memory management
* Updates for the Polyline feature format
* API improvements and bug fixes on the Select, Extent and Snap interactions
* Reprojection support for VectorTile layers
* Full web worker support for Map, with an (Offscreen)Canvas as map target
* Fixed cache and rendering for reprojected raster/image tile layers
* Several updated and new examples, including a globe-like map with Equal Earth projection
