### PR TITLE
[Bugfix] Fix close minidock added via addDock method

### DIFF
--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -2645,25 +2645,29 @@ window.lizMap = function() {
         var docktab = '';
         docktab+='<div class="hide" id="'+dname+'">';
         if( dtype == 'minidock'){
-            docktab+='<div class="mini-dock-close" title="' + lizDict['toolbar.content.stop'] + '" style="padding:7px;float:right;cursor:pointer;"><i class="icon-remove icon-white"></i></div>';
-            docktab+='    <div class="'+dname+'">';
-            docktab+='        <h3>';
-            docktab+='            <span class="title">';
-            docktab+='              <i class="'+dicon+' icon-white"></i>';
-            docktab+='              <span class="text">&nbsp;'+dlabel+'&nbsp;</span>';
-            docktab+='            </span>';
-            docktab+='        </h3>';
+            docktab += `
+                <div class="${dname}">
+                    <h3>
+                        <span class="title">
+                            <button type="button" class="btn-${dname}-close btn-close"
+                                title="${lizDict['toolbar.content.stop']}"></button>
+                            <span class="icon"><i class="${dicon} icon-white"></i></span>
+                            <span class="text">&nbsp;${dlabel}&nbsp;</span>
+                        </span>
+                    </h3>
+                </div>
+            `
         }
         docktab+='        <div class="menu-content">';
         docktab+= dcontent;
         docktab+='        </div>';
         docktab+='    </div>';
-        docktab+='</div>';
+
         if( dtype == 'minidock'){
             $('#mini-dock-content').append(docktab);
-            $('#'+dname+' div.mini-dock-close').click(function(){
+            $('#'+dname+' button.btn-close').click(function(){
                 if( $('#mapmenu .nav-list > li.'+dname).hasClass('active') ){
-                    $('#button-'+dname).click();
+                    document.querySelector(`#button-${dname}`).click()
                 }
             });
         }


### PR DESCRIPTION
In version 3.10, if you add a minidock content with the legacy `addDock` method, you cannot close the panel:

[vokoscreenNG-2026-04-27_12-15-34.webm](https://github.com/user-attachments/assets/6d893759-5caa-477c-a125-70960fde3f9b)

I aligned the panel structure to the ones already present.

Funded by Faunalia
