### PR TITLE
[Feature] Select all filtered features server side

### DIFF
--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -2477,7 +2477,7 @@ var lizAttributeTable = function() {
                 const table = document.getElementById(`attribute-layer-table-${featureType}`);
                 if (!table || !DataTable.isDataTable( $(table) )) return;
                 const eTable = new DataTable.Api(table);
-                const { pages } = {...eTable.page.info()};
+                const { pages, recordsDisplay } = {...eTable.page.info()};
 
                 var hasChanged = false;
                 if( pages == 1 ) {
@@ -2495,6 +2495,10 @@ var lizAttributeTable = function() {
                         hasChanged = true;
                     }
                 } else if(pages > 1) {
+                    let confirmSelection = true;
+                    // warn user if more than 1000 features are involved.
+                    if(recordsDisplay > 1000) confirmSelection = confirm(lizDict['attributeLayers.toolbar.btn.select.searched.warn']);
+                    if(!confirmSelection) return;
                     // call server
                     const datatablesUrl = globalThis['lizUrls'].wms.replace('service', 'datatables/selectFilteredFeatures');
                     const params = {...globalThis['lizUrls'].params};

--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -2467,35 +2467,62 @@ var lizAttributeTable = function() {
              * @param featureType
              * @param supdateDrawing
              */
-            function setSelectedFeaturesFromSearchedFilter( featureType, supdateDrawing ) {
+            async function setSelectedFeaturesFromSearchedFilter( featureType, supdateDrawing ) {
                 // Set function parameters if not given
                 supdateDrawing = typeof supdateDrawing !== 'undefined' ?  supdateDrawing : true;
 
                 // Assure selectedFeatures property exists for the layer
                 if( !config.layers[featureType]['selectedFeatures'] )
                     config.layers[featureType]['selectedFeatures'] = [];
+                const table = document.getElementById(`attribute-layer-table-${featureType}`);
+                if (!table || !DataTable.isDataTable( $(table) )) return;
+                const eTable = new DataTable.Api(table);
+                const { pages } = {...eTable.page.info()};
 
                 var hasChanged = false;
-                // Add filtered featured
-                $('.attribute-table-table[id]').each(function(){
-                    var tableId = $(this).attr('id');
-                    var tableLayerName = $(this).parents('div.dt-container:first').prev('input.attribute-table-hidden-layer').val();
-                    // Get parent table for the feature type
-                    if ( tableLayerName
-                        && DataTable.isDataTable( $(this) )
-                        && lizMap.cleanName( featureType ) == tableLayerName
-                    ){
-
+                if( pages == 1 ) {
+                    // avoid server call and select features on client side
+                    // Add filtered features
+                    var tableLayerName = $(table).parents('div.dt-container:first').prev('input.attribute-table-hidden-layer').val();
+                    if( lizMap.cleanName( featureType ) == tableLayerName ) {
                         var sIds = [];
-                        let rTable = new DataTable.Api(this);
-                        var filteredrowids = rTable.rows( {"filter":"applied"} ).ids();
+                        //let rTable = new DataTable.Api(this);
+                        var filteredrowids = eTable.rows( {"filter":"applied"} ).ids();
                         for ( var i = 0; i < filteredrowids.length; i++ ) {
                             sIds.push( filteredrowids[i] );
                         }
                         config.layers[featureType]['selectedFeatures'] = sIds;
                         hasChanged = true;
                     }
-                })
+                } else if(pages > 1) {
+                    // call server
+                    const datatablesUrl = globalThis['lizUrls'].wms.replace('service', 'datatables/selectFilteredFeatures');
+                    const params = {...globalThis['lizUrls'].params};
+                    params['layerId'] = config.attributeLayers[featureType].layerId;
+
+                    // Using the same parameters as the search builder ensures that the selection
+                    // is consistent with the filtered features.
+                    const selectedFeaturesResponse = await fetch(datatablesUrl + '?' + new URLSearchParams(params).toString(),{
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json;charset=utf-8'
+                        },
+                        body: JSON.stringify({...eTable.ajax.params()})
+                    })
+
+                    if (!selectedFeaturesResponse.ok) return;
+                    const featuresR = await selectedFeaturesResponse.json();
+
+                    const features = (new lizMap.ol.format.GeoJSON()).readFeatures(featuresR);
+
+                    // Array of feature ids matching geometry condition
+                    let featureIds = features.map(feature => feature.getId().split('.')[1]);
+                    featureIds = config.layers[featureType]['selectedFeatures'].concat(featureIds);
+                    featureIds = [...new Set(featureIds)];
+
+                    config.layers[featureType]['selectedFeatures'] = featureIds;
+                    hasChanged = true;
+                }
 
                 if( hasChanged ){
                     lizMap.events.triggerEvent("layerSelectionChanged",

--- a/lizmap/modules/lizmap/controllers/datatables.classic.php
+++ b/lizmap/modules/lizmap/controllers/datatables.classic.php
@@ -47,12 +47,12 @@ class datatablesCtrl extends jController
     private $DTLength;
 
     /**
-     * @var null|array Array of columns order
+     * @var mixed Array of columns order
      */
     private $DTOrder;
 
     /**
-     * @var null|array Array of columns name
+     * @var mixed Array of columns name
      */
     private $DTColumns;
 

--- a/lizmap/modules/lizmap/controllers/datatables.classic.php
+++ b/lizmap/modules/lizmap/controllers/datatables.classic.php
@@ -12,6 +12,7 @@
  */
 
 use GuzzleHttp\Psr7\StreamWrapper as Psr7StreamWrapper;
+use GuzzleHttp\Psr7\Utils as Psr7Utils;
 use JsonMachine\Items as JsonMachineItems;
 use Lizmap\DataTables\DataTables;
 use Lizmap\Project\UnknownLizmapProjectException;
@@ -20,6 +21,66 @@ use Lizmap\Request\WFSRequest;
 
 class datatablesCtrl extends jController
 {
+    /**
+     * @var null|string The repository key string
+     */
+    private $repository;
+
+    /**
+     * @var null|string The qgis project key
+     */
+    private $project;
+
+    /**
+     * @var null|string The layer id
+     */
+    private $layerId;
+
+    /**
+     * @var null|string Pagination start
+     */
+    private $DTStart;
+
+    /**
+     * @var null|string Number of features per page
+     */
+    private $DTLength;
+
+    /**
+     * @var null|array Array of columns order
+     */
+    private $DTOrder;
+
+    /**
+     * @var null|array Array of columns name
+     */
+    private $DTColumns;
+
+    /**
+     * @var null|array Array of search builder condition criteria
+     */
+    private $DTSearchBuilder;
+
+    /**
+     * @var null|string srs code
+     */
+    private $srsName;
+
+    /**
+     * @var array bbox array
+     */
+    private $bbox;
+
+    /**
+     * @var array Array of filtered features ids
+     */
+    private $filteredFeatureIDs;
+
+    /**
+     * @var null|string WFS expression filter
+     */
+    private $expFilter;
+
     /**
      * Sets the error in the provided response object based on the given HTTP error code.
      *
@@ -41,93 +102,111 @@ class datatablesCtrl extends jController
         return $rep;
     }
 
+    /**
+     * Assign values to class instance property.
+     */
+    private function initClassProperties()
+    {
+        $this->repository = $this->param('repository');
+        $this->project = $this->param('project');
+        $this->layerId = $this->param('layerId');
+        $this->DTStart = $this->param('start');
+        $this->DTLength = $this->param('length');
+        $this->DTOrder = $this->param('order');
+        $this->DTColumns = $this->param('columns');
+        $this->DTSearchBuilder = $this->param('searchBuilder');
+        $this->filteredFeatureIDs = $this->param('filteredfeatureids') ? explode(',', $this->param('filteredfeatureids')) : array();
+        $this->srsName = $this->param('srsname');
+        $this->bbox = $this->param('bbox') && $this->srsName ? explode(',', $this->param('bbox')) : array();
+        $this->expFilter = $this->getExpFilter();
+    }
+
+    /**
+     * Return expression filter parameter.
+     *
+     * @return null|string
+     */
+    private function getExpFilter()
+    {
+        $expFilter = $this->param('exp_filter');
+        if (count($this->filteredFeatureIDs) > 0) {
+            $filteredFeatureIDSFilter = '$id IN ('.implode(' , ', $this->filteredFeatureIDs).')';
+            // concat current exp_filter with filteredFeaturesIds filter
+            $expFilter = !$expFilter ? $filteredFeatureIDSFilter : "( {$expFilter} ) AND ( {$filteredFeatureIDSFilter} )";
+        }
+
+        // Handle search made by searchBuilder
+        if ($this->DTSearchBuilder) {
+            $searchBuilderFilter = DataTables::convertSearchToExpression($this->DTSearchBuilder);
+            // concat current exp_filter with searchBuilderFilter filter
+            $expFilter = !$expFilter ? $searchBuilderFilter : "( {$expFilter} ) AND ( {$searchBuilderFilter} )";
+        }
+
+        return $expFilter;
+
+    }
+
     public function index()
     {
         /** @var jResponseJson $rep */
         $rep = $this->getResponse('json');
 
         // Lizmap parameters
-        $repository = $this->param('repository');
-        $project = $this->param('project');
-        $layerId = $this->param('layerId');
+        $this->initClassProperties();
 
-        if (!$repository || !$project || !$layerId) {
+        if (!$this->repository || !$this->project || !$this->layerId) {
             return $this->setErrorResponse($rep, 400, 'The parameters repository, project and layerId are mandatory.');
         }
 
-        // DataTables parameters
-        $DTStart = $this->param('start');
-        $DTLength = $this->param('length');
-        $DTOrder = $this->param('order');
-        $DTColumns = $this->param('columns');
-
         // Check DataTables parameters
-        if (!isset($DTStart) || !isset($DTLength) || !isset($DTOrder) || !isset($DTColumns)) {
+        if (!isset($this->DTStart) || !isset($this->DTLength) || !isset($this->DTOrder) || !isset($this->DTColumns)) {
             return $this->setErrorResponse($rep, 400, 'The DataTables parameters start, length'.
             ', order and columns are mandatory.');
         }
-        if (!is_array($DTOrder) || count($DTOrder) == 0 || !array_key_exists(0, $DTOrder)
-            || !array_key_exists('column', $DTOrder[0]) || !array_key_exists('dir', $DTOrder[0])) {
-            return $this->setErrorResponse($rep, 400, 'The DataTables parameter order '.json_encode($DTOrder).
-            ' is not well formed.');
-        }
-        if (!is_array($DTColumns) || count($DTColumns) == 0) {
-            return $this->setErrorResponse($rep, 400, 'The DataTables parameter columns '.json_encode($DTColumns).
+
+        if (!is_array($this->DTOrder) || count($this->DTOrder) == 0 || !array_key_exists(0, $this->DTOrder)
+            || !array_key_exists('column', $this->DTOrder[0]) || !array_key_exists('dir', $this->DTOrder[0])) {
+            return $this->setErrorResponse($rep, 400, 'The DataTables parameter order '.json_encode($this->DTOrder).
             ' is not well formed.');
         }
 
-        // Extract info for DataTables parameters
-        $DTOrderColumnIndex = $DTOrder[0]['column'];
-        $DTOrderColumnDirection = $DTOrder[0]['dir'] == 'desc' ? 'DESC' : 'ASC';
-        if (!array_key_exists($DTOrderColumnIndex, $DTColumns)) {
-            return $this->setErrorResponse($rep, 400, 'The DataTables parameters order and columns are not compatible.');
-        }
-        if (!array_key_exists('data', $DTColumns[$DTOrderColumnIndex])) {
-            return $this->setErrorResponse($rep, 400, 'The DataTables parameter columns '.json_encode($DTColumns).
+        if (!is_array($this->DTColumns) || count($this->DTColumns) == 0) {
+            return $this->setErrorResponse($rep, 400, 'The DataTables parameter columns '.json_encode($this->DTColumns).
             ' is not well formed.');
-        }
-        $DTOrderColumnName = $DTColumns[$DTOrderColumnIndex]['data'];
-
-        $DTSearchBuilder = '';
-        if ($this->param('searchBuilder')) {
-            $DTSearchBuilder = $this->param('searchBuilder');
-        }
-
-        $filteredFeatureIDs = array();
-        if ($this->param('filteredfeatureids')) {
-            $filteredFeatureIDs = explode(',', $this->param('filteredfeatureids'));
-        }
-        $expFilter = $this->param('exp_filter');
-
-        // Filter by bounding box
-        $bbox = array();
-        $srsName = $this->param('srsname');
-        if ($this->param('bbox') && $srsName) {
-            $bbox = explode(',', $this->param('bbox'));
         }
 
         // Check if when the bbox is defined, it contains 4 number
-        if (count($bbox) > 0 && count($bbox) != 4) {
+        if (count($this->bbox) > 0 && count($this->bbox) != 4) {
             return $this->setErrorResponse($rep, 400, 'The bbox parameter must contain 4 numbers separated by a comma.');
         }
 
+        // Extract info for DataTables parameters
+        $DTOrderColumnIndex = $this->DTOrder[0]['column'];
+        $DTOrderColumnDirection = $this->DTOrder[0]['dir'] == 'desc' ? 'DESC' : 'ASC';
+        if (!array_key_exists($DTOrderColumnIndex, $this->DTColumns)) {
+            return $this->setErrorResponse($rep, 400, 'The DataTables parameters order and columns are not compatible.');
+        }
+        if (!array_key_exists('data', $this->DTColumns[$DTOrderColumnIndex])) {
+            return $this->setErrorResponse($rep, 400, 'The DataTables parameter columns '.json_encode($this->DTColumns).
+            ' is not well formed.');
+        }
+        $DTOrderColumnName = $this->DTColumns[$DTOrderColumnIndex]['data'];
+
         try {
-            $lproj = lizmap::getProject($repository.'~'.$project);
+            $lproj = lizmap::getProject($this->repository.'~'.$this->project);
             if (!$lproj) {
-                return $this->setErrorResponse($rep, 404, 'The lizmap project '.$repository.'~'.$project.' does not exist.');
+                return $this->setErrorResponse($rep, 404, 'The lizmap project '.$this->repository.'~'.$this->project.' does not exist.');
             }
         } catch (UnknownLizmapProjectException $e) {
-            return $this->setErrorResponse($rep, 404, 'The lizmap project '.$repository.'~'.$project.' does not exist.');
+            return $this->setErrorResponse($rep, 404, 'The lizmap project '.$this->repository.'~'.$this->project.' does not exist.');
         }
 
         /** @var null|qgisVectorLayer $layer */
-        $layer = $lproj->getLayer($layerId);
+        $layer = $lproj->getLayer($this->layerId);
         if (!$layer) {
-            return $this->setErrorResponse($rep, 404, 'The layerId '.$layerId.' does not exist.');
+            return $this->setErrorResponse($rep, 404, 'The layerId '.$this->layerId.' does not exist.');
         }
         $typeName = $layer->getWfsTypeName();
-
-        $jsonFeatures = array();
 
         $wfsParamsData = WFSRequest::buildGetFeatureParameters($typeName);
 
@@ -153,38 +232,25 @@ class datatablesCtrl extends jController
 
         $hits = $hitsData->numberOfFeatures;
         $recordsFiltered = $hits;
-        if (count($filteredFeatureIDs) > 0) {
-            $recordsFiltered = count($filteredFeatureIDs);
+        if (count($this->filteredFeatureIDs) > 0) {
+            $recordsFiltered = count($this->filteredFeatureIDs);
         }
 
-        if (count($filteredFeatureIDs) > 0) {
-            $filteredFeatureIDSFilter = '$id IN ('.implode(' , ', $filteredFeatureIDs).')';
-            // concat current exp_filter with filteredFeaturesIds filter
-            $expFilter = !$expFilter ? $filteredFeatureIDSFilter : "( {$expFilter} ) AND ( {$filteredFeatureIDSFilter} )";
-        }
-
-        // Handle search made by searchBuilder
-        if ($DTSearchBuilder) {
-            $searchBuilderFilter = DataTables::convertSearchToExpression($DTSearchBuilder);
-            // concat current exp_filter with searchBuilderFilter filter
-            $expFilter = !$expFilter ? $searchBuilderFilter : "( {$expFilter} ) AND ( {$searchBuilderFilter} )";
-        }
-
-        if ($expFilter) {
-            $wfsParamsData['EXP_FILTER'] = $expFilter;
+        if ($this->expFilter) {
+            $wfsParamsData['EXP_FILTER'] = $this->expFilter;
         }
 
         // Handle filter by extent
-        if (count($bbox) == 4) {
+        if (count($this->bbox) == 4) {
             // Add parameters to get features in the bounding box (paginated)
-            $bboxString = implode(',', $bbox);
+            $bboxString = implode(',', $this->bbox);
             $wfsParamsData['BBOX'] = $bboxString;
-            $wfsParamsData['SRSNAME'] = $srsName;
+            $wfsParamsData['SRSNAME'] = $this->srsName;
         }
 
         $wfsParamsPaginated = array(
-            'MAXFEATURES' => $DTLength,
-            'STARTINDEX' => $DTStart,
+            'MAXFEATURES' => $this->DTLength,
+            'STARTINDEX' => $this->DTStart,
             'SORTBY' => $DTOrderColumnName.' '.$DTOrderColumnDirection,
         );
         // Get paginated features by a WFS resquest
@@ -202,7 +268,7 @@ class datatablesCtrl extends jController
         $featureData = $wfsresponse->getBodyAsString();
 
         // Get hits when data is filtered
-        if ($expFilter || count($bbox) == 4) {
+        if ($this->expFilter || count($this->bbox) == 4) {
 
             $wfsrequest = new WFSRequest($lproj, array_merge($wfsParamsData, $wfsParamsHits), lizmap::getServices());
             $wfsresponse = $wfsrequest->process();
@@ -260,49 +326,30 @@ class datatablesCtrl extends jController
         $rep = $this->getResponse('json');
 
         // Lizmap parameters
-        $repository = $this->param('repository');
-        $project = $this->param('project');
-        $layerId = $this->param('layerId');
+        $this->initClassProperties();
 
-        if (!$repository || !$project || !$layerId) {
+        if (!$this->repository || !$this->project || !$this->layerId) {
             return $this->setErrorResponse($rep, 400, 'The parameters repository, project and layerId are mandatory.');
-        }
-        $DTSearchBuilder = '';
-        if ($this->param('searchBuilder')) {
-            $DTSearchBuilder = $this->param('searchBuilder');
-        }
-
-        $filteredFeatureIDs = array();
-        if ($this->param('filteredfeatureids')) {
-            $filteredFeatureIDs = explode(',', $this->param('filteredfeatureids'));
-        }
-        $expFilter = $this->param('exp_filter');
-
-        // Filter by bounding box
-        $bbox = array();
-        $srsName = $this->param('srsname');
-        if ($this->param('bbox') && $srsName) {
-            $bbox = explode(',', $this->param('bbox'));
         }
 
         // Check if when the bbox is defined, it contains 4 number
-        if (count($bbox) > 0 && count($bbox) != 4) {
+        if (count($this->bbox) > 0 && count($this->bbox) != 4) {
             return $this->setErrorResponse($rep, 400, 'The bbox parameter must contain 4 numbers separated by a comma.');
         }
 
         try {
-            $lproj = lizmap::getProject($repository.'~'.$project);
+            $lproj = lizmap::getProject($this->repository.'~'.$this->project);
             if (!$lproj) {
-                return $this->setErrorResponse($rep, 404, 'The lizmap project '.$repository.'~'.$project.' does not exist.');
+                return $this->setErrorResponse($rep, 404, 'The lizmap project '.$this->repository.'~'.$this->project.' does not exist.');
             }
         } catch (UnknownLizmapProjectException $e) {
-            return $this->setErrorResponse($rep, 404, 'The lizmap project '.$repository.'~'.$project.' does not exist.');
+            return $this->setErrorResponse($rep, 404, 'The lizmap project '.$this->repository.'~'.$this->project.' does not exist.');
         }
 
         /** @var null|qgisVectorLayer $layer */
-        $layer = $lproj->getLayer($layerId);
+        $layer = $lproj->getLayer($this->layerId);
         if (!$layer) {
-            return $this->setErrorResponse($rep, 404, 'The layerId '.$layerId.' does not exist.');
+            return $this->setErrorResponse($rep, 404, 'The layerId '.$this->layerId.' does not exist.');
         }
 
         // filter project layers to get geometry type
@@ -321,29 +368,16 @@ class datatablesCtrl extends jController
 
         $wfsParamsData = WFSRequest::buildGetFeatureParameters($typeName);
 
-        if (count($filteredFeatureIDs) > 0) {
-            $filteredFeatureIDSFilter = '$id IN ('.implode(' , ', $filteredFeatureIDs).')';
-            // concat current exp_filter with filteredFeaturesIds filter
-            $expFilter = !$expFilter ? $filteredFeatureIDSFilter : "( {$expFilter} ) AND ( {$filteredFeatureIDSFilter} )";
-        }
-
-        // Handle search made by searchBuilder
-        if ($DTSearchBuilder) {
-            $searchBuilderFilter = DataTables::convertSearchToExpression($DTSearchBuilder);
-            // concat current exp_filter with searchBuilderFilter filter
-            $expFilter = !$expFilter ? $searchBuilderFilter : "( {$expFilter} ) AND ( {$searchBuilderFilter} )";
-        }
-
-        if ($expFilter) {
-            $wfsParamsData['EXP_FILTER'] = $expFilter;
+        if ($this->expFilter) {
+            $wfsParamsData['EXP_FILTER'] = $this->expFilter;
         }
 
         // Handle filter by extent
-        if (count($bbox) == 4) {
-            // Add parameters to get features in the bounding box (paginated)
-            $bboxString = implode(',', $bbox);
+        if (count($this->bbox) == 4) {
+            // Add parameters to get features in the bounding box
+            $bboxString = implode(',', $this->bbox);
             $wfsParamsData['BBOX'] = $bboxString;
-            $wfsParamsData['SRSNAME'] = $srsName;
+            $wfsParamsData['SRSNAME'] = $this->srsName;
         }
 
         // if the geometry is not of type point, request the geometry extent,
@@ -424,5 +458,81 @@ class datatablesCtrl extends jController
         $rep->data = $finalExtent;
 
         return $rep;
+    }
+
+    /**
+     * Returns all features corresponding to the searching parameters, ignoring pagination.
+     *
+     * @return jResponseBinary|jResponseJson
+     */
+    public function selectFilteredFeatures()
+    {
+
+        /** @var jResponseJson $rep */
+        $rep = $this->getResponse('json');
+
+        // Lizmap parameters
+        $this->initClassProperties();
+
+        if (!$this->repository || !$this->project || !$this->layerId) {
+            return $this->setErrorResponse($rep, 400, 'The parameters repository, project and layerId are mandatory.');
+        }
+
+        // Check if when the bbox is defined, it contains 4 number
+        if (count($this->bbox) > 0 && count($this->bbox) != 4) {
+            return $this->setErrorResponse($rep, 400, 'The bbox parameter must contain 4 numbers separated by a comma.');
+        }
+
+        try {
+            $lproj = lizmap::getProject($this->repository.'~'.$this->project);
+            if (!$lproj) {
+                return $this->setErrorResponse($rep, 404, 'The lizmap project '.$this->repository.'~'.$this->project.' does not exist.');
+            }
+        } catch (UnknownLizmapProjectException $e) {
+            return $this->setErrorResponse($rep, 404, 'The lizmap project '.$this->repository.'~'.$this->project.' does not exist.');
+        }
+
+        /** @var null|qgisVectorLayer $layer */
+        $layer = $lproj->getLayer($this->layerId);
+        if (!$layer) {
+            return $this->setErrorResponse($rep, 404, 'The layerId '.$this->layerId.' does not exist.');
+        }
+
+        $typeName = $layer->getWfsTypeName();
+
+        $wfsParamsData = WFSRequest::buildGetFeatureParameters($typeName);
+
+        if ($this->expFilter) {
+            $wfsParamsData['EXP_FILTER'] = $this->expFilter;
+        }
+
+        // Handle filter by extent
+        if (count($this->bbox) == 4) {
+            // Add parameters to get features in the bounding box (paginated)
+            $bboxString = implode(',', $this->bbox);
+            $wfsParamsData['BBOX'] = $bboxString;
+            $wfsParamsData['SRSNAME'] = $this->srsName;
+        }
+
+        $wfsrequest = new WFSRequest($lproj, $wfsParamsData, lizmap::getServices());
+        $wfsresponse = $wfsrequest->process();
+
+        if ($wfsresponse->getCode() >= 400) {
+            return $this->setErrorResponse($rep, 400, 'The request to get paginated features failed, code: '.$wfsresponse->getCode());
+        }
+        if (!str_contains(strtolower($wfsresponse->getMime()), 'application/vnd.geo+json')) {
+            return $this->setErrorResponse($rep, 400, 'The request to get paginated features failed, mime-type: '.$wfsresponse->getMime());
+        }
+
+        /** @var jResponseBinary $binaryRep */
+        $binaryRep = $this->getResponse('binary');
+        $binaryRep->mimeType = 'application/json';
+
+        $binaryRep->setContentCallback(function () use ($wfsresponse) {
+            $output = Psr7Utils::streamFor(fopen('php://output', 'w+'));
+            Psr7Utils::copyToStream($wfsresponse->getBodyAsStream(), $output);
+        });
+
+        return $binaryRep;
     }
 }

--- a/lizmap/modules/view/locales/en_US/dictionnary.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/dictionnary.UTF-8.properties
@@ -125,6 +125,7 @@ attributeLayers.toolbar.cb.data.detail.title=Display info
 attributeLayers.toolbar.input.search.title=Search
 attributeLayers.toolbar.btn.fit.filtered.extent.title=Zoom to filtered features extent
 attributeLayers.toolbar.btn.select.searched.title=Select searched line
+attributeLayers.toolbar.btn.select.searched.warn=You are about to select more than a 1000 features. This may take a few seconds to process. Are you sure you want to proceed?
 attributeLayers.toolbar.btn.data.unselect.title=Unselect all
 attributeLayers.toolbar.btn.data.moveselectedtotop.title=Display selection only
 attributeLayers.toolbar.btn.data.filter.title=Filter

--- a/tests/end2end/playwright/attribute-table.spec.js
+++ b/tests/end2end/playwright/attribute-table.spec.js
@@ -735,6 +735,32 @@ test.describe('Attribute table @readonly', () => {
 
         requestExpect(getSelectionTokenRequest).toContainParametersInPostData(getSelectionTokenParameters);
         expect(tableHtml.locator('tbody tr.selected')).toHaveCount(50);
+
+        // empty filters and try to select the whole dataset
+        await project.attributeTableActionBar(tableName).locator('.btn-unselect-attributeTable').click();
+
+        // clear filters
+        datatablesRequestPromise = project.waitForDatatablesRequest();
+        await project.openSearchBuilderPanel(tableName, true);
+        datatablesRequest = await datatablesRequestPromise;
+        datatablesResponse = await datatablesRequest.response();
+        responseExpect(datatablesResponse).toBeJson();
+        await expect(project.attributeTableWrapper(tableName).locator('div.dt-info'))
+            .toContainText('Showing 1 to 50 of 5,000 entries');
+        // close panel
+        await project.searchBuilderClosePanel(tableName);
+
+        let dialogPromped = false;
+        page.once('dialog', dialog => {
+            expect(dialog.message()).toBe("You are about to select more than a 1000 features. This may take a few seconds to process. Are you sure you want to proceed?");
+            dialogPromped = true;
+            return dialog.accept()
+        });
+        getSelectionTokenRequestPromise = project.waitForGetSelectionTokenRequest();
+        await project.attributeTableActionBar(tableName).locator('.btn-select-searched').click();
+        expect(dialogPromped).toBeTruthy();
+        getSelectionTokenRequest = await getSelectionTokenRequestPromise;
+        await getSelectionTokenRequest.response();
     });
 
     test('Thumbnail class generate img with good path', async ({ page }) => {

--- a/tests/end2end/playwright/attribute-table.spec.js
+++ b/tests/end2end/playwright/attribute-table.spec.js
@@ -669,11 +669,11 @@ test.describe('Attribute table @readonly', () => {
     });
 
     test('Should select all filtered results', async ({ page }) => {
-        const project = new ProjectPage(page, 'attribute_table');
+        const project = new ProjectPage(page, 'huge_attribute_table');
         await project.open();
 
-        const tableName = 'quartiers_shp';
-        const typeName = 'quartiers_shp';
+        const tableName = 'huge_table';
+        const typeName = 'huge_table';
 
         let datatablesRequest = await project.openAttributeTable(tableName);
         let datatablesResponse = await datatablesRequest.response();
@@ -681,7 +681,40 @@ test.describe('Attribute table @readonly', () => {
         let tableHtml = project.attributeTableHtml(tableName);
 
         // Check table lines
-        await expect(tableHtml.locator('tbody tr')).toHaveCount(7);
+        await expect(tableHtml.locator('tbody tr')).toHaveCount(50);
+        await project.openSearchBuilderPanel(tableName, true);
+
+        // add blank criteria and check fields existance
+        await project.addSearchBuilderCriterion(tableName);
+        const firstCriteria = await project.getSearchBuilderCriterion(tableName, 0);
+
+        // select the field to filter
+        await project.selectSearchBuilderData(firstCriteria, 'Large lookup');
+
+        // select a condition
+        await project.selectSearchBuilderCondition(firstCriteria,'=');
+
+        const typeAHeadElement = firstCriteria.locator('.dtsb-inputCont lizmap-typeahead');
+
+        // check if the input is instance of lizmap-typeahead component
+        await expect(typeAHeadElement).toHaveCount(1);
+
+        // fill typeahead input
+        await project.fillTypeAHeadInput(typeAHeadElement ,'Eurasian Collared-Dove');
+
+        // select a value from available typeahead options
+        await project.selectTypeAHeadOption(typeAHeadElement, '18', 'Eurasian Collared-Dove');
+
+        // launch search and check results
+        let datatablesRequestPromise = project.waitForDatatablesRequest();
+        await project.searchBuilderLaunchSearch(tableName);
+        datatablesRequest = await datatablesRequestPromise;
+        datatablesResponse = await datatablesRequest.response();
+        responseExpect(datatablesResponse).toBeJson();
+        await expect(project.attributeTableWrapper(tableName).locator('div.dt-info'))
+            .toContainText('Showing 1 to 50 of 69 entries (filtered from 5,000 total entries)');
+        // close panel
+        await project.searchBuilderClosePanel(tableName);
 
         // click on select-searched button to select all records
         let getSelectionTokenRequestPromise = project.waitForGetSelectionTokenRequest();
@@ -694,11 +727,14 @@ test.describe('Attribute table @readonly', () => {
             'service': 'WMS',
             'request': 'GETSELECTIONTOKEN',
             'typename': typeName,
-            'ids': '2,6,0,4,3,1,5',
+            'ids': '157,241,330,349,386,490,957,1027,1062,1201,1246,1306,1369,1410,1491,1631,1642,1693,'+
+                    '1831,1837,1853,1950,2000,2014,2035,2124,2233,2355,2376,2409,2435,2460,2482,2513,2754,2778,'+
+                    '2799,2843,2908,3348,3354,3355,3391,3414,3519,3537,3593,3631,3650,3708,3718,3764,3840,3902,3965,'+
+                    '4106,4174,4192,4261,4275,4329,4415,4556,4730,4763,4831,4920,4944,4958',
         }
 
         requestExpect(getSelectionTokenRequest).toContainParametersInPostData(getSelectionTokenParameters);
-        expect(tableHtml.locator('tbody tr.selected')).toHaveCount(7);
+        expect(tableHtml.locator('tbody tr.selected')).toHaveCount(50);
     });
 
     test('Thumbnail class generate img with good path', async ({ page }) => {

--- a/tests/end2end/playwright/requests-datatables.spec.js
+++ b/tests/end2end/playwright/requests-datatables.spec.js
@@ -1080,4 +1080,113 @@ test.describe('Datables Requests @requests @readonly', () => {
         expect(body).toHaveProperty('code', 'Not Found');
         expect(body).toHaveProperty('message', 'Invalid geometry');
     });
+
+    test('Select datatables filtered features request', async({ request }) => {
+        // Simple datatable request
+        let params = new URLSearchParams({
+            repository: 'testsrepository',
+            project: 'huge_attribute_table',
+            layerId: 'huge_table_3a6c5511_aa6a_43fe_957e_e2c3f5b0a085',
+        });
+        let url = `/index.php/lizmap/datatables/selectFilteredFeatures?${params}`;
+        let response = await request.post(url, {
+            data: {
+                start: 0,
+                length: 50,
+                columns: [
+                    {'data': 'lizSelected'},
+                    {'data': 'featureToolbar'},
+                    {'data': 'id'},
+                    {'data': 'lookup_1'},
+                ],
+                order: [{'column': 2, 'dir': 'asc'}],
+                searchBuilder: {
+                    criteria: [
+                        {'condition': '=', 'data': 'Large lookup', 'origData': 'lookup_1', 'value1': '18', 'type': 'string'},
+                    ],
+                    logic: 'AND',
+                },
+            }
+        });
+
+        let body = await checkJson(response, 200);
+        expect(body).toHaveProperty('type', 'FeatureCollection');
+        expect(body).toHaveProperty('features');
+        expect(body.features).toHaveLength(69);
+        /** @type {any[]} */
+        let features = body.features;
+        expect(features.map(feat => feat.id.split('.')[1])).toStrictEqual(
+            [
+                "157",
+                "241",
+                "330",
+                "349",
+                "386",
+                "490",
+                "957",
+                "1027",
+                "1062",
+                "1201",
+                "1246",
+                "1306",
+                "1369",
+                "1410",
+                "1491",
+                "1631",
+                "1642",
+                "1693",
+                "1831",
+                "1837",
+                "1853",
+                "1950",
+                "2000",
+                "2014",
+                "2035",
+                "2124",
+                "2233",
+                "2355",
+                "2376",
+                "2409",
+                "2435",
+                "2460",
+                "2482",
+                "2513",
+                "2754",
+                "2778",
+                "2799",
+                "2843",
+                "2908",
+                "3348",
+                "3354",
+                "3355",
+                "3391",
+                "3414",
+                "3519",
+                "3537",
+                "3593",
+                "3631",
+                "3650",
+                "3708",
+                "3718",
+                "3764",
+                "3840",
+                "3902",
+                "3965",
+                "4106",
+                "4174",
+                "4192",
+                "4261",
+                "4275",
+                "4329",
+                "4415",
+                "4556",
+                "4730",
+                "4763",
+                "4831",
+                "4920",
+                "4944",
+                "4958"
+            ]
+        );
+    })
 });


### PR DESCRIPTION
Following  https://github.com/3liz/lizmap-web-client/pull/6601, this PR aims to follow the logical thread of server-side rendering of the attribute table. When a user wants to select all the filtered features, logically, in my opinion, this also means selecting the records that aren't rendered on the current page.


**FACT**

This can inevitably lead to the selection of many records. I believe this is the correct behavior from a logical standpoint. What can be done is to control the interface behavior so that it's possible to prevent the selection of many records if they exceed a certain (arbitrary) number, or to prompt the user for confirmation before proceeding with the selection.

What do you think?

Backport 3.10

Funded by Faunalia
