### PR TITLE
feat(search): live search while typing, debounced at 100ms

### DIFF
--- a/assets/src/modules/Search.js
+++ b/assets/src/modules/Search.js
@@ -5,6 +5,8 @@
  * @license MPL-2.0
  */
 
+const AUTOCOMPLETE_MIN_LENGTH = 3;
+
 /**
  * @class
  * @name Search
@@ -56,6 +58,20 @@ export default class Search {
     }
 
     /**
+     * Returns a debounced version of fn that fires after delay ms of inactivity
+     * @param {Function} fn
+     * @param {number} delay - milliseconds
+     * @returns {Function}
+     */
+    _debounce(fn, delay) {
+        let timer;
+        return (...args) => {
+            clearTimeout(timer);
+            timer = setTimeout(() => fn(...args), delay);
+        };
+    }
+
+    /**
      * Start the external search
      */
     _startExternalSearch() {
@@ -94,10 +110,57 @@ export default class Search {
     }
 
     /**
-     * PRIVATE method: addExternalSearch
-     * add external search capability
+     * PRIVATE method: fire a lizmapFts search request and display results
      * @param {object} searchConfig - search configuration
-     * @returns {boolean} external search is in the user interface
+     * @param {OpenLayers.Bounds} extent - WGS84 map extent for filtering
+     */
+    _performFtsSearch(searchConfig, extent) {
+        this._startExternalSearch();
+
+        var labrex = this._getHighlightRegEx();
+        $.get(searchConfig.url
+            , {
+                "repository": globalThis['lizUrls'].params.repository,
+                "project": globalThis['lizUrls'].params.project,
+                "query": $('#search-query').val(),
+            }
+            , (results) => {
+                var text = '';
+                var count = 0;
+
+                for (var ftsId in results) {
+                    var ftsLayerResult = results[ftsId];
+                    text += '<li><strong>' + ftsLayerResult.search_name + '</strong>';
+                    text += '<ul>';
+                    for (var i = 0, len = ftsLayerResult.features.length; i < len; i++) {
+                        var ftsFeat = ftsLayerResult.features[i];
+                        var ftsGeometry = OpenLayers.Geometry.fromWKT(ftsFeat.geometry);
+                        if (ftsLayerResult.srid != 'EPSG:4326') {
+                            ftsGeometry.transform(ftsLayerResult.srid, 'EPSG:4326');
+                        }
+                        var bbox = ftsGeometry.getBounds();
+                        if (extent.intersectsBounds(bbox)) {
+                            var lab = ftsFeat.label.replace(labrex, '<strong class="highlight">$1</strong>');
+                            text += '<li><a href="#' + bbox.toBBOX() + '" data-wkt="' + ftsGeometry.toString() + '">' + lab + '</a></li>';
+                            count++;
+                        }
+                    }
+                    text += '</ul></li>';
+                }
+
+                if (count != 0 && text != '') {
+                    this._updateExternalSearch(text);
+                }
+                else {
+                    this._updateExternalSearch('<li><strong>' + lizDict['externalsearch.mapdata'] + '</strong><ul><li>' + lizDict['externalsearch.notfound'] + '</li></ul></li>');
+                }
+            }, 'json');
+    }
+
+    /**
+     * PRIVATE method: add lizmapFts search capability with autocomplete
+     * @param {object} searchConfig - search configuration
+     * @returns {boolean} search is in the user interface
      */
     _addSearch(searchConfig) {
         if (searchConfig.type == 'externalSearch') {
@@ -112,58 +175,158 @@ export default class Search {
         var extent = new OpenLayers.Bounds(this._lizmap3.map.maxExtent.toArray());
         extent.transform(this._map.getView().getProjection().getCode(), wgs84);
 
+        const autoSearch = () => {
+            if ($('#search-query').val().length < AUTOCOMPLETE_MIN_LENGTH) {
+                $('#lizmap-search .items').html('');
+                $('#lizmap-search, #lizmap-search-close').removeClass('open');
+                return;
+            }
+            this._performFtsSearch(searchConfig, extent);
+        };
+
         $('#nominatim-search').submit(() => {
-            this._startExternalSearch();
-
-            // Format answers to highlight searched keywords
-            var labrex = this._getHighlightRegEx();
-            $.get(searchConfig.url
-                , {
-                    "repository": globalThis['lizUrls'].params.repository,
-                    "project": globalThis['lizUrls'].params.project,
-                    "query": $('#search-query').val(),
-                }
-                , (results) => {
-                    var text = '';
-                    var count = 0;
-
-                    // Loop through results
-                    for (var ftsId in results) {
-                        var ftsLayerResult = results[ftsId];
-                        text += '<li><strong>' + ftsLayerResult.search_name + '</strong>';
-                        text += '<ul>';
-                        for (var i = 0, len = ftsLayerResult.features.length; i < len; i++) {
-                            var ftsFeat = ftsLayerResult.features[i];
-                            var ftsGeometry = OpenLayers.Geometry.fromWKT(ftsFeat.geometry);
-                            if (ftsLayerResult.srid != 'EPSG:4326') {
-                                ftsGeometry.transform(ftsLayerResult.srid, 'EPSG:4326');
-                            }
-                            var bbox = ftsGeometry.getBounds();
-                            if (extent.intersectsBounds(bbox)) {
-                                var lab = ftsFeat.label.replace(labrex, '<strong class="highlight">$1</strong>');
-                                text += '<li><a href="#' + bbox.toBBOX() + '" data-wkt="' + ftsGeometry.toString() + '">' + lab + '</a></li>';
-                                count++;
-                            }
-                        }
-                        text += '</ul></li>';
-                    }
-
-                    if (count != 0 && text != '') {
-                        this._updateExternalSearch(text);
-                    }
-                    else {
-                        this._updateExternalSearch('<li><strong>' + lizDict['externalsearch.mapdata'] + '</strong><ul><li>' + lizDict['externalsearch.notfound'] + '</li></ul></li>');
-                    }
-                }, 'json');
+            this._performFtsSearch(searchConfig, extent);
             return false;
         });
+
+        $('#search-query').on('input', this._debounce(autoSearch, 100));
 
         return true;
     }
 
     /**
-     * PRIVATE method: addExternalSearch
-     * add external search capability
+     * PRIVATE method: fire an external geocoder search request and display results
+     * @param {object} searchConfig - search configuration
+     * @param {string|object} service - resolved service URL or Google Geocoder instance
+     * @param {OpenLayers.Bounds} extent - WGS84 map extent for filtering
+     */
+    _performExternalSearch(searchConfig, service, extent) {
+        this._startExternalSearch();
+
+        var labrex = this._getHighlightRegEx();
+        const searchQuery = document.getElementById('search-query').value;
+        switch (searchConfig.service) {
+            case 'nominatim':
+                $.get(service
+                    , { "query": searchQuery, "bbox": extent.toBBOX() }
+                    , data => {
+                        var text = '';
+                        var count = 0;
+                        for (const address of data) {
+                            if (count > 9) {
+                                return false;
+                            }
+                            if (!address.boundingbox) {
+                                return true;
+                            }
+
+                            var bbox = [
+                                address.boundingbox[2],
+                                address.boundingbox[0],
+                                address.boundingbox[3],
+                                address.boundingbox[1]
+                            ];
+                            bbox = new OpenLayers.Bounds(bbox);
+                            if (extent.intersectsBounds(bbox)) {
+                                var lab = address.display_name.replace(labrex, '<strong class="highlight">$1</strong>');
+                                text += `<li><a href="#${bbox.toBBOX()}" data-wkt="POINT(${address.lon} ${address.lat})">${lab}</a></li>`;
+                                count++;
+                            }
+                        }
+                        if (count == 0 || text == '') {
+                            text = '<li>' + lizDict['externalsearch.notfound'] + '</li>';
+                        }
+                        this._updateExternalSearch('<li><strong>OpenStreetMap</strong><ul>' + text + '</ul></li>');
+                    }, 'json');
+                break;
+            case 'ign': {
+                if (searchQuery.length < 3 || searchQuery.length > 200) {
+                    lizMap.addMessage(lizDict['externalsearch.ignlimit'], 'warning', true);
+                    break;
+                }
+                $.get(service
+                    , {
+                        "text": searchQuery,
+                        "type": 'StreetAddress',
+                        "maximumResponses": 10,
+                        "bbox": extent.toBBOX()
+                    }
+                    , data => {
+                        let text = '';
+                        let count = 0;
+                        for (const result of data.results) {
+                            var lab = result.fulltext.replace(labrex, '<strong class="highlight">$1</strong>');
+                            text += `
+                            <li>
+                                <a href="#${result.x},${result.y},${result.x},${result.y}" data-wkt="POINT(${result.x} ${result.y})">
+                                    ${lab}
+                                </a>
+                            </li>`;
+                            count++;
+                        }
+                        if (count == 0 || text == '') {
+                            text = '<li>' + lizDict['externalsearch.notfound'] + '</li>';
+                        }
+                        this._updateExternalSearch('<li><strong>IGN</strong><ul>' + text + '</ul></li>');
+                    }, 'json');
+                break;
+            }
+            case 'google':
+                service.geocode({
+                    'address': searchQuery,
+                    'bounds': new google.maps.LatLngBounds(
+                        new google.maps.LatLng(extent.top, extent.left),
+                        new google.maps.LatLng(extent.bottom, extent.right)
+                    )
+                }, (results, status) => {
+                    if (status == google.maps.GeocoderStatus.OK) {
+                        var text = '';
+                        var count = 0;
+                        for (const address of results) {
+                            if (count > 9) {
+                                return false;
+                            }
+                            var bbox = [];
+                            if (address.geometry.viewport) {
+                                bbox = [
+                                    address.geometry.viewport.getSouthWest().lng(),
+                                    address.geometry.viewport.getSouthWest().lat(),
+                                    address.geometry.viewport.getNorthEast().lng(),
+                                    address.geometry.viewport.getNorthEast().lat()
+                                ];
+                            } else if (address.geometry.bounds) {
+                                bbox = [
+                                    address.geometry.bounds.getSouthWest().lng(),
+                                    address.geometry.bounds.getSouthWest().lat(),
+                                    address.geometry.bounds.getNorthEast().lng(),
+                                    address.geometry.bounds.getNorthEast().lat()
+                                ];
+                            }
+                            if (bbox.length != 4) {
+                                return false;
+                            }
+                            bbox = new OpenLayers.Bounds(bbox);
+                            if (extent.intersectsBounds(bbox)) {
+                                var lab = address.formatted_address.replace(labrex, '<strong class="highlight">$1</strong>');
+                                var wkt = 'POINT(' + address.geometry.location.lng() + ' ' + address.geometry.location.lat() + ')';
+                                text += '<li><a href="#' + bbox.toBBOX() + '" data-wkt="' + wkt + '">' + lab + '</a></li>';
+                                count++;
+                            }
+                        }
+                        if (count == 0 || text == '') {
+                            text = '<li>' + lizDict['externalsearch.notfound'] + '</li>';
+                        }
+                        this._updateExternalSearch('<li><strong>Google</strong><ul>' + text + '</ul></li>');
+                    } else {
+                        this._updateExternalSearch('<li><strong>Google</strong><ul><li>' + lizDict['externalsearch.notfound'] + '</li></ul></li>');
+                    }
+                });
+                break;
+        }
+    }
+
+    /**
+     * PRIVATE method: add external geocoder search capability with autocomplete
      * @param {object} searchConfig - search configuration
      * @returns {boolean} external search is in the user interface
      */
@@ -201,132 +364,21 @@ export default class Search {
             return false;
         }
 
-        $('#nominatim-search').submit(() => {
-            this._startExternalSearch();
-
-            // Format answers to highlight searched keywords
-            var labrex = this._getHighlightRegEx();
-            const searchQuery = document.getElementById('search-query').value;
-            switch (searchConfig.service) {
-                case 'nominatim':
-                    $.get(service
-                        , { "query": searchQuery, "bbox": extent.toBBOX() }
-                        , data => {
-                            var text = '';
-                            var count = 0;
-                            for (const address of data) {
-                                if (count > 9) {
-                                    return false;
-                                }
-                                if (!address.boundingbox) {
-                                    return true;
-                                }
-
-                                var bbox = [
-                                    address.boundingbox[2],
-                                    address.boundingbox[0],
-                                    address.boundingbox[3],
-                                    address.boundingbox[1]
-                                ];
-                                bbox = new OpenLayers.Bounds(bbox);
-                                if (extent.intersectsBounds(bbox)) {
-                                    var lab = address.display_name.replace(labrex, '<strong class="highlight">$1</strong>');
-                                    text += `<li><a href="#${bbox.toBBOX()}" data-wkt="POINT(${address.lon} ${address.lat})">${lab}</a></li>`;
-                                    count++;
-                                }
-                            }
-                            if (count == 0 || text == '') {
-                                text = '<li>' + lizDict['externalsearch.notfound'] + '</li>';
-                            }
-                            this._updateExternalSearch('<li><strong>OpenStreetMap</strong><ul>' + text + '</ul></li>');
-                        }, 'json');
-                    break;
-                case 'ign': {
-                    if (searchQuery.length < 3 || searchQuery.length > 200) {
-                        lizMap.addMessage(lizDict['externalsearch.ignlimit'], 'warning', true);
-                        break;
-                    }
-                    $.get(service
-                        , {
-                            "text": searchQuery,
-                            "type": 'StreetAddress',
-                            "maximumResponses": 10,
-                            "bbox": extent.toBBOX()
-                        }
-                        , data => {
-                            let text = '';
-                            let count = 0;
-                            for (const result of data.results) {
-                                var lab = result.fulltext.replace(labrex, '<strong class="highlight">$1</strong>');
-                                text += `
-                                <li>
-                                    <a href="#${result.x},${result.y},${result.x},${result.y}" data-wkt="POINT(${result.x} ${result.y})">
-                                        ${lab}
-                                    </a>
-                                </li>`;
-                                count++;
-                            }
-                            if (count == 0 || text == '') {
-                                text = '<li>' + lizDict['externalsearch.notfound'] + '</li>';
-                            }
-                            this._updateExternalSearch('<li><strong>IGN</strong><ul>' + text + '</ul></li>');
-                        }, 'json');
-                    break;
-                }
-                case 'google':
-                    service.geocode({
-                        'address': searchQuery,
-                        'bounds': new google.maps.LatLngBounds(
-                            new google.maps.LatLng(extent.top, extent.left),
-                            new google.maps.LatLng(extent.bottom, extent.right)
-                        )
-                    }, (results, status) => {
-                        if (status == google.maps.GeocoderStatus.OK) {
-                            var text = '';
-                            var count = 0;
-                            for (const address of results) {
-                                if (count > 9) {
-                                    return false;
-                                }
-                                var bbox = [];
-                                if (address.geometry.viewport) {
-                                    bbox = [
-                                        address.geometry.viewport.getSouthWest().lng(),
-                                        address.geometry.viewport.getSouthWest().lat(),
-                                        address.geometry.viewport.getNorthEast().lng(),
-                                        address.geometry.viewport.getNorthEast().lat()
-                                    ];
-                                } else if (address.geometry.bounds) {
-                                    bbox = [
-                                        address.geometry.bounds.getSouthWest().lng(),
-                                        address.geometry.bounds.getSouthWest().lat(),
-                                        address.geometry.bounds.getNorthEast().lng(),
-                                        address.geometry.bounds.getNorthEast().lat()
-                                    ];
-                                }
-                                if (bbox.length != 4) {
-                                    return false;
-                                }
-                                bbox = new OpenLayers.Bounds(bbox);
-                                if (extent.intersectsBounds(bbox)) {
-                                    var lab = address.formatted_address.replace(labrex, '<strong class="highlight">$1</strong>');
-                                    var wkt = 'POINT(' + address.geometry.location.lng() + ' ' + address.geometry.location.lat() + ')';
-                                    text += '<li><a href="#' + bbox.toBBOX() + '" data-wkt="' + wkt + '">' + lab + '</a></li>';
-                                    count++;
-                                }
-                            }
-                            if (count == 0 || text == '') {
-                                text = '<li>' + lizDict['externalsearch.notfound'] + '</li>';
-                            }
-                            this._updateExternalSearch('<li><strong>Google</strong><ul>' + text + '</ul></li>');
-                        } else {
-                            this._updateExternalSearch('<li><strong>Google</strong><ul><li>' + lizDict['externalsearch.notfound'] + '</li></ul></li>');
-                        }
-                    });
-                    break;
+        const autoSearch = () => {
+            if ($('#search-query').val().length < AUTOCOMPLETE_MIN_LENGTH) {
+                $('#lizmap-search .items').html('');
+                $('#lizmap-search, #lizmap-search-close').removeClass('open');
+                return;
             }
+            this._performExternalSearch(searchConfig, service, extent);
+        };
+
+        $('#nominatim-search').submit(() => {
+            this._performExternalSearch(searchConfig, service, extent);
             return false;
         });
+
+        $('#search-query').on('input', this._debounce(autoSearch, 100));
 
         return true;
     }

--- a/assets/src/modules/Search.js
+++ b/assets/src/modules/Search.js
@@ -5,6 +5,8 @@
  * @license MPL-2.0
  */
 
+import { Utils } from './Utils.js';
+
 const AUTOCOMPLETE_MIN_LENGTH = 3;
 
 /**
@@ -79,9 +81,9 @@ export default class Search {
      */
     _buildAutoSearch(performFn) {
         return () => {
-            if ($('#search-query').val().length < AUTOCOMPLETE_MIN_LENGTH) {
-                $('#lizmap-search .items').html('');
-                $('#lizmap-search, #lizmap-search-close').removeClass('open');
+            if (document.getElementById('search-query').value.length < AUTOCOMPLETE_MIN_LENGTH) {
+                document.querySelector('#lizmap-search .items').innerHTML = '';
+                document.querySelectorAll('#lizmap-search, #lizmap-search-close').forEach(el => el.classList.remove('open'));
                 return;
             }
             performFn();
@@ -134,44 +136,42 @@ export default class Search {
     _performFtsSearch(searchConfig, extent) {
         this._startExternalSearch();
 
-        var labrex = this._getHighlightRegEx();
-        $.get(searchConfig.url
-            , {
-                "repository": globalThis['lizUrls'].params.repository,
-                "project": globalThis['lizUrls'].params.project,
-                "query": $('#search-query').val(),
-            }
-            , (results) => {
-                var text = '';
-                var count = 0;
+        const labrex = this._getHighlightRegEx();
+        const url = new URL(searchConfig.url, location.href);
+        url.searchParams.set('repository', globalThis['lizUrls'].params.repository);
+        url.searchParams.set('project', globalThis['lizUrls'].params.project);
+        url.searchParams.set('query', document.getElementById('search-query').value);
 
-                for (var ftsId in results) {
-                    var ftsLayerResult = results[ftsId];
-                    text += '<li><strong>' + ftsLayerResult.search_name + '</strong>';
-                    text += '<ul>';
-                    for (var i = 0, len = ftsLayerResult.features.length; i < len; i++) {
-                        var ftsFeat = ftsLayerResult.features[i];
-                        var ftsGeometry = OpenLayers.Geometry.fromWKT(ftsFeat.geometry);
-                        if (ftsLayerResult.srid != 'EPSG:4326') {
-                            ftsGeometry.transform(ftsLayerResult.srid, 'EPSG:4326');
-                        }
-                        var bbox = ftsGeometry.getBounds();
-                        if (extent.intersectsBounds(bbox)) {
-                            var lab = ftsFeat.label.replace(labrex, '<strong class="highlight">$1</strong>');
-                            text += '<li><a href="#' + bbox.toBBOX() + '" data-wkt="' + ftsGeometry.toString() + '">' + lab + '</a></li>';
-                            count++;
-                        }
+        Utils.fetchJSON(url.toString()).then(results => {
+            var text = '';
+            var count = 0;
+
+            for (var ftsId in results) {
+                var ftsLayerResult = results[ftsId];
+                text += '<li><strong>' + ftsLayerResult.search_name + '</strong>';
+                text += '<ul>';
+                for (var i = 0, len = ftsLayerResult.features.length; i < len; i++) {
+                    var ftsFeat = ftsLayerResult.features[i];
+                    var ftsGeometry = OpenLayers.Geometry.fromWKT(ftsFeat.geometry);
+                    if (ftsLayerResult.srid != 'EPSG:4326') {
+                        ftsGeometry.transform(ftsLayerResult.srid, 'EPSG:4326');
                     }
-                    text += '</ul></li>';
+                    var bbox = ftsGeometry.getBounds();
+                    if (extent.intersectsBounds(bbox)) {
+                        var lab = ftsFeat.label.replace(labrex, '<strong class="highlight">$1</strong>');
+                        text += '<li><a href="#' + bbox.toBBOX() + '" data-wkt="' + ftsGeometry.toString() + '">' + lab + '</a></li>';
+                        count++;
+                    }
                 }
+                text += '</ul></li>';
+            }
 
-                if (count != 0 && text != '') {
-                    this._updateExternalSearch(text);
-                }
-                else {
-                    this._updateExternalSearch('<li><strong>' + lizDict['externalsearch.mapdata'] + '</strong><ul><li>' + lizDict['externalsearch.notfound'] + '</li></ul></li>');
-                }
-            }, 'json');
+            if (count != 0 && text != '') {
+                this._updateExternalSearch(text);
+            } else {
+                this._updateExternalSearch('<li><strong>' + lizDict['externalsearch.mapdata'] + '</strong><ul><li>' + lizDict['externalsearch.notfound'] + '</li></ul></li>');
+            }
+        });
     }
 
     /**
@@ -194,12 +194,12 @@ export default class Search {
 
         const autoSearch = this._buildAutoSearch(() => this._performFtsSearch(searchConfig, extent));
 
-        $('#nominatim-search').submit(() => {
+        document.getElementById('nominatim-search').addEventListener('submit', evt => {
+            evt.preventDefault();
             this._performFtsSearch(searchConfig, extent);
-            return false;
         });
 
-        $('#search-query').on('input', this._debounce(autoSearch, 100));
+        document.getElementById('search-query').addEventListener('input', this._debounce(autoSearch, 100));
 
         return true;
     }
@@ -216,69 +216,69 @@ export default class Search {
         var labrex = this._getHighlightRegEx();
         const searchQuery = document.getElementById('search-query').value;
         switch (searchConfig.service) {
-            case 'nominatim':
-                $.get(service
-                    , { "query": searchQuery, "bbox": extent.toBBOX() }
-                    , data => {
-                        var text = '';
-                        var count = 0;
-                        for (const address of data) {
-                            if (count > 9) {
-                                return false;
-                            }
-                            if (!address.boundingbox) {
-                                return true;
-                            }
+            case 'nominatim': {
+                const nominatimUrl = new URL(service);
+                nominatimUrl.searchParams.set('query', searchQuery);
+                nominatimUrl.searchParams.set('bbox', extent.toBBOX());
+                Utils.fetchJSON(nominatimUrl.toString()).then(data => {
+                    var text = '';
+                    var count = 0;
+                    for (const address of data) {
+                        if (count > 9) {
+                            return false;
+                        }
+                        if (!address.boundingbox) {
+                            return true;
+                        }
 
-                            var bbox = [
-                                address.boundingbox[2],
-                                address.boundingbox[0],
-                                address.boundingbox[3],
-                                address.boundingbox[1]
-                            ];
-                            bbox = new OpenLayers.Bounds(bbox);
-                            if (extent.intersectsBounds(bbox)) {
-                                var lab = address.display_name.replace(labrex, '<strong class="highlight">$1</strong>');
-                                text += `<li><a href="#${bbox.toBBOX()}" data-wkt="POINT(${address.lon} ${address.lat})">${lab}</a></li>`;
-                                count++;
-                            }
+                        var bbox = [
+                            address.boundingbox[2],
+                            address.boundingbox[0],
+                            address.boundingbox[3],
+                            address.boundingbox[1]
+                        ];
+                        bbox = new OpenLayers.Bounds(bbox);
+                        if (extent.intersectsBounds(bbox)) {
+                            var lab = address.display_name.replace(labrex, '<strong class="highlight">$1</strong>');
+                            text += `<li><a href="#${bbox.toBBOX()}" data-wkt="POINT(${address.lon} ${address.lat})">${lab}</a></li>`;
+                            count++;
                         }
-                        if (count == 0 || text == '') {
-                            text = '<li>' + lizDict['externalsearch.notfound'] + '</li>';
-                        }
-                        this._updateExternalSearch('<li><strong>OpenStreetMap</strong><ul>' + text + '</ul></li>');
-                    }, 'json');
+                    }
+                    if (count == 0 || text == '') {
+                        text = '<li>' + lizDict['externalsearch.notfound'] + '</li>';
+                    }
+                    this._updateExternalSearch('<li><strong>OpenStreetMap</strong><ul>' + text + '</ul></li>');
+                });
                 break;
+            }
             case 'ign': {
                 if (searchQuery.length < AUTOCOMPLETE_MIN_LENGTH || searchQuery.length > 200) {
                     lizMap.addMessage(lizDict['externalsearch.ignlimit'], 'warning', true);
                     break;
                 }
-                $.get(service
-                    , {
-                        "text": searchQuery,
-                        "type": 'StreetAddress',
-                        "maximumResponses": 10,
-                        "bbox": extent.toBBOX()
-                    }
-                    , data => {
-                        let text = '';
-                        let count = 0;
-                        for (const result of data.results) {
-                            var lab = result.fulltext.replace(labrex, '<strong class="highlight">$1</strong>');
-                            text += `
+                const ignUrl = new URL(service);
+                ignUrl.searchParams.set('text', searchQuery);
+                ignUrl.searchParams.set('type', 'StreetAddress');
+                ignUrl.searchParams.set('maximumResponses', 10);
+                ignUrl.searchParams.set('bbox', extent.toBBOX());
+                Utils.fetchJSON(ignUrl.toString()).then(data => {
+                    let text = '';
+                    let count = 0;
+                    for (const result of data.results) {
+                        var lab = result.fulltext.replace(labrex, '<strong class="highlight">$1</strong>');
+                        text += `
                             <li>
                                 <a href="#${result.x},${result.y},${result.x},${result.y}" data-wkt="POINT(${result.x} ${result.y})">
                                     ${lab}
                                 </a>
                             </li>`;
-                            count++;
-                        }
-                        if (count == 0 || text == '') {
-                            text = '<li>' + lizDict['externalsearch.notfound'] + '</li>';
-                        }
-                        this._updateExternalSearch('<li><strong>IGN</strong><ul>' + text + '</ul></li>');
-                    }, 'json');
+                        count++;
+                    }
+                    if (count == 0 || text == '') {
+                        text = '<li>' + lizDict['externalsearch.notfound'] + '</li>';
+                    }
+                    this._updateExternalSearch('<li><strong>IGN</strong><ul>' + text + '</ul></li>');
+                });
                 break;
             }
             case 'google':
@@ -376,12 +376,12 @@ export default class Search {
 
         const autoSearch = this._buildAutoSearch(() => this._performExternalSearch(searchConfig, service, extent));
 
-        $('#nominatim-search').submit(() => {
+        document.getElementById('nominatim-search').addEventListener('submit', evt => {
+            evt.preventDefault();
             this._performExternalSearch(searchConfig, service, extent);
-            return false;
         });
 
-        $('#search-query').on('input', this._debounce(autoSearch, 100));
+        document.getElementById('search-query').addEventListener('input', this._debounce(autoSearch, 100));
 
         return true;
     }

--- a/assets/src/modules/Search.js
+++ b/assets/src/modules/Search.js
@@ -72,6 +72,23 @@ export default class Search {
     }
 
     /**
+     * Returns an auto-search handler that clears results below min length,
+     * otherwise delegates to performFn
+     * @param {Function} performFn - search function to call when input is long enough
+     * @returns {Function}
+     */
+    _buildAutoSearch(performFn) {
+        return () => {
+            if ($('#search-query').val().length < AUTOCOMPLETE_MIN_LENGTH) {
+                $('#lizmap-search .items').html('');
+                $('#lizmap-search, #lizmap-search-close').removeClass('open');
+                return;
+            }
+            performFn();
+        };
+    }
+
+    /**
      * Start the external search
      */
     _startExternalSearch() {
@@ -175,14 +192,7 @@ export default class Search {
         var extent = new OpenLayers.Bounds(this._lizmap3.map.maxExtent.toArray());
         extent.transform(this._map.getView().getProjection().getCode(), wgs84);
 
-        const autoSearch = () => {
-            if ($('#search-query').val().length < AUTOCOMPLETE_MIN_LENGTH) {
-                $('#lizmap-search .items').html('');
-                $('#lizmap-search, #lizmap-search-close').removeClass('open');
-                return;
-            }
-            this._performFtsSearch(searchConfig, extent);
-        };
+        const autoSearch = this._buildAutoSearch(() => this._performFtsSearch(searchConfig, extent));
 
         $('#nominatim-search').submit(() => {
             this._performFtsSearch(searchConfig, extent);
@@ -240,7 +250,7 @@ export default class Search {
                     }, 'json');
                 break;
             case 'ign': {
-                if (searchQuery.length < 3 || searchQuery.length > 200) {
+                if (searchQuery.length < AUTOCOMPLETE_MIN_LENGTH || searchQuery.length > 200) {
                     lizMap.addMessage(lizDict['externalsearch.ignlimit'], 'warning', true);
                     break;
                 }
@@ -364,14 +374,7 @@ export default class Search {
             return false;
         }
 
-        const autoSearch = () => {
-            if ($('#search-query').val().length < AUTOCOMPLETE_MIN_LENGTH) {
-                $('#lizmap-search .items').html('');
-                $('#lizmap-search, #lizmap-search-close').removeClass('open');
-                return;
-            }
-            this._performExternalSearch(searchConfig, service, extent);
-        };
+        const autoSearch = this._buildAutoSearch(() => this._performExternalSearch(searchConfig, service, extent));
 
         $('#nominatim-search').submit(() => {
             this._performExternalSearch(searchConfig, service, extent);

--- a/lizmap/modules/view/templates/map_headermenu.tpl
+++ b/lizmap/modules/view/templates/map_headermenu.tpl
@@ -2,7 +2,7 @@
     <form id="nominatim-search" class="navbar-search dropdown" role="search">
         <button id="header-clear" class="btn-locate-clear btn btn-sm btn-link icon" type="button" title="{@view~map.search.clear@}"></button>
         <input id="search-query" type="text" class="search-query form-control"
-            placeholder="{@view~map.search.nominatim.placeholder@}"></input>
+            placeholder="{@view~map.search.nominatim.placeholder@}" autocomplete="off"></input>
         <span class="search-icon">
             <button class="icon" type="submit" tabindex="-1">
                 <span>{@view~map.search.nominatim.button@}</span>

--- a/tests/end2end/playwright/location_search.spec.js
+++ b/tests/end2end/playwright/location_search.spec.js
@@ -261,6 +261,85 @@ test.describe('Location search - form_advanced - anonymous - @readonly', () => {
 
 });
 
+test.describe('Location search - live search (auto-trigger) @readonly', () => {
+
+    test.beforeEach(async ({ page }) => {
+        await page.route('**/service/getProjectConfig*', async route => {
+            const response = await route.fetch();
+            const json = await response.json();
+            json.options['searches'] = [
+                {
+                    "type": "Fts",
+                    "service": "lizmapFts",
+                    "url": "/index.php/lizmap/searchFts/get"
+                }
+            ];
+            await route.fulfill({ response, json });
+        });
+    });
+
+    test('Auto-fires FTS search after 3 chars without pressing Enter', async ({ page }) => {
+        const project = new ProjectPage(page, 'location_search');
+        project.waitForGetLegendGraphicDuringLoad = false;
+        await project.open();
+        await page.unroute('**/service/getProjectConfig*');
+
+        const searchLocator = page.getByPlaceholder('Search');
+
+        const searchPromise = page.waitForRequest(/searchFts/);
+        await searchLocator.fill('mos');
+        await searchPromise;
+
+        await expect(page.getByText('Quartier', { exact: true })).toHaveCount(1);
+        await expect(page.locator('#lizmap-search')).toHaveClass(/\bopen\b/);
+    });
+
+    test('No auto-fire below 3 chars', async ({ page }) => {
+        const project = new ProjectPage(page, 'location_search');
+        project.waitForGetLegendGraphicDuringLoad = false;
+        await project.open();
+        await page.unroute('**/service/getProjectConfig*');
+
+        const searchLocator = page.getByPlaceholder('Search');
+
+        let requestFired = false;
+        await page.route('**/searchFts*', async route => {
+            requestFired = true;
+            await route.continue();
+        });
+
+        await searchLocator.fill('mo');
+        await page.waitForTimeout(300);
+
+        expect(requestFired).toBe(false);
+        await expect(page.locator('#lizmap-search')).not.toHaveClass(/\bopen\b/);
+    });
+
+    test('Results cleared when input drops below 3 chars', async ({ page }) => {
+        const project = new ProjectPage(page, 'location_search');
+        project.waitForGetLegendGraphicDuringLoad = false;
+        await project.open();
+        await page.unroute('**/service/getProjectConfig*');
+
+        const searchLocator = page.getByPlaceholder('Search');
+
+        const searchPromise = page.waitForRequest(/searchFts/);
+        await searchLocator.fill('mosson');
+        await searchPromise;
+
+        await expect(page.locator('#lizmap-search')).toHaveClass(/\bopen\b/);
+        await expect(page.getByText('Quartier', { exact: true })).toHaveCount(1);
+
+        // Drop back below minimum — results should clear
+        await searchLocator.fill('mo');
+        await page.waitForTimeout(200);
+
+        await expect(page.locator('#lizmap-search')).not.toHaveClass(/\bopen\b/);
+        await expect(page.getByText('Quartier', { exact: true })).toHaveCount(0);
+    });
+
+});
+
 test.describe('Location search - form_advanced - admin - @readonly', () => {
     test.use({ storageState: getAuthStorageStatePath('admin') });
 


### PR DESCRIPTION
As discussed with @mdouchin in https://github.com/3liz/lizmap-web-client/pull/6733 a draft implementation of a live search - it's not really "autocomplete" rather then "autoexecute" but that made it simpler to implement.

- Auto-search triggers after 3 characters typed (debounced 100ms)
- Manual submit always fires regardless of input length
- Browser history suggestions disabled on search input
- Extracted `_performFtsSearch()` and `_performExternalSearch()` for shared use between submit and input event handlers

<img width="801" height="874" alt="Search" src="https://github.com/user-attachments/assets/acae78c0-e44e-4edb-880c-bdbb17f22d41" />
