### PR TITLE
Fix: WMS baselayers from QGIS layers now proxy through QGIS Server

### DIFF
--- a/assets/src/modules/map.js
+++ b/assets/src/modules/map.js
@@ -420,14 +420,28 @@ export default class map extends olMap {
                     })
                 });
             } else if (baseLayerState.type === BaseLayerTypes.WMS) {
+                // When the external WMS URL is plain HTTP but Lizmap is served
+                // over HTTPS the browser blocks the request as mixed content.
+                // Fall back to the QGIS Server proxy when a project layer is
+                // available, so the upstream WMS is fetched server-side instead.
+                const useProxy = baseLayerState.url.startsWith('http:')
+                    && globalThis.location?.protocol === 'https:'
+                    && baseLayerState.hasItemState
+                    && baseLayerState.hasLayerConfig;
                 baseLayer = new ImageLayer({
                     minResolution: layerMinResolution,
                     maxResolution: layerMaxResolution,
                     source: new ImageWMS({
-                        url: baseLayerState.url,
-                        projection: baseLayerState.crs,
+                        url: useProxy ? serviceURL : baseLayerState.url,
+                        projection: useProxy ? qgisProjectProjection : baseLayerState.crs,
+                        serverType: useProxy ? 'qgis' : undefined,
                         ratio: this._WMSRatio,
-                        params: {
+                        hidpi: useProxy ? this._hidpi : undefined,
+                        params: useProxy ? {
+                            LAYERS: baseLayerState.itemState.wmsName,
+                            FORMAT: baseLayerState.layerConfig.imageFormat,
+                            DPI: 96
+                        } : {
                             LAYERS: baseLayerState.layers,
                             STYLES: baseLayerState.styles,
                             FORMAT: baseLayerState.format


### PR DESCRIPTION
When a raster/WMS QGIS layer is in the baselayers group, map.js passed its raw external URL directly to an OpenLayers ImageWMS source. On HTTPS-served Lizmap instances this breaks when the upstream WMS is only available over HTTP: the browser blocks the request as mixed content, the server returns 404 after the HTTP→HTTPS upgrade, and OpenLayers throws DOMException: Invalid encoded image data.

Fix: detect the mixed-content condition at render time in map.js. When the baselayer URL starts with http:, the page is served over https:, and a QGIS project layer is available (hasItemState + hasLayerConfig), route the request through serviceURL (QGIS Server) using the layer's wmsName. QGIS Server fetches the upstream WMS server-side so the browser only talks to the Lizmap origin over HTTPS.

WMS baselayers with HTTPS URLs and all other baselayer types are unaffected.

Fixes https://github.com/3liz/lizmap-web-client/issues/6798