### PR TITLE
[Bug] Re-enable the filtered feature selection functionality in the attribute table

### DIFF
--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -2208,7 +2208,7 @@ var lizAttributeTable = function() {
                 // Add filtered featured
                 $('.attribute-table-table[id]').each(function(){
                     var tableId = $(this).attr('id');
-                    var tableLayerName = $(this).parents('div.dataTables_wrapper:first').prev('input.attribute-table-hidden-layer').val()
+                    var tableLayerName = $(this).parents('div.dt-container:first').prev('input.attribute-table-hidden-layer').val();
                     // Get parent table for the feature type
                     if ( tableLayerName
                         && DataTable.isDataTable( $(this) )
@@ -2216,7 +2216,7 @@ var lizAttributeTable = function() {
                     ){
 
                         var sIds = [];
-                        var rTable = $(this).DataTable();
+                        let rTable = new DataTable.Api(this);
                         var filteredrowids = rTable.rows( {"filter":"applied"} ).ids();
                         for ( var i = 0; i < filteredrowids.length; i++ ) {
                             sIds.push( filteredrowids[i] );

--- a/tests/end2end/playwright/attribute-table.spec.js
+++ b/tests/end2end/playwright/attribute-table.spec.js
@@ -668,6 +668,39 @@ test.describe('Attribute table @readonly', () => {
         await project.closeAttributeTable();
     });
 
+    test('Should select all filtered results', async ({ page }) => {
+        const project = new ProjectPage(page, 'attribute_table');
+        await project.open();
+
+        const tableName = 'quartiers_shp';
+        const typeName = 'quartiers_shp';
+
+        let datatablesRequest = await project.openAttributeTable(tableName);
+        let datatablesResponse = await datatablesRequest.response();
+        responseExpect(datatablesResponse).toBeJson();
+        let tableHtml = project.attributeTableHtml(tableName);
+
+        // Check table lines
+        await expect(tableHtml.locator('tbody tr')).toHaveCount(7);
+
+        // click on select-searched button to select all records
+        let getSelectionTokenRequestPromise = project.waitForGetSelectionTokenRequest();
+        await project.attributeTableActionBar(tableName).locator('.btn-select-searched').click();
+        let getSelectionTokenRequest = await getSelectionTokenRequestPromise;
+        await getSelectionTokenRequest.response();
+
+        // Check GetSelectionToken request
+        const getSelectionTokenParameters = {
+            'service': 'WMS',
+            'request': 'GETSELECTIONTOKEN',
+            'typename': typeName,
+            'ids': '2,6,0,4,3,1,5',
+        }
+
+        requestExpect(getSelectionTokenRequest).toContainParametersInPostData(getSelectionTokenParameters);
+        expect(tableHtml.locator('tbody tr.selected')).toHaveCount(7);
+    });
+
     test('Thumbnail class generate img with good path', async ({ page }) => {
         const project = new ProjectPage(page, 'attribute_table');
         await project.open();


### PR DESCRIPTION
Here the functionality restored:

[vokoscreenNG-2026-02-26_10-46-03.webm](https://github.com/user-attachments/assets/408f966d-60d7-42d9-b39a-f82ada1c5692)


**NOTE ON TESTS**
The tests can be refined by adding filters using the search builder, but most of the methods for interacting with this component are contained in this PR https://github.com/3liz/lizmap-web-client/pull/6572. I would therefore proceed to integrate them after the latter's merge or, in any case, once it has been decided what to do with it.

Thanks!

Backport 3.10

Funded by Faunalia
