### PR TITLE
[Backport release_3_9] Fix sorting order for WFS requests with PostgreSQL layer

### DIFF
--- a/lizmap/modules/lizmap/lib/Request/WFSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WFSRequest.php
@@ -837,7 +837,7 @@ class WFSRequest extends OGCRequest
                 $field = $exp[0];
                 if (in_array($field, $wfsFields)) {
                     $sort_items[$field] = 'ASC';
-                    if (count($exp) == 2 and $exp[1] == 'd') {
+                    if (count($exp) == 2 && in_array(strtolower($exp[1]), array('d', '+d', 'desc', '+desc'))) {
                         $sort_items[$field] = 'DESC';
                     }
                 }

--- a/tests/units/classes/Request/WFSRequestTest.php
+++ b/tests/units/classes/Request/WFSRequestTest.php
@@ -283,6 +283,26 @@ class WFSRequestTest extends TestCase
             array(array('sortby' => ''), array(), ''),
             array(array('sortby' => 'id a,test d,wfs a'), array(), ''),
             array(array('sortby' => 'id a,test d,wfs a'), array('test', 'field', 'wfs'), ' ORDER BY "test" DESC, "wfs" ASC'),
+            // Test with uppercase 'D'
+            array(array('sortby' => 'id a,test D,wfs a'), array('test', 'field', 'wfs'), ' ORDER BY "test" DESC, "wfs" ASC'),
+            // Test with 'desc' keyword (lowercase)
+            array(array('sortby' => 'id a,test desc,wfs a'), array('test', 'field', 'wfs'), ' ORDER BY "test" DESC, "wfs" ASC'),
+            // Test with 'DESC' keyword (uppercase)
+            array(array('sortby' => 'id a,test DESC,wfs a'), array('test', 'field', 'wfs'), ' ORDER BY "test" DESC, "wfs" ASC'),
+            // Test with '+d' prefix
+            array(array('sortby' => 'id a,test +d,wfs a'), array('test', 'field', 'wfs'), ' ORDER BY "test" DESC, "wfs" ASC'),
+            // Test with '+D' prefix
+            array(array('sortby' => 'id a,test +D,wfs a'), array('test', 'field', 'wfs'), ' ORDER BY "test" DESC, "wfs" ASC'),
+            // Test with '+desc' prefix
+            array(array('sortby' => 'id a,test +desc,wfs a'), array('test', 'field', 'wfs'), ' ORDER BY "test" DESC, "wfs" ASC'),
+            // Test with '+DESC' prefix
+            array(array('sortby' => 'id a,test +DESC,wfs a'), array('test', 'field', 'wfs'), ' ORDER BY "test" DESC, "wfs" ASC'),
+            // Test with mixed case variations
+            array(array('sortby' => 'id Desc,test +D,wfs desc'), array('id', 'test', 'wfs'), ' ORDER BY "id" DESC, "test" DESC, "wfs" DESC'),
+            // Test single field with DESC
+            array(array('sortby' => 'id desc'), array('id'), ' ORDER BY "id" DESC'),
+            // Test single field with +DESC
+            array(array('sortby' => 'id +DESC'), array('id'), ' ORDER BY "id" DESC'),
         );
     }
 


### PR DESCRIPTION
Backport #6674
 **Authored by:** @nboisteault