### PR TITLE
[Bug] Always emit featureDrawn event when feature is uploaed via draw panel

### DIFF
--- a/assets/src/modules/Digitizing.js
+++ b/assets/src/modules/Digitizing.js
@@ -2180,6 +2180,14 @@ export class Digitizing {
                     const featuresGeometry = OL6features.map(feature => feature.getGeometry());
                     const featuresGeometryCollection = new GeometryCollection(featuresGeometry);
                     this._map.zoomToGeometryOrExtent(featuresGeometryCollection.getExtent());
+
+                    // since a feature is added on the map,
+                    // we should emit the "featureDrawn" event anyway, no matter which tool is currently selected.
+                    // Check first if the listener is already registered on source, before manually trigger
+                    // the callback.
+                    if (!this._drawSource.hasListener("addfeature")) {
+                        this._addFeatureSaveDispatchListener();
+                    }
                 }
             };
         })(this);


### PR DESCRIPTION
When the user uploads a feature via the drawing panel, if the currently selected tool is not one of the appropriate drawing tools (e.g. point, line, etc...), the `digitizing.featureDrawn` event is not fired because there is no `addfeature` event associated with the source.

Since a feature has been added, the `featureDrawn` event should still fire, regardless of the currently selected tool.


Backport 3.9 and 3.10

Funded by Faunalia
