### PR TITLE
feat: propagate QGIS selection color to map highlight layer

### DIFF
--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -3009,8 +3009,6 @@ var lizAttributeTable = function() {
                         // done so (it sets olHighlightUpdated:true on the layerSelectionChanged event).
                         if (!olHighlightUpdated && lizMap.mainLizmap?.map?.setHighlightFeatures) {
                             const typeName = lConfig['typename'] || lConfig['shortname'] || featureType;
-                            const featureIds = lConfig.selectedFeatures
-                                .map(id => typeName + '.' + id).join(',');
                             fetch(globalThis['lizUrls'].wms, {
                                 method: 'POST',
                                 body: new URLSearchParams({
@@ -3021,7 +3019,7 @@ var lizAttributeTable = function() {
                                     VERSION: '1.0.0',
                                     OUTPUTFORMAT: 'GeoJSON',
                                     TYPENAME: typeName,
-                                    FEATUREID: featureIds
+                                    EXP_FILTER: '$id IN ( ' + sqlEscapeFilter(lConfig.selectedFeatures) + ' ) '
                                 })
                             }).then(r => r.json()).then(geojson => {
                                 lizMap.mainLizmap.map.setHighlightFeatures(

--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -2249,6 +2249,11 @@ var lizAttributeTable = function() {
                 // Empty array
                 config.layers[featureType]['selectedFeatures'] = [];
 
+                // Clear the OL highlight layer
+                if (lizMap.mainLizmap?.map?.clearHighlightFeatures) {
+                    lizMap.mainLizmap.map.clearHighlightFeatures();
+                }
+
                 lizMap.events.triggerEvent("layerSelectionChanged",
                     {
                         'featureType': featureType,
@@ -3000,6 +3005,27 @@ var lizAttributeTable = function() {
                             selectedFeatures: lConfig.selectedFeatures,
                             token: result.token
                         };
+                        // Populate the OL highlight layer with selected feature geometries.
+                        if (lizMap.mainLizmap?.map?.setHighlightFeatures) {
+                            const typeName = lConfig['typename'] || lConfig['shortname'] || featureType;
+                            fetch(globalThis['lizUrls'].wms, {
+                                method: 'POST',
+                                body: new URLSearchParams({
+                                    repository: globalThis['lizUrls'].params.repository,
+                                    project: globalThis['lizUrls'].params.project,
+                                    SERVICE: 'WFS',
+                                    REQUEST: 'GetFeature',
+                                    VERSION: '1.0.0',
+                                    OUTPUTFORMAT: 'GeoJSON',
+                                    TYPENAME: typeName,
+                                    SELECTIONTOKEN: result.token
+                                })
+                            }).then(r => r.json()).then(geojson => {
+                                lizMap.mainLizmap.map.setHighlightFeatures(
+                                    geojson, 'geojson', lConfig.crs || 'EPSG:4326'
+                                );
+                            });
+                        }
                     });
                 } else {
 

--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -2249,9 +2249,9 @@ var lizAttributeTable = function() {
                 // Empty array
                 config.layers[featureType]['selectedFeatures'] = [];
 
-                // Clear the OL highlight layer
-                if (lizMap.mainLizmap?.map?.clearHighlightFeatures) {
-                    lizMap.mainLizmap.map.clearHighlightFeatures();
+                // Clear the OL selection layer
+                if (lizMap.mainLizmap?.map?.clearSelectionFeatures) {
+                    lizMap.mainLizmap.map.clearSelectionFeatures();
                 }
 
                 lizMap.events.triggerEvent("layerSelectionChanged",
@@ -3007,10 +3007,10 @@ var lizAttributeTable = function() {
                         };
                     });
 
-                    // Populate the OL highlight layer independently of GETSELECTIONTOKEN.
+                    // Populate the OL selection layer independently of GETSELECTIONTOKEN.
                     // Only when SelectionTool has NOT already done so
                     // (it sets olHighlightUpdated:true on the layerSelectionChanged event).
-                    if (!olHighlightUpdated && lizMap.mainLizmap?.map?.setHighlightFeatures) {
+                    if (!olHighlightUpdated && lizMap.mainLizmap?.map?.setSelectionFeatures) {
                         const typeName = lConfig['typename'] || lConfig['shortname'] || featureType;
                         const layerCrs = lConfig.crs || 'EPSG:4326';
                         lizMap.mainLizmap.wfs.getFeature({
@@ -3018,7 +3018,7 @@ var lizAttributeTable = function() {
                             EXP_FILTER: '$id IN ( ' + sqlEscapeFilter(lConfig.selectedFeatures) + ' ) ',
                             SRSNAME: layerCrs
                         }).then(geojson => {
-                            lizMap.mainLizmap.map.setHighlightFeatures(
+                            lizMap.mainLizmap.map.setSelectionFeatures(
                                 geojson, 'geojson', layerCrs
                             );
                         }).catch(() => {});
@@ -3031,11 +3031,11 @@ var lizAttributeTable = function() {
                     lConfig.request_params['selection'] = null;
                     lConfig.request_params['selectiontoken'] = null;
 
-                    // Clear the OL highlight layer only for explicit user deselection
+                    // Clear the OL selection layer only for explicit user deselection
                     // (not when SelectionTool reports no features found in a layer,
                     // which sets olHighlightUpdated:true — it manages its own clearing)
                     if (!olHighlightUpdated) {
-                        lizMap.mainLizmap?.map?.clearHighlightFeatures?.();
+                        lizMap.mainLizmap?.map?.clearSelectionFeatures?.();
                     }
 
                     // Update layer state

--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -3031,6 +3031,13 @@ var lizAttributeTable = function() {
                     lConfig.request_params['selection'] = null;
                     lConfig.request_params['selectiontoken'] = null;
 
+                    // Clear the OL highlight layer only for explicit user deselection
+                    // (not when SelectionTool reports no features found in a layer,
+                    // which sets olHighlightUpdated:true — it manages its own clearing)
+                    if (!olHighlightUpdated) {
+                        lizMap.mainLizmap?.map?.clearHighlightFeatures?.();
+                    }
+
                     // Update layer state
                     lizMap.mainLizmap.state.layersAndGroupsCollection.getLayerByName(lConfig.name).selectedFeatures = null;
                 }

--- a/assets/src/modules/SelectionTool.js
+++ b/assets/src/modules/SelectionTool.js
@@ -151,13 +151,13 @@ export default class SelectionTool {
 
                                 selectionFeature = this.featureDrawnBuffered;
 
-                                this._map.clearHighlightFeatures();
+                                this._map.clearSelectionFeatures();
                                 for (const featureType of this.allFeatureTypeSelected) {
                                     this.selectLayerFeaturesFromSelectionFeature(featureType, selectionFeature, this._geomOperator);
                                 }
                             });
                         } else {
-                            this._map.clearHighlightFeatures();
+                            this._map.clearSelectionFeatures();
                             for (const featureType of this.allFeatureTypeSelected) {
                                 this.selectLayerFeaturesFromSelectionFeature(featureType, selectionFeature, this._geomOperator);
                             }
@@ -345,7 +345,7 @@ export default class SelectionTool {
         }
         this._digitizing.drawLayer.getSource().clear();
         this._bufferLayer.getSource().clear();
-        this._map.clearHighlightFeatures();
+        this._map.clearSelectionFeatures();
     }
 
     filter() {
@@ -524,14 +524,14 @@ export default class SelectionTool {
 
             lConfig['selectedFeatures'] = featureIds;
 
-            // Update client-side highlight layer with configured selection color.
+            // Update client-side selection layer with configured selection color.
             // Always add (never clear here) — the clear happens synchronously before
             // the loop that fires concurrent WFS calls, avoiding race conditions.
             if (featureIds.length > 0 && this.newAddRemoveSelected !== 'remove') {
-                this._map.addHighlightFeatures(response, "geojson", lConfig.crs || "EPSG:4326");
+                this._map.addSelectionFeatures(response, "geojson", lConfig.crs || "EPSG:4326");
             } else if (this.newAddRemoveSelected === 'remove') {
                 // Remaining geometries not available; clear the overlay entirely
-                this._map.clearHighlightFeatures();
+                this._map.clearSelectionFeatures();
             }
 
             this._lizmap3.events.triggerEvent("layerSelectionChanged",

--- a/assets/src/modules/SelectionTool.js
+++ b/assets/src/modules/SelectionTool.js
@@ -426,7 +426,8 @@ export default class SelectionTool {
                         {
                             'featureType': featureType,
                             'featureIds': this._lizmap3.config.layers[featureType]['selectedFeatures'],
-                            'updateDrawing': true
+                            'updateDrawing': true,
+                            'olHighlightUpdated': true
                         }
                     );
                 });
@@ -537,7 +538,8 @@ export default class SelectionTool {
                 {
                     'featureType': targetFeatureType,
                     'featureIds': lConfig['selectedFeatures'],
-                    'updateDrawing': true
+                    'updateDrawing': true,
+                    'olHighlightUpdated': true
                 }
             );
         });

--- a/assets/src/modules/config/Options.js
+++ b/assets/src/modules/config/Options.js
@@ -41,6 +41,7 @@ const optionalProperties = {
     'automatic_permalink': { type: 'boolean', default: false },
     'wms_single_request_for_all_layers' : { type:'boolean', default: false },
     'exclude_basemaps_from_single_wms' : { type:'boolean', default: false },
+    'selectionColor': { type: 'string', default: 'rgba(255, 255, 0, 0.8)' },
 };
 
 /**
@@ -323,6 +324,14 @@ export class OptionsConfig  extends BaseObjectConfig {
      */
     get exclude_basemaps_from_single_wms() {
         return this._exclude_basemaps_from_single_wms;
+    }
+
+    /**
+     * The selection color as rgba() CSS string
+     * @type {string}
+     */
+    get selectionColor() {
+        return this._selectionColor;
     }
 
 }

--- a/assets/src/modules/map.js
+++ b/assets/src/modules/map.js
@@ -892,6 +892,7 @@ export default class map extends olMap {
                 wrapX: false
             }),
             style: {
+                'fill-color': styleColor,
                 'circle-fill-color': styleColor,
                 'circle-stroke-color': styleColor,
                 'circle-stroke-width': styleWidth,
@@ -1022,6 +1023,14 @@ export default class map extends olMap {
      */
     clearHighlightFeatures() {
         this._highlightLayer.getSource().clear();
+    }
+
+    /**
+     * Returns true if the highlight layer currently contains features
+     * @returns {boolean}
+     */
+    get hasHighlightFeatures() {
+        return this._highlightLayer.getSource().getFeatures().length > 0;
     }
 
 

--- a/assets/src/modules/map.js
+++ b/assets/src/modules/map.js
@@ -892,7 +892,6 @@ export default class map extends olMap {
                 wrapX: false
             }),
             style: {
-                'fill-color': styleColor,
                 'circle-fill-color': styleColor,
                 'circle-stroke-color': styleColor,
                 'circle-stroke-width': styleWidth,
@@ -1024,6 +1023,7 @@ export default class map extends olMap {
     clearHighlightFeatures() {
         this._highlightLayer.getSource().clear();
     }
+
 
     /**
      * Synchronize new OL view with OL2 one

--- a/assets/src/modules/map.js
+++ b/assets/src/modules/map.js
@@ -892,7 +892,6 @@ export default class map extends olMap {
                 wrapX: false
             }),
             style: {
-                'fill-color': styleColor,
                 'circle-fill-color': styleColor,
                 'circle-stroke-color': styleColor,
                 'circle-stroke-width': styleWidth,

--- a/assets/src/modules/map.js
+++ b/assets/src/modules/map.js
@@ -885,13 +885,15 @@ export default class map extends olMap {
 
         // Create the highlight layer
         // used to display features on top of all layers
-        const styleColor = 'rgba(255,255,0,0.8)';
+        const styleColor = initialConfig.options.selectionColor;
         const styleWidth = 3;
         this._highlightLayer = new VectorLayer({
             source: new VectorSource({
                 wrapX: false
             }),
             style: {
+                'fill-color': styleColor,
+                'circle-fill-color': styleColor,
                 'circle-stroke-color': styleColor,
                 'circle-stroke-width': styleWidth,
                 'circle-radius': 6,

--- a/assets/src/modules/map.js
+++ b/assets/src/modules/map.js
@@ -884,26 +884,26 @@ export default class map extends olMap {
         );
 
         // Create the highlight layer (popup, locate, search, startup)
-        // Stroke-only: shows feature location without obscuring the map
-        const styleColor = initialConfig.options.selectionColor;
+        // Always yellow stroke-only — fixed color independent of project settings
+        const highlightColor = 'rgba(255,255,0,0.8)';
         const styleWidth = 3;
         this._highlightLayer = new VectorLayer({
             source: new VectorSource({
                 wrapX: false
             }),
             style: {
-                'circle-fill-color': styleColor,
-                'circle-stroke-color': styleColor,
+                'circle-stroke-color': highlightColor,
                 'circle-stroke-width': styleWidth,
                 'circle-radius': 6,
-                'stroke-color': styleColor,
+                'stroke-color': highlightColor,
                 'stroke-width': styleWidth,
             }
         });
         this.addToolLayer(this._highlightLayer);
 
         // Create the selection layer (SelectionTool, attribute table)
-        // Fill + stroke: clearly marks features chosen by the user for operations
+        // Fill + stroke using the project's configured selection color
+        const styleColor = initialConfig.options.selectionColor;
         this._selectionLayer = new VectorLayer({
             source: new VectorSource({
                 wrapX: false

--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -523,9 +523,14 @@ class serviceCtrl extends jController
                         }
                     }
                 }
-                // Add SELECTION for WMS
-                if ($request != 'getfeature' && count($selections) > 0) {
+                // Add SELECTION for print only — GetMap uses client-side highlight layer
+                // so QGIS Server does not render its default yellow into map tiles.
+                if ($request == 'getprint' && count($selections) > 0) {
                     $this->params['SELECTION'] = implode(';', $selections);
+                }
+                // Strip any raw SELECTION param that may have been sent for GetMap
+                if ($request == 'getmap') {
+                    unset($this->params['SELECTION']);
                 }
                 // Add FEATUREID for WFS GetFeature
                 if ($request == 'getfeature' && count($feature_ids) > 0) {

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -752,6 +752,11 @@ class Project
         return $this->qgis->getCanvasColor();
     }
 
+    public function getSelectionColor(): string
+    {
+        return $this->qgis->getSelectionColor();
+    }
+
     public function getWMSInformation()
     {
         $WMSInformation = $this->qgis->getWMSInformation();
@@ -1850,6 +1855,8 @@ class Project
 
         $wmsMaxHeight = $this->qgis->getWMSMaxHeight();
         $configJson->options->wmsMaxHeight = $wmsMaxHeight ?: $services->wmsMaxHeight;
+
+        $configJson->options->selectionColor = $this->qgis->getSelectionColor();
 
         // Update config with layer relations
         $relations = $this->qgis->getRelations();

--- a/lizmap/modules/lizmap/lib/Project/Qgis/ProjectGuiProperties.php
+++ b/lizmap/modules/lizmap/lib/Project/Qgis/ProjectGuiProperties.php
@@ -80,6 +80,24 @@ class ProjectGuiProperties extends BaseQgisXmlObject
     }
 
     /**
+     * Get the selection color as RGBA string.
+     *
+     * @return string The selection color as rgba() CSS string
+     */
+    public function getSelectionColor(): string
+    {
+        if ($this->SelectionColorAlphaPart === null) {
+            return 'rgba(255, 255, 0, 0.8)';
+        }
+        $alphaStr = rtrim(number_format($this->SelectionColorAlphaPart / 255, 4, '.', ''), '0');
+        if (substr($alphaStr, -1) === '.') {
+            $alphaStr .= '0';
+        }
+
+        return 'rgba('.$this->SelectionColorRedPart.', '.$this->SelectionColorGreenPart.', '.$this->SelectionColorBluePart.', '.$alphaStr.')';
+    }
+
+    /**
      * Parse from an XMLReader instance at a child of an element.
      *
      * @param \XMLReader $oXmlReader An XMLReader instance at a child of an element

--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -131,6 +131,11 @@ class QgisProject
     protected $canvasColor = '';
 
     /**
+     * @var string
+     */
+    protected $selectionColor = '';
+
+    /**
      * @var array<string, string> authid => proj4
      */
     protected $allProj4 = array();
@@ -183,6 +188,7 @@ class QgisProject
     protected static $cachedProperties = array(
         'WMSInformation',
         'canvasColor',
+        'selectionColor',
         'allProj4',
         'relations',
         'relationsFields',
@@ -391,6 +397,11 @@ class QgisProject
     public function getCanvasColor()
     {
         return $this->canvasColor;
+    }
+
+    public function getSelectionColor(): string
+    {
+        return $this->selectionColor;
     }
 
     /**
@@ -1190,6 +1201,7 @@ class QgisProject
 
         $this->WMSInformation = $project->getWmsInformationsAsKeyArray();
         $this->canvasColor = $project->properties->Gui->getCanvasColor();
+        $this->selectionColor = $project->properties->Gui->getSelectionColor();
         $this->allProj4 = $project->getProjAsKeyArray();
         $this->themes = $project->getVisibilityPresetsAsKeyArray();
         $this->customProjectVariables = $project->properties->Variables !== null ? $project->properties->Variables->getVariablesAsKeyArray() : array();

--- a/tests/end2end/playwright/attribute-table.spec.js
+++ b/tests/end2end/playwright/attribute-table.spec.js
@@ -350,6 +350,8 @@ test.describe('Attribute table @readonly', () => {
 
         // click to select 6
         getSelectionTokenRequestPromise = project.waitForGetSelectionTokenRequest();
+        // WFS GetFeature fired to update OL highlight layer for 3 selected features
+        let getFeatureHighlightMultiPromise = project.waitForGetFeatureRequest();
         await tr6.locator('lizmap-feature-toolbar .feature-select').click();
         getSelectionTokenRequest = await getSelectionTokenRequestPromise;
         // Once the GetSelectionToken is received, the map is refreshed
@@ -382,6 +384,12 @@ test.describe('Attribute table @readonly', () => {
         await expect(tr6.locator('lizmap-feature-toolbar .feature-select')).toContainClass('active'); // old bootstrap: btn-primary
         await expect(tr6).toContainClass('selected');
 
+        // Wait for WFS GetFeature (highlight layer population) to complete
+        const getFeatureHighlightMulti = await getFeatureHighlightMultiPromise;
+        await getFeatureHighlightMulti.response();
+        // Wait for OL rendering
+        await page.waitForTimeout(100);
+
         // Check rendering
         buffer = await page.screenshot({clip:clip});
         const multiSelectHash = await digestBuffer(buffer);
@@ -389,7 +397,9 @@ test.describe('Attribute table @readonly', () => {
         expect(multiSelectHash).not.toEqual(selectHash);
         expect(multiSelectHash).not.toEqual(filterHash);
         const multiSelectByteLength = buffer.byteLength;
-        expect(multiSelectByteLength).toBeGreaterThan(8000);
+        // OL highlight covers polygon interiors with semi-opaque yellow, reducing PNG entropy
+        // compared to the WMS-only default; the threshold checks the image is not blank
+        expect(multiSelectByteLength).toBeGreaterThan(5000);
         expect(multiSelectByteLength).not.toBe(defaultByteLength);
         expect(multiSelectByteLength).not.toBe(selectByteLength);
         expect(multiSelectByteLength).toBeLessThan(15000);

--- a/tests/end2end/playwright/attribute-table.spec.js
+++ b/tests/end2end/playwright/attribute-table.spec.js
@@ -170,6 +170,8 @@ test.describe('Attribute table @readonly', () => {
         // Select feature
         // click on select Button
         let getSelectionTokenRequestPromise = project.waitForGetSelectionTokenRequest();
+        // WFS GetFeature is fired after selection token is obtained to populate the OL highlight layer
+        let getFeatureHighlightPromise = project.waitForGetFeatureRequest();
         await tr2.locator('lizmap-feature-toolbar .feature-select').click();
         let getSelectionTokenRequest = await getSelectionTokenRequestPromise;
         // Once the GetSelectionToken is received, the map is refreshed
@@ -199,6 +201,12 @@ test.describe('Attribute table @readonly', () => {
         // Check that the select button display that the feature is selected
         await expect(tr2.locator('lizmap-feature-toolbar .feature-select')).toContainClass('active'); // old bootstrap: btn-primary
         await expect(tr2).toContainClass('selected');
+
+        // Wait for WFS GetFeature (highlight layer population) to complete
+        const getFeatureHighlight = await getFeatureHighlightPromise;
+        await getFeatureHighlight.response();
+        // Wait for OL rendering
+        await page.waitForTimeout(100);
 
         // Check rendering
         buffer = await page.screenshot({clip:clip});

--- a/tests/end2end/playwright/attribute-table.spec.js
+++ b/tests/end2end/playwright/attribute-table.spec.js
@@ -392,7 +392,7 @@ test.describe('Attribute table @readonly', () => {
         expect(multiSelectByteLength).toBeGreaterThan(8000);
         expect(multiSelectByteLength).not.toBe(defaultByteLength);
         expect(multiSelectByteLength).not.toBe(selectByteLength);
-        expect(multiSelectByteLength).toBeLessThan(10000);
+        expect(multiSelectByteLength).toBeLessThan(15000);
 
         // click on filter Button
         getFilterTokenRequestPromise = project.waitForGetFilterTokenRequest();

--- a/tests/js-units/node/config/options.test.js
+++ b/tests/js-units/node/config/options.test.js
@@ -81,6 +81,32 @@ describe('OptionsConfig', function () {
         expect(opt.wms_single_request_for_all_layers).to.be.eq(false)
         // Default value for basemaps excluded from the single WMS request
         expect(opt.exclude_basemaps_from_single_wms).to.be.eq(false)
+        // Default value for selectionColor when not provided
+        expect(opt.selectionColor).to.be.eq('rgba(255, 255, 0, 0.8)')
+    })
+
+    it('selectionColor', function () {
+        const baseOpt = {
+            "projection": { "proj4": "+proj=longlat +datum=WGS84 +no_defs", "ref": "EPSG:4326" },
+            "bbox": ["-3.5", "-1.0", "3.5", "1.0"],
+            "mapScales": [10000, 25000, 50000, 100000],
+            "minScale": 10000,
+            "maxScale": 100000,
+            "initialExtent": [-3.5, -1.0, 3.5, 1.0],
+            "popupLocation": "dock",
+            "pointTolerance": 25,
+            "lineTolerance": 10,
+            "polygonTolerance": 5,
+            "datavizLocation": "dock",
+        }
+
+        // Default when not provided
+        let opt = new OptionsConfig(baseOpt)
+        expect(opt.selectionColor).to.be.eq('rgba(255, 255, 0, 0.8)')
+
+        // Custom value provided
+        opt = new OptionsConfig({ ...baseOpt, selectionColor: 'rgba(255, 0, 0, 0.784)' })
+        expect(opt.selectionColor).to.be.eq('rgba(255, 0, 0, 0.784)')
     })
 
     it('use_native_zoom_levels', function () {

--- a/tests/qgis-projects/tests/startup.qgs
+++ b/tests/qgis-projects/tests/startup.qgs
@@ -748,7 +748,7 @@ def my_form_open(dialog, layer, feature):
       <CanvasColorBluePart type="int">255</CanvasColorBluePart>
       <CanvasColorGreenPart type="int">255</CanvasColorGreenPart>
       <CanvasColorRedPart type="int">255</CanvasColorRedPart>
-      <SelectionColorAlphaPart type="int">255</SelectionColorAlphaPart>
+      <SelectionColorAlphaPart type="int">204</SelectionColorAlphaPart>
       <SelectionColorBluePart type="int">0</SelectionColorBluePart>
       <SelectionColorGreenPart type="int">255</SelectionColorGreenPart>
       <SelectionColorRedPart type="int">255</SelectionColorRedPart>

--- a/tests/qgis-projects/tests/startup.qgs
+++ b/tests/qgis-projects/tests/startup.qgs
@@ -748,7 +748,7 @@ def my_form_open(dialog, layer, feature):
       <CanvasColorBluePart type="int">255</CanvasColorBluePart>
       <CanvasColorGreenPart type="int">255</CanvasColorGreenPart>
       <CanvasColorRedPart type="int">255</CanvasColorRedPart>
-      <SelectionColorAlphaPart type="int">204</SelectionColorAlphaPart>
+      <SelectionColorAlphaPart type="int">255</SelectionColorAlphaPart>
       <SelectionColorBluePart type="int">0</SelectionColorBluePart>
       <SelectionColorGreenPart type="int">255</SelectionColorGreenPart>
       <SelectionColorRedPart type="int">255</SelectionColorRedPart>

--- a/tests/units/classes/Project/Qgis/ProjectGuiPropertiesTest.php
+++ b/tests/units/classes/Project/Qgis/ProjectGuiPropertiesTest.php
@@ -58,6 +58,32 @@ class ProjectGuiPropertiesTest extends TestCase
         $this->assertEquals('rgb(50, 100, 200)', $properties->getCanvasColor());
     }
 
+    public function testGetSelectionColor(): void
+    {
+        $data = array(
+            'CanvasColorBluePart' => 255,
+            'CanvasColorGreenPart' => 255,
+            'CanvasColorRedPart' => 255,
+            'SelectionColorAlphaPart' => 255,
+            'SelectionColorBluePart' => 0,
+            'SelectionColorGreenPart' => 255,
+            'SelectionColorRedPart' => 255,
+        );
+
+        $properties = new Qgis\ProjectGuiProperties($data);
+        $this->assertEquals('rgba(255, 255, 0, 1.0)', $properties->getSelectionColor());
+
+        // Only CanvasColor parts are mandatory; SelectionColor defaults when null
+        $data = array(
+            'CanvasColorBluePart' => 255,
+            'CanvasColorGreenPart' => 255,
+            'CanvasColorRedPart' => 255,
+        );
+
+        $properties = new Qgis\ProjectGuiProperties($data);
+        $this->assertEquals('rgba(255, 255, 0, 0.8)', $properties->getSelectionColor());
+    }
+
     public function testExceptionNoSuchProperty(): void
     {
         $data = array(

--- a/tests/units/classes/Project/QgisProjectTest.php
+++ b/tests/units/classes/Project/QgisProjectTest.php
@@ -100,7 +100,7 @@ class QgisProjectTest extends TestCase
 
     public function testCacheConstruct(): void
     {
-        $cachedProperties = array('WMSInformation', 'canvasColor', 'allProj4',
+        $cachedProperties = array('WMSInformation', 'canvasColor', 'selectionColor', 'allProj4',
             'relations', 'themes', 'useLayerIDs', 'layers', 'data',
             'qgisProjectVersion', 'customProjectVariables', 'relationsFields',
             'wfsLayerIds');


### PR DESCRIPTION
Read SelectionColor from the QGIS project Gui properties and expose it through the PHP→JSON→JS pipeline so the OpenLayers highlight/ selection overlay respects the user-configured color instead of the hardcoded yellow rgba(255,255,0,0.8).

- ProjectGuiProperties: add getSelectionColor() with 0-255→0-1 alpha
- QgisProject: cache and expose selectionColor property
- Project: add getSelectionColor() wrapper; inject into getUpdatedConfig()
- Options.js: add selectionColor optional property with default fallback
- map.js: use initialConfig.options.selectionColor for highlight style

Superseeds https://github.com/3liz/lizmap-web-client/issues/748
Fixes: https://github.com/3liz/lizmap-web-client/issues/4520

ToDo: Respect "per layer" custom selection color as configured in the layer properties of QGIS

![Selection Color](https://github.com/user-attachments/assets/1acf961e-c8ef-47e9-8b53-8c48e3528772)
