### PR TITLE
CSS: Drop outdated rules about btn-stop and btn-print-clear

### DIFF
--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -1936,34 +1936,6 @@ transform: none !important;
   margin-top: 3px;
 }
 
-#toolbar .title .btn.btn-print-clear,
-#dock .title .btn.btn-print-clear,
-#mini-dock .title .btn.btn-print-clear,
-#right-dock .title .btn.btn-print-clear {
-  background-position : -20px -100px;
-}
-
-#toolbar .title .btn.btn-print-clear:hover,
-#dock .title .btn.btn-print-clear:hover,
-#mini-dock .title .btn.btn-print-clear:hover,
-#right-dock .title .btn.btn-print-clear:hover {
-  background-position : 0 -100px;
-}
-
-#toolbar .title .btn.btn-stop,
-#dock .title .btn.btn-stop,
-#mini-dock .title .btn.btn-stop,
-#right-dock .title .btn.btn-stop {
-  background-position : 0 -20px;
-}
-
-#toolbar .title .btn.btn-stop:hover,
-#dock .title .btn.btn-stop:hover,
-#mini-dock .title .btn.btn-stop:hover,
-#right-dock .title .btn.btn-stop:hover {
-  background-position : -20px -20px;
-}
-
 #toolbar .menu-content .btn.btn-success,
 #dock .menu-content .btn.btn-success,
 #sub-dock .menu-content .btn.btn-success,

--- a/lizmap/www/themes/default/css/map.css
+++ b/lizmap/www/themes/default/css/map.css
@@ -453,22 +453,6 @@ Timemanager
   background-position : -20px 0;
 }
 
-#toolbar .title .btn.btn-print-clear {
-  background-position : -20px -100px;
-}
-
-#toolbar .title .btn.btn-print-clear:hover {
-  background-position : 0 -100px;
-}
-
-#toolbar .title .btn.btn-stop {
-  background-position : 0 -20px;
-}
-
-#toolbar .title .btn.btn-stop:hover {
-  background-position : -20px -20px;
-}
-
 #toolbar .menu-content .btn.btn-success{
   background-color: #93C01F;
   background-image: linear-gradient(center top, #9BC144, #93C01F);


### PR DESCRIPTION
The btn-stop and btn-print-clear rules were about background-position but those classes were always associated with btn-error which set background to none. So those rules were outdated.

Linked to https://github.com/3liz/lizmap-web-client/pull/6675