### PR TITLE
Tests: Bump Redis to 8 in docker compose

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       start_interval: 2s
       start_period: 10s
   redis:
-    image: redis:7-alpine
+    image: redis:8-alpine
     container_name: "lizmap${LZMBRANCH}_test_redis"
   openldap:
     build: ./docker-conf/openldap


### PR DESCRIPTION
Use last Redis version for tests environment.