### PR TITLE
Fix: JS querySelectorAll on input.lizmap-popup-layer-feature-id with layerId value

### DIFF
--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -1578,7 +1578,7 @@ window.lizMap = function() {
 
                     // Do not get the filter token if the popup is not displayed
                     nbPopupDisplayed = document.querySelectorAll(
-                  `input.lizmap-popup-layer-feature-id[value^=${lConfig.id}]`
+                  `input.lizmap-popup-layer-feature-id[value^="${lConfig.id}"]`
                     ).length;
                     if (nbPopupDisplayed == 0) {
                         continue;


### PR DESCRIPTION
The layerId value was not under `"` in the `querySelectorAll` for `input.lizmap-popup-layer-feature-id`. This generated this error :

```
Uncaught DOMException: Document.querySelectorAll: 'input.lizmap-popup-layer-feature-id[value^=20250702_IRVE_a2582227_d4b1_4afd_a71a_070817a670ed]' is not a valid selector
    layerFilterParamChanged map.js:1581
    triggerEvent OpenLayers.js:497
    I attributeTable.js:2548
    S attributeTable.js:2356
    R attributeTable.js:2957
    layerFilteredFeaturesChanged attributeTable.js:3440
    triggerEvent OpenLayers.js:497
    layerfeatureremovefilter attributeTable.js:2295
    triggerEvent OpenLayers.js:497
    lizmaplocatefeaturecanceled attributeTable.js:3517
    triggerEvent OpenLayers.js:497
    addLocateByLayer lizmap.js:1257
```

Funded by [Terre de Provence Agglomération](https://www.terredeprovence-agglo.com/)