### PR TITLE
Fix: "Clear Search" button not visible (master) and not clearing highlight / results + google search result not highlighted on map

### DIFF
--- a/assets/src/modules/Search.js
+++ b/assets/src/modules/Search.js
@@ -25,11 +25,34 @@ export default class Search {
         var configOptions = this._lizmap3.config.options;
         if (('searches' in configOptions) && (configOptions.searches.length > 0)) {
             this._addSearches();
+            this._addClearHandler();
         }
         else {
             $('#nominatim-search').remove();
             $('#lizmap-search, #lizmap-search-close').remove();
         }
+    }
+
+    /**
+     * PRIVATE method: bind the header clear button to reset search state
+     */
+    _addClearHandler() {
+        const headerClear = document.getElementById('header-clear');
+        if (headerClear) {
+            headerClear.addEventListener('click', () => {
+                this._clearSearch();
+            });
+        }
+    }
+
+    /**
+     * Clear search input, results, and map highlight
+     */
+    _clearSearch() {
+        document.getElementById('search-query').value = '';
+        this._map.clearHighlightFeatures();
+        $('#lizmap-search .items').html('');
+        $('#lizmap-search, #lizmap-search-close').removeClass('open');
     }
 
     /**
@@ -287,7 +310,8 @@ export default class Search {
                                 bbox = new OpenLayers.Bounds(bbox);
                                 if (extent.intersectsBounds(bbox)) {
                                     var lab = address.formatted_address.replace(labrex, '<strong class="highlight">$1</strong>');
-                                    text += '<li><a href="#' + bbox.toBBOX() + '">' + lab + '</a></li>';
+                                    var wkt = 'POINT(' + address.geometry.location.lng() + ' ' + address.geometry.location.lat() + ')';
+                                    text += '<li><a href="#' + bbox.toBBOX() + '" data-wkt="' + wkt + '">' + lab + '</a></li>';
                                     count++;
                                 }
                             }
@@ -383,6 +407,7 @@ export default class Search {
             });
 
             $('#lizmap-search-close button').click(() => {
+                this._map.clearHighlightFeatures();
                 $('#lizmap-search, #lizmap-search-close').removeClass('open');
                 return false;
             });

--- a/lizmap/modules/view/locales/en_US/map.UTF-8.properties
+++ b/lizmap/modules/view/locales/en_US/map.UTF-8.properties
@@ -9,6 +9,7 @@ legend.map=Legend/Map
 
 search.nominatim.placeholder=Search
 search.nominatim.button=Searching
+search.clear=Clear search
 
 print.navbar.title=Print
 tooltip.navbar.title=Tooltip

--- a/lizmap/modules/view/templates/map_headermenu.tpl
+++ b/lizmap/modules/view/templates/map_headermenu.tpl
@@ -1,6 +1,6 @@
 <div id="auth" class="container-fluid justify-content-end">
     <form id="nominatim-search" class="navbar-search dropdown" role="search">
-        <button id="header-clear" class="btn-locate-clear btn btn-sm btn-link icon" type="button"></button>
+        <button id="header-clear" class="btn-locate-clear btn btn-sm btn-link icon" type="button" title="{@view~map.search.clear@}"></button>
         <input id="search-query" type="text" class="search-query form-control"
             placeholder="{@view~map.search.nominatim.placeholder@}"></input>
         <span class="search-icon">

--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -659,6 +659,7 @@ button.btn-primary:hover > [class*=" icon-"] {
   margin-top:1px;
   height:30px;
   width:260px;
+  position: relative;
 }
 
 #headermenu .navbar-search .search-query {
@@ -668,6 +669,8 @@ button.btn-primary:hover > [class*=" icon-"] {
   right: 0;
   padding-top:2px;
   padding-bottom:2px;
+  height: 26px;
+  box-sizing: border-box;
 }
 
 #headermenu .navbar-search .search-icon {
@@ -683,8 +686,22 @@ button.btn-primary:hover > [class*=" icon-"] {
 
 #headermenu .navbar-search .icon {
   background-color: transparent;
+  background-image: url("images/sprite_20_tools.png");
+  background-repeat: no-repeat;
   background-position: -400px 0;
   border: none;
+  width: 20px;
+  height: 20px;
+}
+
+#header-clear {
+  background-position: -875px 0 !important;
+  position: absolute;
+  right: calc(100% + 4px);
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 3;
+  cursor: pointer;
 }
 
 #headermenu .navbar-search .icon span {

--- a/lizmap/www/themes/default/css/map.css
+++ b/lizmap/www/themes/default/css/map.css
@@ -45,14 +45,20 @@
 }
 
 #header-clear {
+  background-image: url("images/sprite_20_tools.png");
+  background-repeat: no-repeat;
   background-position: -875px 0 !important;
+  width: 20px;
+  height: 20px;
 }
-
-#headermenu .dropdown-menu > li > a
 
 #headermenu .btn-locate-clear.icon {
   background-color: transparent;
+  background-image: url("images/sprite_20_tools.png");
+  background-repeat: no-repeat;
   background-position: -875px 0;
+  width: 20px;
+  height: 20px;
   margin-top: 5px;
 }
 


### PR DESCRIPTION
- Add click handler on #header-clear to clear search input, highlight, and results dropdown (fixes 3liz#6522)

- Clear highlight when closing search results dropdown

- Fix missing sprite background-image and positioning for the clear button in the BS5 header layout

- Constrain search input height to fit within header bar

- Add data-wkt to Google geocoder results so they show the yellow highlight circle like Nominatim and IGN (fixes 3liz#6407)

- Add "Clear search" tooltip to the clear button

- Remove orphaned CSS selector in theme


![Search](https://github.com/user-attachments/assets/71e87e25-0b1c-4e55-bf12-c0ea4ae91d7a)
