### PR TITLE
Auto-activate snapping via snap_on_start config

### DIFF
--- a/assets/src/modules/Snapping.js
+++ b/assets/src/modules/Snapping.js
@@ -7,7 +7,7 @@
 
 import { mainEventDispatcher } from '../modules/Globals.js';
 import Edition from './Edition.js';
-import { MapRootState } from './state/MapLayer.js';
+import { MapLayerLoadStatus, MapRootState } from './state/MapLayer.js';
 import { TreeRootState } from './state/LayerTree.js';
 
 /**
@@ -39,6 +39,8 @@ export default class Snapping {
         this._snapEnabled = {};
         this._snapToggled = {};
         this._snapLayers = [];
+        this._snapOnStart = false;
+        this._pendingMapReadyListener = null;
 
         // Create layer to store snap features
         const snapLayer = new OpenLayers.Layer.Vector('snaplayer', {
@@ -136,6 +138,9 @@ export default class Snapping {
                                     'snap_segments_tolerance': editionLayerConfig.hasOwnProperty('snap_segments_tolerance') ? editionLayerConfig.snap_segments_tolerance : 10,
                                     'snap_intersections_tolerance': editionLayerConfig.hasOwnProperty('snap_intersections_tolerance') ? editionLayerConfig.snap_intersections_tolerance : 10
                                 };
+
+                                this._snapOnStart = editionLayerConfig.hasOwnProperty('snap_on_start')
+                                    && editionLayerConfig.snap_on_start === 'True';
                             }
                         }
                     }
@@ -161,6 +166,12 @@ export default class Snapping {
                         this._setSnapLayersVisibility,
                         ['layer.visibility.changed','group.visibility.changed']
                     );
+
+                    // Auto-activate snapping if configured (snap_on_start).
+                    // Legacy configs without the key do not auto-activate.
+                    if (this._snapOnStart) {
+                        this._activateWhenMapReady();
+                    }
                 }
             },
             'edition.formDisplayed'
@@ -169,6 +180,13 @@ export default class Snapping {
         // Clean snap when edition ends
         mainEventDispatcher.addListener(
             () => {
+                // Remove pending map-ready listener if still waiting
+                if (this._pendingMapReadyListener) {
+                    this._rootMapGroup.removeListener(
+                        this._pendingMapReadyListener, 'layer.load.status.changed'
+                    );
+                    this._pendingMapReadyListener = null;
+                }
                 this.active = false;
                 this._lizmap3.map.getLayersByName('snaplayer')[0].destroyFeatures();
                 this.config = undefined;
@@ -182,6 +200,45 @@ export default class Snapping {
             },
             'edition.formClosed'
         );
+    }
+
+    /**
+     * Activate snapping only after all visible map layers have finished loading.
+     * This prevents snap WFS requests from competing with map tile rendering
+     * on QGIS Server, which can significantly slow down large projects.
+     * @private
+     */
+    _activateWhenMapReady() {
+        const visibleLayers = this._rootMapGroup.findMapLayers().filter(l => l.visibility);
+        const stillLoading = visibleLayers.filter(
+            l => l.loadStatus === MapLayerLoadStatus.Loading
+              || l.loadStatus === MapLayerLoadStatus.Undefined
+        );
+
+        if (stillLoading.length === 0) {
+            this.active = true;
+            let previousMessage = document.getElementById('lizmap-snapping-message');
+            if (previousMessage) previousMessage.remove();
+            this._lizmap3.addMessage(lizDict['snapping.message.activated'] || 'Snapping has been automatically activated.', 'info', true, 7000).attr('id', 'lizmap-snapping-message');
+        } else {
+            const listener = () => {
+                const remaining = this._rootMapGroup.findMapLayers().filter(
+                    l => l.visibility
+                      && (l.loadStatus === MapLayerLoadStatus.Loading
+                       || l.loadStatus === MapLayerLoadStatus.Undefined)
+                );
+                if (remaining.length === 0) {
+                    this._rootMapGroup.removeListener(listener, 'layer.load.status.changed');
+                    this._pendingMapReadyListener = null;
+                    this.active = true;
+                    let previousMessage = document.getElementById('lizmap-snapping-message');
+                    if (previousMessage) previousMessage.remove();
+                    this._lizmap3.addMessage(lizDict['snapping.message.activated'] || 'Snapping has been automatically activated.', 'info', true, 7000).attr('id', 'lizmap-snapping-message');
+                }
+            };
+            this._pendingMapReadyListener = listener;
+            this._rootMapGroup.addListener(listener, 'layer.load.status.changed');
+        }
     }
 
     getSnappingData () {

--- a/lizmap/modules/view/locales/en_US/dictionnary.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/dictionnary.UTF-8.properties
@@ -229,6 +229,7 @@ selectiontool.toolbar.geomOperator.crosses=Crosses
 selectiontool.toolbar.geomOperator.disjoint=Disjoint
 selectiontool.toolbar.geomOperator.touches=Touches
 selectiontool.message.start=Selection tool activated. Draw a shape on the map to select features.
+snapping.message.activated=Snapping has been automatically activated.
 
 digitizing.toolbar.drawTools=Draw tools
 digitizing.toolbar.color=Pick draw color

--- a/tests/end2end/playwright/snap.spec.js
+++ b/tests/end2end/playwright/snap.spec.js
@@ -11,6 +11,12 @@ test.describe('Snap on edition', () => {
     test('Snap panel functionalities', async ({ page }) => {
         const project = new ProjectPage(page, 'form_edition_multilayer_snap');
 
+        // Set up request watchers before opening the form, as snapping is auto-activated on form display
+        let getSnappingPointFeatureRequestPromise = page.waitForRequest(
+            request => request.method() === 'POST' && request.postData() != null && request.postData()?.includes('GetFeature') === true && request.postData()?.includes('form_edition_snap_point') === true);
+        let getSnappingPointDescribeFeatureRequestPromise = page.waitForRequest(
+            request => request.method() === 'POST' && request.postData() != null && request.postData()?.includes('DescribeFeatureType') === true && request.postData()?.includes('form_edition_snap_point') === true);
+
         const formRequest = await project.openEditingFormWithLayer('form_edition_snap_control');
         await formRequest.response();
 
@@ -21,14 +27,7 @@ test.describe('Snap on edition', () => {
         // move to digitization panel
         await page.getByRole('tab', { name: 'Digitization' }).click()
 
-        let getSnappingPointFeatureRequestPromise = page.waitForRequest(
-            request => request.method() === 'POST' && request.postData() != null && request.postData()?.includes('GetFeature') === true && request.postData()?.includes('form_edition_snap_point') === true);
-        let getSnappingPointDescribeFeatureRequestPromise = page.waitForRequest(
-            request => request.method() === 'POST' && request.postData() != null && request.postData()?.includes('DescribeFeatureType') === true && request.postData()?.includes('form_edition_snap_point') === true);
-
-        // activate snapping
-        await page.getByRole('button', { name: 'Start' }).click();
-
+        // snapping is auto-activated when snap layers are configured
         await Promise.all([getSnappingPointFeatureRequestPromise, getSnappingPointDescribeFeatureRequestPromise])
 
         // check snap panel and controls

--- a/tests/qgis-projects/tests/form_edition_multilayer_snap.qgs.cfg
+++ b/tests/qgis-projects/tests/form_edition_multilayer_snap.qgs.cfg
@@ -259,6 +259,7 @@
             "snap_vertices_tolerance": 10,
             "snap_segments_tolerance": 10,
             "snap_intersections_tolerance": 10,
+            "snap_on_start": "True",
             "provider": "postgres",
             "capabilities": {
                 "createFeature": "True",


### PR DESCRIPTION
## Summary
- Auto-activate snapping when editing starts if the layer has `snap_on_start: "True"` in the cfg
- Defers WFS snap requests until map tiles finish loading so QGIS Server doesnt get blocked on large projects
- Shows a info message for 7 seconds when snapping activtes
- Legacy configs without the key wont auto-activate, so backwards compatible

Selection tool changes moved to #6614 as requested by @rldhont. The companion plugin PR for the `snap_on_start` checkbox is here: https://github.com/3liz/lizmap-plugin/compare/master...meyerlor:lizmap-plugin:feature/snap-on-start

## Test plan
Existing snap E2E test has been updated. Could probably add a test for a layer without `snap_on_start` to verify it doesnt auto-activate, and maybe one for the deferred loading behaviour on larger projects.