### PR TITLE
Remove `capture` attribute for image upload , use it in accept for ImageUpload control

### DIFF
--- a/lizmap/modules/lizmap/lib/Form/QgisFormControl.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisFormControl.php
@@ -376,7 +376,6 @@ class QgisFormControl
         }
         $upload->mimetype = $this->properties->getMimeTypes();
         $upload->accept = $this->properties->getUploadAccept();
-        $upload->capture = $this->properties->getUploadCapture();
         $this->DefaultRoot = $this->getEditAttribute('DefaultRoot');
 
         // WebDAV External Resource

--- a/lizmap/modules/lizmap/lib/Project/Qgis/Layer/VectorLayer.php
+++ b/lizmap/modules/lizmap/lib/Project/Qgis/Layer/VectorLayer.php
@@ -417,14 +417,13 @@ class VectorLayer extends Qgis\BaseQgisObject
     {
         $mimeTypes = array();
         $acceptAttr = '';
-        $captureAttr = '';
         $imageUpload = false;
         $defaultRoot = '';
 
         if ($fieldEditType === 'Photo') {
+            // https://stackoverflow.com/questions/21523544/html-file-input-control-with-capture-and-accept-attributes-works-wrong/60176010#60176010
             $mimeTypes = array('image/jpg', 'image/jpeg', 'image/pjpeg', 'image/png', 'image/gif');
-            $acceptAttr = implode(', ', $mimeTypes);
-            $captureAttr = 'environment';
+            $acceptAttr = implode(', ', $mimeTypes).';capture=camera';
             $imageUpload = true;
         } elseif ($fieldEditType === 'ExternalResource') {
             $accepts = array();
@@ -501,7 +500,6 @@ class VectorLayer extends Qgis\BaseQgisObject
                     $mimeTypes = array('image/jpg', 'image/jpeg', 'image/pjpeg', 'image/png', 'image/gif');
                     $acceptAttr = 'image/jpg, image/jpeg, image/pjpeg, image/png, image/gif';
                 }
-                $captureAttr = 'environment';
                 $imageUpload = true;
             }
             $defaultRoot = $fieldEditOptions['DefaultRoot'] ?? '';
@@ -520,7 +518,6 @@ class VectorLayer extends Qgis\BaseQgisObject
         $fieldEditOptions['UploadMimeTypes'] = $mimeTypes;
         $fieldEditOptions['DefaultRoot'] = $defaultRoot;
         $fieldEditOptions['UploadAccept'] = $acceptAttr;
-        $fieldEditOptions['UploadCapture'] = $captureAttr;
         $fieldEditOptions['UploadImage'] = $imageUpload;
     }
 

--- a/lizmap/modules/lizmap/lib/Project/QgisProject.php
+++ b/lizmap/modules/lizmap/lib/Project/QgisProject.php
@@ -1247,14 +1247,13 @@ class QgisProject
     {
         $mimeTypes = array();
         $acceptAttr = '';
-        $captureAttr = '';
         $imageUpload = false;
         $defaultRoot = '';
 
         if ($fieldEditType === 'Photo') {
+            // https://stackoverflow.com/questions/21523544/html-file-input-control-with-capture-and-accept-attributes-works-wrong/60176010#60176010
             $mimeTypes = array('image/jpg', 'image/jpeg', 'image/pjpeg', 'image/png', 'image/gif');
-            $acceptAttr = implode(', ', $mimeTypes);
-            $captureAttr = 'environment';
+            $acceptAttr = implode(', ', $mimeTypes).';capture=camera';
             $imageUpload = true;
         } elseif ($fieldEditType === 'ExternalResource') {
             $accepts = array();
@@ -1331,7 +1330,6 @@ class QgisProject
                     $mimeTypes = array('image/jpg', 'image/jpeg', 'image/pjpeg', 'image/png', 'image/gif');
                     $acceptAttr = 'image/jpg, image/jpeg, image/pjpeg, image/png, image/gif';
                 }
-                $captureAttr = 'environment';
                 $imageUpload = true;
             }
             $defaultRoot = $fieldEditOptions['DefaultRoot'] ?? '';
