### PR TITLE
Improve FTS search: ordering, result limits and 2-column display

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapFts.class.php
+++ b/lizmap/modules/lizmap/classes/lizmapFts.class.php
@@ -27,10 +27,14 @@ class lizmapFts
         // Build search query
 
         // SELECT
+        // word_similarity measures how well the search term matches the best
+        // word-level substring of item_label. Unlike similarity(), it gives
+        // equal scores to all labels that contain the search term as a whole
+        // word, so the secondary alphabetical sort on item_label is effective.
         $sql = "
         SELECT
         item_layer, item_label, concat('EPSG:', ST_SRID(geom)) AS item_epsg, ST_AsText(geom) AS item_wkt,
-        similarity(trim( :searchedString ), item_label) AS sim
+        word_similarity(trim( :searchedString ), item_label) AS sim
         ";
 
         // FROM
@@ -92,7 +96,7 @@ class lizmapFts
      *
      * @return List of matching places
      */
-    public static function getData($project, $searchedString, $debug, $limit = 40)
+    public static function getData($project, $searchedString, $debug, $limit = 500)
     {
         $terms = preg_split('/\s+/', $searchedString);
         $sql = lizmapFts::generateSql($project, count($terms));
@@ -134,8 +138,8 @@ class lizmapFts
             $result = $resultSet->fetchAll();
 
             // Limitations
-            $limit_tot = 60;
-            $limit_search = 30;
+            $limit_tot = 100;
+            $limit_search = 50;
 
             // Prepare array to count items per layer
             $nb = array('search' => array(), 'tot' => 0);

--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -3155,9 +3155,9 @@ lizmap-mouse-position > div.coords-unit > select{
   z-index: 1040;
   overflow: auto;
   background-color: rgb(0 0 0 / 70%);
-  max-height: 99%;
+  max-height: 95%;
   right: 100px;
-  max-width: 70%;
+  max-width: 85%;
   color: white;
   border-radius: 5px;
   font-size: 0.8em;
@@ -3192,12 +3192,27 @@ lizmap-mouse-position > div.coords-unit > select{
 
 
 #lizmap-search .items > li > ul{
-  margin: 0 10px 10px 25px
+  margin: 0 10px 10px 25px;
+}
+
+/* Two columns only when a category has more than 30 results */
+#lizmap-search .items > li > ul:has(> li:nth-child(31)) {
+  columns: 2 240px;
+  column-gap: 1.5em;
+}
+
+#lizmap-search .items > li > ul > li {
+  break-inside: avoid; /* keep each result in a single column */
+  max-width: 280px;    /* cap column item width so long names wrap instead of stretching */
+  overflow-wrap: break-word;
 }
 
 #lizmap-search a{
   color:white;
   font-size:0.9em;
+  display: block;      /* fills item width so hover area and wrapping work correctly */
+  white-space: normal;
+  overflow-wrap: break-word;
 }
 
 #lizmap-search a:hover{

--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -3217,9 +3217,9 @@ lizmap-paste-stored-geom > button {
   z-index: 1040;
   overflow: auto;
   background-color: rgb(0 0 0 / 70%);
-  max-height: 99%;
+  max-height: 95%;
   right: 100px;
-  max-width: 70%;
+  max-width: 85%;
   color: white;
   border-radius: 5px;
   font-size: 0.8em;
@@ -3254,12 +3254,27 @@ lizmap-paste-stored-geom > button {
 
 
 #lizmap-search .items > li > ul{
-  margin: 0 10px 10px 25px
+  margin: 0 10px 10px 25px;
+}
+
+/* Two columns only when a category has more than 30 results */
+#lizmap-search .items > li > ul:has(> li:nth-child(31)) {
+  columns: 2 240px;
+  column-gap: 1.5em;
+}
+
+#lizmap-search .items > li > ul > li {
+  break-inside: avoid; /* keep each result in a single column */
+  max-width: 280px;    /* cap column item width so long names wrap instead of stretching */
+  overflow-wrap: break-word;
 }
 
 #lizmap-search a{
   color:white;
   font-size:0.9em;
+  display: block;      /* fills item width so hover area and wrapping work correctly */
+  white-space: normal;
+  overflow-wrap: break-word;
 }
 
 #lizmap-search a:hover{


### PR DESCRIPTION
- Switch similarity() to word_similarity() so short search terms (e.g. "106") score equally for all labels containing the term as a whole word, letting the secondary ORDER BY item_label produce a clean alphabetical list
- Raise SQL fetch limit (40→500), per-layer cap (30→50) and total cap (60→100) to prevent late-alphabet results being silently dropped
- Widen search panel (max-width 70%→85%), cap height at 95%
- Apply 2-column layout via CSS :has() only when a category has 11+ results; each item is capped at 280px with word wrapping

<img width="629" height="690" alt="grafik" src="https://github.com/user-attachments/assets/59f0f278-ed6a-4e70-8cf7-71a55a1e6c87" />
