### PR TITLE
Respect legend_image_option setting when loading symbology

### DIFF
--- a/assets/src/modules/Legend.js
+++ b/assets/src/modules/Legend.js
@@ -6,7 +6,7 @@
  */
 
 import { LayerTreeGroupState } from '../modules/state/LayerTree.js'
-import { updateLayerTreeLayerSymbology, updateLayerTreeGroupLayersSymbology } from '../modules/action/Symbology.js';
+import { updateLayerTreeLayerSymbology, updateLayerTreeLayersSymbology } from '../modules/action/Symbology.js';
 
 /**
  * @class
@@ -24,12 +24,19 @@ export default class Legend {
             return;
         }
 
-        updateLayerTreeGroupLayersSymbology(layerTree);
+        // Filter out layers with legendImageOption set to "disabled"
+        const treeLayers = layerTree.findTreeLayers().filter(
+            layer => layer.layerConfig.legendImageOption !== "disabled"
+        );
+        updateLayerTreeLayersSymbology(treeLayers);
 
         // Refresh symbology when a layer's style changes
         layerTree.addListener(
             evt => {
-                updateLayerTreeLayerSymbology(layerTree.getTreeLayerByName(evt.name));
+                const layer = layerTree.getTreeLayerByName(evt.name);
+                if (layer.layerConfig.legendImageOption !== "disabled") {
+                    updateLayerTreeLayerSymbology(layer);
+                }
             },['layer.style.changed']
         );
     }


### PR DESCRIPTION
The legend_image_option configuration was only checked when displaying symbology in the UI, but symbology was still being loaded from the server even when set to 'disabled'. This resulted in unnecessary network requests.

Filter out layers with legendImageOption set to 'disabled' before loading symbology, both during initial load and when layer styles change.

Fixes unnecessary symbology loading for layers with disabled legends:
https://github.com/3liz/lizmap-web-client/issues/5852