### PR TITLE
Fix sync edition map and view map

### DIFF
--- a/assets/src/modules/map.js
+++ b/assets/src/modules/map.js
@@ -654,7 +654,8 @@ export default class map extends olMap {
 
         this.on('moveend', () => {
             if (!this._newOlMap) {
-                lizMap.map.setCenter(undefined,this.getView().getZoom(), false, false);
+                //lizMap.map.setCenter(undefined,this.getView().getZoom(), false, false);
+                this.refreshOL2View();
             }
         });
 


### PR DESCRIPTION
The edition map is managed by OL2 and view map by OL10. The sync is not well performed.

Funded by EPF-HDF