### PR TITLE
Fix print layout order to respect cfg configuration

### DIFF
--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -1984,6 +1984,8 @@ class Project
         $server = new Server();
         $serverMetadata = $server->getMetadata();
         $serverPlugins = $serverMetadata['qgis_server_info']['plugins'];
+        // Build a lookup of print templates by title
+        $printTemplatesByTitle = array();
         foreach ($this->printCapabilities as $printTemplate) {
             /** @var array $printTemplate */
             if ($serverPlugins['atlasprint']['version'] == 'not found'
@@ -1995,8 +1997,24 @@ class Project
             }
             if ($enabledLayoutNames === null
                 || in_array($printTemplate['title'], $enabledLayoutNames)) {
-                $configJson->printTemplates[] = $printTemplate;
+                $printTemplatesByTitle[$printTemplate['title']] = $printTemplate;
             }
+        }
+        // Order printTemplates to match the layouts.list order from the cfg
+        if ($enabledLayoutNames !== null) {
+            foreach ($enabledLayoutNames as $layoutName) {
+                if (array_key_exists($layoutName, $printTemplatesByTitle)) {
+                    $configJson->printTemplates[] = $printTemplatesByTitle[$layoutName];
+                }
+            }
+            // Append any templates not in the cfg (e.g. atlas-only templates filtered above)
+            foreach ($printTemplatesByTitle as $title => $tmpl) {
+                if (!in_array($title, $enabledLayoutNames)) {
+                    $configJson->printTemplates[] = $tmpl;
+                }
+            }
+        } else {
+            $configJson->printTemplates = array_values($printTemplatesByTitle);
         }
 
         // Add export layer right

