### PR TITLE
JS: Defined image symbology for layer

### DIFF
--- a/assets/src/components/Treeview.js
+++ b/assets/src/components/Treeview.js
@@ -65,6 +65,31 @@ export default class Treeview extends HTMLElement {
             </ul>
         </li>`
 
+        this._symbolImageTemplate = symbol =>
+            html`
+        <label class="symbol-title">
+            <img class="legend" alt="${symbol.title}" src="${this._createGetMediaLink(symbol.url)}">
+        </label>`
+
+        this._symbolIconTemplate = symbol =>
+            html`
+        <label class="symbol-title">
+            ${symbol.ruleKey
+                ? html`<input type="checkbox" .checked=${symbol.checked} @click=${() => symbol.checked = !symbol.checked}>`
+                : ''
+            }
+            <img class="legend" src="${symbol.icon}">
+            ${symbol.title}
+        </label>
+        ${(symbol.childrenCount)
+            ? html`
+                    <ul class="symbols">
+                        ${symbol.children.map(s => this._symbolTemplate(s))}
+                    </ul>`
+                : ''
+        }
+        `
+
         this._symbolTemplate = symbol =>
             html`
         <li class="symbol ${symbol.type}${this._isInScale(symbol) ? '' : ' not-in-scale'}${symbol.ruleKey && !symbol.checked ? ' not-visible' : ''}">
@@ -73,21 +98,8 @@ export default class Treeview extends HTMLElement {
                         <div class="expandable ${symbol.expanded ? 'expanded' : ''}" @click=${() => symbol.expanded = !symbol.expanded}></div>`
                     : ''
             }
-            <label class="symbol-title">
-                ${symbol.ruleKey
-                    ? html`<input type="checkbox" .checked=${symbol.checked} @click=${() => symbol.checked = !symbol.checked}>`
-                    : ''
-                }
-                <img class="legend" src="${symbol.icon}">
-                ${symbol.title}
-            </label>
-            ${(symbol.childrenCount)
-                ? html`
-                        <ul class="symbols">
-                            ${symbol.children.map(s => this._symbolTemplate(s))}
-                        </ul>`
-                    : ''
-            }
+            ${symbol.type === 'image' ? html`${this._symbolImageTemplate(symbol)}` : ''}
+            ${symbol.type !== 'image' ? html`${this._symbolIconTemplate(symbol)}` : ''}
         </li>`
 
         this._layerTemplate = (layer, parent) =>

--- a/assets/src/modules/state/Symbology.js
+++ b/assets/src/modules/state/Symbology.js
@@ -20,6 +20,7 @@ import {
     base64svgPolygonLayer,
     base64svgRasterLayer,
 } from './SymbologyIcons.js';
+import { MEDIA_REGEX, URL_REGEX } from './../../utils/Constants.js';
 
 
 /**
@@ -199,6 +200,53 @@ export class LayerIconSymbology extends BaseIconSymbology {
      */
     get name() {
         return this._name;
+    }
+}
+
+const symbolImageProperties = {
+    'url': {type: 'string'},
+    'title': {type: 'string'},
+}
+/**
+ * Class representing a layer icon symbology
+ * @class
+ * @augments BaseIconSymbology
+ */
+export class SymbolImageSymbology extends BaseIconSymbology {
+
+    /**
+     * Create a layer icon symbology instance based on a node object provided by QGIS Server
+     * @param {object}  node      - the QGIS node symbology
+     * @param {string}  node.type  - the node type: image
+     * @param {string}  node.url   - the url image
+     * @param {string}  node.title - the node title
+     */
+    constructor(node) {
+
+        if (!node.hasOwnProperty('type') || node.type != 'image') {
+            throw new ValidationError('The symbol image symbology is only available for image type!');
+        }
+
+        super(node, symbolImageProperties, {})
+
+        if (!MEDIA_REGEX.test(node?.url) && !URL_REGEX.test(node?.url)) {
+            throw new ValidationError('The symbol image symbology is only available for media path or url!');
+        }
+
+        /**
+         * The private layer name
+         * @type {string}
+         * @private
+         */
+        this._url;
+    }
+
+    /**
+     * The image url
+     * @type {string}
+     */
+    get url() {
+        return this._url;
     }
 }
 

--- a/assets/src/utils/Constants.js
+++ b/assets/src/utils/Constants.js
@@ -21,9 +21,16 @@ export const MEDIA_REGEX = /^(\/)?(?:\.\.\/)?media\//;
 
 /**
  * @constant
+ * Regex to check if a path is an URL wich starts with /, http://, https:// or data:
+ */
+export const URL_REGEX = /^\/|(?:https?:\/\/)|(?:data:)/
+
+/**
+ * @constant
  * Constants object to be exposed to the global scop
  */
 export const Constants = Object.freeze({
     ADJUSTED_DPI: ADJUSTED_DPI,
     MEDIA_REGEX: MEDIA_REGEX,
+    URL_REGEX: URL_REGEX,
 });

--- a/tests/js-units/node/constants.test.js
+++ b/tests/js-units/node/constants.test.js
@@ -1,6 +1,15 @@
 import { expect } from 'chai';
 
-import { MEDIA_REGEX } from 'assets/src/utils/Constants.js'
+import { MEDIA_REGEX, URL_REGEX } from 'assets/src/utils/Constants.js'
+import {
+    base64png,
+    base64pngNullData,
+    base64svg,
+    base64svgPointLayer,
+    base64svgLineLayer,
+    base64svgPolygonLayer,
+    base64svgRasterLayer,
+} from 'assets/src/modules/state/SymbologyIcons.js';
 
 describe('MEDIA_REGEX', function () {
     it('media folder in repository', function () {
@@ -14,5 +23,37 @@ describe('MEDIA_REGEX', function () {
     it('not a media path', function() {
         expect(MEDIA_REGEX.test('tests/media/foo/bar.png')).to.be.false;
         expect(MEDIA_REGEX.test('../tests/media/foo/bar.png')).to.be.false;
+        expect(MEDIA_REGEX.test('http://localhost:8130/media/foo/bar.png')).to.be.false;
+        expect(MEDIA_REGEX.test('https://localhost:8130/media/foo/bar.png')).to.be.false;
+        expect(MEDIA_REGEX.test(base64png+base64pngNullData)).to.be.false;
+        expect(MEDIA_REGEX.test(base64svg+base64svgPointLayer)).to.be.false;
+    });
+});
+
+
+describe('URL_REGEX', function () {
+    it('path starts with http://', function () {
+        expect(URL_REGEX.test('http://localhost:8130/media/foo/bar.png')).to.be.true;
+    });
+
+    it('path starts with https://', function () {
+        expect(URL_REGEX.test('https://localhost:8130/media/foo/bar.png')).to.be.true;
+    });
+
+    it('path starts with data:', function () {
+        expect(URL_REGEX.test(base64png+base64pngNullData)).to.be.true;
+        expect(URL_REGEX.test(base64svg+base64svgPointLayer)).to.be.true;
+        expect(URL_REGEX.test(base64svg+base64svgLineLayer)).to.be.true;
+        expect(URL_REGEX.test(base64svg+base64svgPolygonLayer)).to.be.true;
+        expect(URL_REGEX.test(base64svg+base64svgRasterLayer)).to.be.true;
+        let data = "iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAAU0lEQVQ4jWNgGAV0A4z4JJWVlf8j8+\/evYtTPQs+Q9YelkMRC7Zl+I\/LMKyC2AxBGPYIq8uYcLmIVDBEDLp79y5jsO0jkgwiKfphlpBkwyigPgAATTcaN5pMVDUAAAAASUVORK5CYII=";
+        expect(URL_REGEX.test(base64png+data)).to.be.true;
+    });
+
+    it('not an url', function() {
+        expect(URL_REGEX.test('tests/media/foo/bar.png')).to.be.false;
+        expect(URL_REGEX.test('../tests/media/foo/bar.png')).to.be.false;
+        expect(URL_REGEX.test('media/foo/bar.png')).to.be.false;
+        expect(URL_REGEX.test('../media/foo/bar.png')).to.be.false;
     });
 });

--- a/tests/js-units/node/state/symbology.test.js
+++ b/tests/js-units/node/state/symbology.test.js
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs';
 
 import { ValidationError } from 'assets/src/modules/Errors.js';
 import { base64png, base64pngNullData } from 'assets/src/modules/state/SymbologyIcons.js';
-import { BaseIconSymbology, LayerIconSymbology, SymbolIconSymbology, SymbolRuleSymbology, BaseSymbolsSymbology, LayerSymbolsSymbology, LayerGroupSymbology, buildLayerSymbology } from 'assets/src/modules/state/Symbology.js';
+import { BaseIconSymbology, LayerIconSymbology, SymbolImageSymbology, SymbolIconSymbology, SymbolRuleSymbology, BaseSymbolsSymbology, LayerSymbolsSymbology, LayerGroupSymbology, buildLayerSymbology } from 'assets/src/modules/state/Symbology.js';
 
 describe('BaseIconSymbology', function () {
     it('Simple', function () {
@@ -82,6 +82,113 @@ describe('LayerIconSymbology', function () {
         } catch (error) {
             expect(error.name).to.be.eq('ValidationError')
             expect(error.message).to.be.eq('The properties: `name` are required in the cfg object!')
+            expect(error).to.be.instanceOf(ValidationError)
+        }
+    })
+})
+
+describe('SymbolImageSymbology', function () {
+    it('Valid with http URL', function () {
+        const icon = new SymbolImageSymbology({
+            "url":"http://localhost:8130/image.png",
+            "title":"layer_legend_image",
+            "type":"image",
+        })
+        expect(icon).to.be.instanceOf(BaseIconSymbology)
+        expect(icon).to.be.instanceOf(SymbolImageSymbology)
+        expect(icon.url).to.be.eq("http://localhost:8130/image.png")
+        expect(icon.title).to.be.eq('layer_legend_image')
+        expect(icon.type).to.be.eq('image')
+    })
+
+    it('Valid with https URL', function () {
+        const icon = new SymbolImageSymbology({
+            "url":"https://localhost:8130/image.png",
+            "title":"layer_legend_image",
+            "type":"image",
+        })
+        expect(icon).to.be.instanceOf(BaseIconSymbology)
+        expect(icon).to.be.instanceOf(SymbolImageSymbology)
+        expect(icon.url).to.be.eq("https://localhost:8130/image.png")
+        expect(icon.title).to.be.eq('layer_legend_image')
+        expect(icon.type).to.be.eq('image')
+    })
+
+    it('Valid with data URL', function () {
+        const icon = new SymbolImageSymbology({
+            "url":base64png+base64pngNullData,
+            "title":"layer_legend_image",
+            "type":"image",
+        })
+        expect(icon).to.be.instanceOf(BaseIconSymbology)
+        expect(icon).to.be.instanceOf(SymbolImageSymbology)
+        expect(icon.url).to.be.eq(base64png+base64pngNullData)
+        expect(icon.title).to.be.eq('layer_legend_image')
+        expect(icon.type).to.be.eq('image')
+    })
+
+    it('Valid with media path', function () {
+        const icon = new SymbolImageSymbology({
+            "url":"media/foo/bar.png",
+            "title":"layer_legend_image",
+            "type":"image",
+        })
+        expect(icon).to.be.instanceOf(BaseIconSymbology)
+        expect(icon).to.be.instanceOf(SymbolImageSymbology)
+        expect(icon.url).to.be.eq("media/foo/bar.png")
+        expect(icon.title).to.be.eq('layer_legend_image')
+        expect(icon.type).to.be.eq('image')
+    })
+
+    it('Valid with relative path', function () {
+        const icon = new SymbolImageSymbology({
+            "url":"/assets/foo/bar.png",
+            "title":"layer_legend_image",
+            "type":"image",
+        })
+        expect(icon).to.be.instanceOf(BaseIconSymbology)
+        expect(icon).to.be.instanceOf(SymbolImageSymbology)
+        expect(icon.url).to.be.eq("/assets/foo/bar.png")
+        expect(icon.title).to.be.eq('layer_legend_image')
+        expect(icon.type).to.be.eq('image')
+    })
+
+    it('Failing type', function () {
+        try {
+            new SymbolImageSymbology({
+                "url":"http://localhost/image.png",
+                "title":"layer_legend_image",
+            })
+        } catch (error) {
+            expect(error.name).to.be.eq('ValidationError')
+            expect(error.message).to.be.eq('The symbol image symbology is only available for image type!')
+            expect(error).to.be.instanceOf(ValidationError)
+        }
+    })
+
+    it('Failing url', function () {
+        try {
+            new SymbolImageSymbology({
+                "url":"assets/foo/bar.png",
+                "title":"layer_legend_image",
+                "type":"image",
+            })
+        } catch (error) {
+            expect(error.name).to.be.eq('ValidationError')
+            expect(error.message).to.be.eq('The symbol image symbology is only available for media path or url!')
+            expect(error).to.be.instanceOf(ValidationError)
+        }
+    })
+
+    it('Failing required properties', function () {
+        try {
+            new SymbolImageSymbology({
+                "title":"layer_legend_image",
+                "type":"image",
+            })
+        } catch (error) {
+            expect(error.name).to.be.eq('ValidationError')
+            expect(error.message).to.be.eq('The properties: `url` are required in the cfg object!')
             expect(error).to.be.instanceOf(ValidationError)
         }
     })


### PR DESCRIPTION
This class `SymbolImageSymbology` has been created to provide a layer's legend as an image.
