### PR TITLE
fix: increase ST_AsGeoJSON precision to 9 decimal digits

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/WFSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WFSRequest.php
@@ -1196,7 +1196,7 @@ class WFSRequest extends OGCRequest
 
             // Transform into GeoJSON
             $sql .= '
-                        ST_AsGeoJSON('.$geosql.')::json As geometry,
+                        ST_AsGeoJSON('.$geosql.', 9)::json As geometry,
             ';
         } else {
             $sql .= '

--- a/tests/units/classes/Request/WFSRequestTest.php
+++ b/tests/units/classes/Request/WFSRequestTest.php
@@ -398,6 +398,31 @@ class WFSRequestTest extends TestCase
         $this->assertEquals($expectedSql, $result);
     }
 
+    public function testSetGeojsonSqlPrecision(): void
+    {
+        $wfs = new WFSRequestForTests();
+        $wfs->datasource = (object) array('key' => 'id', 'geocol' => 'geom');
+        $wfs->selectFields = array('"id"');
+
+        $method = new \ReflectionMethod($wfs, 'setGeojsonSql');
+        $method->setAccessible(true);
+
+        $sql = $method->invoke(
+            $wfs,
+            'SELECT "id", "geom" AS "geosource" FROM mytable',
+            new jDbConnectionForTests(),
+            'my_layer',
+            'geom'
+        );
+
+        $this->assertStringContainsString(
+            'ST_AsGeoJSON(ST_Transform(lg.geosource::geometry, 4326), 9)',
+            $sql,
+            "ST_AsGeoJSON must specify 9 decimal digits for coordinate precision.\n"
+            ."Generated SQL:\n".substr($sql, strpos($sql, 'ST_AsGeoJSON') ?: 0, 200)
+        );
+    }
+
     public function testBuildGetFeatureParameters(): void
     {
         $genericParameters = WFSRequestForTests::$genericGetFeatureParameters;


### PR DESCRIPTION
Fixes coordinate truncation in PostGIS WFS direct path. ST_AsGeoJSON defaults to 6 decimals for degrees (~11cm) and only 1 for meters (~10cm), which is insufficient for snapping accuracy. Using 9 decimals matches QGIS Server's own GeoJSON output precision.
Includes unit-test.