### PR TITLE
fix: properly align label/value rows in drag&drop popup form

### DIFF
--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -1627,6 +1627,32 @@ div.modal .form-horizontal .controls {
   margin-right: 10px;
 }
 
+/* Drag-and-drop popup: flex layout for label/value rows.
+   Selectors use div.container.popup_lizmap_dd (specificity 31) to
+   beat any stale theme CSS with equal selectors + !important (specificity 21). */
+div.container.popup_lizmap_dd .control-group {
+  display: flex !important;
+  align-items: center;
+  column-gap: 4px;
+  margin-bottom: 2px;
+}
+
+div.container.popup_lizmap_dd label {
+  flex: 0 0 clamp(80px, 40%, 150px) !important;
+  max-width: clamp(80px, 40%, 150px);
+  hyphens: auto;
+  overflow-wrap: break-word;
+}
+
+div.container.popup_lizmap_dd .controls {
+  flex: 1 1 0 !important;
+  min-width: 0 !important;
+  margin: 0 !important;
+  padding-left: 0 !important;
+  hyphens: auto;
+  overflow-wrap: break-word;
+}
+
 #dock .form-horizontal .controls label.checkbox,
 div.modal .form-horizontal .controls label.checkbox {
   max-width: 200px;

--- a/lizmap/www/themes/default/css/map.css
+++ b/lizmap/www/themes/default/css/map.css
@@ -1109,18 +1109,28 @@ div.popup_lizmap_dd {
   font-size: 12px;
 }
 
-div.popup_lizmap_dd .form-horizontal .form-group {
-  margin-bottom: 0 !important;
+div.popup_lizmap_dd .control-group {
+  display: flex !important;
+  align-items: center;
+  column-gap: 4px;
+  margin-bottom: 2px;
 }
 
 div.popup_lizmap_dd label {
-  padding-top: 0 !important;
+  flex: 0 0 clamp(80px, 40%, 150px) !important;
+  max-width: clamp(80px, 40%, 150px);
   font-size: 12px !important;
-  width: 130px !important;
+  hyphens: auto;
+  overflow-wrap: break-word;
 }
 
 div.popup_lizmap_dd .controls {
-  margin-left: 140px !important;
+  flex: 1 1 0 !important;
+  min-width: 0 !important;
+  margin: 0 !important;
+  padding-left: 0 !important;
+  hyphens: auto;
+  overflow-wrap: break-word;
 }
 
 /* ATLAS */


### PR DESCRIPTION
The QGIS drag&drop form popup uses Bootstrap 2/3 classes (form-horizontal, control-group, control-label, controls) that Bootstrap 5 no longer supports. Labels were stacking vertically above values instead of rendering side-by-side.

Changes in assets/css/map.css and themes/default/css/map.css:
- Replace float-era width+margin-left approach with flexbox on .control-group
- Label column uses clamp(80px, 40%, 150px) for a consistent responsive width that scales with the popup container
- .controls takes remaining space with flex: 1 1 0
- margin and padding on .controls zeroed out
- align-items: center so single-line values sit mid-height of multi-line labels
- hyphens: auto for syllabic line breaks (uses page lang attribute)
- overflow-wrap: break-word for long values
- Selectors use div.container.popup_lizmap_dd (specificity 31) to win over any stale theme CSS using div.popup_lizmap_dd (specificity 21) with !important

Before (LWC 3.11):
<img width="444" height="759" alt="Lizmap_3 11Drag Drop" src="https://github.com/user-attachments/assets/7c2486a9-700e-470e-ae2b-1b77eea1c8fb" />

After:
<img width="493" height="806" alt="Lizmap_3 11Drag Drop_Fix" src="https://github.com/user-attachments/assets/d5615286-5d67-404b-9b66-b2e35b4cd799" />
