### PR TITLE
[Fix] Upgrade Alpine to 3.22 and Php to 8.3 for Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,46 +1,46 @@
 ARG REGISTRY_PREFIX=''
-FROM ${REGISTRY_PREFIX}alpine:3.21 AS build
+FROM ${REGISTRY_PREFIX}alpine:3.22 AS build
 
 COPY lizmap_web_client.zip .
 RUN unzip lizmap_web_client.zip
 
-FROM alpine:3.21
+FROM alpine:3.22
 LABEL org.opencontainers.image.authors="David Marteau <david.marteau@3liz.com>"
 LABEL Description="Lizmap web client" Vendor="3liz.org" Version="23.02.0"
 
 RUN apk update && apk upgrade && \
     apk --no-cache add git fcgi \
     icu-data-full \
-    php82 \
-    php82-ctype \
-    php82-curl \
-    php82-dom \
-    php82-exif \
-    php82-fileinfo \
-    php82-fpm \
-    php82-gd \
-    php82-gettext \
-    php82-iconv \
-    php82-intl \
-    php82-json \
-    php82-ldap \
-    php82-mbstring \
-    php82-opcache \
-    php82-openssl \
-    php82-pdo \
-    php82-pdo_sqlite \
-    php82-pdo_pgsql \
-    php82-pgsql \
-    php82-phar \
-    php82-redis \
-    php82-session \
-    php82-simplexml \
-    php82-sqlite3 \
-    php82-tokenizer \
-    php82-xml \
-    php82-xmlreader \
-    php82-xmlwriter \
-    php82-zip \
+    php83 \
+    php83-ctype \
+    php83-curl \
+    php83-dom \
+    php83-exif \
+    php83-fileinfo \
+    php83-fpm \
+    php83-gd \
+    php83-gettext \
+    php83-iconv \
+    php83-intl \
+    php83-json \
+    php83-ldap \
+    php83-mbstring \
+    php83-opcache \
+    php83-openssl \
+    php83-pdo \
+    php83-pdo_sqlite \
+    php83-pdo_pgsql \
+    php83-pgsql \
+    php83-phar \
+    php83-redis \
+    php83-session \
+    php83-simplexml \
+    php83-sqlite3 \
+    php83-tokenizer \
+    php83-xml \
+    php83-xmlreader \
+    php83-xmlwriter \
+    php83-zip \
     composer \
     shadow
 
@@ -64,7 +64,7 @@ COPY php-fpm-healthcheck /usr/local/bin/
 
 RUN chmod 755 /bin/lizmap-entrypoint.sh /bin/update-config.php /usr/local/bin/php-fpm-healthcheck
 
-ENV PHP_INI_DIR=/etc/php82
+ENV PHP_INI_DIR=/etc/php83
 
 HEALTHCHECK \
     --interval=30s \
@@ -75,4 +75,4 @@ HEALTHCHECK \
 
 WORKDIR /www
 ENTRYPOINT ["/bin/lizmap-entrypoint.sh"]
-CMD ["/usr/sbin/php-fpm81", "-F", "-O"]
+CMD ["/usr/sbin/php-fpm83", "-F", "-O"]

--- a/docker/lizmap-entrypoint.sh
+++ b/docker/lizmap-entrypoint.sh
@@ -127,13 +127,13 @@ sed -i "/^;clear_env =/c\clear_env = no" $PHP_INI_DIR/php-fpm.d/www.conf
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then
-	set -- php-fpm81 -F -O "$@"
+	set -- php-fpm83 -F -O "$@"
 fi
 
 # For compatibility
 if [ $1 == "php-fpm" ]; then
     shift
-    set -- php-fpm81 -F -O "$@"
+    set -- php-fpm83 -F -O "$@"
 fi
 
 echo "Create the account for $LIZMAP_ADMIN_LOGIN"


### PR DESCRIPTION
Fix docker builds, currently broken due to two issues:

* References to the old version (8.1) in https://github.com/3liz/lizmap-web-client/blob/93187c27d14e03af877070d728690cd474cc2335/docker/Dockerfile#L78 https://github.com/3liz/lizmap-web-client/blob/93187c27d14e03af877070d728690cd474cc2335/docker/lizmap-entrypoint.sh#L130 https://github.com/3liz/lizmap-web-client/blob/93187c27d14e03af877070d728690cd474cc2335/docker/lizmap-entrypoint.sh#L136

* Dependency issue in Alpine 3.21/3.22, where composer (installed in the Dockerfile) depends on php8.3 (see https://pkgs.alpinelinux.org/package/v3.21/community/x86_64/composer). This means that the image is built with:
    * php8.2 with extensions
    * php8.3 without extensions, and this is the default version

    So update-config.php (https://github.com/3liz/lizmap-web-client/blob/master/docker/lizmap-entrypoint.sh#L85) fails because it's run with php8.3, missing various necessary extensions.

The easiest solution is to upgrade to PHP 8.3, so that versions match. The upgrade to Alpine 3.22 is not strictly necessary, 3.21 works as well.

As far as I can tell, the latest docker image (3liz/lizmap-web-client:3.10.0-beta.3) is broken due to these issues.

Funded by Faunalia