@@ -1350,7 +1348,6 @@ class QgisProject
         $fieldEditOptions['UploadMimeTypes'] = $mimeTypes;
         $fieldEditOptions['DefaultRoot'] = $defaultRoot;
         $fieldEditOptions['UploadAccept'] = $acceptAttr;
-        $fieldEditOptions['UploadCapture'] = $captureAttr;
         $fieldEditOptions['UploadImage'] = $imageUpload;
     }
 

--- a/tests/units/classes/Project/Qgis/VectorLayerTest.php
+++ b/tests/units/classes/Project/Qgis/VectorLayerTest.php
@@ -750,7 +750,7 @@ def my_form_open(dialog, layer, feature):
         );
         $this->assertEquals($mimeTypes, $formControls['photo']->getMimeTypes());
         $this->assertEquals('.gif, .jpeg, .png', $formControls['photo']->getUploadAccept());
-        $this->assertEquals('environment', $formControls['photo']->getUploadCapture());
+        $this->assertEquals('', $formControls['photo']->getUploadCapture());
         $this->assertTrue($formControls['photo']->isImageUpload());
 
         $xmlStr = '
@@ -2038,7 +2038,7 @@ def my_form_open(dialog, layer, feature):
             $formControls['remote']->getMimeTypes()
         );
         $this->assertEquals('image/jpg, image/jpeg, image/pjpeg, image/png, image/gif', $formControls['remote']->getUploadAccept());
-        $this->assertEquals('environment', $formControls['remote']->getUploadCapture());
+        $this->assertEquals('', $formControls['remote']->getUploadCapture());
         $this->assertEquals('', $formControls['remote']->getEditAttribute('DefaultRoot'));
         $this->assertEquals('WebDAV', $formControls['remote']->getEditAttribute('StorageType'));
         $this->assertEquals("'http://webdav/shapeData/'||file_name(@selected_file_path)", $formControls['remote']->getEditAttribute('webDAVStorageUrl'));

--- a/tests/units/classes/Project/QgisProjectTest.php
+++ b/tests/units/classes/Project/QgisProjectTest.php
@@ -2006,15 +2006,15 @@ class QgisProjectTest extends TestCase
         $this->assertTrue(array_key_exists('photo_file', $props));
         $imageFile = $props['photo_file'];
         $this->assertEquals('upload', $imageFile->getMarkup());
-        $this->assertEquals('environment', $imageFile->getUploadCapture());
-        $this->assertEquals('image/jpg, image/jpeg, image/pjpeg, image/png, image/gif', $imageFile->getUploadAccept());
+        $this->assertEquals('', $imageFile->getUploadCapture());
+        $this->assertEquals('image/jpg, image/jpeg, image/pjpeg, image/png, image/gif;capture=camera', $imageFile->getUploadAccept());
         $this->assertEquals(array('image/jpg', 'image/jpeg', 'image/pjpeg', 'image/png', 'image/gif'), $imageFile->getMimeTypes());
         $this->assertTrue($imageFile->isImageUpload());
 
         $this->assertTrue(array_key_exists('documentviewer_file', $props));
         $imageFile = $props['documentviewer_file'];
         $this->assertEquals('upload', $imageFile->getMarkup());
-        $this->assertEquals('environment', $imageFile->getUploadCapture());
+        $this->assertEquals('', $imageFile->getUploadCapture());
         $this->assertEquals('.png, .jpg', $imageFile->getUploadAccept());
         $this->assertEquals(array('image/png', 'image/jpg', 'image/jpeg', 'image/pjpeg'), $imageFile->getMimeTypes());
         $this->assertTrue($imageFile->isImageUpload());


### PR DESCRIPTION
On iOs `capture` attribute for image upload force the user to use the camera, and deny from browsing the gallery.

Thanks to [Stack overflow](https://stackoverflow.com/questions/21523544/html-file-input-control-with-capture-and-accept-attributes-works-wrong/60176010#60176010) , using `accept="image/*;capture=camera"` allow both behaviour (photo or file browsing) 

Ticket : #1727

Funded by Valabre
