### PR TITLE
[Bug] Cloning lizUrls.params object in datatables url definition

### DIFF
--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -1501,7 +1501,7 @@ var lizAttributeTable = function() {
                 // Datatable configuration
                 if ( !DataTable.isDataTable( aTable ) ) {
                     const datatablesUrl = globalThis['lizUrls'].wms.replace('service', 'datatables');
-                    const params = globalThis['lizUrls'].params;
+                    const params = {...globalThis['lizUrls'].params};
                     params['layerId'] = lConfig.id;
 
                     DataTable.defaults.column.orderSequence = ['asc', 'desc'];


### PR DESCRIPTION
Assigning the "layerId" property to the "params" object was modifying the global `lizUrls.param` object. I don't think this was the intended behavior; if it was, feel free to ignore this PR.

Backport 3.10

Funded by Faunalia
