### PR TITLE
Tests e2e: Move action tests form Cypress to Playwright

### DIFF
--- a/tests/end2end/cypress/integration/feature_toolbar-ghaction.js
+++ b/tests/end2end/cypress/integration/feature_toolbar-ghaction.js
@@ -115,55 +115,6 @@ describe('Feature Toolbar in popup', function () {
         cy.get('#message .jelix-msg-item-success').should('have.text', 'Selected features have been correctly linked.')
     })
 
-    it('should display working project action selector', function () {
-        // Get the project action
-        // Check the dock is visible
-        cy.get('a#button-action').should('have.length', 1)
-
-        // Open the project action dock
-        cy.get('a#button-action').click()
-
-        // Select an action
-        cy.get('#lizmap-project-actions select.action-select').select('project_map_center_buffer')
-
-        // Run the project action
-        cy.get('#lizmap-project-actions button.action-run-button').click()
-
-        // Check result
-        cy.get('#message #lizmap-action-message p').should('have.text', 'The displayed geometry represents the buffer 2000 m of the current map center')
-
-        // Deactivate
-        cy.get('#lizmap-project-actions button.action-deactivate-button').click()
-
-        // Check
-        cy.get('#message').should('be.empty')
-
-    })
-
-    it('should display working layer action selector', function () {
-        // Select the layer in the legend tree
-        cy.get('#node-parent_layer ~ .node .icon-info-sign').click({force: true})
-
-        // Check the action selector is present
-        cy.get('#sub-dock div.layer-action-selector-container').should('have.length', 1);
-
-        // Select an action
-        cy.get('#sub-dock div.layer-action-selector-container select.action-select').select('layer_spatial_extent')
-
-        // Run the project action
-        cy.get('#sub-dock div.layer-action-selector-container button.action-run-button').click()
-
-        // Check result
-        cy.get('#message #lizmap-action-message p').should('have.text', 'The displayed geometry represents the contour of all the layer features')
-
-        // Deactivate
-        cy.get('#sub-dock div.layer-action-selector-container button.action-run-button').click()
-
-        // Check
-        cy.get('#message').should('be.empty')
-
-    })
-
     it('should start child edition linked to a parent feature from the child feature toolbar', function () {
         // Click feature with id=2 on the map
         cy.mapClick(1055, 437)

--- a/tests/end2end/playwright/action.spec.js
+++ b/tests/end2end/playwright/action.spec.js
@@ -1,0 +1,208 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+// import { expect as requestExpect } from './fixtures/expect-request.js'
+import { expect as responseExpect } from './fixtures/expect-response.js'
+import { ProjectPage } from './pages/project';
+
+test.describe('Lizmap actions', () => {
+
+    test.beforeEach(async ({ page }) => {
+        const project = new ProjectPage(page, 'feature_toolbar');
+        await project.open();
+    });
+
+    test('should display working project action', async ({ page }) => {
+        // Check the button action and the action dock exists
+        await expect(page.locator('#button-action')).toHaveCount(1);
+        const actionDock = page.locator('#action');
+        await expect(actionDock).toHaveCount(1);
+        const actionContainer = page.locator('#lizmap-project-actions');
+        await expect(actionContainer).toHaveCount(1);
+        const actionSelect = actionContainer.locator('select.action-select');
+        await expect(actionSelect).toHaveCount(1);
+
+        // The action dock is hidden
+        await actionDock.isHidden();
+        await actionContainer.isHidden();
+        await actionSelect.isHidden();
+
+        // The action message is hidden
+        const actionMessage = page.locator('#lizmap-action-message');
+        actionMessage.isHidden();
+
+        // Open action dock
+        await page.locator('#button-action').click();
+
+        // Check that the action dock is opened
+        await actionDock.isVisible();
+        await actionContainer.isVisible();
+        await actionSelect.isVisible();
+
+        // The action message is still hidden
+        actionMessage.isHidden();
+
+        // Check select options
+        const action_options = await actionSelect.locator('option').allTextContents();
+        expect(action_options).toHaveLength(3);
+        expect(action_options).toEqual(expect.arrayContaining([
+            '-- Choose an action -- ',
+            'Get the buffer of the current map center point',
+            'Get the buffer of the point drawn by the user',
+        ]));
+
+        // Check select options values, it should be the same length
+        const action_values = await actionSelect.locator('option')
+            // @ts-ignore HTMLOptionElement has value property but it is not known
+            .evaluateAll(list => list.map(opt => opt.value));
+        expect(action_values).toHaveLength(3);
+        expect(action_values).toEqual(expect.arrayContaining([
+            '',
+            'project_map_center_buffer',
+            'project_map_drawn_point_buffer',
+        ]));
+
+        // Check the select default value
+        await expect(actionSelect).toHaveValue('');
+        // Check the default description
+        await expect(actionContainer.locator('div.action-description')).toHaveText(
+            'Choose an action to run'
+        );
+
+        // Select an action
+        await actionSelect.selectOption('project_map_center_buffer');
+
+        // Check the action description
+        await expect(actionContainer.locator('div.action-description')).toHaveText(
+            'This is an example action which returns a circle at the center of the map'
+        );
+
+        // Create the promise to wait for the request to action service
+        const actionPromise = page.waitForRequest(/action\/service/);
+        // Run the action
+        await actionContainer.locator('button.action-run-button').click();
+        // Wait for the request to action service
+        const actionRequest = await actionPromise;
+        /*
+        The content-type of the POST request is application/JSON
+        We have to implement a new method
+        requestExpect(actionRequest).toContainJsonInPostData({
+            featureId: null,
+            layerId: null,
+            mapCenter: /^POINT\(\d\.\d* \d\d\.\d*\)$/,
+            mapExtent: /^POLYGON\(\(\d\.\d* \d\.\d*,\d\.\d* \d\.\d*,\d\.\d* \d\.\d*,\d\.\d* \d\.\d*,\d\.\d* \d\.\d*\)\)$/,
+            name: 'project_map_center_buffer',
+            wkt: null,
+        });
+        */
+        // Wait for the response
+        const actionResponse = await actionRequest.response();
+        // Check the response
+        responseExpect(actionResponse).toBeJson();
+
+        // Check the dsiplay message
+        actionMessage.isVisible();
+        await expect(actionMessage).toHaveText(
+            'The displayed geometry represents the buffer 2000 m of the current map center'
+        );
+
+        // Deactivate
+        await actionContainer.locator('button.action-deactivate-button').click();
+
+        // The action message is back to be hidden
+        actionMessage.isHidden();
+    });
+
+    test('should display working layer action selector', async ({ page }) => {
+        const layerName = 'parent_layer';
+        // Display info button
+        await expect(page.getByTestId(layerName).locator('.icon-info-sign')).toBeHidden();
+        await page.getByTestId(layerName).hover();
+        await expect(page.getByTestId(layerName).locator('.icon-info-sign')).toBeVisible();
+
+        // Display sub dock metadata
+        await expect(page.locator('#sub-dock')).toBeHidden();
+        await page.getByTestId(layerName).locator('.icon-info-sign').click();
+        await expect(page.locator('#sub-dock')).toBeVisible();
+
+        // Check sub dock metadata content
+        await expect(page.locator('#sub-dock .sub-metadata h3 .text')).toHaveText('Information');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt')).toHaveCount(6);
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(0)).toHaveText('Name');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(1)).toHaveText('Type');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(2)).toHaveText('Zoom to the layer extent');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(3)).toHaveText('Opacity');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(4)).toHaveText('Export');
+        await expect(page.locator('#sub-dock .sub-metadata .menu-content dt').nth(5)).toHaveText('Actions');
+
+        // Check actions container
+        const actionContainer = page.locator('#sub-dock .layer-action-selector-container');
+        await expect(actionContainer).toHaveCount(1);
+        await expect(actionContainer).toBeVisible();
+        await expect(page.locator('#sub-dock lizmap-action-selector')).toHaveCount(1);
+        await expect(page.locator('#sub-dock lizmap-action-selector')).toBeVisible();
+        const actionSelect = actionContainer.locator('select.action-select');
+        await expect(actionSelect).toHaveCount(1);
+        await expect(actionSelect).toBeVisible();
+
+        // The action message is hidden
+        const actionMessage = page.locator('#lizmap-action-message');
+        actionMessage.isHidden();
+
+        // Check select options
+        const action_options = await actionSelect.locator('option').allTextContents();
+        expect(action_options).toHaveLength(2);
+        expect(action_options).toEqual(expect.arrayContaining([
+            '-- Choose an action -- ',
+            'Get the contour of all the layer features',
+        ]));
+
+        // Check select options values, it should be the same length
+        const action_values = await actionSelect.locator('option')
+            // @ts-ignore HTMLOptionElement has value property but it is not known
+            .evaluateAll(list => list.map(opt => opt.value));
+        expect(action_values).toHaveLength(2);
+        expect(action_values).toEqual(expect.arrayContaining([
+            '',
+            'layer_spatial_extent',
+        ]));
+
+        // Check the select default value
+        await expect(actionSelect).toHaveValue('');
+        // Check the default description
+        await expect(actionContainer.locator('div.action-description')).toHaveText(
+            'Choose an action to run'
+        );
+
+        // Select an action
+        await actionSelect.selectOption('layer_spatial_extent');
+
+        // Check the action description
+        await expect(actionContainer.locator('div.action-description')).toHaveText(
+            'This action will draw a polygon which represents the contour of all the features'
+        );
+
+        // Create the promise to wait for the request to action service
+        const actionPromise = page.waitForRequest(/action\/service/);
+        // Run the action
+        await actionContainer.locator('button.action-run-button').click();
+        // Wait for the request to action service
+        const actionRequest = await actionPromise;
+
+        // Wait for the response
+        const actionResponse = await actionRequest.response();
+        // Check the response
+        responseExpect(actionResponse).toBeJson();
+
+        // Check the dsiplay message
+        actionMessage.isVisible();
+        await expect(actionMessage).toHaveText(
+            'The displayed geometry represents the contour of all the layer features'
+        );
+
+        // Deactivate
+        await actionContainer.locator('button.action-deactivate-button').click();
+
+        // The action message is back to be hidden
+        actionMessage.isHidden();
+    });
+});


### PR DESCRIPTION
Continue to move end2end tests from Cypress to Playwright