### PR TITLE
Fix dock height overflow on mobile devices and use content-based for menu

### DIFF
--- a/lizmap/www/assets/css/media.css
+++ b/lizmap/www/assets/css/media.css
@@ -264,8 +264,9 @@ only screen and (                   device-height <= 640px) {
     width: max-content; /* Automatic width based on content */
     min-width: 250px;
     max-width: 400px;
-    left: -100%; /* Completely outside viewport */
-    transition: left 0.3s cubic-bezier(0.77,0.2,0.05,1.0);
+    left: 0;
+    transform: translateX(-100%); /* Completely outside viewport */
+    transition: transform 0.3s cubic-bezier(0.77,0.2,0.05,1.0);
   }
 
   #mapmenu > div{
@@ -332,7 +333,7 @@ only screen and (                   device-height <= 640px) {
   }
 
   #menuToggle.opened ~ #mapmenu{
-    left: 0;
+    transform: translateX(0);
   }
 
   #menuToggle{


### PR DESCRIPTION
Constrain dock container to viewport height to prevent content from extending beyond the visible area. Add vertical scrolling when dock content exceeds available space.

<img width="740" height="381" alt="Baselayer_available" src="https://github.com/user-attachments/assets/82cfb4da-0e14-49ec-8d61-a2952756cb0c" />

Change menu width from fixed 80% to content-based with constraints. Menu now adapts to content width with minimum 250px and maximum 400px. Adjust positioning to use -100% for cleaner off-screen placement.

<img width="760" height="398" alt="fixed_legende" src="https://github.com/user-attachments/assets/22c7a53b-b25a-4f75-ae29-d7a69461cefa" />

Superseeded https://github.com/3liz/lizmap-web-client/pull/6368 wrote by @meyerlor

Funded by Klein und Leber GbR https://www.gisgeometer.de/