### PR TITLE
[Bug] Remove duplicate table redraw

### DIFF
--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -2750,12 +2750,6 @@ var lizAttributeTable = function() {
                 // Update layer state
                 lizMap.mainLizmap.state.layersAndGroupsCollection.getLayerByName(layerConfig.name).expressionFilter = null;
 
-                // Refresh attributeTable
-                var opTable = '#attribute-layer-table-'+lizMap.cleanName( typeName );
-                if( $( opTable ).length ){
-                    getDataAndRefreshAttributeTable(typeName, null, opTable);
-                }
-
                 // And send event so that getFeatureInfo and getPrint use the updated layer filters
                 lizMap.events.triggerEvent("layerFilterParamChanged",
                     {


### PR DESCRIPTION
When a map filter is cleared (for example, by clicking the filter icon in the layer tree), the `getDataAndRefreshAttributeTable` function is called.
The current logic of the function does not take into account the new server-side layout/rendering of the attribute table and requests the entire data set. Furthermore, immediately after this function is called, the corresponding attribute table is redrawn again by firing the `layerFilteredFeaturesChanged` event. This causes the table to be updated twice.

I think about it a little bit and in the end I decided to remove the `getDataAndRefreshAttributeTable` call because, in my opinion, it is no longer necessary in the new attribute table management. This function calls other function but it seems to me that they are needed only to manage the whole dataset coming from the WFS call, and this job is already done by the `dataTable.draw()` method, called in the `layerFilteredFeaturesChanged`  event callback.

Last note: by removing this call, `getDataAndRefreshAttributeTable` is no longer used by other methods or functions. I've chosen not to remove it for now, so that any rollbacks are easier.


Funded by Faunalia
