### PR TITLE
Fix tooltip z-index in edition digitization tab

### DIFF
--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -3004,6 +3004,8 @@ lizmap-mouse-position > div.coords-unit > select{
 
 .edition-tabs .nav-pills {
   margin-bottom: 10px;
+  position: relative;
+  z-index: 1;
 }
 
 .edition-tabs .nav-pills a {


### PR DESCRIPTION
Tooltips for geometry tools (Move, Rotate, etc.) in the Edition digitization tab were appearing under the Form/Digitization navigation tabs. Add position:relative and z-index:1 to ensure tooltips display above tab navigation.

<img width="450" height="433" alt="Tooltip-Digitizing" src="https://github.com/user-attachments/assets/1ea42912-c0db-494f-a3db-293f56b42cdf" />

Superseeded https://github.com/3liz/lizmap-web-client/pull/6368 wrote by @meyerlor

Funded by Klein und Leber GbR https://www.gisgeometer.de/