### PR TITLE
Use boostrap 5 Card in dashboard Widgets

### DIFF
--- a/lizmap/app/themes/default/master_admin/zone_dashboard.tpl
+++ b/lizmap/app/themes/default/master_admin/zone_dashboard.tpl
@@ -6,19 +6,19 @@
 
 {assign $nbPerCol = ceil(count($widgets)/2)}
 <div id="dashboard-content" class="row">
-    <div id="dashboard-left-column" class="span6">
+    <div class="col-sm-6">
         {for $i=0; $i<$nbPerCol;$i++}
-        <div class="dashboard-widget well">
-            <h3>{$widgets[$i]->title|eschtml}</h3>
-            <div class="dashboard-widget-content">{$widgets[$i]->content}</div>
+        <div class="card">
+            <h3 class="card-header">{$widgets[$i]->title|eschtml}</h3>
+            <div class="card-body">{$widgets[$i]->content}</div>
         </div>
         {/for}
     </div>
-    <div id="dashboard-right-column" class="span6">
+    <div class="col-sm-6">
         {for $i=$nbPerCol; $i<count($widgets);$i++}
-        <div class="dashboard-widget well">
-            <h3>{$widgets[$i]->title|eschtml}</h3>
-            <div class="dashboard-widget-content">{$widgets[$i]->content}</div>
+        <div class="card">
+            <h3 class="card-header">{$widgets[$i]->title|eschtml}</h3>
+            <div class="card-body">{$widgets[$i]->content}</div>
         </div>
         {/for}
     </div>

--- a/lizmap/www/assets/css/admin.css
+++ b/lizmap/www/assets/css/admin.css
@@ -64,17 +64,6 @@ fieldset {
     background-color:transparent;
 }
 
-
-#dashboard-content {
-    padding-left: 2.1277%;
-}
-
-.dashboard-widget h3 {
-    background-color: #eee;
-    margin: 0 0 10px;
-    padding: 0 10px;
-}
-
 .table-server-info th,
 .table-server-info td
 {


### PR DESCRIPTION
 On LWC < 3.10 : dashboard Widget use `well` class


<img width="1480" height="467" alt="Screenshot 2026-02-13 at 14-47-21 Tableau de bord - Administration" src="https://github.com/user-attachments/assets/61f97459-0cdd-44c9-b462-29e92e80f12b" />

No more supported by Boostrap 5 (`Card` is suggested (see #4861)) 

<img width="1498" height="345" alt="Screenshot 2026-02-13 at 14-44-26 Tableau de bord - Administration" src="https://github.com/user-attachments/assets/5a42a879-508a-4a10-9d97-fbb740616bd0" />

this PR remove the `well` class and the `dashboard-*` css class/id provided by jelix but not really fitted for bootstrap5 , and use native `card-*`

<img width="1498" height="315" alt="Screenshot 2026-02-13 at 14-43-57 Tableau de bord - Administration" src="https://github.com/user-attachments/assets/139a2fc6-59d4-49c8-8df2-215f8af64613" />


Ticket : #4861 

Funded by 3Liz


