### PR TITLE
[Feature] Add oTable instance to attributeLayerContentReady event

### DIFF
--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -1607,6 +1607,7 @@ var lizAttributeTable = function() {
 
                             lizMap.events.triggerEvent("attributeLayerContentReady",{
                                 'featureType': featureType,
+                                'oTable': oTable
                             });
                         }
                         ,order: [[ firstDisplayedColIndex, "asc" ]]


### PR DESCRIPTION
Starting with #5562, the `dataTable` dependency has been removed from assets (i.e. https://github.com/3liz/lizmap-web-client/pull/5562/changes#diff-22f48903b6f59bdcaf26720187c7b5b47f61b13206d39a914d04e8a8ac99c4b0L38). 

As a result, it is no longer possible to access a table's `dataTable` instance from its corresponding HTML node, a feature that was useful in external custom js scripts.
To avoid exposing additional dependencies in the `lizMap` singleton, it may be useful to pass the `oTable` instance in the  `attributeLayerContentReady` event along with the `featureType` property.

Backport 3.10

Funded by Faunalia
