### PR TITLE
Exclude basemaps from single WMS layer option

### DIFF
--- a/assets/src/modules/SingleWMSLayer.js
+++ b/assets/src/modules/SingleWMSLayer.js
@@ -137,10 +137,13 @@ export default class SingleWMSLayer {
         this._orderedLayers = [];
 
         // construct base and map layers array
+        // Also ensure visibility is calculated for each layer before first render
         this._singleWMSLayerList.forEach((m,k) => {
             if (m instanceof BaseLayerState) {
                 this._baseLayers.push(k);
             } else if (m instanceof MapLayerState){
+                // Force visibility calculation in case it hasn't been computed yet
+                m.calculateVisibility();
                 this._mapLayers.push(k);
             }
         });
@@ -343,7 +346,8 @@ export default class SingleWMSLayer {
                     this._layerStyles.push(selectedBaseLayerState.wmsSelectedStyleName || "");
                 }
             } else if (currentLayerState instanceof MapLayerState){
-                // get item visibility
+                // Check if layer should be rendered using visibility
+                // visibility considers both the layer's checked state and parent group visibility
                 if(currentLayerState.visibility) {
                     this._layersName.push(currentLayerState.name);
                     this._layersWmsName.push(currentLayerState.wmsName);

--- a/assets/src/modules/config/Options.js
+++ b/assets/src/modules/config/Options.js
@@ -36,7 +36,8 @@ const optionalProperties = {
     'hideGroupCheckbox': { type: 'boolean', default: false },
     'activateFirstMapTheme': { type: 'boolean', default: false },
     'automatic_permalink': { type: 'boolean', default: false },
-    'wms_single_request_for_all_layers' : { type:'boolean', default: false }
+    'wms_single_request_for_all_layers' : { type:'boolean', default: false },
+    'exclude_basemaps_from_single_wms' : { type:'boolean', default: false }
 };
 
 /**
@@ -72,6 +73,7 @@ export class OptionsConfig  extends BaseObjectConfig {
      * @param {boolean}  [cfg.activateFirstMapTheme]              - is first map theme activated ?
      * @param {boolean}  [cfg.automatic_permalink]                - is automatic permalink activated ?
      * @param {boolean}  [cfg.wms_single_request_for_all_layers]  - are layers loaded as single WMS image ?
+     * @param {boolean}  [cfg.exclude_basemaps_from_single_wms]   - are basemaps excluded from single WMS request ?
      */
     constructor(cfg) {
         if (!cfg || typeof cfg !== "object") {
@@ -283,6 +285,14 @@ export class OptionsConfig  extends BaseObjectConfig {
      */
     get wms_single_request_for_all_layers() {
         return this._wms_single_request_for_all_layers;
+    }
+
+    /**
+     * Basemaps are excluded from the single WMS request
+     * @type {boolean}
+     */
+    get exclude_basemaps_from_single_wms() {
+        return this._exclude_basemaps_from_single_wms;
     }
 
 }

--- a/assets/src/modules/map.js
+++ b/assets/src/modules/map.js
@@ -499,10 +499,13 @@ export default class map extends olMap {
                         source: new WMTS(options)
                     });
                 } else {
-                    if(mapState.singleWMSLayer){
+                    // Check if basemaps should be included in single WMS or rendered separately
+                    if(mapState.singleWMSLayer && !mapState.excludeBasemapsFromSingleWMS){
+                        // Include basemaps in single WMS request
                         baseLayerState.singleWMSLayer = true;
                         this._statesSingleWMSLayers.set(baseLayerState.name, baseLayerState);
                     } else {
+                        // Render basemaps as separate layers (improves performance for COG basemaps)
                         if (this._useCustomTileWms) {
                             baseLayer = new TileLayer({
                                 // extent: extent,

--- a/assets/src/modules/state/Map.js
+++ b/assets/src/modules/state/Map.js
@@ -151,8 +151,10 @@ export class MapState extends EventDispatcher {
 
         // Values from options
         this._singleWMSLayer = false;
+        this._excludeBasemapsFromSingleWMS = false;
         if (options) {
             this._singleWMSLayer = options.wms_single_request_for_all_layers; // default value is defined as false
+            this._excludeBasemapsFromSingleWMS = options.exclude_basemaps_from_single_wms; // default value is defined as false
             this._scales = buildScales(options);
             this._maxZoom = this._scales.length - 1;
             this._projection = options.projection.ref;
@@ -414,6 +416,14 @@ export class MapState extends EventDispatcher {
      */
     get singleWMSLayer(){
         return this._singleWMSLayer;
+    }
+
+    /**
+     * Config excludeBasemapsFromSingleWMS
+     * @type {boolean}
+     */
+    get excludeBasemapsFromSingleWMS(){
+        return this._excludeBasemapsFromSingleWMS;
     }
 
     /**

--- a/tests/end2end/playwright/pages/project.js
+++ b/tests/end2end/playwright/pages/project.js
@@ -247,6 +247,26 @@ export class ProjectPage extends BasePage {
     }
 
     /**
+     * Waits for a single WMS GetMap request (with multiple layers)
+     * This filters out basemap-only GetMap requests which have only one layer
+     * Single WMS requests combine multiple layers, so LAYERS contains commas
+     * @returns {Promise<Request>} The single WMS GetMap request
+     */
+    async waitForSingleWMSGetMapRequest() {
+        return this.page.waitForRequest(
+            request => {
+                if (request.method() !== 'GET') return false;
+                const url = request.url();
+                if (!url.includes('WMS') || !url.includes('GetMap')) return false;
+                // Check for multiple layers (comma-separated) to filter out single basemap requests
+                const layersMatch = url.match(/LAYERS=([^&]*)/i);
+                if (!layersMatch) return false;
+                return layersMatch[1].includes('%2C') || layersMatch[1].includes(',');
+            }
+        );
+    }
+
+    /**
      * Waits for a GetTile request
      * @returns {Promise<Request>} The GetTile request
      */

--- a/tests/end2end/playwright/singleWMS.spec.js
+++ b/tests/end2end/playwright/singleWMS.spec.js
@@ -11,7 +11,7 @@ test.describe('Single WMS layer', () => {
             tag:['@readonly']
         }, async ({ page }) => {
             const project = new ProjectPage(page, 'single_wms_image');
-            const requestMapPromise = project.waitForGetMapRequest();
+            const requestMapPromise = project.waitForSingleWMSGetMapRequest();
             const requestTilePromise = project.waitForGetTileRequest();
             await project.open();
 
@@ -21,8 +21,8 @@ test.describe('Single WMS layer', () => {
                 'VERSION': '1.3.0',
                 'REQUEST': 'GetMap',
                 'FORMAT': 'image/png',
-                'STYLES':'default,default,default,default,default,',
-                'LAYERS':'single_wms_baselayer,single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
+                'STYLES':'default,default,default,default,',
+                'LAYERS':'single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
             }
 
             const requestTile = await requestTilePromise;
@@ -79,15 +79,15 @@ test.describe('Single WMS layer', () => {
 
             // turn off single_wms_lines layer
             await page.getByTestId('single_wms_lines').locator('> div input').click();
-            const requestSwitchPromise = project.waitForGetMapRequest();
+            const requestSwitchPromise = project.waitForSingleWMSGetMapRequest();
             const requestSwitch = await requestSwitchPromise;
             const expectedSwitchParameters = {
                 'SERVICE': 'WMS',
                 'VERSION': '1.3.0',
                 'REQUEST': 'GetMap',
                 'FORMAT': 'image/png',
-                'STYLES':'default,default,default,default,',
-                'LAYERS':'single_wms_baselayer,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
+                'STYLES':'default,default,default,',
+                'LAYERS':'single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
             }
             requestExpect(requestSwitch).toContainParametersInUrl(expectedSwitchParameters);
             await requestSwitch.response();
@@ -96,15 +96,15 @@ test.describe('Single WMS layer', () => {
 
             // switch layer in a group
             await page.getByTestId('single_wms_lines_group').locator('> div input').click();
-            const requestGroupPromise = project.waitForGetMapRequest();
+            const requestGroupPromise = project.waitForSingleWMSGetMapRequest();
             const requestGroup = await requestGroupPromise;
             const expectedGroupParameters = {
                 'SERVICE': 'WMS',
                 'VERSION': '1.3.0',
                 'REQUEST': 'GetMap',
                 'FORMAT': 'image/png',
-                'STYLES':'default,default,default,',
-                'LAYERS':'single_wms_baselayer,single_wms_points,single_wms_points_group,GroupAsLayer',
+                'STYLES':'default,default,',
+                'LAYERS':'single_wms_points,single_wms_points_group,GroupAsLayer',
             }
 
             requestExpect(requestGroup).toContainParametersInUrl(expectedGroupParameters);
@@ -114,15 +114,15 @@ test.describe('Single WMS layer', () => {
 
             // switch Group as layer
             await page.getByTestId('GroupAsLayer').locator('> div input').click();
-            const requestGroupAsLayerPromise = project.waitForGetMapRequest();
+            const requestGroupAsLayerPromise = project.waitForSingleWMSGetMapRequest();
             const requestGroupAsLayer = await requestGroupAsLayerPromise;
             const expectedGroupAsLayerParameters = {
                 'SERVICE': 'WMS',
                 'VERSION': '1.3.0',
                 'REQUEST': 'GetMap',
                 'FORMAT': 'image/png',
-                'STYLES':'default,default,default',
-                'LAYERS':'single_wms_baselayer,single_wms_points,single_wms_points_group',
+                'STYLES':'default,default',
+                'LAYERS':'single_wms_points,single_wms_points_group',
             }
             requestExpect(requestGroupAsLayer).toContainParametersInUrl(expectedGroupAsLayerParameters);
             await requestGroupAsLayer.response();
@@ -140,8 +140,8 @@ test.describe('Single WMS layer', () => {
                     const searchParam = new URLSearchParams(url);
                     expect(searchParam.get('FORMAT') == 'image%2Fpng').toBeTruthy();
                     expect(searchParam.get('SERVICE') == 'WMS').toBeTruthy();
-                    expect(searchParam.get('STYLES') == 'default%2Cdefault%2Cdefault%2Cdefault%2Cdefault%2C').toBeTruthy();
-                    expect(searchParam.get('LAYERS') == 'single_wms_baselayer%2Csingle_wms_lines%2Csingle_wms_points%2Csingle_wms_points_group%2Csingle_wms_lines_group%2CGroupAsLayer').toBeTruthy();
+                    expect(searchParam.get('STYLES') == 'default%2Cdefault%2Cdefault%2Cdefault%2C').toBeTruthy();
+                    expect(searchParam.get('LAYERS') == 'single_wms_lines%2Csingle_wms_points%2Csingle_wms_points_group%2Csingle_wms_lines_group%2CGroupAsLayer').toBeTruthy();
                 }
             })
 
@@ -169,15 +169,15 @@ test.describe('Single WMS layer', () => {
             let styleLayer = page.locator("#sub-dock").locator("select.styleLayer");
 
             await styleLayer.selectOption("white_dots");
-            const requestStylePromise = project.waitForGetMapRequest();
+            const requestStylePromise = project.waitForSingleWMSGetMapRequest();
             const requestStyle = await requestStylePromise;
             const expectedStyleParameters = {
                 'SERVICE': 'WMS',
                 'VERSION': '1.3.0',
                 'REQUEST': 'GetMap',
                 'FORMAT': 'image/png',
-                'STYLES':'default,default,white_dots,default,default,',
-                'LAYERS':'single_wms_baselayer,single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
+                'STYLES':'default,white_dots,default,default,',
+                'LAYERS':'single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
             }
             requestExpect(requestStyle).toContainParametersInUrl(expectedStyleParameters);
             await requestStyle.response();
@@ -221,7 +221,7 @@ test.describe('Single WMS layer', () => {
             requestExpect(requestToken).toContainParametersInPostData(expectedFilterTokenParameter);
 
             // map is refreshing
-            const requestFilteredMapPromise = project.waitForGetMapRequest();
+            const requestFilteredMapPromise = project.waitForSingleWMSGetMapRequest();
             await requestToken.response();
 
             const requestFilteredMap = await requestFilteredMapPromise;
@@ -230,9 +230,9 @@ test.describe('Single WMS layer', () => {
                 'VERSION': '1.3.0',
                 'REQUEST': 'GetMap',
                 'FORMAT': 'image/png',
-                'STYLES':'default,default,default,default,default,',
+                'STYLES':'default,default,default,default,',
                 'FILTERTOKEN': /^[a-zA-Z0-9]{32}$/,
-                'LAYERS':'single_wms_baselayer,single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
+                'LAYERS':'single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
             }
             requestExpect(requestFilteredMap).toContainParametersInUrl(expectedFilteredMapParameters);
             await requestFilteredMap.response();
@@ -247,7 +247,7 @@ test.describe('Single WMS layer', () => {
             let styleLayer = page.locator("#sub-dock").locator("select.styleLayer");
 
             await styleLayer.selectOption("white_dots");
-            const requestFilteredStylePromise = project.waitForGetMapRequest();
+            const requestFilteredStylePromise = project.waitForSingleWMSGetMapRequest();
 
             const requestFilteredStyle = await requestFilteredStylePromise;
             const expectedFilteredStyleParameters = {
@@ -255,9 +255,9 @@ test.describe('Single WMS layer', () => {
                 'VERSION': '1.3.0',
                 'REQUEST': 'GetMap',
                 'FORMAT': 'image/png',
-                'STYLES':'default,default,white_dots,default,default,',
+                'STYLES':'default,white_dots,default,default,',
                 'FILTERTOKEN': /^[a-zA-Z0-9]{32}$/,
-                'LAYERS':'single_wms_baselayer,single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
+                'LAYERS':'single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
             }
             requestExpect(requestFilteredStyle).toContainParametersInUrl(expectedFilteredStyleParameters);
             await requestFilteredStyle.response();
@@ -274,7 +274,7 @@ test.describe('Single WMS layer', () => {
             await lines.locator(".expandable").click();
 
             await lines.locator("ul.symbols > li").nth(0).locator("input").click();
-            const requestLegendPromise = project.waitForGetMapRequest();
+            const requestLegendPromise = project.waitForSingleWMSGetMapRequest();
 
             const requestLegend = await requestLegendPromise;
             const expectedLegendParameters = {
@@ -282,10 +282,10 @@ test.describe('Single WMS layer', () => {
                 'VERSION': '1.3.0',
                 'REQUEST': 'GetMap',
                 'FORMAT': 'image/png',
-                'STYLES':'default,default,default,default,default,',
+                'STYLES':'default,default,default,default,',
                 'LEGEND_ON':'single_wms_lines:1,2,3,4',
                 'LEGEND_OFF':'single_wms_lines:0',
-                'LAYERS':'single_wms_baselayer,single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
+                'LAYERS':'single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
             }
             requestExpect(requestLegend).toContainParametersInUrl(expectedLegendParameters);
             await requestLegend.response();
@@ -321,7 +321,7 @@ test.describe('Single WMS layer', () => {
             requestExpect(requestToken).toContainParametersInPostData(expectedFilterTokenParameter);
 
             // map is refreshing
-            const requestFiltereLegendPromise = project.waitForGetMapRequest();
+            const requestFiltereLegendPromise = project.waitForSingleWMSGetMapRequest();
             await requestToken.response();
 
             const requestFiltereLegend = await requestFiltereLegendPromise;
@@ -330,11 +330,11 @@ test.describe('Single WMS layer', () => {
                 'VERSION': '1.3.0',
                 'REQUEST': 'GetMap',
                 'FORMAT': 'image/png',
-                'STYLES':'default,default,default,default,default,',
+                'STYLES':'default,default,default,default,',
                 'LEGEND_ON':'single_wms_lines:1,2,3,4',
                 'LEGEND_OFF':'single_wms_lines:0',
                 'FILTERTOKEN': /^[a-zA-Z0-9]{32}$/,
-                'LAYERS':'single_wms_baselayer,single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
+                'LAYERS':'single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
             }
             requestExpect(requestFiltereLegend).toContainParametersInUrl(expectedFiltereLegendParameters);
             await requestFiltereLegend.response();
@@ -348,7 +348,7 @@ test.describe('Single WMS layer', () => {
             await project.open();
 
             // switch base layer
-            const requestTileBaseLayerPromise = project.waitForGetMapRequest();
+            const requestTileBaseLayerPromise = project.waitForSingleWMSGetMapRequest();
             await page.locator("lizmap-base-layers select").selectOption("single_wms_tiled_baselayer")
 
             const requestTileBaseLayer = await requestTileBaseLayerPromise;
@@ -366,7 +366,7 @@ test.describe('Single WMS layer', () => {
             await page.waitForTimeout(500);
 
             // switch to second WMS baselayer
-            const requestSecondBaseLayerPromise = project.waitForGetMapRequest();
+            const requestSecondBaseLayerPromise = project.waitForSingleWMSGetMapRequest();
             await page.locator("lizmap-base-layers select").selectOption("single_wms_baselayer_two");
 
             const requestSecondBaseLayer = await requestSecondBaseLayerPromise;
@@ -375,8 +375,8 @@ test.describe('Single WMS layer', () => {
                 'VERSION': '1.3.0',
                 'REQUEST': 'GetMap',
                 'FORMAT': 'image/png',
-                'STYLES':'default,default,default,default,default,',
-                'LAYERS':'single_wms_baselayer_two,single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
+                'STYLES':'default,default,default,default,',
+                'LAYERS':'single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
             }
             requestExpect(requestSecondBaseLayer).toContainParametersInUrl(expectedSecondBaseLayerParameters);
             await requestSecondBaseLayer.response();
@@ -397,7 +397,7 @@ test.describe('Single WMS layer', () => {
             await project.fillEditionFormTextInput('title', 'Test insert');
 
             // submit the form
-            const requestMapPromise = project.waitForGetMapRequest();
+            const requestMapPromise = project.waitForSingleWMSGetMapRequest();
             project.editingSubmitForm();
             const requestMap = await requestMapPromise;
             const expectedMapParameters = {
@@ -405,8 +405,8 @@ test.describe('Single WMS layer', () => {
                 'VERSION': '1.3.0',
                 'REQUEST': 'GetMap',
                 'FORMAT': 'image/png',
-                'STYLES':'default,default,default,default,default,',
-                'LAYERS':'single_wms_baselayer,single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
+                'STYLES':'default,default,default,default,',
+                'LAYERS':'single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
             }
             requestExpect(requestMap).toContainParametersInUrl(expectedMapParameters);
             await requestMap.response();

--- a/tests/qgis-projects/tests/single_wms_image.qgs.cfg
+++ b/tests/qgis-projects/tests/single_wms_image.qgs.cfg
@@ -46,6 +46,7 @@
         "polygonTolerance": 5,
         "automatic_permalink": true,
         "wms_single_request_for_all_layers": true,
+        "exclude_basemaps_from_single_wms": true,
         "tmTimeFrameSize": 10,
         "tmTimeFrameType": "seconds",
         "tmAnimationFrameLength": 1000,


### PR DESCRIPTION
Having local basemaps like Orthofotos in an Cloud-Optimized format (COG - JPEG tiles in a TIFF container) and setting the option "Load layers as single WMS" highly degrades rendering time of lizmap projects. Switching from "no basemap" or OSM to the DOP adds 2-3s of rendering time for the client.

Checking the qgis-server logs led me to the conclusion that the problem can not be here: rendering time for the DOP was well below 1s (300-500ms) so the high cost likely comes from converting the original JPEG to PNG (the format of the combined requests) - setting the file format of the DOP layer in the lizmap plugin to jpeg does not change anything, as the JPEG-based DOP is added to the WMS stack which is delivered in PNG.

I propose to always render basemaps as separate layers and exclude them from the single WMS layer stack to circumvent this problem and deliver DOP as JPEG and speed up rendering time by the factor 10 (300ms instead of ~3000).

I also updated tests accordingly.

I'm very open to other suggestions for this particular problem!

The as-is status/loading time:
<img width="1915" height="694" alt="grafik" src="https://github.com/user-attachments/assets/8121648a-c472-4c9b-a905-c824d833703c" />



Here the result of rendering times with the proposed solution:
<img width="1909" height="701" alt="grafik" src="https://github.com/user-attachments/assets/4c8afcc4-604b-4ba2-9bb7-b9f1651982de" />
