### PR TITLE
JS: Add tests about config's option exclude_basemaps_from_single_wms

### DIFF
--- a/assets/src/modules/config/Options.js
+++ b/assets/src/modules/config/Options.js
@@ -40,7 +40,7 @@ const optionalProperties = {
     'activateFirstMapTheme': { type: 'boolean', default: false },
     'automatic_permalink': { type: 'boolean', default: false },
     'wms_single_request_for_all_layers' : { type:'boolean', default: false },
-    'exclude_basemaps_from_single_wms' : { type:'boolean', default: false }
+    'exclude_basemaps_from_single_wms' : { type:'boolean', default: false },
 };
 
 /**

--- a/tests/js-units/node/config.test.js
+++ b/tests/js-units/node/config.test.js
@@ -166,6 +166,7 @@ describe('Config', function () {
 
         expect(initialConfig.options).to.be.instanceOf(OptionsConfig)
         expect(initialConfig.options.wms_single_request_for_all_layers).to.be.eq(true)
+        expect(initialConfig.options.exclude_basemaps_from_single_wms).to.be.eq(false)
     })
 
 })

--- a/tests/js-units/node/config/options.test.js
+++ b/tests/js-units/node/config/options.test.js
@@ -79,6 +79,8 @@ describe('OptionsConfig', function () {
         expect(opt.use_native_zoom_levels).to.be.eq(false)
         // Default value for singleWMS option is false (option wms_single_request_for_all_layers not defined)
         expect(opt.wms_single_request_for_all_layers).to.be.eq(false)
+        // Default value for basemaps excluded from the single WMS request
+        expect(opt.exclude_basemaps_from_single_wms).to.be.eq(false)
     })
 
     it('use_native_zoom_levels', function () {


### PR DESCRIPTION
Add some unit tests about config's option exclude_basemaps_from_single_wms