### PR TITLE
[Bug] Reset file input after upload in Draw panel

### DIFF
--- a/assets/src/components/Digitizing.js
+++ b/assets/src/components/Digitizing.js
@@ -438,6 +438,7 @@ export default class Digitizing extends HTMLElement {
                                     const parent = event.target.parentElement.parentElement;
                                     parent.querySelector('.file-name').textContent = file.name;
                                     mainLizmap.digitizing.import(file);
+                                    event.target.value = '';
                                 }
                             }}>
                     </label>


### PR DESCRIPTION
If you load a file into the drawing panel and delete the newly added feature, and then want to load the same old file, the feature will not be added.

[vokoscreenNG-2026-01-22_10-34-50.webm](https://github.com/user-attachments/assets/f2f29a3c-f3f1-46cd-a051-41126672d0ea)


The reason is related to the `input` file which cannot trigger the `change` event since it maintains the reference to the same file.

A quick solution is to reset the input value as soon as the feature is loaded, but it's important to first define how this functionality is intended.

In my opinion, uploading is intended only as a quick way to draw/replicate a feature, which the user can then make changes to. It should also be possible to reload the same feature, even multiple times. In this scenario, the file name next to the `input` would be understood as "last uploaded file", otherwise it would lose any further relevance.

Alternatively, it should be possible for the user to manually reset the input file, but this seems a bit over-engineered for such a feature to me.

What do you think?

Backport relaese 3.9 and 3.10

Funded by Faunalia
