### PR TITLE
Fix: JS - to zoom to point with feature-toolbar in attribute table

### DIFF
--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -2392,7 +2392,11 @@ window.lizMap = function() {
         }
         // Or get the feature via WFS in needed
         else{
-            getFeatureData(featureType, null, featureId, 'extent', false, null, null,
+            var geometryName = 'extent';
+            if (layerConfig['geometryType'] == 'point') {
+                geometryName = null; // to get default geometry
+            }
+            getFeatureData(featureType, null, featureId, geometryName, false, null, null,
                 function( aName, aFilter, cFeatures, cAliases ){
 
                     if (cFeatures.length == 1) {

--- a/assets/src/modules/map.js
+++ b/assets/src/modules/map.js
@@ -1159,7 +1159,7 @@ export default class map extends olMap {
      */
     zoomToGeometryOrExtent(geometryOrExtent, options) {
         const geometryType = geometryOrExtent.getType?.();
-        if (geometryType && (this._initialConfig.options.max_scale_lines_polygons || this._initialConfig.options.max_scale_lines_polygons)) {
+        if (geometryType && (this._initialConfig.options.max_scale_lines_polygons || this._initialConfig.options.max_scale_points)) {
             let maxScale;
             if (['Polygon', 'Linestring', 'MultiPolygon', 'MultiLinestring'].includes(geometryType)){
                 maxScale = this._initialConfig.options.max_scale_lines_polygons;


### PR DESCRIPTION
QGIS Server does not build extent for point since version 3.?? but point does not contains to many coordinates. So when Lizmap requests layer feature for point layer, Lizmap will request the geometry instead of extent.

Fixes #6415
