### PR TITLE
fix: handle google-hybrid base layer and exact lyrs matching

### DIFF
--- a/assets/src/modules/config/BaseLayer.js
+++ b/assets/src/modules/config/BaseLayer.js
@@ -316,7 +316,9 @@ const googleProperties = {
 }
 
 const googleOptionalProperties = {
-    'key': { type: 'string', nullable: true }
+    'key': { type: 'string', nullable: true },
+    'layerTypes': { type: 'array', contentType: 'string' },
+    'overlay': { type: 'boolean' },
 }
 
 /**
@@ -327,11 +329,13 @@ const googleOptionalProperties = {
 export class GoogleBaseLayerConfig extends BaseLayerConfig {
     /**
      * Create a GOOGLE base layer config based on a config object
-     * @param {string} name           - the base layer name
-     * @param {object} cfg            - the lizmap config object for GOOGLE base layer
-     * @param {string} cfg.title      - the base layer title
-     * @param {string} cfg.mapType    - the base layer mapType
-     * @param {string} [cfg.key]      - the base layer key
+     * @param {string} name                  - the base layer name
+     * @param {object} cfg                   - the lizmap config object for GOOGLE base layer
+     * @param {string} cfg.title             - the base layer title
+     * @param {string} cfg.mapType           - the base layer mapType
+     * @param {string} [cfg.key]             - the base layer key
+     * @param {string[]} [cfg.layerTypes]    - additional layer types (e.g. ['layerRoadmap'])
+     * @param {boolean} [cfg.overlay]        - display only layerTypes without the base mapType
      */
     constructor(name, cfg) {
         if (!cfg || typeof cfg !== "object") {
@@ -352,6 +356,22 @@ export class GoogleBaseLayerConfig extends BaseLayerConfig {
      */
     get mapType() {
         return this._mapType;
+    }
+
+    /**
+     * The Google layer types (e.g. ['layerRoadmap'] for hybrid)
+     * @type {string[]|null}
+     */
+    get layerTypes() {
+        return this._layerTypes;
+    }
+
+    /**
+     * Whether to display only layerTypes without the underlying mapType
+     * @type {boolean|null}
+     */
+    get overlay() {
+        return this._overlay;
     }
 
 }
@@ -804,10 +824,18 @@ const QMSExternalLayer = {
         "mapType": "satellite",
         "key":""
     },
+    "google-hybrid": {
+        "type" :"google",
+        "title": "Google Hybrid",
+        "mapType": "satellite",
+        "layerTypes": ["layerRoadmap"],
+        "key":""
+    },
     "google-terrain": {
         "type" :"google",
         "title": "Google Terrain",
         "mapType": "terrain",
+        "layerTypes": ["layerRoadmap"],
         "key":""
 
     }
@@ -906,21 +934,29 @@ export class BaseLayersConfig {
                                 // add the apikey to the configuration
                                 Object.assign(extendedCfg[layerTreeItem.name],{key:options["bingKey"]})
                             } else if (externalUrl && externalUrl.includes('google.com') && options["googleKey"]){
-                                if (externalUrl.includes('lyrs=m')) {
+                                // Extract the exact lyrs value to avoid substring false-positives (e.g. lyrs=svv matching lyrs=s)
+                                const lyrsMatch = externalUrl.match(/[?&/]lyrs=([^&%]+)/);
+                                const lyrs = lyrsMatch ? lyrsMatch[1] : null;
+                                if (lyrs === 'm') {
                                     // roads
                                     extendedCfg[layerTreeItem.name] = structuredClone(QMSExternalLayer["google-streets"])
-                                } else if (externalUrl.includes('lyrs=s')){
+                                } else if (lyrs === 's'){
                                     // satellite map
                                     extendedCfg[layerTreeItem.name] = structuredClone(QMSExternalLayer["google-satellite"])
-                                } else if (externalUrl.includes('lyrs=p') || externalUrl.includes('lyrs=t')){
+                                } else if (lyrs === 'y'){
+                                    // hybrid (satellite + road labels)
+                                    extendedCfg[layerTreeItem.name] = structuredClone(QMSExternalLayer["google-hybrid"])
+                                } else if (lyrs === 'p' || lyrs === 't'){
                                     // terrain
                                     extendedCfg[layerTreeItem.name] = structuredClone(QMSExternalLayer["google-terrain"])
                                 } else {
-                                    // Fallback to google-streets
-                                    extendedCfg[layerTreeItem.name] = structuredClone(QMSExternalLayer["google-streets"])
+                                    // Unknown Google layer type (e.g. StreetView availability) - keep as XYZ
+                                    extendedCfg[layerTreeItem.name] = structuredClone(layerTreeItem.layerConfig.externalAccess);
                                 }
-                                // add the apikey to the configuration
-                                Object.assign(extendedCfg[layerTreeItem.name],{key:options["googleKey"]})
+                                // add the apikey only for Google Maps Tiles API layers
+                                if (extendedCfg[layerTreeItem.name].type === 'google') {
+                                    Object.assign(extendedCfg[layerTreeItem.name],{key:options["googleKey"]})
+                                }
                             }
                             else {
                                 // layer could be converted to XYZ or WMTS background layers

--- a/assets/src/modules/map.js
+++ b/assets/src/modules/map.js
@@ -475,14 +475,21 @@ export default class map extends olMap {
                     }),
                 });
             } else if (baseLayerState.type === BaseLayerTypes.Google) {
+                const googleSourceOptions = {
+                    key: baseLayerState.key,
+                    mapType: baseLayerState.googleMapType,
+                };
+                if (baseLayerState.googleLayerTypes) {
+                    googleSourceOptions.layerTypes = baseLayerState.googleLayerTypes;
+                }
+                if (baseLayerState.googleOverlay !== null) {
+                    googleSourceOptions.overlay = baseLayerState.googleOverlay;
+                }
                 baseLayer = new TileLayer({
                     minResolution: layerMinResolution,
                     maxResolution: layerMaxResolution,
                     preload: Infinity,
-                    source: new Google({
-                        key: baseLayerState.key,
-                        mapType: baseLayerState.googleMapType,
-                    }),
+                    source: new Google(googleSourceOptions),
                 });
             } else if (baseLayerState.type === BaseLayerTypes.Lizmap) {
                 if (baseLayerState.layerConfig.cached) {

--- a/assets/src/modules/state/BaseLayer.js
+++ b/assets/src/modules/state/BaseLayer.js
@@ -357,6 +357,22 @@ export class GoogleBaseLayerState extends BaseLayerState {
     get googleMapType() {
         return this._baseLayerConfig.mapType;
     }
+
+    /**
+     * The google layer types (e.g. ['layerRoadmap'] for hybrid)
+     * @type {string[]|null}
+     */
+    get googleLayerTypes() {
+        return this._baseLayerConfig.layerTypes;
+    }
+
+    /**
+     * Whether to display only layerTypes without the underlying mapType
+     * @type {boolean|null}
+     */
+    get googleOverlay() {
+        return this._baseLayerConfig.overlay;
+    }
 }
 
 /**

--- a/tests/js-units/node/config/baselayer.test.js
+++ b/tests/js-units/node/config/baselayer.test.js
@@ -6,7 +6,7 @@ import { ValidationError, ConversionError } from 'assets/src/modules/Errors.js';
 import { AttributionConfig } from 'assets/src/modules/config/Attribution.js';
 import { LayerConfig, LayersConfig } from 'assets/src/modules/config/Layer.js';
 import { LayerTreeGroupConfig, buildLayerTreeConfig } from 'assets/src/modules/config/LayerTree.js';
-import { BaseLayerTypes, BaseLayerConfig, EmptyBaseLayerConfig, XyzBaseLayerConfig, BingBaseLayerConfig, WmtsBaseLayerConfig, WmsBaseLayerConfig, BaseLayersConfig } from 'assets/src/modules/config/BaseLayer.js';
+import { BaseLayerTypes, BaseLayerConfig, EmptyBaseLayerConfig, XyzBaseLayerConfig, BingBaseLayerConfig, GoogleBaseLayerConfig, WmtsBaseLayerConfig, WmsBaseLayerConfig, BaseLayersConfig } from 'assets/src/modules/config/BaseLayer.js';
 
 describe('BaseLayerConfig', function () {
     it('simple', function () {
@@ -155,6 +155,102 @@ describe('WmtsBaseLayerConfig', function () {
         expect(lizmapBl.numZoomLevels).to.be.eq(16)
         expect(lizmapBl.hasAttribution).to.be.false
         expect(lizmapBl.attribution).to.be.null
+    })
+})
+
+describe('GoogleBaseLayerConfig', function () {
+    it('simple', function () {
+        const googleBl = new GoogleBaseLayerConfig('google-streets', {
+            'title': 'Google Streets',
+            'mapType': 'roadmap',
+            'key': 'test-key'
+        })
+        expect(googleBl).to.be.instanceOf(BaseLayerConfig)
+        expect(googleBl).to.be.instanceOf(GoogleBaseLayerConfig)
+        expect(googleBl.type).to.be.eq(BaseLayerTypes.Google)
+        expect(googleBl.name).to.be.eq('google-streets')
+        expect(googleBl.title).to.be.eq('Google Streets')
+        expect(googleBl.mapType).to.be.eq('roadmap')
+        expect(googleBl.hasKey).to.be.true
+        expect(googleBl.key).to.be.eq('test-key')
+        expect(googleBl.layerTypes).to.be.null
+        expect(googleBl.overlay).to.be.null
+    })
+
+    it('with layerTypes (hybrid)', function () {
+        const googleHybridBl = new GoogleBaseLayerConfig('google-hybrid', {
+            'title': 'Google Hybrid',
+            'mapType': 'satellite',
+            'key': 'test-key',
+            'layerTypes': ['layerRoadmap']
+        })
+        expect(googleHybridBl).to.be.instanceOf(GoogleBaseLayerConfig)
+        expect(googleHybridBl.type).to.be.eq(BaseLayerTypes.Google)
+        expect(googleHybridBl.name).to.be.eq('google-hybrid')
+        expect(googleHybridBl.title).to.be.eq('Google Hybrid')
+        expect(googleHybridBl.mapType).to.be.eq('satellite')
+        expect(googleHybridBl.layerTypes).to.be.deep.eq(['layerRoadmap'])
+        expect(googleHybridBl.overlay).to.be.null
+    })
+
+    it('with layerTypes (terrain)', function () {
+        const googleTerrainBl = new GoogleBaseLayerConfig('google-terrain', {
+            'title': 'Google Terrain',
+            'mapType': 'terrain',
+            'key': 'test-key',
+            'layerTypes': ['layerRoadmap']
+        })
+        expect(googleTerrainBl).to.be.instanceOf(GoogleBaseLayerConfig)
+        expect(googleTerrainBl.type).to.be.eq(BaseLayerTypes.Google)
+        expect(googleTerrainBl.name).to.be.eq('google-terrain')
+        expect(googleTerrainBl.title).to.be.eq('Google Terrain')
+        expect(googleTerrainBl.mapType).to.be.eq('terrain')
+        expect(googleTerrainBl.layerTypes).to.be.deep.eq(['layerRoadmap'])
+    })
+
+    it('with overlay', function () {
+        const googleOverlayBl = new GoogleBaseLayerConfig('google-overlay', {
+            'title': 'Google Overlay',
+            'mapType': 'satellite',
+            'key': 'test-key',
+            'layerTypes': ['layerRoadmap'],
+            'overlay': true
+        })
+        expect(googleOverlayBl).to.be.instanceOf(GoogleBaseLayerConfig)
+        expect(googleOverlayBl.type).to.be.eq(BaseLayerTypes.Google)
+        expect(googleOverlayBl.layerTypes).to.be.deep.eq(['layerRoadmap'])
+        expect(googleOverlayBl.overlay).to.be.true
+    })
+
+    it('without key', function () {
+        const googleBl = new GoogleBaseLayerConfig('google-streets', {
+            'title': 'Google Streets',
+            'mapType': 'roadmap',
+            'key': ''
+        })
+        expect(googleBl).to.be.instanceOf(GoogleBaseLayerConfig)
+        expect(googleBl.type).to.be.eq(BaseLayerTypes.Google)
+        expect(googleBl.mapType).to.be.eq('roadmap')
+        expect(googleBl.hasKey).to.be.false
+        expect(googleBl.key).to.be.null
+    })
+
+    it('ValidationError: empty cfg', function () {
+        try {
+            new GoogleBaseLayerConfig('test', {})
+        } catch (error) {
+            expect(error.name).to.be.eq('ValidationError')
+            expect(error).to.be.instanceOf(ValidationError)
+        }
+    })
+
+    it('ValidationError: missing mapType', function () {
+        try {
+            new GoogleBaseLayerConfig('test', { 'title': 'Test' })
+        } catch (error) {
+            expect(error.name).to.be.eq('ValidationError')
+            expect(error).to.be.instanceOf(ValidationError)
+        }
     })
 })
 

--- a/tests/js-units/node/state/baselayer.test.js
+++ b/tests/js-units/node/state/baselayer.test.js
@@ -9,7 +9,8 @@ import { buildLayersOrder } from 'assets/src/modules/config/LayersOrder.js';
 import { LayersAndGroupsCollection } from 'assets/src/modules/state/Layer.js';
 import { OptionsConfig } from 'assets/src/modules/config/Options.js';
 
-import { BaseLayerState, EmptyBaseLayerState, BaseLayersState } from 'assets/src/modules/state/BaseLayer.js';
+import { BaseLayerState, EmptyBaseLayerState, GoogleBaseLayerState, BaseLayersState } from 'assets/src/modules/state/BaseLayer.js';
+import { GoogleBaseLayerConfig } from 'assets/src/modules/config/BaseLayer.js';
 
 /**
  * Returns the BaseLayersState for the project
@@ -115,6 +116,85 @@ describe('EmptyBaseLayerState', function () {
         } catch (error) {
             expect(error.name).to.be.eq('TypeError')
             expect(error.message).to.be.eq('Not an `empty` base layer config. Get `lizmap` type for `name` base layer!')
+            expect(error).to.be.instanceOf(TypeError)
+        }
+        expect(baselayer).to.be.null
+    })
+})
+
+describe('GoogleBaseLayerState', function () {
+
+    it('simple', function () {
+        const blConfig = new GoogleBaseLayerConfig('google-streets', {
+            'title': 'Google Streets',
+            'mapType': 'roadmap',
+            'key': 'test-key'
+        })
+        const baselayer = new GoogleBaseLayerState(blConfig)
+        expect(baselayer).to.be.instanceOf(BaseLayerState)
+        expect(baselayer).to.be.instanceOf(GoogleBaseLayerState)
+        expect(baselayer.type).to.be.eq(BaseLayerTypes.Google)
+        expect(baselayer.name).to.be.eq('google-streets')
+        expect(baselayer.title).to.be.eq('Google Streets')
+        expect(baselayer.googleMapType).to.be.eq('roadmap')
+        expect(baselayer.hasKey).to.be.true
+        expect(baselayer.key).to.be.eq('test-key')
+        expect(baselayer.googleLayerTypes).to.be.null
+        expect(baselayer.googleOverlay).to.be.null
+    })
+
+    it('with layerTypes (hybrid)', function () {
+        const blConfig = new GoogleBaseLayerConfig('google-hybrid', {
+            'title': 'Google Hybrid',
+            'mapType': 'satellite',
+            'key': 'test-key',
+            'layerTypes': ['layerRoadmap']
+        })
+        const baselayer = new GoogleBaseLayerState(blConfig)
+        expect(baselayer).to.be.instanceOf(GoogleBaseLayerState)
+        expect(baselayer.type).to.be.eq(BaseLayerTypes.Google)
+        expect(baselayer.name).to.be.eq('google-hybrid')
+        expect(baselayer.title).to.be.eq('Google Hybrid')
+        expect(baselayer.googleMapType).to.be.eq('satellite')
+        expect(baselayer.googleLayerTypes).to.be.deep.eq(['layerRoadmap'])
+        expect(baselayer.googleOverlay).to.be.null
+    })
+
+    it('with layerTypes (terrain)', function () {
+        const blConfig = new GoogleBaseLayerConfig('google-terrain', {
+            'title': 'Google Terrain',
+            'mapType': 'terrain',
+            'key': 'test-key',
+            'layerTypes': ['layerRoadmap']
+        })
+        const baselayer = new GoogleBaseLayerState(blConfig)
+        expect(baselayer).to.be.instanceOf(GoogleBaseLayerState)
+        expect(baselayer.googleMapType).to.be.eq('terrain')
+        expect(baselayer.googleLayerTypes).to.be.deep.eq(['layerRoadmap'])
+    })
+
+    it('with overlay', function () {
+        const blConfig = new GoogleBaseLayerConfig('google-overlay', {
+            'title': 'Google Overlay',
+            'mapType': 'satellite',
+            'key': 'test-key',
+            'layerTypes': ['layerRoadmap'],
+            'overlay': true
+        })
+        const baselayer = new GoogleBaseLayerState(blConfig)
+        expect(baselayer).to.be.instanceOf(GoogleBaseLayerState)
+        expect(baselayer.googleLayerTypes).to.be.deep.eq(['layerRoadmap'])
+        expect(baselayer.googleOverlay).to.be.true
+    })
+
+    it('Error type', function () {
+        const blConfig = new BaseLayerConfig('name', {'title': 'title'})
+        let baselayer = null;
+        try {
+            baselayer = new GoogleBaseLayerState(blConfig)
+        } catch (error) {
+            expect(error.name).to.be.eq('TypeError')
+            expect(error.message).to.be.eq('Not an `google` base layer config. Get `lizmap` type for `name` base layer!')
             expect(error).to.be.instanceOf(TypeError)
         }
         expect(baselayer).to.be.null


### PR DESCRIPTION
Add google-hybrid support via Google Maps Tiles API (mapType: satellite + layerTypes: layerRoadmap). Add required layerTypes: layerRoadmap to terrain, fixing "terrain map type must always contain a roadmap layer" API error (#5550). Fix lyrs substring matching bug where lyrs=svv (StreetView availability) falsely matched lyrs=s check, causing satellite display. Unknown lyrs types now fall through to XYZ instead of google-streets.

Fixes #6637 and #5550 
