### PR TITLE
fix: edition form – ValueMap and Checkbox show NULL when editing a feature

### DIFF
--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -652,6 +652,13 @@ class QgisForm implements QgisFormControlsInterface
                         }
                     }
                 }
+                // Cast to string so that form widget comparisons work correctly.
+                // PDO in PHP 8.1+ returns native types (e.g. integers) instead of
+                // strings, which breaks strict === comparisons in fillSelect() and
+                // valueOnCheck comparisons in checkbox rendering.
+                if ($value !== null) {
+                    $value = (string) $value;
+                }
                 $form->setData($ref, $value);
             }
         }

--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -652,12 +652,25 @@ class QgisForm implements QgisFormControlsInterface
                         }
                     }
                 }
-                // Cast to string so that form widget comparisons work correctly.
-                // PDO in PHP 8.1+ returns native types (e.g. integers) instead of
-                // strings, which breaks strict === comparisons in fillSelect() and
-                // valueOnCheck comparisons in checkbox rendering.
+                // Normalize the DB value to a plain string so that form widget
+                // comparisons work correctly:
+                //
+                // 1. PDO in PHP 8.1+ returns native types (int, float, bool)
+                //    instead of strings, which breaks the strict === comparison
+                //    in fillSelect() and the valueOnCheck comparison in checkbox
+                //    rendering.
+                //
+                // 2. PostgreSQL numeric/decimal columns return values with the
+                //    column-defined scale (e.g. "0.40" for numeric(10,2)) while
+                //    QGIS ValueMap keys are stored without trailing zeros ("0.4").
+                //    Stripping trailing decimal zeros aligns both sides.
                 if ($value !== null) {
-                    $value = (string) $value;
+                    if (!is_string($value)) {
+                        $value = (string) $value;
+                    }
+                    if (strpos($value, '.') !== false && is_numeric($value)) {
+                        $value = rtrim(rtrim($value, '0'), '.');
+                    }
                 }
                 $form->setData($ref, $value);
             }


### PR DESCRIPTION
## Problem

When editing an existing feature, Value Map dropdowns and Checkbox
widgets display NULL/no selection instead of the feature's actual value.

![EMptyValues1](https://github.com/user-attachments/assets/7f77fe8a-d454-4d79-91a5-2ee8e16f93b5)


Two root causes:

1. **PHP 8.1+ PDO type changes** – PDO now returns native PHP types
   (int, float, bool) instead of strings by default
   (ATTR_STRINGIFY_FETCHES defaults to false). The strict `===`
   comparison in `fillSelect()` and the `!=` comparison in
   `jFormsControlCheckbox::setData()` both expect strings, so
   native-typed values never match.

2. **PostgreSQL numeric/decimal precision** – numeric columns with a
   defined scale (e.g. `numeric(10,2)`) return values with trailing
   zeros (`"0.40"`), while QGIS ValueMap keys are stored without them
   (`"0.4"`). The strict comparison therefore fails.

## Fix

In `QgisForm::setFormDataFromFields()`, normalize the DB value before
passing it to `setData()`:

- Cast non-string values to string
- Strip trailing decimal zeros from numeric strings

![EMptyValues2](https://github.com/user-attachments/assets/c6dbf2a2-9782-41e6-aaf3-2e14c1e140f7)

Backport to 3.9 would be highly appreciated!