### PR TITLE
QGIS project parsing - Fix error when raster renderer & huesaturation are not defined

### DIFF
--- a/lizmap/modules/lizmap/lib/Project/Qgis/Layer/RasterLayerPipe.php
+++ b/lizmap/modules/lizmap/lib/Project/Qgis/Layer/RasterLayerPipe.php
@@ -18,19 +18,13 @@ use Lizmap\Project;
 /**
  * QGIS Raster layer pipe.
  *
- * @property RasterLayerRasterRenderer $renderer
- * @property RasterLayerHueSaturation  $hueSaturation
+ * @property null|RasterLayerRasterRenderer $renderer
+ * @property null|RasterLayerHueSaturation  $hueSaturation
  */
 class RasterLayerPipe extends Project\Qgis\BaseQgisXmlObject
 {
     /** @var array<string> The instance properties */
     protected $properties = array(
-        'renderer',
-        'hueSaturation',
-    );
-
-    /** @var array<string> The not null properties */
-    protected $mandatoryProperties = array(
         'renderer',
         'hueSaturation',
     );


### PR DESCRIPTION
In some QGIS projects, the properties huesaturation and renderer are not always set for rasters.
Allow them to be empty

Funded by 3liz
