### PR TITLE
Tests e2e: well unroute

### DIFF
--- a/tests/end2end/playwright/axis_orientation.spec.js
+++ b/tests/end2end/playwright/axis_orientation.spec.js
@@ -62,6 +62,7 @@ test.describe('Axis Orientation',
             await expect(bundeslanderByteLength).toBeGreaterThan(blankByteLength);
 
             // Catch GetTile request
+            /** @type {string[]} GetTiles - Array of tiles url string */
             let GetTiles = [];
             await page.route('https://tile.openstreetmap.org/*/*/*.png', async (route) => {
                 const request = route.request();
@@ -99,7 +100,9 @@ test.describe('Axis Orientation',
             await expect(GetTiles[3]).toContain('6/34/21.png')
             await expect(GetTiles[4]).toContain('6/33/22.png')
             await expect(GetTiles[5]).toContain('6/34/22.png')
-            await page.unroute('https://tile.openstreetmap.org/*/*/*.png')
+
+            // Remove listen to osm tiles
+            await page.unroute('https://tile.openstreetmap.org/*/*/*.png');
 
             // Wait for transition
             await page.waitForTimeout(1000);
@@ -156,6 +159,7 @@ test.describe('Axis Orientation',
             await expect(judetByteLength).toBeGreaterThan(blankByteLength);
 
             // Catch GetTile request
+            /** @type {string[]} GetTiles - Array of tiles url string */
             let GetTiles = [];
             await page.route('https://tile.openstreetmap.org/*/*/*.png', async (route) => {
                 const request = route.request();
@@ -193,7 +197,9 @@ test.describe('Axis Orientation',
             expect(GetTiles[3]).toContain('6/36/23.png')
             expect(GetTiles[4]).toContain('6/37/22.png')
             expect(GetTiles[5]).toContain('6/37/23.png')
-            await page.unroute('https://tile.openstreetmap.org/*/*/*.png')
+
+            // Remove listen to osm tiles
+            await page.unroute('https://tile.openstreetmap.org/*/*/*.png');
 
             // Wait for transition
             await page.waitForTimeout(1000);

--- a/tests/end2end/playwright/edition-form.spec.js
+++ b/tests/end2end/playwright/edition-form.spec.js
@@ -85,6 +85,7 @@ test.describe('Edition Form Validation', () => {
         await expect(page.locator("#lizmap-edition-message")).toBeVisible();
         await expect(page.locator("#message > div")).toHaveClass(/alert-danger/);
 
+        // Remove listen to create feature
         await page.unroute('**/edition/createFeature*');
     })
 
@@ -125,6 +126,7 @@ test.describe('Edition Form Validation', () => {
         // form closed
         await expect(page.locator('#edition-form-container')).toBeHidden();
 
+        // Remove listen to save feature
         await page.unroute('**/edition/saveFeature*');
     })
 })

--- a/tests/end2end/playwright/error-occurred.spec.js
+++ b/tests/end2end/playwright/error-occurred.spec.js
@@ -28,41 +28,61 @@ test.describe('Error occurred', () => {
     })
 
     test('Project  error', async ({ page }) => {
+        // Catch GetProjectConfig to abort request
         await page.route('**/service/getProjectConfig*', async route => {
             await route.abort()
         });
         // Error catch
         await gotoMap('/index.php/view/map/?repository=testsrepository&project=world-3857', page, false);
+
+        // Remove catching GetProjectConfig
+        await page.unroute('**/service/getProjectConfig*');
+
         // Go back home
         await goBackHomeAfterError(page);
     })
 
     test('GetCapabilities WMS error', async ({ page }) => {
+        // Catch WMS GetCapabilities to abort request
         await page.route(/SERVICE=WMS&REQUEST=GetCapabilities/, async route => {
             await route.abort()
         });
         // Error catch
         await gotoMap('/index.php/view/map/?repository=testsrepository&project=world-3857', page, false);
+
+        // Remove catching WMS GetCapabilities
+        await page.unroute(/SERVICE=WMS&REQUEST=GetCapabilities/);
+
         // Go back home
         await goBackHomeAfterError(page);
     })
 
     test('GetCapabilities WMTS error', async ({ page }) => {
+        // Catch WMTS GetCapabilities to abort request
         await page.route(/SERVICE=WMTS&REQUEST=GetCapabilities/, async route => {
             await route.abort()
         });
         // Error catch
         await gotoMap('/index.php/view/map/?repository=testsrepository&project=world-3857', page, false);
+
+        // Remove catching WMTS GetCapabilities
+        await page.unroute(/SERVICE=WMTS&REQUEST=GetCapabilities/);
+
         // Go back home
         await goBackHomeAfterError(page);
     })
 
     test('GetCapabilities WFS error', async ({ page }) => {
+        // Catch WFS GetCapabilities to abort request
         await page.route(/SERVICE=WFS&REQUEST=GetCapabilities/, async route => {
             await route.abort()
         });
         // Error catch
         await gotoMap('/index.php/view/map/?repository=testsrepository&project=world-3857', page, false);
+
+        // Remove catching WFS GetCapabilities
+        await page.unroute(/SERVICE=WFS&REQUEST=GetCapabilities/);
+
         // Go back home
         await goBackHomeAfterError(page);
     })

--- a/tests/end2end/playwright/external_wms_layer.spec.js
+++ b/tests/end2end/playwright/external_wms_layer.spec.js
@@ -110,5 +110,8 @@ test.describe('External WMS layers', () => {
         // Check response
         getMapResponse = await getMapRequest.response();
         responseExpect(getMapResponse).toBeImageWebp();
+
+        // Remove listen to osm tiles
+        await page.unroute('https://tile.openstreetmap.org/*/*/*.png');
     });
 });

--- a/tests/end2end/playwright/feature-toolbar.spec.js
+++ b/tests/end2end/playwright/feature-toolbar.spec.js
@@ -998,6 +998,9 @@ test.describe('Feature toolbar zoom to max @readonly', () => {
         let getMapResponse = await getMapRequest.response();
         responseExpect(getMapResponse).toBeImagePng();
 
+        // Remove catching GetProjectConfig
+        await page.unroute('**/service/getProjectConfig*');
+
         // Display layer tramway_lines
         getMapRequestPromise = project.waitForGetMapRequest();
         await page.getByTestId('tramway_lines').locator('.node').click();
@@ -1082,6 +1085,9 @@ test.describe('Feature toolbar zoom to max @readonly', () => {
         // Check response
         let getMapResponse = await getMapRequest.response();
         responseExpect(getMapResponse).toBeImagePng();
+
+        // Remove catching GetProjectConfig
+        await page.unroute('**/service/getProjectConfig*');
 
         // Display layer tramway_lines
         getMapRequestPromise = project.waitForGetMapRequest();
@@ -1172,6 +1178,9 @@ test.describe('Feature toolbar zoom to max @readonly', () => {
         let getMapResponse = await getMapRequest.response();
         responseExpect(getMapResponse).toBeImagePng();
 
+        // Remove catching GetProjectConfig
+        await page.unroute('**/service/getProjectConfig*');
+
         // Click on parent_layer
         let getFeatureInfoPromise = project.waitForGetFeatureInfoRequest();
         await project.clickOnMap(436, 290);
@@ -1241,6 +1250,9 @@ test.describe('Feature toolbar zoom to max @readonly', () => {
         // Check response
         let getMapResponse = await getMapRequest.response();
         responseExpect(getMapResponse).toBeImagePng();
+
+        // Remove catching GetProjectConfig
+        await page.unroute('**/service/getProjectConfig*');
 
         // Open Attribute table
         let datatablesRequest = await project.openAttributeTable('parent_layer', true);
@@ -1312,6 +1324,9 @@ test.describe('Feature toolbar zoom to max @readonly', () => {
         // Check response
         let getMapResponse = await getMapRequest.response();
         responseExpect(getMapResponse).toBeImagePng();
+
+        // Remove catching GetProjectConfig
+        await page.unroute('**/service/getProjectConfig*');
 
         // Check scale
         await expect(page.locator('#overview-bar .ol-scale-text')).not.toHaveText('1 : ' + (max_scale_lines_polygons).toLocaleString(locale));

--- a/tests/end2end/playwright/location_search.spec.js
+++ b/tests/end2end/playwright/location_search.spec.js
@@ -65,6 +65,9 @@ test.describe('Location search @readonly', () => {
 
         await expect(searchLocator).toHaveCount(1);
 
+        // Remove catching GetProjectConfig
+        await page.unroute('**/service/getProjectConfig*');
+
         await searchLocator.click();
         await searchLocator.fill('arceaux');
 
@@ -97,6 +100,9 @@ test.describe('Location search @readonly', () => {
         const searchLocator = page.getByPlaceholder('Search');
 
         await expect(searchLocator).toHaveCount(1);
+
+        // Remove catching GetProjectConfig
+        await page.unroute('**/service/getProjectConfig*');
 
         await searchLocator.click();
         await searchLocator.fill('arceaux');
@@ -171,6 +177,9 @@ test.describe('Location search @readonly', () => {
         const searchLocator = page.getByPlaceholder('Search');
 
         await expect(searchLocator).toHaveCount(0);
+
+        // Remove catching GetProjectConfig
+        await page.unroute('**/service/getProjectConfig*');
     });
 
 });

--- a/tests/end2end/playwright/permalink.spec.js
+++ b/tests/end2end/playwright/permalink.spec.js
@@ -18,6 +18,11 @@ test.describe('Permalink', () => {
         });
     });
 
+    test.afterEach(async ({ page }) => {
+        // Remove catching GetProjectConfig
+        await page.unroute('**/service/getProjectConfig*');
+    });
+
     test('Hash changes when map center is changed', async ({ page }) => {
         await gotoMap('/index.php/view/map?repository=testsrepository&project=layer_legends', page);
         await page.evaluate(() => lizMap.mainLizmap.map.getView().setCenter([770485, 6277813]));
@@ -586,6 +591,11 @@ test.describe('Automatic permalink disabled', () => {
             }
             await route.fulfill({ response, json });
         });
+    });
+
+    test.afterEach(async ({ page }) => {
+        // Remove catching GetProjectConfig
+        await page.unroute('**/service/getProjectConfig*');
     });
 
     test('Hash does not change when map center is changed', async ({ page }) => {

--- a/tests/end2end/playwright/popup.spec.js
+++ b/tests/end2end/playwright/popup.spec.js
@@ -361,6 +361,9 @@ test.describe('Popup @readonly', () => {
         const project = new ProjectPage(page, 'popup');
         await project.open();
 
+        // Remove catching GetProjectConfig
+        await page.unroute('**/service/getProjectConfig*');
+
         let getFeatureInfoPromise = project.waitForGetFeatureInfoRequest();
         await project.clickOnMap(510, 415);
         let getFeatureInfoRequest = await getFeatureInfoPromise;
@@ -373,7 +376,6 @@ test.describe('Popup @readonly', () => {
         await expect(lizmapFeaturesTable).toHaveAttribute('layerTitle', 'children_layer');
         await expect(lizmapFeaturesTable).toHaveAttribute('uniqueField', 'id');
         await expect(lizmapFeaturesTable).toHaveAttribute('expressionFilter', 'parent_id = \'1\'');
-        await page.unroute('**/service/getProjectConfig*');
     });
 
     test('getFeatureInfo request should contain a FILTERTOKEN parameter when the layer is filtered', async ({ page }) => {
@@ -653,6 +655,9 @@ test.describe('Popup config mocked with "minidock" option', () => {
 
         const project = new ProjectPage(page, 'popup');
         await project.open();
+
+        // Remove catching GetProjectConfig
+        await page.unroute('**/service/getProjectConfig*');
 
         // When clicking on a triangle feature a popup must appear
         await page.locator('#newOlMap').click({

--- a/tests/end2end/playwright/print.spec.js
+++ b/tests/end2end/playwright/print.spec.js
@@ -992,6 +992,7 @@ test.describe('Print 3857', () => {
 test.describe('Print base layers', () => {
     test.beforeEach(async ({ page }) => {
         // Catch openstreetmap requests to mock them
+        /** @type {string[]} */
         let GetTiles = [];
         await page.route('https://tile.openstreetmap.org/*/*/*.png', async (route) => {
             const request = route.request();
@@ -1027,7 +1028,9 @@ test.describe('Print base layers', () => {
         while (GetTiles.length < 6) {
             await page.waitForTimeout(100);
         }
-        await expect(GetTiles.length).toBeGreaterThanOrEqual(6);
+        expect(GetTiles.length).toBeGreaterThanOrEqual(6);
+
+        // Remove listen to osm tiles
         await page.unroute('https://tile.openstreetmap.org/*/*/*.png');
     });
 
@@ -1122,6 +1125,7 @@ test.describe('Print base layers', () => {
 
         // Print quartiers not open-topo-map
         // Catch opentopomap request to mock them
+        /** @type {string[]} */
         let GetTiles = [];
         await page.route('https://*.tile.opentopomap.org/*/*/*.png', async (route) => {
             const request = route.request();
@@ -1160,6 +1164,8 @@ test.describe('Print base layers', () => {
             await page.waitForTimeout(100);
         }
         await expect(GetTiles.length).toBeGreaterThanOrEqual(6);
+
+        // Remove listen to opentopomap tiles
         await page.unroute('https://*.tile.opentopomap.org/*/*/*.png');
 
         getPrintRequestPromise = page.waitForRequest(
@@ -1263,6 +1269,9 @@ test.describe('Error while printing', () => {
         ).toBeVisible();
 
         await expect(page.locator("#message > div:last-child")).toHaveClass(/alert-danger/);
+
+        // Stop listening to WMS requests
+        await page.unroute('**/service*');
     });
 
 
@@ -1300,6 +1309,9 @@ test.describe('Error while printing', () => {
         )).toBeVisible();
 
         await expect(page.locator("#message > div:last-child")).toHaveClass(/alert-danger/);
+
+        // Stop listening to WMS requests
+        await page.unroute('**/service*');
     });
 
     test('Remove print overlay when switching to another minidock', async ({ page }) => {

--- a/tests/end2end/playwright/print_in_project_projection.spec.js
+++ b/tests/end2end/playwright/print_in_project_projection.spec.js
@@ -52,8 +52,10 @@ test.describe('Print in project projection @readonly', () => {
         requestExpect(getPrintRequest).toContainParametersInPostData(expectedParameters);
         const searchParams = new URLSearchParams(getPrintRequest?.postData() ?? '');
         expect(searchParams.size).toBe(14)
-        await getPrintRequest.response()
-        await page.unroute('**/service*')
+        await getPrintRequest.response();
+
+        // Stop listening to WMS requests
+        await page.unroute('**/service*');
     })
 
     test('Print external baselayer', async ({ page }) => {
@@ -101,7 +103,9 @@ test.describe('Print in project projection @readonly', () => {
         requestExpect(getPrintRequest).toContainParametersInPostData(expectedParameters);
         const searchParams = new URLSearchParams(getPrintRequest?.postData() ?? '');
         expect(searchParams.size).toBe(14)
-        await getPrintRequest.response()
-        await page.unroute('**/service*')
+        await getPrintRequest.response();
+
+        // Stop listening to WMS requests
+        await page.unroute('**/service*');
     })
 })

--- a/tests/end2end/playwright/sub-dock.spec.js
+++ b/tests/end2end/playwright/sub-dock.spec.js
@@ -316,6 +316,9 @@ test.describe('Sub dock @readonly', () => {
         const project = new ProjectPage(page, 'permalink');
         await project.open();
 
+        // Remove listen to GetProjectConfig
+        await page.unroute('**/service/getProjectConfig*');
+
         // Display sub dock metadata for layer in WFS with multiple styles
         await page.getByTestId('sousquartiers').hover();
         await page.getByTestId('sousquartiers').locator('.icon-info-sign').click();
@@ -347,7 +350,7 @@ test.describe('Sub dock @readonly', () => {
 
     test('Export layer without attribute table config', async ({ page }) => {
         // Remove attribute table config
-        await page.route('**/service/getProjectConfig*', async route => {
+        await ('**/service/getProjectConfig*', async route => {
             const response = await route.fetch();
             const json = await response.json();
             json.attributeLayers = {};
@@ -398,6 +401,9 @@ test.describe('Sub dock @readonly', () => {
 
         const project = new ProjectPage(page, 'permalink');
         await project.open();
+
+        // Remove listen to GetProjectConfig
+        await page.unroute('**/service/getProjectConfig*');
 
         // Display sub dock metadata for layer in WFS with multiple styles
         await page.getByTestId('sousquartiers').hover();

--- a/tests/end2end/playwright/theme.spec.js
+++ b/tests/end2end/playwright/theme.spec.js
@@ -379,6 +379,9 @@ test.describe('Theme and automatic permalink @readonly', () => {
         await project.open();
         let getMapRequest = await getMapRequestPromise;
         await getMapRequest.response();
+
+        // Remove listen to GetProjectConfig
+        await page.unroute('**/service/getProjectConfig*');
     });
 
     test('must display theme1 at startup', async ({ page }) => {

--- a/tests/end2end/playwright/tooltip.spec.js
+++ b/tests/end2end/playwright/tooltip.spec.js
@@ -98,6 +98,7 @@ test.describe('Tooltip @readonly', () => {
         // An error message is displayed
         await expect(page.locator('#message')).toBeVisible();
 
+        // Remove listen to features tooltips
         await page.unroute('**/lizmap/features/tooltips*');
     });
 

--- a/tests/end2end/playwright/treeview.spec.js
+++ b/tests/end2end/playwright/treeview.spec.js
@@ -11,7 +11,9 @@ test.describe('Treeview', () => {
         // Wait for WMS GetCapabilities promise
         let getCapabilitiesWMSPromise = page.waitForRequest(/SERVICE=WMS&REQUEST=GetCapabilities/);
 
+        /** @type {URLSearchParams[]} */
         const GetMaps = [];
+        /** @type {URLSearchParams[]} */
         const GetLegends = [];
         await page.route('**/service*', async route => {
             const request = await route.request();
@@ -223,6 +225,9 @@ test.describe('Treeview mocked', () => {
         const project = new ProjectPage(page, 'treeview');
         await project.open();
 
+        // Remove listen to GetProjectConfig
+        await page.unroute('**/service/getProjectConfig*');
+
         await expect(page.locator('lizmap-treeview div.group > input')).toHaveCount(0);
     });
 
@@ -231,7 +236,9 @@ test.describe('Treeview mocked', () => {
             tag: ['@mock', '@readonly'],
         }, async ({ page }) => {
             // we can't use Project page, because we are making GetLegendGraphic failing on purpose
+            /** @type {URLSearchParams[]} */
             const timedOutRequest = [];
+            /** @type {URLSearchParams[]} */
             const GetLegends = [];
             await page.route('**/service*', async route => {
                 const request = await route.request();
@@ -328,6 +335,7 @@ test.describe('Treeview mocked', () => {
             });
             */
 
+            // Stop listening to WMS requests
             await page.unroute('**/service*');
         });
 
@@ -336,8 +344,11 @@ test.describe('Treeview mocked', () => {
             tag: ['@mock', '@readonly'],
         }, async ({ page }) => {
             // we can't use Project page, because we are making GetLegendGraphic failing on purpose
+            /** @type {URLSearchParams[]} */
             const timedOutRequest = [];
+            /** @type {URLSearchParams[]} */
             const GetMaps = [];
+            /** @type {URLSearchParams[]} */
             const GetLegends = [];
             await page.route('**/service*', async route => {
                 const request = await route.request();
@@ -455,6 +466,7 @@ test.describe('Treeview mocked', () => {
                 expect(searchParams.get('STYLES')).not.toContain(',');
             });
 
+            // Stop listening to WMS requests
             await page.unroute('**/service*');
         });
 });

--- a/tests/end2end/playwright/viewport.spec.js
+++ b/tests/end2end/playwright/viewport.spec.js
@@ -52,6 +52,8 @@ test.describe('Viewport devicePixelRatio 1', () => {
         expect(await page.evaluate(() => globalThis.lizMap.mainLizmap.initialConfig.options.wmsMaxHeight)).toBe(950);
         expect(await page.evaluate(() => window.devicePixelRatio)).toBe(1);
         expect(await page.evaluate(() => globalThis.lizMap.mainLizmap.map.getSize())).toStrictEqual([870, 575]);
+
+        // Remove catching GetProjectConfig
         await page.unroute('**/service/getProjectConfig*')
 
         // Catch GetMaps request;
@@ -78,6 +80,7 @@ test.describe('Viewport devicePixelRatio 1', () => {
             expect(GetMap).toContain('&DPI=96&')
         }
 
+        // Stop listening to WMS requests
         await page.unroute('**/service*')
     })
 })
@@ -133,6 +136,8 @@ test.describe('Viewport devicePixelRatio 2', () => {
         expect(await page.evaluate(() => globalThis.lizMap.mainLizmap.initialConfig.options.wmsMaxHeight)).toBe(1900);
         expect(await page.evaluate(() => window.devicePixelRatio)).toBe(2);
         expect(await page.evaluate(() => globalThis.lizMap.mainLizmap.map.getSize())).toStrictEqual([870, 620]);
+
+        // Remove catching GetProjectConfig
         await page.unroute('**/service/getProjectConfig*')
 
         // Catch GetMaps request;
@@ -159,6 +164,8 @@ test.describe('Viewport devicePixelRatio 2', () => {
             expect(GetMap).toContain('&HEIGHT=682&')
             expect(GetMap).toContain('&DPI=96&')
         }
+
+        // Stop listening to WMS requests
         await page.unroute('**/service*')
     })
 })

--- a/tests/end2end/playwright/wmts.spec.js
+++ b/tests/end2end/playwright/wmts.spec.js
@@ -50,6 +50,8 @@ test.describe('WMTS', () => {
         expect(GetTiles[5]).toContain('TileMatrix=2')
         expect(GetTiles[5]).toContain('TileRow=4')
         expect(GetTiles[5]).toContain('TileCol=8')
-        await page.unroute('**/service*')
+
+        // Stop listening to WMS requests
+        await page.unroute('**/service*');
     })
 })


### PR DESCRIPTION
To ensure that Playwright tests close correctly, we must delete listen to request with `page.unroute`
