### PR TITLE
Removed console_log from index.js

### DIFF
--- a/assets/src/index.js
+++ b/assets/src/index.js
@@ -82,7 +82,6 @@ const waitFor = async function waitFor(maxWait, sleepStep, f){
 };
 
 const definedCustomElements = () => {
-    console.log('Defining custom elements...');
     window.customElements.define('lizmap-geolocation', Geolocation);
     window.customElements.define('lizmap-geolocation-survey', GeolocationSurvey);
     window.customElements.define('lizmap-features-table', FeaturesTable);


### PR DESCRIPTION
I believe this is a typo from previous developments, but if it was intentional, please ignore this PR.

Backport 3.10

Funded by Faunalia
