### PR TITLE
Fix: searchBuilder with column aliases

### DIFF
--- a/lizmap/modules/lizmap/lib/DataTables/DataTables.php
+++ b/lizmap/modules/lizmap/lib/DataTables/DataTables.php
@@ -3,7 +3,7 @@
 namespace Lizmap\DataTables;
 
 /**
- * @phpstan-type DTCriteria array{type: string, data: ?string, condition: ?string, value1: ?string, value2: ?string}
+ * @phpstan-type DTCriteria array{type: string, data: ?string, origData: ?string, condition: ?string, value1: ?string, value2: ?string}
  * @phpstan-type DTSearchBuilder array{criteria: DTCriteria[], logic: ?string}
  */
 class DataTables
@@ -16,7 +16,7 @@ class DataTables
     public static function convertCriteriaToExpression($criteria): string
     {
         // Check column
-        $column = $criteria['data'] ?? '';
+        $column = $criteria['origData'] ?? '';
         if ($column == '') {
             return '';
         }

--- a/tests/end2end/playwright/requests-datatables.spec.js
+++ b/tests/end2end/playwright/requests-datatables.spec.js
@@ -143,7 +143,7 @@ test.describe('Datables Requests @requests @readonly', () => {
                 order: [{'column': 2, 'dir': 'asc'}],
                 searchBuilder: {
                     criteria: [
-                        {'condition': '=', 'data': 'quartmno', 'value1': 'CX', 'type': 'string'},
+                        {'condition': '=', 'data': 'quartmno', 'origData': 'quartmno', 'value1': 'CX', 'type': 'string'},
                     ],
                     logic: 'AND',
                 },
@@ -181,7 +181,7 @@ test.describe('Datables Requests @requests @readonly', () => {
                 order: [{'column': 2, 'dir': 'asc'}],
                 searchBuilder: {
                     criteria: [
-                        {'condition': 'starts', 'data': 'quartmno', 'value1': 'C', 'type': 'string'},
+                        {'condition': 'starts', 'data': 'quartmno', 'origData': 'quartmno', 'value1': 'C', 'type': 'string'},
                     ],
                     logic: 'AND',
                 },
@@ -219,8 +219,8 @@ test.describe('Datables Requests @requests @readonly', () => {
                 order: [{'column': 2, 'dir': 'asc'}],
                 searchBuilder: {
                     criteria: [
-                        {'condition': 'starts', 'data': 'quartmno', 'value1': 'C', 'type': 'string'},
-                        {'condition': 'starts', 'data': 'quartmno', 'value1': 'P', 'type': 'string'},
+                        {'condition': 'starts', 'data': 'quartmno', 'origData': 'quartmno', 'value1': 'C', 'type': 'string'},
+                        {'condition': 'starts', 'data': 'quartmno', 'origData': 'quartmno', 'value1': 'P', 'type': 'string'},
                     ],
                     logic: 'OR',
                 },
@@ -318,7 +318,7 @@ test.describe('Datables Requests @requests @readonly', () => {
                 order: [{'column': 2, 'dir': 'asc'}],
                 searchBuilder: {
                     criteria: [
-                        {'condition': 'starts', 'data': 'libquart', 'value1': 'pres', 'type': 'string'},
+                        {'condition': 'starts', 'data': 'libquart', 'origData': 'libquart', 'value1': 'pres', 'type': 'string'},
                     ],
                     logic: 'AND',
                 },

--- a/tests/units/classes/DataTables/DataTablesTest.php
+++ b/tests/units/classes/DataTables/DataTablesTest.php
@@ -13,7 +13,8 @@ class DataTablesTest extends TestCase
     public function testConvertCriteriaToExpression(): void
     {
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'condition' => '=',
             'value1' => 'test',
             'type' => 'string',
@@ -22,7 +23,8 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, 'name = \'test\'');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'condition' => '!=',
             'value1' => '1',
             'type' => 'num',
@@ -31,7 +33,8 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, 'name != 1');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'condition' => '<',
             'value1' => '1.5',
             'type' => 'num',
@@ -40,7 +43,8 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, 'name < 1.5');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'condition' => '<=',
             'value1' => 2,
             'type' => 'num',
@@ -49,7 +53,8 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, 'name <= 2');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'condition' => '>',
             'value1' => 0.5,
             'type' => 'num',
@@ -58,7 +63,8 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, 'name > 0.5');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'condition' => '>=',
             'value1' => 'C',
             'type' => 'string',
@@ -67,7 +73,8 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, 'name >= \'C\'');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'condition' => 'starts',
             'value1' => 'test',
             'type' => 'string',
@@ -76,7 +83,8 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, 'name ILIKE \'test%\'');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'condition' => '!starts',
             'value1' => 'test',
             'type' => 'string',
@@ -85,7 +93,8 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, 'name NOT ILIKE \'test%\'');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'condition' => 'contains',
             'value1' => 'test',
             'type' => 'string',
@@ -94,7 +103,8 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, 'name ILIKE \'%test%\'');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'condition' => '!contains',
             'value1' => 'test',
             'type' => 'string',
@@ -103,7 +113,8 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, 'name NOT ILIKE \'%test%\'');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'condition' => 'ends',
             'value1' => 'test',
             'type' => 'string',
