### PR TITLE
Fix PHP: Logger::log signature

### DIFF
--- a/lizmap/modules/lizmap/lib/Logger/Logger.php
+++ b/lizmap/modules/lizmap/lib/Logger/Logger.php
@@ -110,13 +110,11 @@ class Logger extends AbstractLogger
     /**
      * Logs with an arbitrary level.
      *
-     * @param mixed              $level
-     * @param string|\Stringable $message
-     * @param array              $context
+     * @param mixed $level
      *
      * @throws InvalidArgumentException
      */
-    public function log($level, $message, $context = array())
+    public function log($level, string|\Stringable $message, array $context = array()): void
     {
         if (!in_array($level, self::LogLevels)) {
             throw new InvalidArgumentException('Invalid log level');


### PR DESCRIPTION
Fixes #6431

```
PHP message: PHP Fatal error:
Declaration of Lizmap\Logger\Logger::log($level, $message, $context = []) must be compatible
with Psr\Log\AbstractLogger::log($level, Stringable|string $message, array $context = []): void
```
