### PR TITLE
Remove x from btn-selectiontool-clear

### DIFF
--- a/assets/src/components/SelectionTool.js
+++ b/assets/src/components/SelectionTool.js
@@ -37,7 +37,7 @@ export default class SelectionTool extends HTMLElement {
                     class="btn-selectiontool-clear btn-close"
                     title="${lizDict['toolbar.content.stop']}"
                     @click=${() => mainLizmap.selectionTool.disable()}
-                    >×</button>
+                    ></button>
                 <span class="icon-star icon-white"></span>
                 <span class="text">&nbsp;${lizDict['selectiontool.toolbar.title']}&nbsp;</span>
             </span>


### PR DESCRIPTION
After this https://github.com/3liz/lizmap-web-client/pull/6675 it's not needed anymore

Fix this 
<img width="99" height="49" alt="image" src="https://github.com/user-attachments/assets/9ec118d4-a7b1-4639-879d-34ce035ecd89" />

To this

<img width="96" height="31" alt="image" src="https://github.com/user-attachments/assets/0f9da98d-5c01-497d-b963-092cf1c531da" />

Backport to 3.10