### PR TITLE
[Bug][Discussion] Datatables request: Concat all filters in final EXP_FILTER WFS parameter

### DIFF
--- a/lizmap/modules/lizmap/controllers/datatables.classic.php
+++ b/lizmap/modules/lizmap/controllers/datatables.classic.php
@@ -156,12 +156,16 @@ class datatablesCtrl extends jController
         }
 
         if (count($filteredFeatureIDs) > 0) {
-            $wfsParamsData['EXP_FILTER'] = '$id IN ('.implode(' , ', $filteredFeatureIDs).')';
+            $filteredFeatureIDSFilter = '$id IN ('.implode(' , ', $filteredFeatureIDs).')';
+            // concat current exp_filter with filteredFeaturesIds filter
+            $expFilter = !$expFilter ? $filteredFeatureIDSFilter : "( {$expFilter} ) AND ( {$filteredFeatureIDSFilter} )";
         }
 
         // Handle search made by searchBuilder
         if ($DTSearchBuilder) {
-            $expFilter = DataTables::convertSearchToExpression($DTSearchBuilder);
+            $searchBuilderFilter = DataTables::convertSearchToExpression($DTSearchBuilder);
+            // concat current exp_filter with searchBuilderFilter filter
+            $expFilter = !$expFilter ? $searchBuilderFilter : "( {$expFilter} ) AND ( {$searchBuilderFilter} )";
         }
 
         if ($expFilter) {


### PR DESCRIPTION
Currently, the filter set on the `searchBuilder` overrides all other filters. If the map filter is also applied, the attribute table displays all features matching the `searchBuilder` parameter, rather than just those filtered on the map. The current behavior is as follows:

[vokoscreenNG-2026-03-06_12-12-47.webm](https://github.com/user-attachments/assets/6f45c34c-ac79-4427-b42e-e40e9e119eea)

This PR wants to restore the previous behavior:

[vokoscreenNG-2026-03-06_12-17-51.webm](https://github.com/user-attachments/assets/cc297fd3-9c2e-4bd3-94c7-e5b84062deed)

I added the discussion "tag" because I'm not sure if this is the desired behavior or if I'm missing something.

Thanks!

Backport 3.10

Funded by Faunalia
