### PR TITLE
fix(edition): fix digitization tab layout overflow and button alignment

### DIFF
--- a/lizmap/modules/view/templates/map_edition.tpl
+++ b/lizmap/modules/view/templates/map_edition.tpl
@@ -72,12 +72,12 @@
                             <div id="edition-point-coord-form-group" class="jforms-table-group">
                                 <div id="handle-point-coord">
                                     <h3>{@view~edition.point.coord.title@}</h3>
-                                    <div class="form-group row mb-3">
-                                        <label class="jforms-label form-label" for="edition-point-coord-crs"
+                                    <div class="form-group row g-0 mb-2">
+                                        <label class="jforms-label form-label col-auto" for="edition-point-coord-crs"
                                             id="edition-point-coord-crs-label">{@view~edition.point.coord.crs.label@}</label>
-                                        <div class="controls">
+                                        <div class="controls col">
                                             <select name="coord-crs" id="edition-point-coord-crs"
-                                                class="jforms-ctrl-menulist form-select">
+                                                class="jforms-ctrl-menulist form-select form-select-sm">
                                                 <option value="4326" selected="selected"><span>EPSG:4326</span></option>
                                                 <option id="edition-point-coord-crs-layer" value="" style="display:none;">
                                                 </option>
@@ -86,47 +86,47 @@
                                             </select>
                                         </div>
                                     </div>
-                                    <div class="form-group row mb-3">
-                                        <label class="jforms-label form-label" for="edition-point-coord-x"
+                                    <div class="form-group row g-0 mb-2">
+                                        <label class="jforms-label form-label col-auto" for="edition-point-coord-x"
                                             id="edition-point-coord-x-label">{@view~edition.point.coord.x.label@}</label>
-                                        <div class="controls">
+                                        <div class="controls col">
                                             <input name="coord-x" id="edition-point-coord-x"
                                                 class="jforms-ctrl-input form-control form-control-sm" value="" type="text">
                                         </div>
                                     </div>
-                                    <div class="form-group row mb-3">
-                                        <label class="jforms-label form-label" for="edition-point-coord-y"
+                                    <div class="form-group row g-0 mb-2">
+                                        <label class="jforms-label form-label col-auto" for="edition-point-coord-y"
                                             id="edition-point-coord-y-label">{@view~edition.point.coord.y.label@}</label>
-                                        <div class="controls">
+                                        <div class="controls col">
                                             <input name="coord-y" id="edition-point-coord-y"
                                                 class="jforms-ctrl-input form-control form-control-sm" value="" type="text">
                                         </div>
                                     </div>
-                                    <div class="form-group row mb-3 hidden">
+                                    <div class="form-group row g-0 mb-2 hidden">
                                         <label
-                                            class="jforms-label form-label">{@view~edition.segment.length.label@}</label>
-                                        <div class="controls">
+                                            class="jforms-label form-label col-auto">{@view~edition.segment.length.label@}</label>
+                                        <div class="controls col">
                                             <label id="edition-segment-length"></label>
                                         </div>
                                     </div>
-                                    <div class="form-group row mb-3 hidden">
+                                    <div class="form-group row g-0 mb-2 hidden">
                                         <label
-                                            class="jforms-label form-label">{@view~edition.segment.angle.label@}</label>
-                                        <div class="controls">
+                                            class="jforms-label form-label col-auto">{@view~edition.segment.angle.label@}</label>
+                                        <div class="controls col">
                                             <label id="edition-segment-angle"></label>
                                         </div>
                                     </div>
-                                    <div class="form-group row mb-3">
-                                        <div class="controls">
+                                    <div class="form-group row g-0 mb-2">
+                                        <div class="controls col">
                                             <button name="submit" id="edition-point-coord-add"
                                                 class="btn btn-sm">{@view~edition.point.coord.add.label@}</button>
                                             <button name="submit" id="edition-point-coord-submit"
                                                 class="btn btn-sm">{@view~edition.point.coord.finalize.label@}</button>
                                         </div>
                                     </div>
-                                    <div class="form-group row mb-3" id="edition-point-coord-geolocation-group"
+                                    <div class="form-group row g-0 mb-2" id="edition-point-coord-geolocation-group"
                                         style="display:none;">
-                                        <div class="controls form-check">
+                                        <div class="controls form-check col">
                                             <label class="jforms-label checkbox form-check-label" for="edition-point-coord-geolocation"
                                                 id="edition-point-coord-geolocation-label">
                                                 <input name="checked" id="edition-point-coord-geolocation"

--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -2991,6 +2991,18 @@ lizmap-mouse-position > div.coords-unit > select{
   z-index: 1;
 }
 
+#tabdigitization {
+  padding-top: 5px;
+}
+
+#edition-geomtool-container,
+#edition-geomtool-restart-drawing,
+lizmap-paste-geom > button,
+lizmap-paste-stored-geom > button {
+  margin-left: 5px;
+}
+
+
 .edition-tabs .nav-pills a {
   color: black;
 }
@@ -3123,6 +3135,7 @@ lizmap-mouse-position > div.coords-unit > select{
 #dock #edition-point-coord-form{
   margin-bottom: 5px;
 }
+
 
 #edition-point-coord-form-group h3{
   color: black;
@@ -3663,14 +3676,14 @@ lizmap-fullscreen button svg {
   margin: auto;
 }
 
-lizmap-paste-geom {
-  display: inline-block;
+lizmap-paste-geom,
+lizmap-paste-stored-geom {
+  display: contents;
 }
 
 lizmap-paste-geom svg {
-  width: 24px;
-  height: 24px;
-  display: inline-block;
+  width: 20px;
+  height: 20px;
   vertical-align: text-top;
 }
 

--- a/lizmap/www/themes/default/css/map.css
+++ b/lizmap/www/themes/default/css/map.css
@@ -1050,12 +1050,12 @@ div.popup_lizmap_dd .nav-tabs > li.active > a:focus {
 
 #edition div.tab-pane,
 div.popup_lizmap_dd div.tab-pane {
-  border-left: 1px solid var(--color-contrasted-elements);
-  border-right: 1px solid var(--color-contrasted-elements);
-  border-bottom: 1px solid var(--color-contrasted-elements);
   padding: 5px;
   padding-bottom: 10px;
   margin-bottom: 5px;
+  border-left: 1px solid var(--color-contrasted-elements);
+  border-right: 1px solid var(--color-contrasted-elements);
+  border-bottom: 1px solid var(--color-contrasted-elements);
 }
 
 #edition div.tab-pane.attribute-layer-child-content,


### PR DESCRIPTION
Bootstrap 5's` .row` negative gutters caused form-select/form-control to overflow the fieldset in the digitization coordinate form. Add `g-0` (zero gutters), `col-auto` on labels and `col on .controls divs` to contain them.

Also fix several CSS layout issues in the digitization tab:
- Add padding-top to `#tabdigitization` to give content breathing room
- Add `margin-left` to geomtool buttons to align with the themed fieldset (highlighted red in the screenshot)
- Fix` lizmap-paste-geom` button height: use `display:contents` on the custom element wrapper and size the inner SVG to match the other icon sprites


<img width="446" height="625" alt="grafik" src="https://github.com/user-attachments/assets/e53fe903-7ed2-4095-ba4e-010518415baf" />