--- a/tests/end2end/playwright/print.spec.js
+++ b/tests/end2end/playwright/print.spec.js
@@ -34,9 +34,9 @@ test.describe('Print', () => {
         await expect(page.locator('#print-scale > option')).toHaveCount(6);
         await expect(page.locator('#print-scale > option')).toContainText(
             ['500,000', '250,000', '100,000', '50,000', '25,000', '10,000']);
-        // Templates
+        // Templates - order must match layouts.list order in cfg
         await expect(page.locator('#print-template > option')).toHaveCount(3);
-        await expect(page.locator('#print-template > option')).toContainText(['print_labels', 'print_map']);
+        await expect(page.locator('#print-template > option')).toHaveText(['print_labels', 'print_overview', 'print_map']);
 
         // Test `print_labels` template
 
@@ -45,7 +45,7 @@ test.describe('Print', () => {
         await expect(page.locator('.print-dpi')).toHaveCount(0);
 
         // Test `print_map` template
-        await page.locator('#print-template').selectOption('1');
+        await page.locator('#print-template').selectOption('2');
 
         // Format and DPI lists exist as there are multiple values
         await expect(page.locator('#print-format > option')).toHaveCount(2);
@@ -53,7 +53,7 @@ test.describe('Print', () => {
         await expect(page.locator('.btn-print-dpis > option')).toHaveCount(2);
         await expect(page.locator('.btn-print-dpis > option')).toContainText(['100', '200']);
 
-        // PNG is default
+        // JPEG is default
         expect(await page.locator('#print-format').inputValue()).toBe('jpeg');
         // 200 DPI is default
         expect(await page.locator('.btn-print-dpis').inputValue()).toBe('200');
@@ -100,37 +100,8 @@ test.describe('Print', () => {
             name, getPrintRequest.postData() ?? '', expectedParameters1);
         await expectToHaveLengthCompare(name, Array.from(getPrintParams.keys()), expectedLength, Object.keys(expectedParameters1));
 
-        // Test `print_map` template
-        await page.locator('#print-template').selectOption('1');
-
-        getPrintPromise = page.waitForRequest(
-            request =>
-                request.method() === 'POST' &&
-                request.postData()?.includes('GetPrint') === true
-        );
-        await page.locator('#print-launch').click();
-        getPrintRequest = await getPrintPromise;
-        // Extend and update GetPrint parameters
-        const expectedParameters2 = Object.assign({}, expectedParameters, {
-            'FORMAT': 'jpeg',
-            'DPI': '200',
-            'TEMPLATE': 'print_map',
-            'map0:EXTENT': /765699.\d+,6271792.\d+,775499.\d+,6286992.\d+/,
-            'map0:SCALE': '100000',
-            'map0:LAYERS': 'OpenStreetMap,quartiers,sousquartiers',
-            'map0:STYLES': 'default,défaut,défaut',
-            'map0:OPACITIES': '204,255,255',
-        })
-        name = 'Print requests 2';
-        getPrintParams = await expectParametersToContain(name, getPrintRequest.postData() ?? '', expectedParameters2);
-        await expectToHaveLengthCompare(
-            name,
-            Array.from(getPrintParams.keys()),
-            13, Object.keys(expectedParameters2)
-        );
-
         // Test `print_overview` template
-        await page.locator('#print-template').selectOption('2');
+        await page.locator('#print-template').selectOption('1');
         getPrintPromise = page.waitForRequest(
             request =>
                 request.method() === 'POST' &&
@@ -152,13 +123,42 @@ test.describe('Print', () => {
             'map1:OPACITIES': '204,255,255',
             'map0:EXTENT': /761864.\d+,6274266.\d+,779334.\d+,6284518.\d+/,
         })
-        name = 'Print requests 3';
+        name = 'Print requests 2';
         getPrintParams = await expectParametersToContain(name, getPrintRequest.postData() ?? '', expectedParameters3);
         await expectToHaveLengthCompare(
             name,
             Array.from(getPrintParams.keys()),
             14,
             Object.keys(expectedParameters3)
+        );
+
+        // Test `print_map` template
+        await page.locator('#print-template').selectOption('2');
+
+        getPrintPromise = page.waitForRequest(
+            request =>
+                request.method() === 'POST' &&
+                request.postData()?.includes('GetPrint') === true
+        );
+        await page.locator('#print-launch').click();
+        getPrintRequest = await getPrintPromise;
+        // Extend and update GetPrint parameters
+        const expectedParameters2 = Object.assign({}, expectedParameters, {
+            'FORMAT': 'jpeg',
+            'DPI': '200',
+            'TEMPLATE': 'print_map',
+            'map0:EXTENT': /765699.\d+,6271792.\d+,775499.\d+,6286992.\d+/,
+            'map0:SCALE': '100000',
+            'map0:LAYERS': 'OpenStreetMap,quartiers,sousquartiers',
+            'map0:STYLES': 'default,défaut,défaut',
+            'map0:OPACITIES': '204,255,255',
+        })
+        name = 'Print requests 3';
+        getPrintParams = await expectParametersToContain(name, getPrintRequest.postData() ?? '', expectedParameters2);
+        await expectToHaveLengthCompare(
+            name,
+            Array.from(getPrintParams.keys()),
+            13, Object.keys(expectedParameters2)
         );
 
         // Redlining with circle
@@ -567,9 +567,9 @@ test.describe('Print - user in group a', () => {
     });
 
     test('Print UI', async ({ page }) => {
-        // Templates
+        // Templates - order must match layouts.list order in cfg
         await expect(page.locator('#print-template > option')).toHaveCount(3);
-        await expect(page.locator('#print-template > option')).toContainText(['print_labels', 'print_map']);
+        await expect(page.locator('#print-template > option')).toHaveText(['print_labels', 'print_overview', 'print_map']);
 
         // Test `print_labels` template
 
@@ -578,7 +578,7 @@ test.describe('Print - user in group a', () => {
         await expect(page.locator('.print-dpi')).toHaveCount(0);
 
         // Test `print_map` template
-        await page.locator('#print-template').selectOption('1');
+        await page.locator('#print-template').selectOption('2');
 
         // Format and DPI lists exist as there are multiple values
         await expect(page.locator('#print-format > option')).toHaveCount(2);
@@ -586,7 +586,7 @@ test.describe('Print - user in group a', () => {
         await expect(page.locator('.btn-print-dpis > option')).toHaveCount(2);
         await expect(page.locator('.btn-print-dpis > option')).toContainText(['100', '200']);
 
-        // PNG is default
+        // JPEG is default
         expect(await page.locator('#print-format').inputValue()).toBe('jpeg');
         // 200 DPI is default
         expect(await page.locator('.btn-print-dpis').inputValue()).toBe('200');
@@ -606,9 +606,9 @@ test.describe('Print - admin', () => {
     });
 
     test('Print UI', async ({ page }) => {
-        // Templates
+        // Templates - order must match layouts.list order in cfg
         await expect(page.locator('#print-template > option')).toHaveCount(4);
-        await expect(page.locator('#print-template > option')).toContainText(['print_labels', 'print_map', 'print_allowed_groups']);
+        await expect(page.locator('#print-template > option')).toHaveText(['print_labels', 'print_overview', 'print_map', 'print_allowed_groups']);
 
         // Test `print_labels` template
 
@@ -617,7 +617,7 @@ test.describe('Print - admin', () => {
         await expect(page.locator('.print-dpi')).toHaveCount(0);
 
         // Test `print_map` template
-        await page.locator('#print-template').selectOption('1');
+        await page.locator('#print-template').selectOption('2');
 
         // Format and DPI lists exist as there are multiple values
         await expect(page.locator('#print-format > option')).toHaveCount(2);
@@ -625,13 +625,13 @@ test.describe('Print - admin', () => {
         await expect(page.locator('.btn-print-dpis > option')).toHaveCount(2);
         await expect(page.locator('.btn-print-dpis > option')).toContainText(['100', '200']);
 
-        // PNG is default
+        // JPEG is default
         expect(await page.locator('#print-format').inputValue()).toBe('jpeg');
         // 200 DPI is default
         expect(await page.locator('.btn-print-dpis').inputValue()).toBe('200');
 
         // Test `print_allowed_groups` template
-        await page.locator('#print-template').selectOption('2');
+        await page.locator('#print-template').selectOption('3');
 
         // Format and DPI lists exist as there are multiple values
         await expect(page.locator('#print-format > option')).toHaveCount(4);
@@ -639,9 +639,9 @@ test.describe('Print - admin', () => {
         await expect(page.locator('.btn-print-dpis > option')).toHaveCount(3);
         await expect(page.locator('.btn-print-dpis > option')).toContainText(['100', '200', '300']);
 
-        // PNG is default
+        // PDF is default
         expect(await page.locator('#print-format').inputValue()).toBe('pdf');
-        // 200 DPI is default
+        // 100 DPI is default
         expect(await page.locator('.btn-print-dpis').inputValue()).toBe('100');
     });
 });

--- a/tests/end2end/playwright/requests-getprojectconfig.spec.js
+++ b/tests/end2end/playwright/requests-getprojectconfig.spec.js
@@ -604,6 +604,28 @@ test.describe('Request Lizmap GetProjectConfig - anonymous - @requests @readonly
             }
         });
         expect(body.printTemplates[1]).toMatchObject({
+            title: 'print_overview',
+            width: 297,
+            height: 210,
+            maps: [{
+                id: 'map0',
+                width: 46,
+                height: 44,
+                grid: false,
+                overviewMap: body.printTemplates[1].maps[1].uuid,
+            },{
+                id: 'map1',
+                width: 253,
+                height: 171,
+                grid: false,
+                overviewMap: null,
+            }],
+            labels: [],
+            atlas: {
+                enabled: false,
+            }
+        });
+        expect(body.printTemplates[2]).toMatchObject({
             title: 'print_map',
             width: 297,
             height: 210,
@@ -619,7 +641,7 @@ test.describe('Request Lizmap GetProjectConfig - anonymous - @requests @readonly
                 enabled: false,
             }
         });
-        expect(body.printTemplates[2]).toMatchObject({
+        expect(body.printTemplates[3]).toMatchObject({
             title: 'atlas_quartiers',
             width: 297,
             height: 210,
@@ -636,7 +658,7 @@ test.describe('Request Lizmap GetProjectConfig - anonymous - @requests @readonly
                 coverageLayer: body.layers.quartiers.id,
             }
         });
-        expect(body.printTemplates[3]).toMatchObject({
+        expect(body.printTemplates[4]).toMatchObject({
             title: 'atlas_sousquartiers',
             width: 297,
             height: 210,
@@ -653,28 +675,6 @@ test.describe('Request Lizmap GetProjectConfig - anonymous - @requests @readonly
                 coverageLayer: body.layers.sousquartiers.id,
             }
         });
-        expect(body.printTemplates[4]).toMatchObject({
-            title: 'print_overview',
-            width: 297,
-            height: 210,
-            maps: [{
-                id: 'map0',
-                width: 46,
-                height: 44,
-                grid: false,
-                overviewMap: body.printTemplates[4].maps[1].uuid,
-            },{
-                id: 'map1',
-                width: 253,
-                height: 171,
-                grid: false,
-                overviewMap: null,
-            }],
-            labels: [],
-            atlas: {
-                enabled: false,
-            }
-        });
 
         expect(body.layouts.config).toHaveProperty('default_popup_print', true);
         expect(body.layouts.list).not.toEqual([]);
@@ -688,6 +688,14 @@ test.describe('Request Lizmap GetProjectConfig - anonymous - @requests @readonly
             default_dpi: '100',
         });
         expect(body.layouts.list[1]).toEqual({
+            layout: 'print_overview',
+            enabled: true,
+            formats_available: ['pdf'],
+            default_format: 'pdf',
+            dpi_available: ['100'],
+            default_dpi: '100',
+        });
+        expect(body.layouts.list[2]).toEqual({
             layout: 'print_map',
             enabled: true,
             formats_available: ['png', 'jpeg'],
@@ -695,7 +703,7 @@ test.describe('Request Lizmap GetProjectConfig - anonymous - @requests @readonly
             dpi_available: ['100', '200'],
             default_dpi: '200',
         });
-        expect(body.layouts.list[2]).toEqual({
+        expect(body.layouts.list[3]).toEqual({
             layout: 'atlas_quartiers',
             enabled: true,
             formats_available: ['pdf'],
@@ -704,16 +712,8 @@ test.describe('Request Lizmap GetProjectConfig - anonymous - @requests @readonly
             default_dpi: '100',
             icon: 'media/svg/tree-fill.svg',
         });
-        expect(body.layouts.list[3]).toEqual({
-            layout: 'atlas_sousquartiers',
-            enabled: true,
-            formats_available: ['pdf'],
-            default_format: 'pdf',
-            dpi_available: ['100'],
-            default_dpi: '100',
-        });
         expect(body.layouts.list[4]).toEqual({
-            layout: 'print_overview',
+            layout: 'atlas_sousquartiers',
             enabled: true,
             formats_available: ['pdf'],
             default_format: 'pdf',
@@ -983,6 +983,28 @@ test.describe('Request Lizmap GetProjectConfig - admin - @requests @readonly', (
             }
         });
         expect(body.printTemplates[1]).toMatchObject({
+            title: 'print_overview',
+            width: 297,
+            height: 210,
+            maps: [{
+                id: 'map0',
+                width: 46,
+                height: 44,
+                grid: false,
+                overviewMap: body.printTemplates[1].maps[1].uuid,
+            },{
+                id: 'map1',
+                width: 253,
+                height: 171,
+                grid: false,
+                overviewMap: null,
+            }],
+            labels: [],
+            atlas: {
+                enabled: false,
+            }
+        });
+        expect(body.printTemplates[2]).toMatchObject({
             title: 'print_map',
             width: 297,
             height: 210,
@@ -998,7 +1020,7 @@ test.describe('Request Lizmap GetProjectConfig - admin - @requests @readonly', (
                 enabled: false,
             }
         });
-        expect(body.printTemplates[2]).toMatchObject({
+        expect(body.printTemplates[3]).toMatchObject({
             title: 'atlas_quartiers',
             width: 297,
             height: 210,
@@ -1015,7 +1037,7 @@ test.describe('Request Lizmap GetProjectConfig - admin - @requests @readonly', (
                 coverageLayer: body.layers.quartiers.id,
             }
         });
-        expect(body.printTemplates[3]).toMatchObject({
+        expect(body.printTemplates[4]).toMatchObject({
             title: 'atlas_sousquartiers',
             width: 297,
             height: 210,
@@ -1032,30 +1054,8 @@ test.describe('Request Lizmap GetProjectConfig - admin - @requests @readonly', (
                 coverageLayer: body.layers.sousquartiers.id,
             }
         });
-        expect(body.printTemplates[4]).toMatchObject({
-            title: 'print_allowed_groups',
-        });
         expect(body.printTemplates[5]).toMatchObject({
-            title: 'print_overview',
-            width: 297,
-            height: 210,
-            maps: [{
-                id: 'map0',
-                width: 46,
-                height: 44,
-                grid: false,
-                overviewMap: body.printTemplates[5].maps[1].uuid,
-            },{
-                id: 'map1',
-                width: 253,
-                height: 171,
-                grid: false,
-                overviewMap: null,
-            }],
-            labels: [],
-            atlas: {
-                enabled: false,
-            }
+            title: 'print_allowed_groups',
         });
 
         expect(body.layouts.config).toHaveProperty('default_popup_print', true);
@@ -1070,6 +1070,14 @@ test.describe('Request Lizmap GetProjectConfig - admin - @requests @readonly', (
             default_dpi: '100',
         });
         expect(body.layouts.list[1]).toEqual({
+            layout: 'print_overview',
+            enabled: true,
+            formats_available: ['pdf'],
+            default_format: 'pdf',
+            dpi_available: ['100'],
+            default_dpi: '100',
+        });
+        expect(body.layouts.list[2]).toEqual({
             layout: 'print_map',
             enabled: true,
             formats_available: ['png', 'jpeg'],
@@ -1077,7 +1085,7 @@ test.describe('Request Lizmap GetProjectConfig - admin - @requests @readonly', (
             dpi_available: ['100', '200'],
             default_dpi: '200',
         });
-        expect(body.layouts.list[2]).toEqual({
+        expect(body.layouts.list[3]).toEqual({
             layout: 'atlas_quartiers',
             enabled: true,
             formats_available: ['pdf'],
@@ -1086,7 +1094,7 @@ test.describe('Request Lizmap GetProjectConfig - admin - @requests @readonly', (
             default_dpi: '100',
             icon: 'media/svg/tree-fill.svg',
         });
-        expect(body.layouts.list[3]).toEqual({
+        expect(body.layouts.list[4]).toEqual({
             layout: 'atlas_sousquartiers',
             enabled: true,
             formats_available: ['pdf'],
@@ -1094,20 +1102,12 @@ test.describe('Request Lizmap GetProjectConfig - admin - @requests @readonly', (
             dpi_available: ['100'],
             default_dpi: '100',
         });
-        expect(body.layouts.list[4]).toEqual({
+        expect(body.layouts.list[5]).toEqual({
             layout: 'print_allowed_groups',
             enabled: true,
             formats_available: ['pdf', 'svg', 'png', 'jpeg'],
             default_format: 'pdf',
             dpi_available: ['100', '200', '300'],
-            default_dpi: '100',
-        });
-        expect(body.layouts.list[5]).toEqual({
-            layout: 'print_overview',
-            enabled: true,
-            formats_available: ['pdf'],
-            default_format: 'pdf',
-            dpi_available: ['100'],
             default_dpi: '100',
         });
 

--- a/tests/qgis-projects/tests/print.qgs.cfg
+++ b/tests/qgis-projects/tests/print.qgs.cfg
@@ -224,6 +224,18 @@
                 "default_dpi": "100"
             },
             {
+                "layout": "print_overview",
+                "enabled": true,
+                "formats_available": [
+                    "pdf"
+                ],
+                "default_format": "pdf",
+                "dpi_available": [
+                    "100"
+                ],
+                "default_dpi": "100"
+            },
+            {
                 "layout": "print_map",
                 "enabled": true,
                 "formats_available": [
@@ -304,18 +316,6 @@
                     "100",
                     "200",
                     "300"
-                ],
-                "default_dpi": "100"
-            },
-            {
-                "layout": "print_overview",
-                "enabled": true,
-                "formats_available": [
-                    "pdf"
-                ],
-                "default_format": "pdf",
-                "dpi_available": [
-                    "100"
                 ],
                 "default_dpi": "100"
             }


### PR DESCRIPTION
printTemplates was built by iterating printCapabilities in QGIS XML order, ignoring the user-configured order in layouts.list from the cfg file. Since the frontend matches these arrays by index, the print dropdown showed layouts in QGIS's internal order instead of the order set in the Lizmap plugin.

Reorder printTemplates to match the layouts.list order from the cfg.