### PR TITLE
e2e: cypress w/ firefox browser in CI

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -325,7 +325,7 @@ jobs:
         uses: cypress-io/github-action@v6.10.2
         with:
           install: false
-          browser: chrome
+          browser: firefox
           headed: true
           working-directory: tests/end2end
           spec: cypress/integration/*-ghaction.js


### PR DESCRIPTION
Cypress 9.7.0 does not work w/ Chrome. Let's use Firefox instead of Chrome

Funded by 3Liz
