### PR TITLE
QGIS Server plugins repository: using qgis-plugins.3liz.org

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -55,7 +55,7 @@ build-plugins:
 	    -u $(LIZMAP_USER_ID):$(LIZMAP_GROUP_ID) \
 	    --rm -i \
 	    -e QGSRV_SERVER_PLUGINPATH=/srv/plugins \
-	    -e QGIS_PLUGIN_MANAGER_SOURCES_FILE=/src/docker-conf/stable-plugin-sources.list \
+	    -e QGIS_PLUGIN_MANAGER_SOURCES_FILE=/src/docker-conf/plugin-sources.list \
 	    -e QGIS_PLUGIN_MANAGER_CACHE_DIR=/tmp/cache-plugin-manager \
 	    -v $(shell pwd)/qgis-server-plugins:/srv/plugins \
 	    -v $(shell pwd)/:/src \

--- a/tests/add_server_plugins.sh
+++ b/tests/add_server_plugins.sh
@@ -24,13 +24,17 @@ qgis-plugin-manager install -f atlasprint
 
 # echo "QGIS Server Lizmap plugin"
 # Latest commit
-# echo "Latest commit from https://packages.3liz.org"
-# wget https://packages.3liz.org/pub/lizmap-server-qgis-plugin/lizmap_server.master.zip -O /tmp/lizmap_server.master.zip
+# echo "Latest commit from https://qgis-plugins.3liz.org"
+# qgis-plugin-manager install --pre -f "Lizmap server"
+
+# Specific version
+# VERSION=2.14.1
+# echo "Specific version from https://qgis-plugins.3liz.org"
+# qgis-plugin-manager install -f "Lizmap server"==${VERSION}
 
 # Latest release
-# VERSION=1.1.1
+# VERSION=2.14.1
 # echo "Stable release from GitHub"
 # wget https://github.com/3liz/qgis-lizmap-server-plugin/releases/latest/download/lizmap_server.${VERSION}.zip -O /tmp/lizmap_server.master.zip
-
 # unzip -o /tmp/lizmap_server.master.zip -d /srv/plugins/
 # rm /tmp/lizmap_server.master.zip

--- a/tests/docker-conf/plugin-sources.list
+++ b/tests/docker-conf/plugin-sources.list
@@ -1,0 +1,1 @@
+https://qgis-plugins.3liz.org/plugins.xml?qgis=[VERSION]

--- a/tests/docker-conf/stable-plugin-sources.list
+++ b/tests/docker-conf/stable-plugin-sources.list
@@ -1,1 +1,0 @@
-https://packages.3liz.org/pub/server-plugins-repository/stable/plugins.[VERSION].xml

--- a/tests/docker-conf/unstable-plugin-sources.list
+++ b/tests/docker-conf/unstable-plugin-sources.list
@@ -1,1 +1,0 @@
-https://packages.3liz.org/pub/server-plugins-repository/unstable/plugins.[VERSION].xml


### PR DESCRIPTION
The 3Liz's QGIS Server plugins repository has been moved to https://qgis-plugins.3liz.org instead of https://packages.3liz.org/pub/server-plugins-repository
