### PR TITLE
Tests e2e: replace `expectParametersToContain` by `expectRequest`

### DIFF
--- a/tests/end2end/playwright/atlas.spec.js
+++ b/tests/end2end/playwright/atlas.spec.js
@@ -1,186 +1,183 @@
 // @ts-check
 import { test } from '@playwright/test';
 import { AtlasPage } from './pages/atlaspage';
-import { expectParametersToContain } from './globals';
+import { expect as requestExpect } from './fixtures/expect-request.js';
 
-test.describe('Atlas',
-    {
-        tag: ['@readonly'],
-    }, () => {
+test.describe('Atlas @readonly', () => {
 
-        test('Center 4326', async ({ page }) => {
-            // atlas project
-            const atlasPage = new AtlasPage(page, 'atlas');
-            await atlasPage.open();
-            await atlasPage.openAtlasPanel();
+    test('Center 4326', async ({ page }) => {
+        // atlas project
+        const atlasPage = new AtlasPage(page, 'atlas');
+        await atlasPage.open();
+        await atlasPage.openAtlasPanel();
 
-            // Select a feature
-            let getFeatureInfoRequestPromise = atlasPage.waitForGetFeatureInfoRequest();
-            let getMapPromise = atlasPage.waitForGetMapRequest();
+        // Select a feature
+        let getFeatureInfoRequestPromise = atlasPage.waitForGetFeatureInfoRequest();
+        let getMapPromise = atlasPage.waitForGetMapRequest();
 
-            await atlasPage.selectAtlasFeature('2');
+        await atlasPage.selectAtlasFeature('2');
 
-            let getFeatureInfoRequest = await getFeatureInfoRequestPromise;
+        let getFeatureInfoRequest = await getFeatureInfoRequestPromise;
 
-            let getMapRequest = await getMapPromise;
+        let getMapRequest = await getMapPromise;
 
-            const getFeatureInfoExpectedParameters = {
-                'SERVICE': 'WMS',
-                'VERSION': '1.3.0',
-                'REQUEST': 'GetFeatureInfo',
-                'INFO_FORMAT': /^text\/html/,
-                'LAYERS': 'Quartiers_a_Montpellier',
-                'QUERY_LAYERS': 'Quartiers_a_Montpellier',
-                'STYLES': '',
-                'FEATURE_COUNT': '1',
-                'FILTER': `Quartiers_a_Montpellier:"quartier" = '2'`,
-            }
-            await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', getFeatureInfoExpectedParameters);
+        const getFeatureInfoExpectedParameters = {
+            'SERVICE': 'WMS',
+            'VERSION': '1.3.0',
+            'REQUEST': 'GetFeatureInfo',
+            'INFO_FORMAT': /^text\/html/,
+            'LAYERS': 'Quartiers_a_Montpellier',
+            'QUERY_LAYERS': 'Quartiers_a_Montpellier',
+            'STYLES': '',
+            'FEATURE_COUNT': '1',
+            'FILTER': `Quartiers_a_Montpellier:"quartier" = '2'`,
+        }
+        requestExpect(getFeatureInfoRequest).toContainParametersInPostData(getFeatureInfoExpectedParameters);
 
-            const getMapExpectedParameters = {
-                'SERVICE': 'WMS',
-                'VERSION': '1.3.0',
-                'REQUEST': 'GetMap',
-                'FORMAT': /^image\/png/,
-                'TRANSPARENT': /\b(\w*^true$\w*)\b/gmi,
-                'LAYERS': 'Quartiers_a_Montpellier',
-                'CRS': 'EPSG:4326',
-                'STYLES': 'default',
-                'WIDTH': '711',
-                'HEIGHT': '633',
-                'BBOX': /43.5504\d+,3.7379\d+,43.7012\d+,3.9072\d+/,
-            }
-            await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
+        const getMapExpectedParameters = {
+            'SERVICE': 'WMS',
+            'VERSION': '1.3.0',
+            'REQUEST': 'GetMap',
+            'FORMAT': /^image\/png/,
+            'TRANSPARENT': /\b(\w*^true$\w*)\b/gmi,
+            'LAYERS': 'Quartiers_a_Montpellier',
+            'CRS': 'EPSG:4326',
+            'STYLES': 'default',
+            'WIDTH': '711',
+            'HEIGHT': '633',
+            'BBOX': /43.5504\d+,3.7379\d+,43.7012\d+,3.9072\d+/,
+        }
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
 
-            // Click on next button
-            getFeatureInfoRequestPromise = atlasPage.waitForGetFeatureInfoRequest();
-            getMapPromise = atlasPage.waitForGetMapRequest();
+        // Click on next button
+        getFeatureInfoRequestPromise = atlasPage.waitForGetFeatureInfoRequest();
+        getMapPromise = atlasPage.waitForGetMapRequest();
 
-            await atlasPage.atlasNextButton.click();
-            getFeatureInfoRequest = await getFeatureInfoRequestPromise;
-            getMapRequest = await getMapPromise;
+        await atlasPage.atlasNextButton.click();
+        getFeatureInfoRequest = await getFeatureInfoRequestPromise;
+        getMapRequest = await getMapPromise;
 
-            getFeatureInfoExpectedParameters['FILTER'] = `Quartiers_a_Montpellier:"quartier" = '3'`;
-            await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', getFeatureInfoExpectedParameters);
+        getFeatureInfoExpectedParameters['FILTER'] = `Quartiers_a_Montpellier:"quartier" = '3'`;
+        requestExpect(getFeatureInfoRequest).toContainParametersInPostData(getFeatureInfoExpectedParameters);
 
-            getMapExpectedParameters['BBOX'] = /43.5356\d+,3.7540\d+,43.6863\d+,3.9233\d+/;
-            await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
+        getMapExpectedParameters['BBOX'] = /43.5356\d+,3.7540\d+,43.6863\d+,3.9233\d+/;
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
 
-            // Select feature 5
-            getFeatureInfoRequestPromise = atlasPage.waitForGetFeatureInfoRequest();
-            getMapPromise = atlasPage.waitForGetMapRequest();
+        // Select feature 5
+        getFeatureInfoRequestPromise = atlasPage.waitForGetFeatureInfoRequest();
+        getMapPromise = atlasPage.waitForGetMapRequest();
 
-            await atlasPage.selectAtlasFeature('5');
-            getFeatureInfoRequest = await getFeatureInfoRequestPromise;
-            getMapRequest = await getMapPromise;
+        await atlasPage.selectAtlasFeature('5');
+        getFeatureInfoRequest = await getFeatureInfoRequestPromise;
+        getMapRequest = await getMapPromise;
 
-            getFeatureInfoExpectedParameters['FILTER'] = `Quartiers_a_Montpellier:"quartier" = '5'`;
-            await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', getFeatureInfoExpectedParameters);
+        getFeatureInfoExpectedParameters['FILTER'] = `Quartiers_a_Montpellier:"quartier" = '5'`;
+        requestExpect(getFeatureInfoRequest).toContainParametersInPostData(getFeatureInfoExpectedParameters);
 
-            getMapExpectedParameters['BBOX'] = /43.5143\d+,3.8037\d+,43.6651\d+,3.9729\d+/;
-            await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
+        getMapExpectedParameters['BBOX'] = /43.5143\d+,3.8037\d+,43.6651\d+,3.9729\d+/;
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
 
-            // Click on previous button
-            getFeatureInfoRequestPromise = atlasPage.waitForGetFeatureInfoRequest();
-            getMapPromise = atlasPage.waitForGetMapRequest();
+        // Click on previous button
+        getFeatureInfoRequestPromise = atlasPage.waitForGetFeatureInfoRequest();
+        getMapPromise = atlasPage.waitForGetMapRequest();
 
-            await atlasPage.atlasPreviousButton.click();
-            getFeatureInfoRequest = await getFeatureInfoRequestPromise;
-            getMapRequest = await getMapPromise;
+        await atlasPage.atlasPreviousButton.click();
+        getFeatureInfoRequest = await getFeatureInfoRequestPromise;
+        getMapRequest = await getMapPromise;
 
-            getFeatureInfoExpectedParameters['FILTER'] = `Quartiers_a_Montpellier:"quartier" = '4'`;
-            await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', getFeatureInfoExpectedParameters);
+        getFeatureInfoExpectedParameters['FILTER'] = `Quartiers_a_Montpellier:"quartier" = '4'`;
+        requestExpect(getFeatureInfoRequest).toContainParametersInPostData(getFeatureInfoExpectedParameters);
 
-            getMapExpectedParameters['BBOX'] = /43.5100\d+,3.7720\d+,43.6607\d+,3.9413\d+/;
-            await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
+        getMapExpectedParameters['BBOX'] = /43.5100\d+,3.7720\d+,43.6607\d+,3.9413\d+/;
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
 
-        });
-
-        test('Zoom 2154', async ({ page }) => {
-            // atlas project
-            const atlasPage = new AtlasPage(page, 'atlas_2154');
-            await atlasPage.open();
-            await atlasPage.openAtlasPanel();
-
-            // Select a feature
-            let getFeatureInfoRequestPromise = atlasPage.waitForGetFeatureInfoRequest();
-            let getMapPromise = atlasPage.waitForGetMapRequest();
-
-            await atlasPage.selectAtlasFeature('2');
-
-            let getFeatureInfoRequest = await getFeatureInfoRequestPromise;
-
-            let getMapRequest = await getMapPromise;
-
-            const getFeatureInfoExpectedParameters = {
-                'SERVICE': 'WMS',
-                'VERSION': '1.3.0',
-                'REQUEST': 'GetFeatureInfo',
-                'INFO_FORMAT': /^text\/html/,
-                'LAYERS': 'Quartiers_a_Montpellier',
-                'QUERY_LAYERS': 'Quartiers_a_Montpellier',
-                'STYLES': '',
-                'FEATURE_COUNT': '1',
-                'FILTER': `Quartiers_a_Montpellier:"quartier" = '2'`,
-            }
-            await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', getFeatureInfoExpectedParameters);
-
-            const getMapExpectedParameters = {
-                'SERVICE': 'WMS',
-                'VERSION': '1.3.0',
-                'REQUEST': 'GetMap',
-                'FORMAT': /^image\/png/,
-                'TRANSPARENT': /\b(\w*^true$\w*)\b/gmi,
-                'LAYERS': 'Quartiers_a_Montpellier',
-                'CRS': 'EPSG:2154',
-                'STYLES': 'default',
-                'WIDTH': '711',
-                'HEIGHT': '633',
-                'BBOX': /761703.56\d+,6276912.17\d+,771109.52\d+,6285286.25\d+/,
-            }
-            await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
-
-            // Click on next button
-            getFeatureInfoRequestPromise = atlasPage.waitForGetFeatureInfoRequest();
-            getMapPromise = atlasPage.waitForGetMapRequest();
-
-            await atlasPage.atlasNextButton.click();
-            getFeatureInfoRequest = await getFeatureInfoRequestPromise;
-            getMapRequest = await getMapPromise;
-
-            getFeatureInfoExpectedParameters['FILTER'] = `Quartiers_a_Montpellier:"quartier" = '3'`;
-            await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', getFeatureInfoExpectedParameters);
-
-            getMapExpectedParameters['BBOX'] = /763029.00\d+,6275270.57\d+,772434.95\d+,6283644.64\d+/;
-            await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
-
-            // Select feature 5
-            getFeatureInfoRequestPromise = atlasPage.waitForGetFeatureInfoRequest();
-            getMapPromise = atlasPage.waitForGetMapRequest();
-
-            await atlasPage.selectAtlasFeature('5');
-            getFeatureInfoRequest = await getFeatureInfoRequestPromise;
-            getMapRequest = await getMapPromise;
-
-            getFeatureInfoExpectedParameters['FILTER'] = `Quartiers_a_Montpellier:"quartier" = '5'`;
-            await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', getFeatureInfoExpectedParameters);
-
-            getMapExpectedParameters['BBOX'] = /769418.61\d+,6275047.74\d+,774121.59\d+,6279234.78\d+/;
-            await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
-
-            // Click on previous button
-            getFeatureInfoRequestPromise = atlasPage.waitForGetFeatureInfoRequest();
-            getMapPromise = atlasPage.waitForGetMapRequest();
-
-            await atlasPage.atlasPreviousButton.click();
-            getFeatureInfoRequest = await getFeatureInfoRequestPromise;
-            getMapRequest = await getMapPromise;
-
-            getFeatureInfoExpectedParameters['FILTER'] = `Quartiers_a_Montpellier:"quartier" = '4'`;
-            await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', getFeatureInfoExpectedParameters);
-
-            getMapExpectedParameters['BBOX'] = /764495.97\d+,6272453.77\d+,773901.92\d+,6280827.84\d+/;
-            await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
-
-        });
     });
+
+    test('Zoom 2154', async ({ page }) => {
+        // atlas project
+        const atlasPage = new AtlasPage(page, 'atlas_2154');
+        await atlasPage.open();
+        await atlasPage.openAtlasPanel();
+
+        // Select a feature
+        let getFeatureInfoRequestPromise = atlasPage.waitForGetFeatureInfoRequest();
+        let getMapPromise = atlasPage.waitForGetMapRequest();
+
+        await atlasPage.selectAtlasFeature('2');
+
+        let getFeatureInfoRequest = await getFeatureInfoRequestPromise;
+
+        let getMapRequest = await getMapPromise;
+
+        const getFeatureInfoExpectedParameters = {
+            'SERVICE': 'WMS',
+            'VERSION': '1.3.0',
+            'REQUEST': 'GetFeatureInfo',
+            'INFO_FORMAT': /^text\/html/,
+            'LAYERS': 'Quartiers_a_Montpellier',
+            'QUERY_LAYERS': 'Quartiers_a_Montpellier',
+            'STYLES': '',
+            'FEATURE_COUNT': '1',
+            'FILTER': `Quartiers_a_Montpellier:"quartier" = '2'`,
+        }
+        requestExpect(getFeatureInfoRequest).toContainParametersInPostData(getFeatureInfoExpectedParameters);
+
+        const getMapExpectedParameters = {
+            'SERVICE': 'WMS',
+            'VERSION': '1.3.0',
+            'REQUEST': 'GetMap',
+            'FORMAT': /^image\/png/,
+            'TRANSPARENT': /\b(\w*^true$\w*)\b/gmi,
+            'LAYERS': 'Quartiers_a_Montpellier',
+            'CRS': 'EPSG:2154',
+            'STYLES': 'default',
+            'WIDTH': '711',
+            'HEIGHT': '633',
+            'BBOX': /761703.56\d+,6276912.17\d+,771109.52\d+,6285286.25\d+/,
+        }
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
+
+        // Click on next button
+        getFeatureInfoRequestPromise = atlasPage.waitForGetFeatureInfoRequest();
+        getMapPromise = atlasPage.waitForGetMapRequest();
+
+        await atlasPage.atlasNextButton.click();
+        getFeatureInfoRequest = await getFeatureInfoRequestPromise;
+        getMapRequest = await getMapPromise;
+
+        getFeatureInfoExpectedParameters['FILTER'] = `Quartiers_a_Montpellier:"quartier" = '3'`;
+        requestExpect(getFeatureInfoRequest).toContainParametersInPostData(getFeatureInfoExpectedParameters);
+
+        getMapExpectedParameters['BBOX'] = /763029.00\d+,6275270.57\d+,772434.95\d+,6283644.64\d+/;
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
+
+        // Select feature 5
+        getFeatureInfoRequestPromise = atlasPage.waitForGetFeatureInfoRequest();
+        getMapPromise = atlasPage.waitForGetMapRequest();
+
+        await atlasPage.selectAtlasFeature('5');
+        getFeatureInfoRequest = await getFeatureInfoRequestPromise;
+        getMapRequest = await getMapPromise;
+
+        getFeatureInfoExpectedParameters['FILTER'] = `Quartiers_a_Montpellier:"quartier" = '5'`;
+        requestExpect(getFeatureInfoRequest).toContainParametersInPostData(getFeatureInfoExpectedParameters);
+
+        getMapExpectedParameters['BBOX'] = /769418.61\d+,6275047.74\d+,774121.59\d+,6279234.78\d+/;
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
+
+        // Click on previous button
+        getFeatureInfoRequestPromise = atlasPage.waitForGetFeatureInfoRequest();
+        getMapPromise = atlasPage.waitForGetMapRequest();
+
+        await atlasPage.atlasPreviousButton.click();
+        getFeatureInfoRequest = await getFeatureInfoRequestPromise;
+        getMapRequest = await getMapPromise;
+
+        getFeatureInfoExpectedParameters['FILTER'] = `Quartiers_a_Montpellier:"quartier" = '4'`;
+        requestExpect(getFeatureInfoRequest).toContainParametersInPostData(getFeatureInfoExpectedParameters);
+
+        getMapExpectedParameters['BBOX'] = /764495.97\d+,6272453.77\d+,773901.92\d+,6280827.84\d+/;
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
+
+    });
+});

--- a/tests/end2end/playwright/axis_orientation.spec.js
+++ b/tests/end2end/playwright/axis_orientation.spec.js
@@ -4,7 +4,8 @@ import * as fs from 'fs/promises'
 import { existsSync } from 'node:fs';
 import { test, expect } from '@playwright/test';
 import {ProjectPage} from "./pages/project";
-import { expectParametersToContain, playwrightTestFile} from "./globals";
+import { expect as requestExpect } from './fixtures/expect-request.js';
+import { playwrightTestFile} from "./globals";
 
 // To update OSM and GeoPF tiles in the mock directory
 // IMPORTANT, this must not be set to `true` while committing, on GitHub. Set to `false`.
@@ -43,7 +44,7 @@ test.describe('Axis Orientation',
                 'HEIGHT': '633',
                 'BBOX': /5276843.28\d+,-14455.54\d+,6114251.21\d+,1252901.15\d+/,
             }
-            await expectParametersToContain('GetMap', getMapRequest.url(), expectedParameters)
+            requestExpect(getMapRequest).toContainParametersInUrl(expectedParameters);
 
             const getMapResponse = await getMapRequest.response();
             expect(getMapResponse).not.toBeNull();
@@ -135,7 +136,7 @@ test.describe('Axis Orientation',
                 'HEIGHT': '633',
                 'BBOX': /72126.00\d+,-122200.57\d+,909533.92\d+,1145156.12\d+/,
             }
-            await expectParametersToContain('GetMap', getMapRequest.url(), expectedParameters);
+            requestExpect(getMapRequest).toContainParametersInUrl(expectedParameters);
 
             const getMapResponse = await getMapRequest.response();
             expect(getMapResponse).not.toBeNull();

--- a/tests/end2end/playwright/dataviz.spec.js
+++ b/tests/end2end/playwright/dataviz.spec.js
@@ -2,7 +2,6 @@
 import { test, expect } from '@playwright/test';
 import { expect as responseExpect } from './fixtures/expect-response.js'
 import { ProjectPage } from "./pages/project";
-//import { expectParametersToContain } from './globals';
 
 test.describe('Dataviz tests @readonly', () => {
 

--- a/tests/end2end/playwright/edition-form.spec.js
+++ b/tests/end2end/playwright/edition-form.spec.js
@@ -2,7 +2,6 @@
 import { test, expect } from '@playwright/test';
 import { expect as responseExpect } from './fixtures/expect-response.js'
 import { expect as requestExpect } from './fixtures/expect-request.js'
-import { expectParametersToContain } from './globals';
 import { ProjectPage } from "./pages/project";
 
 test.describe('Edition Form Validation', () => {
@@ -582,7 +581,7 @@ test.describe(
                 'CRS': 'EPSG:4326',
                 'BBOX': /43.5515\d+,3.7760\d+,43.6884\d+,3.9831\d+/,
             }
-            await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', expectedParameters);
+            requestExpect(getFeatureInfoRequest).toContainParametersInPostData(expectedParameters);
 
             // wait for response
             let getFeatureInfoResponse = await getFeatureInfoRequest.response();

--- a/tests/end2end/playwright/embedded-relation.spec.js
+++ b/tests/end2end/playwright/embedded-relation.spec.js
@@ -1,8 +1,8 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { expect as requestExpect } from './fixtures/expect-request.js';
 import { expect as responseExpect } from './fixtures/expect-response.js'
 import {ProjectPage} from "./pages/project";
-import { expectParametersToContain } from './globals';
 
 test.describe('Display embedded relation in popup',
     {
@@ -39,7 +39,7 @@ test.describe('Display embedded relation in popup',
                 'CRS': 'EPSG:4326',
                 'BBOX': /-0.2789\d+,-0.7174\d+,0.4056\d+,0.3183\d+/,
             }
-            await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', expectedParameters);
+            requestExpect(getFeatureInfoRequest).toContainParametersInPostData(expectedParameters);
 
             // wait for response
             let getFeatureInfoResponse = await getFeatureInfoRequest.response();
@@ -107,7 +107,7 @@ test.describe('Display embedded relation in popup',
                 'CRS': 'EPSG:4326',
                 'BBOX': /-0.2789\d+,-0.7174\d+,0.4056\d+,0.3183\d+/,
             }
-            await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', expectedParameters);
+            requestExpect(getFeatureInfoRequest).toContainParametersInPostData(expectedParameters);
 
             // wait for response
             getFeatureInfoResponse = await getFeatureInfoRequest.response();

--- a/tests/end2end/playwright/feature-toolbar.spec.js
+++ b/tests/end2end/playwright/feature-toolbar.spec.js
@@ -1,8 +1,8 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { expect as requestExpect } from './fixtures/expect-request.js';
 import { expect as responseExpect } from './fixtures/expect-response.js'
 import { ProjectPage } from "./pages/project";
-import { expectParametersToContain } from './globals';
 
 /**
  * Playwright Locator
@@ -26,7 +26,7 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'LAYERS': 'parent_layer',
             'QUERY_LAYERS': 'parent_layer',
         }
-        await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', getFeatureInfoExpectedParameters);
+        requestExpect(getFeatureInfoRequest).toContainParametersInPostData(getFeatureInfoExpectedParameters);
         let getFeatureInfoResponse = await getFeatureInfoRequest.response();
         responseExpect(getFeatureInfoResponse).toBeHtml();
 
@@ -51,8 +51,9 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'HEIGHT': '633',
             'BBOX': /759253.2\d+,6270938.6\d+,784600.4\d+,6287686.8\d+/,
         }
-        await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
-        await getMapRequest.response();
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
+        let getMapResponse = await getMapRequest.response();
+        responseExpect(getMapResponse).toBeImagePng();
 
         // Click on zoom to in feature-toolbar
         getMapRequestPromise = project.waitForGetMapRequest();
@@ -71,8 +72,9 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'HEIGHT': '633',
             'BBOX': /771293.1\d+,6278894.0\d+,772560.5\d+,6279731.4\d+/,
         }
-        await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
-        await getMapRequest.response();
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
+        getMapResponse = await getMapRequest.response();
+        responseExpect(getMapResponse).toBeImagePng();
     });
 
     test('should center', async ({ page }) => {
@@ -91,7 +93,7 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'LAYERS': 'parent_layer',
             'QUERY_LAYERS': 'parent_layer',
         }
-        await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', getFeatureInfoExpectedParameters);
+        requestExpect(getFeatureInfoRequest).toContainParametersInPostData(getFeatureInfoExpectedParameters);
         let getFeatureInfoResponse = await getFeatureInfoRequest.response();
         responseExpect(getFeatureInfoResponse).toBeHtml();
 
@@ -116,8 +118,9 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'HEIGHT': '633',
             'BBOX': /759253.2\d+,6270938.6\d+,784600.4\d+,6287686.8\d+/,
         }
-        await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
-        await getMapRequest.response();
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
+        let getMapResponse = await getMapRequest.response();
+        responseExpect(getMapResponse).toBeImagePng();
 
         // two more clicks on zoom-in
         getMapRequestPromise = project.waitForGetMapRequest();
@@ -146,8 +149,9 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'HEIGHT': '633',
             'BBOX': /770659.5\d+,6278475.3\d+,773194.2\d+,6280150.1\d+/,
         }
-        await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
-        await getMapRequest.response();
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
+        getMapResponse = await getMapRequest.response();
+        responseExpect(getMapResponse).toBeImagePng();
 
         // Click on center to in feature-toolbar
         getMapRequestPromise = project.waitForGetMapRequest();
@@ -166,8 +170,9 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'HEIGHT': '633',
             'BBOX': /781176.6\d+,6278640.6\d+,783711.4\d+,6280315.5\d+/,
         }
-        await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
-        await getMapRequest.response();
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
+        getMapResponse = await getMapRequest.response();
+        responseExpect(getMapResponse).toBeImagePng();
     });
 
     test('should select', async ({ page }) => {
@@ -186,7 +191,7 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'LAYERS': 'parent_layer',
             'QUERY_LAYERS': 'parent_layer',
         }
-        await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', getFeatureInfoExpectedParameters);
+        requestExpect(getFeatureInfoRequest).toContainParametersInPostData(getFeatureInfoExpectedParameters);
         let getFeatureInfoResponse = await getFeatureInfoRequest.response();
         responseExpect(getFeatureInfoResponse).toBeHtml();
 
@@ -207,7 +212,7 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'typename': 'parent_layer',
             'ids': '1',
         }
-        await expectParametersToContain('GetSelectionToken', getSelectionTokenRequest.postData() ?? '', getSelectionTokenParameters);
+        requestExpect(getSelectionTokenRequest).toContainParametersInPostData(getSelectionTokenParameters);
 
         // Once the GetSelectionToken is received, the map is refreshed
         let getMapRequestPromise = project.waitForGetMapRequest();
@@ -229,8 +234,9 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'BBOX': /740242.9\d+,6258377.5\d+,803610.7\d+,6300247.9\d+/,
             'SELECTIONTOKEN': /^[a-zA-Z0-9]{32}$/,
         }
-        await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
-        await getMapRequest.response();
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
+        let getMapResponse = await getMapRequest.response();
+        responseExpect(getMapResponse).toBeImagePng();
 
         // Check that the select button display that the feature is selected
         await expect(featureToolbar.locator('button.feature-select')).toContainClass('btn-primary');
@@ -245,11 +251,10 @@ test.describe('Feature toolbar in popup @readonly', () => {
         await expect(firstTr.locator('lizmap-feature-toolbar button.feature-select')).toContainClass('btn-primary');
 
         // An other click on select Button to unselect
-        getMapRequestPromise = project.waitForGetMapRequest();
         await featureToolbar.locator('button.feature-select').click();
-        getMapRequest = await getMapRequestPromise;
-        await getMapRequest.response();
+        // No GetMap request because of some OpenLayers cache
 
+        // Check that the feature is unselected
         await expect(featureToolbar.locator('button.feature-select')).not.toContainClass('btn-primary');
         await expect(firstTr).not.toContainClass('selected');
         await expect(firstTr.locator('lizmap-feature-toolbar button.feature-select')).not.toContainClass('btn-primary');
@@ -271,7 +276,7 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'LAYERS': 'parent_layer',
             'QUERY_LAYERS': 'parent_layer',
         }
-        await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', getFeatureInfoExpectedParameters);
+        requestExpect(getFeatureInfoRequest).toContainParametersInPostData(getFeatureInfoExpectedParameters);
         let getFeatureInfoResponse = await getFeatureInfoRequest.response();
         responseExpect(getFeatureInfoResponse).toBeHtml();
 
@@ -292,7 +297,7 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'typename': 'parent_layer',
             'filter': 'parent_layer:"id" IN ( 1 ) ',
         }
-        await expectParametersToContain('GetFilterToken', getFilterTokenRequest.postData() ?? '', getFilterTokenParameters);
+        requestExpect(getFilterTokenRequest).toContainParametersInPostData(getFilterTokenParameters);
 
         // Once the GetFilterToken is received, the map is refreshed
         let getMapRequestPromise = project.waitForGetMapRequest();
@@ -314,8 +319,9 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'BBOX': /740242.9\d+,6258377.5\d+,803610.7\d+,6300247.9\d+/,
             'FILTERTOKEN': /^[a-zA-Z0-9]{32}$/,
         }
-        await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
-        await getMapRequest.response();
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
+        let getMapResponse = await getMapRequest.response();
+        responseExpect(getMapResponse).toBeImagePng();
 
         // Check that the filter button display that the feature is filtered
         await expect(featureToolbar.locator('button.feature-filter')).toContainClass('btn-primary');
@@ -361,7 +367,7 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'LAYERS': 'parent_layer',
             'QUERY_LAYERS': 'parent_layer',
         }
-        await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', getFeatureInfoExpectedParameters);
+        requestExpect(getFeatureInfoRequest).toContainParametersInPostData(getFeatureInfoExpectedParameters);
         let getFeatureInfoResponse = await getFeatureInfoRequest.response();
         responseExpect(getFeatureInfoResponse).toBeHtml();
 
@@ -398,7 +404,7 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'typename': 'parent_layer',
             'ids': '1',
         }
-        await expectParametersToContain('GetSelectionToken', getSelectionTokenRequest.postData() ?? '', getSelectionTokenParameters);
+        requestExpect(getSelectionTokenRequest).toContainParametersInPostData(getSelectionTokenParameters);
 
         // Once the GetFilterToken is received, the map is refreshed
         let getMapRequestPromise = project.waitForGetMapRequest();
@@ -420,8 +426,9 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'BBOX': /770659.5\d+,6278475.3\d+,773194.2\d+,6280150.1\d+/,
             'SELECTIONTOKEN': /^[a-zA-Z0-9]{32}$/,
         }
-        await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
-        await getMapRequest.response();
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
+        let getMapResponse = await getMapRequest.response();
+        responseExpect(getMapResponse).toBeImagePng();
 
         // Check that the action button display that the action has been launched on the feature
         await expect(featureToolbar.locator('button.popup-action')).toContainClass('btn-primary');
@@ -452,7 +459,7 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'LAYERS': 'parent_layer',
             'QUERY_LAYERS': 'parent_layer',
         }
-        await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', getFeatureInfoExpectedParameters);
+        requestExpect(getFeatureInfoRequest).toContainParametersInPostData(getFeatureInfoExpectedParameters);
         let getFeatureInfoResponse = await getFeatureInfoRequest.response();
         responseExpect(getFeatureInfoResponse).toBeHtml();
 
@@ -475,8 +482,8 @@ test.describe('Feature toolbar in popup @readonly', () => {
             layerId: /^parent_layer_[a-zA-Z0-9_]*/,
             featureId: '2',
         };
-        await expectParametersToContain('modifyFeature', modifyFeatureRequest.url(), expectedParameters);
-        await expectParametersToContain('editFeature', editFeatureRequest.url(), expectedParameters);
+        requestExpect(modifyFeatureRequest).toContainParametersInUrl(expectedParameters);
+        requestExpect(editFeatureRequest).toContainParametersInUrl(expectedParameters);
 
         // id input is visible
         await expect(page.locator('#jforms_view_edition_id')).toBeVisible();
@@ -504,7 +511,7 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'LAYERS': 'parent_layer',
             'QUERY_LAYERS': 'parent_layer',
         }
-        await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', getFeatureInfoExpectedParameters);
+        requestExpect(getFeatureInfoRequest).toContainParametersInPostData(getFeatureInfoExpectedParameters);
         let getFeatureInfoResponse = await getFeatureInfoRequest.response();
         responseExpect(getFeatureInfoResponse).toBeHtml();
 
@@ -530,8 +537,8 @@ test.describe('Feature toolbar in popup @readonly', () => {
 
         // Check request
         let expectedParameters = {layerId: /^children_layer_[a-zA-Z0-9_]*/};
-        await expectParametersToContain('createFeature', createFeatureRequest.url(), expectedParameters);
-        await expectParametersToContain('editFeature', editFeatureRequest.url(), expectedParameters);
+        requestExpect(createFeatureRequest).toContainParametersInUrl(expectedParameters);
+        requestExpect(editFeatureRequest).toContainParametersInUrl(expectedParameters);
 
         // Parent_id is hidden in form when edition is started from parent form
         await expect(page.locator('#jforms_view_edition_parent_id')).toBeHidden();
@@ -559,7 +566,7 @@ test.describe('Feature toolbar in popup @readonly', () => {
             'LAYERS': 'parent_layer',
             'QUERY_LAYERS': 'parent_layer',
         }
-        await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', getFeatureInfoExpectedParameters);
+        requestExpect(getFeatureInfoRequest).toContainParametersInPostData(getFeatureInfoExpectedParameters);
         let getFeatureInfoResponse = await getFeatureInfoRequest.response();
         responseExpect(getFeatureInfoResponse).toBeHtml();
 
@@ -607,8 +614,9 @@ test.describe('Feature toolbar in attribute table @readonly', () => {
             'HEIGHT': '633',
             'BBOX': /759253.2\d+,6270938.6\d+,784600.4\d+,6287686.8\d+/,
         }
-        await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
-        await getMapRequest.response();
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
+        let getMapResponse = await getMapRequest.response();
+        responseExpect(getMapResponse).toBeImagePng();
 
         // Open Attribute table
         let datatablesRequest = await project.openAttributeTable('parent_layer', true);
@@ -638,8 +646,9 @@ test.describe('Feature toolbar in attribute table @readonly', () => {
             'HEIGHT': '633',
             'BBOX': /771293.1\d+,6278894.0\d+,772560.5\d+,6279731.4\d+/,
         }
-        await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
-        await getMapRequest.response();
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
+        getMapResponse = await getMapRequest.response();
+        responseExpect(getMapResponse).toBeImagePng();
 
         // Use the second line
         let secondTr = project.attributeTableHtml('parent_layer').locator('tbody tr').nth(1);
@@ -663,8 +672,9 @@ test.describe('Feature toolbar in attribute table @readonly', () => {
             'HEIGHT': '633',
             'BBOX': /781810.3\d+,6279059.3\d+,783077.7\d+,6279896.8\d+/,
         }
-        await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
-        await getMapRequest.response();
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
+        getMapResponse = await getMapRequest.response();
+        responseExpect(getMapResponse).toBeImagePng();
     });
 
     test('should select', async ({ page }) => {
@@ -689,8 +699,9 @@ test.describe('Feature toolbar in attribute table @readonly', () => {
             'HEIGHT': '633',
             'BBOX': /759253.2\d+,6270938.6\d+,784600.4\d+,6287686.8\d+/,
         }
-        await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
-        await getMapRequest.response();
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
+        let getMapResponse = await getMapRequest.response();
+        responseExpect(getMapResponse).toBeImagePng();
 
         // Open Attribute table
         let datatablesRequest = await project.openAttributeTable('parent_layer', true);
@@ -715,7 +726,7 @@ test.describe('Feature toolbar in attribute table @readonly', () => {
             'typename': 'parent_layer',
             'ids': '1',
         }
-        await expectParametersToContain('GetSelectionToken', getSelectionTokenRequest.postData() ?? '', getSelectionTokenParameters);
+        requestExpect(getSelectionTokenRequest).toContainParametersInPostData(getSelectionTokenParameters);
 
         // Once the GetSelectionToken is received, the map is refreshed
         getMapRequestPromise = project.waitForGetMapRequest();
@@ -724,7 +735,7 @@ test.describe('Feature toolbar in attribute table @readonly', () => {
 
         // Check GetMap request with selection token parameter
         getMapExpectedParameters['SELECTIONTOKEN'] = /^[a-zA-Z0-9]{32}$/;
-        await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
         await getMapRequest.response();
 
         // Check that the select button display that the feature is selected
@@ -761,8 +772,8 @@ test.describe('Feature toolbar in attribute table @readonly', () => {
             layerId: /^parent_layer_[a-zA-Z0-9_]*/,
             featureId: '2',
         };
-        await expectParametersToContain('modifyFeature', modifyFeatureRequest.url(), expectedParameters);
-        await expectParametersToContain('editFeature', editFeatureRequest.url(), expectedParameters);
+        requestExpect(modifyFeatureRequest).toContainParametersInUrl(expectedParameters);
+        requestExpect(editFeatureRequest).toContainParametersInUrl(expectedParameters);
 
         // id input is visible
         await expect(page.locator('#jforms_view_edition_id')).toBeVisible();
@@ -806,8 +817,8 @@ test.describe('Feature toolbar in attribute table @readonly', () => {
 
         // Check request
         let expectedParameters = {layerId: /^children_layer_[a-zA-Z0-9_]*/};
-        await expectParametersToContain('createFeature', createFeatureRequest.url(), expectedParameters);
-        await expectParametersToContain('editFeature', editFeatureRequest.url(), expectedParameters);
+        requestExpect(createFeatureRequest).toContainParametersInUrl(expectedParameters);
+        requestExpect(editFeatureRequest).toContainParametersInUrl(expectedParameters);
 
         // Parent_id is hidden in form when edition is started from parent form
         await expect(page.locator('#jforms_view_edition_parent_id')).toBeHidden();

--- a/tests/end2end/playwright/n_to_m_relations.spec.js
+++ b/tests/end2end/playwright/n_to_m_relations.spec.js
@@ -1,8 +1,8 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { expect as requestExpect } from './fixtures/expect-request.js';
 import { expect as responseExpect } from './fixtures/expect-response.js'
 import {ProjectPage} from "./pages/project";
-import { expectParametersToContain } from './globals';
 
 test.describe('N to M relations',
     {
@@ -315,7 +315,7 @@ test.describe('N to M relations',
                 'CRS': 'EPSG:4326',
                 'BBOX': /43.2302\d+,4.3586\d+,43.5724\d+,4.8765\d+/,
             }
-            await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', expectedParameters);
+            requestExpect(getFeatureInfoRequest).toContainParametersInPostData(expectedParameters);
 
             // wait for response
             let getFeatureInfoResponse = await getFeatureInfoRequest.response();

--- a/tests/end2end/playwright/overview.spec.js
+++ b/tests/end2end/playwright/overview.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { test } from '@playwright/test';
-import { expectParametersToContain } from './globals';
+import { expect as requestExpect } from './fixtures/expect-request.js';
 import {ProjectPage} from "./pages/project";
 
 test.describe('Overview',
@@ -27,7 +27,7 @@ test.describe('Overview',
                 'HEIGHT': '110',
                 'BBOX': /758432.36\d*,6273694.3\d*,782221.64\d*,6284973.7\d*/,
             }
-            await expectParametersToContain('GetMap', request.url(), expectedParameters);
+            requestExpect(request).toContainParametersInUrl(expectedParameters);
             await request.response();
         });
 
@@ -51,7 +51,7 @@ test.describe('Overview',
                 'HEIGHT': '110',
                 'BBOX': /43.559491\d*,3.765259\d*,43.659592\d*,3.976380\d*/,
             }
-            await expectParametersToContain('GetMap', request.url(), expectedParameters);
+            requestExpect(request).toContainParametersInUrl(expectedParameters);
             await request.response();
         });
 
@@ -74,7 +74,7 @@ test.describe('Overview',
                 'HEIGHT': '110',
                 'BBOX': /411699.32\d*,5396012.89\d*,450848.73\d*,5414575.11\d*/,
             }
-            await expectParametersToContain('GetMap', request.url(), expectedParameters);
+            requestExpect(request).toContainParametersInUrl(expectedParameters);
             await request.response();
         });
     });

--- a/tests/end2end/playwright/permalink.spec.js
+++ b/tests/end2end/playwright/permalink.spec.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
-import {expectParametersToContain, gotoMap, reloadMap} from './globals';
+import { expect as requestExpect } from './fixtures/expect-request.js';
+import {gotoMap, reloadMap} from './globals';
 
 test.describe('Permalink', () => {
 
@@ -734,7 +735,7 @@ test.describe('BBox parameter', () => {
             'HEIGHT': '633',
             'BBOX': /762375.04\d+,6277986.97\d+,775048.61\d+,6286361.05\d+/,
         }
-        await expectParametersToContain('GetMap', getMapRequest.url(), expectedParameters);
+        requestExpect(getMapRequest).toContainParametersInUrl(expectedParameters);
 
         // Check Permalink tool
         const new_share_value = await page.locator('#input-share-permalink').inputValue();
@@ -783,7 +784,7 @@ test.describe('BBox parameter', () => {
             'HEIGHT': '633',
             'BBOX': /762375.04\d+,6277986.97\d+,775048.61\d+,6286361.05\d+/,
         }
-        await expectParametersToContain('GetMap', getMapRequest.url(), expectedParameters);
+        requestExpect(getMapRequest).toContainParametersInUrl(expectedParameters);
 
         // Check Permalink tool
         const new_share_value = await page.locator('#input-share-permalink').inputValue();

--- a/tests/end2end/playwright/singleWMS.spec.js
+++ b/tests/end2end/playwright/singleWMS.spec.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { expect as requestExpect } from './fixtures/expect-request.js';
 import { expect as responseExpect } from './fixtures/expect-response.js'
-import { expectParametersToContain } from './globals';
 import { ProjectPage } from "./pages/project";
 
 test.describe('Single WMS layer', () => {
@@ -34,8 +34,8 @@ test.describe('Single WMS layer', () => {
                 'layer':'single_wms_polygons',
             }
 
-            await expectParametersToContain('GetMap', requestMap.url(), expectedMapParameters);
-            await expectParametersToContain('GetTile', requestTile.url(), expectedTileParameters);
+            requestExpect(requestMap).toContainParametersInUrl(expectedMapParameters);
+            requestExpect(requestTile).toContainParametersInUrl(expectedTileParameters);
             await requestMap.response();
             await requestTile.response();
         });
@@ -89,7 +89,7 @@ test.describe('Single WMS layer', () => {
                 'STYLES':'default,default,default,default,',
                 'LAYERS':'single_wms_baselayer,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
             }
-            await expectParametersToContain('GetMap', requestSwitch.url(), expectedSwitchParameters);
+            requestExpect(requestSwitch).toContainParametersInUrl(expectedSwitchParameters);
             await requestSwitch.response();
 
             await page.waitForTimeout(400);
@@ -107,7 +107,7 @@ test.describe('Single WMS layer', () => {
                 'LAYERS':'single_wms_baselayer,single_wms_points,single_wms_points_group,GroupAsLayer',
             }
 
-            await expectParametersToContain('GetMap', requestGroup.url(), expectedGroupParameters);
+            requestExpect(requestGroup).toContainParametersInUrl(expectedGroupParameters);
             await requestGroup.response();
 
             await page.waitForTimeout(400);
@@ -124,7 +124,7 @@ test.describe('Single WMS layer', () => {
                 'STYLES':'default,default,default',
                 'LAYERS':'single_wms_baselayer,single_wms_points,single_wms_points_group',
             }
-            await expectParametersToContain('GetMap', requestGroupAsLayer.url(), expectedGroupAsLayerParameters);
+            requestExpect(requestGroupAsLayer).toContainParametersInUrl(expectedGroupAsLayerParameters);
             await requestGroupAsLayer.response();
 
             //enable all switched off layer
@@ -179,7 +179,7 @@ test.describe('Single WMS layer', () => {
                 'STYLES':'default,default,white_dots,default,default,',
                 'LAYERS':'single_wms_baselayer,single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
             }
-            await expectParametersToContain('GetMap', requestStyle.url(), expectedStyleParameters);
+            requestExpect(requestStyle).toContainParametersInUrl(expectedStyleParameters);
             await requestStyle.response();
         });
 
@@ -218,7 +218,7 @@ test.describe('Single WMS layer', () => {
                 'typename': 'single_wms_points',
                 'filter': 'single_wms_points:"id" IN ( 1 ) ',
             }
-            await expectParametersToContain('GetFilterToken', requestToken.postData() ?? '', expectedFilterTokenParameter);
+            requestExpect(requestToken).toContainParametersInPostData(expectedFilterTokenParameter);
 
             // map is refreshing
             const requestFilteredMapPromise = project.waitForGetMapRequest();
@@ -234,7 +234,7 @@ test.describe('Single WMS layer', () => {
                 'FILTERTOKEN': /^[a-zA-Z0-9]{32}$/,
                 'LAYERS':'single_wms_baselayer,single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
             }
-            await expectParametersToContain('GetMap', requestFilteredMap.url(), expectedFilteredMapParameters);
+            requestExpect(requestFilteredMap).toContainParametersInUrl(expectedFilteredMapParameters);
             await requestFilteredMap.response();
 
             // change the style while filtering
@@ -259,7 +259,7 @@ test.describe('Single WMS layer', () => {
                 'FILTERTOKEN': /^[a-zA-Z0-9]{32}$/,
                 'LAYERS':'single_wms_baselayer,single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
             }
-            await expectParametersToContain('GetMap', requestFilteredStyle.url(), expectedFilteredStyleParameters);
+            requestExpect(requestFilteredStyle).toContainParametersInUrl(expectedFilteredStyleParameters);
             await requestFilteredStyle.response();
         });
 
@@ -287,7 +287,7 @@ test.describe('Single WMS layer', () => {
                 'LEGEND_OFF':'single_wms_lines:0',
                 'LAYERS':'single_wms_baselayer,single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
             }
-            await expectParametersToContain('GetMap', requestLegend.url(), expectedLegendParameters);
+            requestExpect(requestLegend).toContainParametersInUrl(expectedLegendParameters);
             await requestLegend.response();
 
             // filter
@@ -318,7 +318,7 @@ test.describe('Single WMS layer', () => {
                 'typename': 'single_wms_lines',
                 'filter': 'single_wms_lines:"id" IN ( 3 ) ',
             }
-            await expectParametersToContain('GetFilterToken', requestToken.postData() ?? '', expectedFilterTokenParameter);
+            requestExpect(requestToken).toContainParametersInPostData(expectedFilterTokenParameter);
 
             // map is refreshing
             const requestFiltereLegendPromise = project.waitForGetMapRequest();
@@ -336,7 +336,7 @@ test.describe('Single WMS layer', () => {
                 'FILTERTOKEN': /^[a-zA-Z0-9]{32}$/,
                 'LAYERS':'single_wms_baselayer,single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
             }
-            await expectParametersToContain('GetMap', requestFiltereLegend.url(), expectedFiltereLegendParameters);
+            requestExpect(requestFiltereLegend).toContainParametersInUrl(expectedFiltereLegendParameters);
             await requestFiltereLegend.response();
         });
 
@@ -360,7 +360,7 @@ test.describe('Single WMS layer', () => {
                 'STYLES':'default,default,default,default,',
                 'LAYERS':'single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
             }
-            await expectParametersToContain('GetMap', requestTileBaseLayer.url(), expectedTileBaseLayerParameters);
+            requestExpect(requestTileBaseLayer).toContainParametersInUrl(expectedTileBaseLayerParameters);
             await requestTileBaseLayer.response();
 
             await page.waitForTimeout(500);
@@ -378,7 +378,7 @@ test.describe('Single WMS layer', () => {
                 'STYLES':'default,default,default,default,default,',
                 'LAYERS':'single_wms_baselayer_two,single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
             }
-            await expectParametersToContain('GetMap', requestSecondBaseLayer.url(), expectedSecondBaseLayerParameters);
+            requestExpect(requestSecondBaseLayer).toContainParametersInUrl(expectedSecondBaseLayerParameters);
             await requestSecondBaseLayer.response();
         });
 
@@ -400,7 +400,7 @@ test.describe('Single WMS layer', () => {
             const requestMapPromise = project.waitForGetMapRequest();
             project.editingSubmitForm();
             const requestMap = await requestMapPromise;
-            const expectedrequestMapParameters = {
+            const expectedMapParameters = {
                 'SERVICE': 'WMS',
                 'VERSION': '1.3.0',
                 'REQUEST': 'GetMap',
@@ -408,7 +408,7 @@ test.describe('Single WMS layer', () => {
                 'STYLES':'default,default,default,default,default,',
                 'LAYERS':'single_wms_baselayer,single_wms_lines,single_wms_points,single_wms_points_group,single_wms_lines_group,GroupAsLayer',
             }
-            await expectParametersToContain('GetMap', requestMap.url(), expectedrequestMapParameters);
+            requestExpect(requestMap).toContainParametersInUrl(expectedMapParameters);
             await requestMap.response();
         });
 });

--- a/tests/end2end/playwright/sub-dock.spec.js
+++ b/tests/end2end/playwright/sub-dock.spec.js
@@ -4,7 +4,8 @@ import * as fs from 'fs/promises'
 import { existsSync } from 'node:fs';
 import { Buffer } from 'node:buffer';
 import { test, expect } from '@playwright/test';
-import { playwrightTestFile , expectParametersToContain } from './globals';
+import { expect as requestExpect } from './fixtures/expect-request.js';
+import { playwrightTestFile } from './globals';
 import { ProjectPage } from "./pages/project";
 
 // To update OSM and GeoPF tiles in the mock directory
@@ -119,7 +120,7 @@ test.describe('Sub dock @readonly', () => {
             'HEIGHT': '633',
             'BBOX': /412967.3\d+,5393197.8\d+,449580.6\d+,5417390.1\d+/,
         }
-        await expectParametersToContain('GetMap', getMapRequest.url(), getMapExpectedParameters);
+        requestExpect(getMapRequest).toContainParametersInUrl(getMapExpectedParameters);
         // Check sub dock metadata content
         await expect(page.locator('#sub-dock .sub-metadata h3 .text')).toHaveText('Information');
         await expect(page.locator('#sub-dock .sub-metadata .menu-content dt')).toHaveCount(4);
@@ -313,7 +314,7 @@ test.describe('Sub dock @readonly', () => {
             'OUTPUTFORMAT': 'GeoJSON',
             'TYPENAME': 'sousquartiers',
         };
-        await expectParametersToContain('Export GeoJSON from sub-dock', getFeatureRequest.postData() ?? '', expectedParameters);
+        requestExpect(getFeatureRequest).toContainParametersInPostData(expectedParameters);
         const response = await getFeatureRequest.response();
 
         // check response
@@ -396,7 +397,7 @@ test.describe('Sub dock @readonly', () => {
             'OUTPUTFORMAT': 'GeoJSON',
             'TYPENAME': 'sousquartiers',
         };
-        await expectParametersToContain('Export GeoJSON from sub-dock', getFeatureRequest.postData() ?? '', expectedParameters);
+        requestExpect(getFeatureRequest).toContainParametersInPostData(expectedParameters);
         const response = await getFeatureRequest.response();
 
         // check response

--- a/tests/end2end/playwright/viewport.spec.js
+++ b/tests/end2end/playwright/viewport.spec.js
@@ -1,7 +1,8 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { expect as requestExpect } from './fixtures/expect-request.js';
 import { expect as responseExpect } from './fixtures/expect-response.js'
-import {expectParametersToContain, gotoMap} from './globals';
+import {gotoMap} from './globals';
 
 test.describe('Viewport devicePixelRatio 1', () => {
     test('Greater than WMS max size', async ({ page }) => {
@@ -246,7 +247,7 @@ test.describe('Viewport standard', () => {
             'HEIGHT': '633',
             'BBOX': /-9373014.15\d+,-6193233.77\d+,9373014.15\d+,6193233.77\d+/,
         }
-        await expectParametersToContain('GetMap', getMapRequest.url(), expectedParameters);
+        requestExpect(getMapRequest).toContainParametersInUrl(expectedParameters);
 
         // Check zoom
         expect(await page.evaluate(() => lizMap.mainLizmap.map.getView().getZoom())).toBe(1);
@@ -276,7 +277,7 @@ test.describe('Viewport standard', () => {
             'HEIGHT': '909',
             'BBOX': /-7005300.76\d+,-8893601.11\d+,7005300.76\d+,8893601.11\d+/,
         }
-        await expectParametersToContain('GetMap', getMapRequest.url(), expectedParameters);
+        requestExpect(getMapRequest).toContainParametersInUrl(expectedParameters);
 
         // Check zoom
         expect(await page.evaluate(() => lizMap.mainLizmap.map.getView().getZoom())).toBe(1);

--- a/tests/end2end/playwright/webdav-upload.spec.js
+++ b/tests/end2end/playwright/webdav-upload.spec.js
@@ -1,7 +1,8 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { expect as requestExpect } from './fixtures/expect-request.js';
 import { expect as responseExpect } from './fixtures/expect-response.js'
-import { expectParametersToContain, playwrightTestFile } from './globals';
+import { playwrightTestFile } from './globals';
 import { ProjectPage } from "./pages/project";
 
 test.describe('WebDAV Server',
@@ -256,7 +257,7 @@ test.describe('WebDAV Server',
                 'CRS': 'EPSG:4326',
                 'BBOX': /44.6568\d+,-1.2512\d+,47.3951\d+,2.8918\d+/,
             }
-            await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', expectedParameters);
+            requestExpect(getFeatureInfoRequest).toContainParametersInPostData(expectedParameters);
 
             // wait for response
             let getFeatureInfoResponse = await getFeatureInfoRequest.response();
@@ -328,7 +329,7 @@ test.describe('WebDAV Server',
                 'CRS': 'EPSG:4326',
                 'BBOX': /44.6568\d+,-1.2512\d+,47.3951\d+,2.8918\d+/,
             }
-            await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', expectedParameters);
+            requestExpect(getFeatureInfoRequest).toContainParametersInPostData(expectedParameters);
 
             // wait for response
             let getFeatureInfoResponse = await getFeatureInfoRequest.response();
@@ -453,7 +454,7 @@ test.describe('WebDAV Server',
                 'CRS': 'EPSG:4326',
                 'BBOX': /44.6568\d+,-1.2512\d+,47.3951\d+,2.8918\d+/,
             }
-            await expectParametersToContain('GetFeatureInfo', getFeatureInfoRequest.postData() ?? '', expectedParameters);
+            requestExpect(getFeatureInfoRequest).toContainParametersInPostData(expectedParameters);
 
             // wait for response
             let getFeatureInfoResponse = await getFeatureInfoRequest.response();


### PR DESCRIPTION
Modernize Playwright e2e tests by replacing `expectParametersToContain` by `expectRequest`.