### PR TITLE
Remove type hint for message parameter in log method

### DIFF
--- a/lizmap/modules/lizmap/lib/Logger/Logger.php
+++ b/lizmap/modules/lizmap/lib/Logger/Logger.php
@@ -116,8 +116,7 @@ class Logger extends AbstractLogger
      *
      * @throws InvalidArgumentException
      */
-    public function log($level, $message, array $context = array())
-
+    public function log($level, $message, $context = array())
     {
         if (!in_array($level, self::LogLevels)) {
             throw new InvalidArgumentException('Invalid log level');


### PR DESCRIPTION
Fixes #6431
PHP Fatal Error in Lizmap\Logger\Logger due to signature mismatch with psr/log: 2.*

<!--
Add the word "fix" in front of "#" if it fixes the ticket
or do nothing to only mention it.

funded by NAME
If funded by someone else than 3Liz, please add label "sponsored development"

Please mention if the PR should be backported and to which versions.

Please add new tests if possible (JS, PHP, End2End…)
-->

Ticket : #

Funded by
