### PR TITLE
PHP: Enahncing getBooleanOption by using filter_var

### DIFF
--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -628,11 +628,7 @@ class serviceCtrl extends jController
         // Check DXF export rights if FORMAT is application/dxf
         if (isset($this->params['format']) && strtolower($this->params['format']) === 'application/dxf') {
             // Check if DXF export is enabled
-            $dxfExportEnabled = $this->project->getOption('dxfExportEnabled');
-            // Handle both boolean (from use_proper_boolean) and string 'True'/'true'
-            $isDxfEnabled = is_bool($dxfExportEnabled) ? $dxfExportEnabled : (strtolower($dxfExportEnabled) === 'true');
-
-            if (!$isDxfEnabled) {
+            if (!$this->project->getBooleanOption('dxfExportEnabled')) {
                 jMessage::add('DXF export is not enabled for this project', 'Forbidden');
 
                 return $this->serviceException();

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -2484,11 +2484,7 @@ class Project
         }
 
         // DXF Export - check if enabled and user has access
-        $dxfExportEnabled = $this->cfg->getOption('dxfExportEnabled');
-        // Handle both boolean (from use_proper_boolean) and string 'True'/'true'
-        $isDxfEnabled = is_bool($dxfExportEnabled) ? $dxfExportEnabled : (strtolower($dxfExportEnabled) === 'true');
-
-        if ($isDxfEnabled) {
+        if ($this->cfg->getBooleanOption('dxfExportEnabled')) {
             $allowedGroups = $this->cfg->getOption('allowedGroups');
             $hasAccess = true;
 

--- a/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
+++ b/lizmap/modules/lizmap/lib/Project/ProjectConfig.php
@@ -440,7 +440,7 @@ class ProjectConfig
     public function getBooleanOption($name)
     {
         if (property_exists($this->options, $name)) {
-            return strtolower($this->options->{$name}) == 'true';
+            return filter_var($this->options->{$name}, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
         }
 
         return null;


### PR DESCRIPTION
To better parsed boolean option, the `getBooleanOption` method has been enhanced by using `filter_var($this->options->{$name}, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)`.