### PR TITLE
Fix: Undefined variable $ro in checkboxes_htmlbootstrap formwidget, A…

### DIFF
--- a/lizmap/plugins/formwidget/checkboxes_htmlbootstrap/checkboxes_htmlbootstrap.formwidget.php
+++ b/lizmap/plugins/formwidget/checkboxes_htmlbootstrap/checkboxes_htmlbootstrap.formwidget.php
@@ -29,6 +29,7 @@ class checkboxes_htmlbootstrapFormWidget extends checkboxes_htmlFormWidget
     {
         $attr = $this->getControlAttributes();
         $value = $this->getValue();
+        $ro = $this->ctrl->readOnly;
 
         $attr['name'] = $this->ctrl->ref.'[]';
         unset($attr['title']);


### PR DESCRIPTION
…dd readOnly attribute handling in outputControl

This Pull Request fixes a regression in the `checkboxes_htmlbootstrap` form widget that causes `E_WARNING: Undefined variable $ro` under PHP 8.x and `E_NOTICE` on earlier versions.

**Issue:**
In the `outputControl()` method, the variable `$ro` (representing the ReadOnly state) is used to determine CSS classes but is never initialized within the scope of the function.

**Solution:**
Initialized `$ro` by retrieving the `readOnly` property from the control object: `$ro = $this->ctrl->readOnly;`

**Impact:**
- Fixes log pollution in `var/log/errors.txt`.
- Ensures proper CSS class assignment (`jforms-required` or `jforms-readonly`) for checkbox controls when using the Bootstrap theme.

<!--
Add the word "fix" in front of "#" if it fixes the ticket
or do nothing to only mention it.

funded by NAME
If funded by someone else than 3Liz, please add label "sponsored development"

Please mention if the PR should be backported and to which versions.

Please add new tests if possible (JS, PHP, End2End…)
-->

Ticket : #

Funded by
