### PR TITLE
FIX JS : Zoom to point from attribute table and respect max zoom scale

### DIFF
--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -309,7 +309,7 @@ var lizAttributeTable = function() {
 
                 const wfsParams = {
                     TYPENAME: typeName,
-                    GEOMETRYNAME: 'extent'
+                    GEOMETRYNAME: layerConfig['geometryType'] == 'point' ? null : 'extent',
                 };
 
                 let fetchRequests = [];
@@ -401,7 +401,7 @@ var lizAttributeTable = function() {
 
                 const wfsParams = {
                     TYPENAME: typeName,
-                    GEOMETRYNAME: 'extent'
+                    GEOMETRYNAME:  layerConfig['geometryType'] == 'point' ? null : 'extent',
                 };
 
                 if(filter){
@@ -3175,7 +3175,7 @@ var lizAttributeTable = function() {
                     const typeName = pivotConfig[1].typename;
                     const wfsParams = {
                         TYPENAME: typeName,
-                        GEOMETRYNAME: 'extent'
+                        GEOMETRYNAME:  pivotConfig[1]['geometryType'] == 'point' ? null : 'extent',
                     };
                     wfsParams['EXP_FILTER'] = '"' + referencedPivotField + '" = ' + "'" + referencedFieldValue + "'";
 

--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -2280,6 +2280,11 @@ window.lizMap = function() {
 
         $('body').css('cursor', 'wait');
 
+        // If the geometry type is point, force to get the geometry
+        if (aConfig['geometryType'] == 'point') {
+            aGeometryName = null;
+        }
+
         var getFeatureUrlData = lizMap.getVectorLayerWfsUrl( aName, aFilter, aFeatureID, aGeometryName, restrictToMapExtent, startIndex, maxFeatures );
 
         // see if a request for the same feature is not already made


### PR DESCRIPTION
QGIS Server can provide extent or center instead of geometry but for point or multipoint, it's not advantageous.

Fixes #6415