@@ -112,7 +123,8 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, 'name ILIKE \'%test\'');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'condition' => '!ends',
             'value1' => 'test',
             'type' => 'string',
@@ -121,7 +133,8 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, 'name NOT ILIKE \'%test\'');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'condition' => 'null',
             'type' => 'string',
         );
@@ -129,7 +142,8 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, 'name IS NULL');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'condition' => '!null',
             'type' => 'string',
         );
@@ -137,7 +151,8 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, 'name IS NOT NULL');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'condition' => 'between',
             'value1' => 'a',
             'value2' => 'd',
@@ -147,7 +162,8 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, 'name BETWEEN \'a\' AND \'d\'');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'condition' => '!between',
             'value1' => 'a',
             'value2' => 'd',
@@ -157,7 +173,8 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, 'name NOT BETWEEN \'a\' AND \'d\'');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'condition' => 'between',
             'value1' => 0,
             'value2' => 5,
@@ -167,7 +184,8 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, 'name BETWEEN 0 AND 5');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'condition' => '!between',
             'value1' => '0',
             'value2' => '5',
@@ -177,7 +195,8 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, 'name NOT BETWEEN 0 AND 5');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
             'type' => 'string',
             'condition' => '=',
         );
@@ -194,14 +213,23 @@ class DataTablesTest extends TestCase
         $this->assertEquals($exp, '');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
             'type' => '',
         );
         $exp = DataTables::convertCriteriaToExpression($criteria);
         $this->assertEquals($exp, '');
 
         $criteria = array(
-            'data' => 'name',
+            'data' => 'Name',
+            'origData' => 'name',
+            'type' => '',
+        );
+        $exp = DataTables::convertCriteriaToExpression($criteria);
+        $this->assertEquals($exp, '');
+
+        $criteria = array(
+            'data' => 'Name',
+            'origData' => 'name',
             'type' => 'string',
         );
         $exp = DataTables::convertCriteriaToExpression($criteria);
@@ -213,7 +241,8 @@ class DataTablesTest extends TestCase
         $search = array(
             'criteria' => array(
                 array(
-                    'data' => 'name',
+                    'data' => 'Name',
+                    'origData' => 'name',
                     'condition' => '=',
                     'value1' => 'test',
                     'type' => 'string',
@@ -226,13 +255,15 @@ class DataTablesTest extends TestCase
         $search = array(
             'criteria' => array(
                 array(
-                    'data' => 'name',
+                    'data' => 'Name',
+                    'origData' => 'name',
                     'condition' => '>=',
                     'value1' => 'a',
                     'type' => 'string',
                 ),
                 array(
-                    'data' => 'name',
+                    'data' => 'Name',
+                    'origData' => 'name',
                     'condition' => '<=',
                     'value1' => 'd',
                     'type' => 'string',
@@ -245,13 +276,15 @@ class DataTablesTest extends TestCase
         $search = array(
             'criteria' => array(
                 array(
-                    'data' => 'name',
+                    'data' => 'Name',
+                    'origData' => 'name',
                     'condition' => 'starts',
                     'value1' => 'test',
                     'type' => 'string',
                 ),
                 array(
-                    'data' => 'name',
+                    'data' => 'Name',
+                    'origData' => 'name',
                     'condition' => 'ends',
                     'value1' => 'test',
                     'type' => 'string',


### PR DESCRIPTION
In the attribute table, if you set aliases for columns, the actual column name is passed through the `origData` property, not the `data` property. This causes an error in the WFS service because it uses the column description instead of the column name to perform the filter.

Fixes #6349