### PR TITLE
Auto-activate box selection on tool open

### DIFF
--- a/assets/src/modules/SelectionTool.js
+++ b/assets/src/modules/SelectionTool.js
@@ -188,6 +188,10 @@ export default class SelectionTool {
                     this._digitizing.context = event.id;
                     this._digitizing.singlePartGeometry = true;
                     this._digitizing.toggleVisibility(true);
+                    this._digitizing.toolSelected = 'box';
+                    let previousMessage = document.getElementById('lizmap-selection-message');
+                    if (previousMessage) previousMessage.remove();
+                    this._lizmap3.addMessage(lizDict['selectiontool.message.start'], 'info', true, 7000).attr('id', 'lizmap-selection-message');
                 }
             },
             minidockclosed: (event) => {

--- a/lizmap/modules/view/locales/en_US/dictionnary.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/dictionnary.UTF-8.properties
@@ -227,6 +227,7 @@ selectiontool.toolbar.geomOperator.contains=Contains
 selectiontool.toolbar.geomOperator.crosses=Crosses
 selectiontool.toolbar.geomOperator.disjoint=Disjoint
 selectiontool.toolbar.geomOperator.touches=Touches
+selectiontool.message.start=Selection tool activated. Draw a shape on the map to select features.
 
 digitizing.toolbar.drawTools=Draw tools
 digitizing.toolbar.color=Pick draw color

--- a/tests/end2end/playwright/popup.spec.js
+++ b/tests/end2end/playwright/popup.spec.js
@@ -401,10 +401,13 @@ test.describe('Popup @readonly', () => {
     test('With selection tool', async ({ page }) => {
         const project = new ProjectPage(page, 'popup');
         await project.open();
-        // Open Selection tool
+        // Open Selection tool - box draw is auto-activated
         await page.locator('#button-selectiontool').click();
 
-        // Popup still available
+        // Deactivate draw - popup should be available
+        await page.locator('.digitizing-buttons > button').first().click();
+
+        // Popup available when draw is inactive
         let getFeatureInfoRequestPromise = project.waitForGetFeatureInfoRequest();
         await project.clickOnMap(250, 415);
         let getFeatureInfoRequest = await getFeatureInfoRequestPromise;
@@ -414,7 +417,7 @@ test.describe('Popup @readonly', () => {
         await expect(project.map.locator('#liz_layer_popup')).toBeVisible();
         await page.getByRole('link', { name: '✖' }).click();
 
-        // Activate draw
+        // Activate draw with point tool via dropdown
         await page.getByRole('button', { name: 'Toggle Dropdown' }).click();
         await page.locator('.selectiontool .digitizing-point > svg > use').click();
 


### PR DESCRIPTION
- Auto-activate box selection when opening the selection tool panel, saves the user one click
- Shows a info message for 7 seconds to guide the user
- Updated popup E2E test to deactivate draw before testing since box draw is now auto-active

Split from #6603 as requested by @rldhont.

Existing popup E2E test was updated. I Could add a dedicated test that verifies box selection is active right after opening the panel.