### PR TITLE
[Feature] Rely on attributeEditorRelation cardinality to display many to many relations

### DIFF
--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -208,7 +208,7 @@ var lizAttributeTable = function() {
                             const tableSelector = '#attribute-layer-table-' + cleanName;
 
                             // Get data and fill attribute table
-                            getDataAndFillAttributeTable(layerName, layerFilter, false, tableSelector, false);
+                            getDataAndFillAttributeTable(layerName, layerFilter, false, tableSelector);
 
                             const tabElement = document.getElementById('nav-tab-attribute-layer-' + cleanName);
                             bootstrap.Tab.getOrCreateInstance(tabElement).show();
@@ -287,11 +287,9 @@ var lizAttributeTable = function() {
              * @param filter
              * @param isLinefilter
              * @param tableSelector
-             * @param forceEmptyTable
              * @param callBack
              */
-            function getDataAndFillAttributeTable(layerName, filter, isLinefilter = false, tableSelector, forceEmptyTable, callBack){
-
+            function getDataAndFillAttributeTable(layerName, filter, isLinefilter = false, tableSelector, callBack){
                 let layerConfig = lizMap.config.layers[layerName];
                 const typeName = layerConfig?.shortname || layerConfig?.typename || layerConfig?.name;
 
@@ -888,13 +886,13 @@ var lizAttributeTable = function() {
                         var parentLayerName = attributeLayersDic[ cleanName ];
                         var parentLayerId = config.layers[parentLayerName]['id'];
                         var aName = attributeLayersDic[ $(this).val() ];
-                        var pivotId = $(this).attr("data-pivot");
+                        var pivotId = $(this).data("pivot");
                         var lid = config.layers[aName]['id'];
                         if (creationContext == 'parent') {
                             lizMap.launchEdition( lid, null, null);
                         } else {
                             lizMap.getLayerFeature(parentLayerName, parentFeatId, function(parentFeat) {
-                                lizMap.launchEdition( lid, null, {layerId:parentLayerId, feature:parentFeat, pivotId:pivotId});
+                                lizMap.launchEdition( lid, null, {layerId:parentLayerId, feature:parentFeat, pivotId:pivotId });
                             });
                         }
 
@@ -1210,25 +1208,26 @@ var lizAttributeTable = function() {
                             config.layers,
                             'id'
                         );
-                        var isNToM = false;
+                        var isNToM = relation.nmRelation;
                         var pivotConfig = null;
                         var mLayerConfig = null;
 
                         if (referencingLayerConfig && referencingLayerConfig[0] in config.attributeLayers) {
                             // check if the renferencing layer is a pivot
-                            mLayerConfig = getPivotLinkedLayerConfiguration(parentLayerId, referencingLayerConfig[1]);
                             // if so, switch the child layer to the "n_layer" if the n_layer could be displayed in attribute table
-                            if( mLayerConfig && mLayerConfig.config && mLayerConfig.config[0] in config.attributeLayers) {
+                            if (isNToM) {
                                 // store original pivot configuration
-                                pivotConfig = referencingLayerConfig;
-                                isNToM = true;
+                                mLayerConfig = getPivotLinkedLayerConfiguration(parentLayerId, referencingLayerConfig[1]);
+                                if (mLayerConfig && mLayerConfig.config && mLayerConfig.config[0] in config.attributeLayers) {
+                                    pivotConfig = referencingLayerConfig;
+                                }
                             }
                             childCount+=1;
                             if( childCount > 1)
                                 childActive = '';
                             // if the detected relation is n to m, then use mLayer configuration to display the child attribute table
-                            var childLayerConfig = isNToM ? mLayerConfig.config[1] : referencingLayerConfig[1];
-                            var childLayerName = isNToM ? mLayerConfig.config[0] : referencingLayerConfig[0];
+                            var childLayerConfig = pivotConfig ? mLayerConfig.config[1] : referencingLayerConfig[1];
+                            var childLayerName = pivotConfig ? mLayerConfig.config[0] : referencingLayerConfig[0];
                             var childAttributeLayerConfig = config.attributeLayers[childLayerName];
 
                             // Discard if the editor does not want this layer to be displayed in child table
@@ -1263,7 +1262,7 @@ var lizAttributeTable = function() {
                                     }
                                 }
                                 // if the m layer is displayed then check also the edition capabilities on pivot
-                                if(canCreateChild && isNToM){
+                                if(canCreateChild && pivotConfig){
                                     // check edition capabilities for pivot table
                                     canCreateChild = pivotConfig[0] in config.editionLayers && config.editionLayers[pivotConfig[0]] && config.editionLayers[pivotConfig[0]].capabilities.createFeature == 'True'
                                 }
@@ -1271,14 +1270,14 @@ var lizAttributeTable = function() {
                             if( canCreateChild ){
                                 // Add a button to create a new feature for this child layer
                                 let childButtonItem = `
-                                    <button class="btn btn-sm btn-createFeature-attributeTable new-child" data-pivot="${isNToM ? pivotConfig[1].id : ''}" value="${lizMap.cleanName(childLayerName)}" title="${lizDict['attributeLayers.toolbar.btn.data.createFeature.title']}">
+                                    <button class="btn btn-sm btn-createFeature-attributeTable new-child" data-pivot="${pivotConfig ? pivotConfig[1].id : ''}" value="${lizMap.cleanName(childLayerName)}" title="${lizDict['attributeLayers.toolbar.btn.data.createFeature.title']}">
                                     ➕ ${childLayerConfig.title}
                                     </button>
                                 `;
                                 childCreateButtonItems.push(childButtonItem);
 
                                 // Link parent with the selected features of the child
-                                layerLinkButtonItems.push('<li><a href="#' + lizMap.cleanName(isNToM ? pivotConfig[0] : childLayerName) + '" class="btn-linkFeatures-attributeTable dropdown-item">' + (isNToM ? pivotConfig[1].title : childLayerConfig.title) +'</a></li>' );
+                                layerLinkButtonItems.push('<li><a href="#' + lizMap.cleanName(pivotConfig ? pivotConfig[0] : childLayerName) + '" class="btn-linkFeatures-attributeTable dropdown-item">' + (pivotConfig ? pivotConfig[1].title : childLayerConfig.title) +'</a></li>' );
                             }
                         }
                     }
@@ -1350,7 +1349,8 @@ var lizAttributeTable = function() {
                             var isNToM = false, mLayerConfig = null;
                             // check if the referencingLayer is a pivot table
                             mLayerConfig = getPivotLinkedLayerConfiguration(parentLayerId, referencingLayerConfig[1]);
-                            if (mLayerConfig) {
+                            isNToM = relation.nmRelation;
+                            if (isNToM && mLayerConfig) {
                                 // if the realtion is n to m, switch the layer config to the mLayer
                                 referencingLayerConfig = mLayerConfig.config;
                                 isNToM = true;
@@ -1365,14 +1365,13 @@ var lizAttributeTable = function() {
                                 if ( isNToM ) {
                                     // get feature from pivot
                                     getPivotWFSFeatures(relation.referencingLayer, mLayerConfig.relation, fp[relation.referencedField]).then((filterString)=>{
-                                        getEditionChildData(childLayerName, filterString, childTableSelector, filterString ? false : true);
+                                        getEditionChildData(childLayerName, filterString, childTableSelector );
                                     })
                                 } else {
                                     if( relation.referencingLayer == childLayerConfig.id ){
                                         filter = '"' + relation.referencingField + '" = ' + "'" + fp[relation.referencedField] + "'";
                                     }
-
-                                    getDataAndFillAttributeTable(childLayerName, filter, true, childTableSelector, false);
+                                    getDataAndFillAttributeTable(childLayerName, filter, true, childTableSelector);
                                 }
                             }
                         }
@@ -2333,10 +2332,9 @@ var lizAttributeTable = function() {
              * @param childLayerName
              * @param filter
              * @param childTable
-             * @param forceEmptyTable
              */
-            function getEditionChildData( childLayerName, filter, childTable, forceEmptyTable = false ){
-                getDataAndFillAttributeTable(childLayerName, filter, true, childTable, forceEmptyTable, () => {
+            function getEditionChildData( childLayerName, filter, childTable ){
+                getDataAndFillAttributeTable(childLayerName, filter, true, childTable, () => {
                     // Check edition capabilities
                     var canCreateChildren = false;
                     var canEdit = false;
@@ -3439,8 +3437,10 @@ var lizAttributeTable = function() {
                         const refAttributeLayerConf = lizMap.getLayerConfigById( pivotId, lizMap.config.attributeLayers, 'layerId' );
                         if(refAttributeLayerConf && refAttributeLayerConf[1]?.pivot == 'True'){
                             // check if pivot is in relations for both layers
-                            const validRelation = [nlayerId,mLayerId].every((layerId)=>{
-                                return config.relations[layerId] && config.relations[layerId].filter((rlayer)=>{ return rlayer.referencingLayer == pivotId}).length == 1
+                            const validRelation = [nlayerId,mLayerId].every((layerId)=> {
+                                return config.relations[layerId] && config.relations[layerId].filter((rlayer) =>
+                                    rlayer.referencingLayer == pivotId && rlayer.nmRelation
+                                ).length == 1
                             })
                             if (validRelation)
                                 return pivotId;
@@ -3779,7 +3779,7 @@ var lizAttributeTable = function() {
                                     }
                                     var parentLayerId = layerId;
                                     var aName = attributeLayersDic[ $(this).val() ];
-                                    var pivotId = $(this).attr("data-pivot");
+                                    var pivotId = $(this).data("pivot");
                                     lizMap.getLayerFeature(featureType, fid, function(parentFeat) {
                                         var lid = config.layers[aName]['id'];
                                         lizMap.launchEdition( lid, null, {layerId:parentLayerId, feature:parentFeat, pivotId: pivotId});
@@ -3818,13 +3818,12 @@ var lizAttributeTable = function() {
                                     var rGetLayerConfig = lizMap.getLayerConfigById( rLayerId );
                                     if ( rGetLayerConfig ) {
                                         // check if relation is nToM
-                                        var isNToM = false, mLayerConfig = null;
                                         // check if the referencingLayer is a pivot table
-                                        mLayerConfig = getPivotLinkedLayerConfiguration(layerId, rGetLayerConfig[1]);
-                                        if (mLayerConfig) {
+                                        const mLayerConfig = getPivotLinkedLayerConfiguration(layerId, rGetLayerConfig[1]);
+                                        const isNToM = r.nmRelation && mLayerConfig;
+                                        if (isNToM) {
                                             // if the realtion is n to m, switch the layer config to the mLayer
                                             rGetLayerConfig = mLayerConfig.config;
-                                            isNToM = true;
                                         }
 
                                         let rLayerName = rGetLayerConfig[0];
@@ -3837,11 +3836,11 @@ var lizAttributeTable = function() {
                                         if(rLayerName in config.attributeLayers){
                                             if (isNToM) {
                                                 getPivotWFSFeatures(r.referencingLayer, mLayerConfig.relation, fp[r.referencedField]).then((filterString)=>{
-                                                    getEditionChildData(rLayerName, filterString, childTable, filterString ? false : true);
+                                                    getEditionChildData(rLayerName, filterString, childTable);
                                                 })
                                             } else {
                                                 filter = '"' + r.referencingField + '" = ' + "'" + fp[r.referencedField] + "'";
-                                                getEditionChildData( rLayerName, filter, childTable );
+                                                getEditionChildData( rLayerName, filter, childTable);
                                             }
                                         }
 

--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -1102,8 +1102,13 @@ window.lizMap = function() {
                     relationId: relation.relationId, // relationId
                 };
                 const pivotAttributeLayerConf = lizMap.getLayerConfigById( rLayerId, lizMap.config.attributeLayers, 'layerId' );
+                const isNtoM = relation.nmRelation;
                 // check if child is a pivot table
-                if (pivotAttributeLayerConf && pivotAttributeLayerConf[1]?.pivot == 'True' && config.relations.pivot && config.relations.pivot[rLayerId]) {
+                if (isNtoM &&
+                    pivotAttributeLayerConf &&
+                    pivotAttributeLayerConf[1]?.pivot == 'True' &&
+                    config.relations.pivot && config.relations.pivot[rLayerId]
+                ) {
                     // looking for related children
                     const pivotConfig =  lizMap.getLayerConfigById(
                         rLayerId,

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -950,7 +950,12 @@ class editionCtrl extends jController
                 if ($kRel == $m_layerId || $kRel == $n_layerId) {
                     if (is_array($relation)) {
                         $filtered = array_filter($relation, function ($ar) use ($pivotId, $pivotConf, $kRel) {
-                            return is_array($ar) && array_key_exists('referencingLayer', $ar) && array_key_exists('referencingField', $ar) && $ar['referencingLayer'] == $pivotId && $ar['referencingField'] == $pivotConf[$kRel];
+                            return is_array($ar)
+                            && array_key_exists('referencingLayer', $ar)
+                            && array_key_exists('referencingField', $ar)
+                            && $ar['referencingLayer'] == $pivotId
+                            && $ar['referencingField'] == $pivotConf[$kRel]
+                            && $ar['nmRelation'] === true;
                         });
                         if (count($filtered) == 1) {
                             if ($kRel == $m_layerId && !$m_relation) {

--- a/lizmap/modules/lizmap/lib/Project/Qgis/Layer/MapLayer.php
+++ b/lizmap/modules/lizmap/lib/Project/Qgis/Layer/MapLayer.php
@@ -163,6 +163,17 @@ class MapLayer extends Qgis\BaseQgisXmlObject
             $data['rendererV2'] = $data['renderer-v2'];
             unset($data['renderer-v2']);
         }
+
+        // flatten attributeEditorForm properties
+        if (array_key_exists('attributeEditorForm', $data)
+            && array_key_exists('attributeEditorField', $data['attributeEditorForm'])) {
+            $data['attributeEditorField'] = $data['attributeEditorForm']['attributeEditorField'];
+        }
+        if (array_key_exists('attributeEditorForm', $data)
+            && array_key_exists('attributeEditorRelation', $data['attributeEditorForm'])) {
+            $data['attributeEditorRelation'] = $data['attributeEditorForm']['attributeEditorRelation'];
+        }
+
         if (array_key_exists('type', $data)
             && $data['type'] === 'vector') {
             return new VectorLayer($data);
@@ -206,6 +217,45 @@ MapLayer::registerChildParser('srs', function ($oXmlReader) {
 MapLayer::registerChildParser('map-layer-style-manager', function ($oXmlReader) {
     return MapLayerStyleManager::fromXmlReader($oXmlReader);
 });
+
+MapLayer::registerChildParser('attributeEditorForm', function ($oXmlReader) {
+    $data = array();
+    if ($oXmlReader->isEmptyElement) {
+        return $data;
+    }
+    $depth = $oXmlReader->depth;
+    $localName = $oXmlReader->localName;
+    while ($oXmlReader->read()) {
+        if ($oXmlReader->nodeType == \XMLReader::END_ELEMENT
+            && $oXmlReader->localName == $localName
+            && $oXmlReader->depth == $depth) {
+            break;
+        }
+
+        if ($oXmlReader->nodeType != \XMLReader::ELEMENT) {
+            continue;
+        }
+
+        /* WARNING!!
+        The attributeEditorField and attributeEditorRelation tags
+        may be nested within attributeEditorContainer tags and other tags, so parse all elements
+        and not just the direct children of the attributeEditoForm tag.
+
+        if ($oXmlReader->depth != $depth + 1) {
+            continue;
+        }
+        */
+
+        if ($oXmlReader->localName == 'attributeEditorField') {
+            $data['attributeEditorField'][] = VectorLayerAttributeEditorField::fromXmlReader($oXmlReader);
+        } elseif ($oXmlReader->localName == 'attributeEditorRelation') {
+            $data['attributeEditorRelation'][] = VectorLayerAttributeEditorRelation::fromXmlReader($oXmlReader);
+        }
+    }
+
+    return $data;
+});
+
 MapLayer::registerChildParser('fieldConfiguration', function ($oXmlReader) {
     $data = array();
     if ($oXmlReader->isEmptyElement) {

--- a/lizmap/modules/lizmap/lib/Project/Qgis/Layer/VectorLayer.php
+++ b/lizmap/modules/lizmap/lib/Project/Qgis/Layer/VectorLayer.php
@@ -19,32 +19,34 @@ use Lizmap\Project\Qgis;
 /**
  * QGIS Vector layer.
  *
- * @property string                                 $id
- * @property bool                                   $embedded
- * @property string                                 $type
- * @property string                                 $layername
- * @property Qgis\SpatialRefSys                     $srs
- * @property string                                 $datasource
- * @property string                                 $provider
- * @property MapLayerStyleManager                   $styleManager
- * @property null|string                            $shortname
- * @property null|string                            $title
- * @property null|string                            $abstract
- * @property null|array<string>                     $keywordList
- * @property null|string                            $previewExpression
- * @property float                                  $layerOpacity
- * @property MapLayerStyleManager                   $styleManager
- * @property array<VectorLayerField>                $fieldConfiguration
- * @property array<VectorLayerAlias>                $aliases
- * @property array<VectorLayerConstraint>           $constraints
- * @property array<VectorLayerConstraintExpression> $constraintExpressions
- * @property array<VectorLayerDefault>              $defaults
- * @property array<VectorLayerEditableField>        $editable
- * @property array<VectorLayerJoin>                 $vectorjoins
- * @property AttributeTableConfig                   $attributetableconfig
- * @property null|array<string>                     $excludeAttributesWMS
- * @property null|array<string>                     $excludeAttributesWFS
- * @property null|RendererV2                        $rendererV2
+ * @property string                                    $id
+ * @property bool                                      $embedded
+ * @property string                                    $type
+ * @property string                                    $layername
+ * @property Qgis\SpatialRefSys                        $srs
+ * @property string                                    $datasource
+ * @property string                                    $provider
+ * @property MapLayerStyleManager                      $styleManager
+ * @property null|string                               $shortname
+ * @property null|string                               $title
+ * @property null|string                               $abstract
+ * @property null|array<string>                        $keywordList
+ * @property null|string                               $previewExpression
+ * @property float                                     $layerOpacity
+ * @property MapLayerStyleManager                      $styleManager
+ * @property array<VectorLayerField>                   $fieldConfiguration
+ * @property array<VectorLayerAlias>                   $aliases
+ * @property array<VectorLayerConstraint>              $constraints
+ * @property array<VectorLayerConstraintExpression>    $constraintExpressions
+ * @property array<VectorLayerDefault>                 $defaults
+ * @property array<VectorLayerEditableField>           $editable
+ * @property array<VectorLayerJoin>                    $vectorjoins
+ * @property AttributeTableConfig                      $attributetableconfig
+ * @property null|array<string>                        $excludeAttributesWMS
+ * @property null|array<string>                        $excludeAttributesWFS
+ * @property null|RendererV2                           $rendererV2
+ * @property array<VectorLayerAttributeEditorField>    $attributeEditorField
+ * @property array<VectorLayerAttributeEditorRelation> $attributeEditorRelation
  */
 class VectorLayer extends Qgis\BaseQgisObject
 {
@@ -75,6 +77,8 @@ class VectorLayer extends Qgis\BaseQgisObject
         'attributetableconfig',
         'vectorjoins',
         'rendererV2',
+        'attributeEditorField',
+        'attributeEditorRelation',
     );
 
     /** @var array<string> The not null properties */
@@ -147,6 +151,30 @@ class VectorLayer extends Qgis\BaseQgisObject
         }
 
         return null;
+    }
+
+    /**
+     * Get the attribute editor relation configuration for the given relation id.
+     *
+     * @param string $id
+     *
+     * @return null|VectorLayerAttributeEditorRelation
+     */
+    public function getAttributeEditorRelationConfiguration($id)
+    {
+        if ($this->attributeEditorRelation === null) {
+            return null;
+        }
+        $editorRelation = null;
+        foreach ($this->attributeEditorRelation as $attributeEditor) {
+            if ($attributeEditor->relation == $id) {
+                $editorRelation = $attributeEditor;
+
+                break;
+            }
+        }
+
+        return $editorRelation;
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/Project/Qgis/Layer/VectorLayerAttributeEditorField.php
+++ b/lizmap/modules/lizmap/lib/Project/Qgis/Layer/VectorLayerAttributeEditorField.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * QGIS Vector layer attribute editor field.
+ *
+ * @author    3liz
+ * @copyright 2026 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+namespace Lizmap\Project\Qgis\Layer;
+
+use Lizmap\Project\Qgis;
+
+/**
+ * QGIS Vector layer attribute editor field.
+ *
+ * @property string      $name
+ * @property null|string $showLabel
+ */
+class VectorLayerAttributeEditorField extends Qgis\BaseQgisXmlObject
+{
+    /** @var array<string> The instance properties */
+    protected $properties = array(
+        'name',
+        'showLabel',
+    );
+
+    /** @var string The XML element local name */
+    protected static $qgisLocalName = 'attributeEditorField';
+
+    /** @var array<string> The not null properties */
+    protected $mandatoryProperties = array(
+        'name',
+        'showLabel',
+    );
+
+    /**
+     * Get element attributes as array.
+     *
+     * @param \XMLReader $oXmlReader An XMLReader instance at an element
+     *
+     * @return array{name: null|string, showLabel: null|string}
+     */
+    protected static function getAttributes($oXmlReader)
+    {
+        return array(
+            'name' => $oXmlReader->getAttribute('name'),
+            'showLabel' => $oXmlReader->getAttribute('showLabel'),
+        );
+    }
+}

--- a/lizmap/modules/lizmap/lib/Project/Qgis/Layer/VectorLayerAttributeEditorRelation.php
+++ b/lizmap/modules/lizmap/lib/Project/Qgis/Layer/VectorLayerAttributeEditorRelation.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * QGIS Vector layer attribute editor relation.
+ *
+ * @author    3liz
+ * @copyright 2026 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+namespace Lizmap\Project\Qgis\Layer;
+
+use Lizmap\Project\Qgis;
+
+/**
+ * QGIS Vector layer attribute editor relation.
+ *
+ * @property string      $name
+ * @property null|string $relation
+ * @property null|string $label
+ * @property null|string $nmRelationId
+ * @property null|string $showLabel
+ */
+class VectorLayerAttributeEditorRelation extends Qgis\BaseQgisXmlObject
+{
+    /** @var array<string> The instance properties */
+    protected $properties = array(
+        'name',
+        'relation',
+        'label',
+        'nmRelationId',
+        'showLabel',
+    );
+
+    /** @var array<string> The not null properties */
+    protected $mandatoryProperties = array(
+        'name',
+        'relation',
+    );
+
+    /** @var string The XML element local name */
+    protected static $qgisLocalName = 'attributeEditorRelation';
+
+    /**
+     * Get element attributes as array.
+     *
+     * @param \XMLReader $oXmlReader An XMLReader instance at an element
+     *
+     * @return array{label: null|string, name: null|string, nmRelationId: null|string, relation: null|string, showLabel: null|string}
+     */
+    protected static function getAttributes($oXmlReader)
+    {
+        return array(
+            'name' => $oXmlReader->getAttribute('name'),
+            'relation' => $oXmlReader->getAttribute('relation'),
+            'label' => $oXmlReader->getAttribute('label'),
+            'nmRelationId' => $oXmlReader->getAttribute('nmRelationId'),
+            'showLabel' => $oXmlReader->getAttribute('showLabel'),
+        );
+    }
+
+    /**
+     * Reads relation cardinality from attributeEditorRelation configuration.
+     *
+     * @return bool
+     */
+    public function isnmRelation()
+    {
+        return $this->nmRelationId !== '';
+    }
+}

--- a/lizmap/modules/lizmap/lib/Project/Qgis/ProjectInfo.php
+++ b/lizmap/modules/lizmap/lib/Project/Qgis/ProjectInfo.php
@@ -295,7 +295,8 @@ class ProjectInfo extends BaseQgisXmlObject
         foreach ($this->relations as $relation) {
             // Get referenced layer
             $referencedLayer = $this->getLayerById($relation->referencedLayer);
-
+            // get cardinality for specific layer
+            $attributeEditorRelation = $referencedLayer->getAttributeEditorRelationConfiguration($relation->id);
             // Build relations key array
             if (!array_key_exists($relation->referencedLayer, $data)) {
                 $data[$relation->referencedLayer] = array();
@@ -308,6 +309,7 @@ class ProjectInfo extends BaseQgisXmlObject
                 'previewField' => $previewField !== '' ? $previewField : $relation->referencedField,
                 'relationName' => $relation->name,
                 'relationId' => $relation->id,
+                'nmRelation' => $attributeEditorRelation ? $attributeEditorRelation->isnmRelation() : false,
             );
 
             // Collect pivot informations

--- a/tests/end2end/playwright/n_to_m_relations.spec.js
+++ b/tests/end2end/playwright/n_to_m_relations.spec.js
@@ -28,8 +28,8 @@ test.describe('N to M relations',
             datatablesResponse = await datatablesRequest.response();
             responseExpect(datatablesResponse).toBeJson();
 
-            //back to natural areas panel
-            await page.locator('#nav-tab-attribute-layer-natural_areas').click();
+            // back to natural areas panel
+            await project.switchAttributeTable('natural_areas');
 
             let attrTable = page.locator("#attribute-layer-table-natural_areas");
             await expect(attrTable).toHaveCount(1);
@@ -59,7 +59,11 @@ test.describe('N to M relations',
             }
 
             // check child layer html divs
+            // n:m cardinality
             await expect(page.locator("#nav-tab-attribute-child-tab-natural_areas-birds")).toHaveCount(1);
+            // 1:n cardinality
+            await expect(page.locator("#nav-tab-attribute-child-tab-natural_areas-birds_areas")).toHaveCount(1);
+            // simple 1:n
             await expect(page.locator("#nav-tab-attribute-child-tab-natural_areas-birds_spots")).toHaveCount(1);
 
             // click on first row of main table and open "m" layer attribute table
@@ -126,9 +130,39 @@ test.describe('N to M relations',
                 await expect(featToolbar.locator(".feature-toolbar button[title='Create feature']")).toBeHidden();
             }
 
-            // change tab to inspect bird spots (1:n control)
-            await page.locator("#nav-tab-attribute-child-tab-natural_areas-birds_spots").click();
+            // change tab to inspect pivot table (1:n cardinality)
+            await project.switchChildAttributeTable('natural_areas-birds_areas');
+            let pivotCardinalityTable = page.locator("#attribute-layer-table-natural_areas-birds_areas");
 
+            await expect(pivotCardinalityTable).toHaveCount(1);
+
+            // inspect pivot layer related table
+            await expect(pivotCardinalityTable.locator("tbody tr")).toHaveCount(3);
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("5");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("1");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(0).locator("td").nth(3)).toHaveText("2");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("6");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("3");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(1).locator("td").nth(3)).toHaveText("2");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("7");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("5");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(2).locator("td").nth(3)).toHaveText("2");
+
+            let pivotCardinalityTableFeatureToolbar = pivotCardinalityTable.locator("tbody tr").all();
+            for (const tr of await pivotCardinalityTableFeatureToolbar) {
+                const featToolbar = tr.locator("td").nth(0).locator("lizmap-feature-toolbar");
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Select']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Filter']")).toBeHidden();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Zoom']")).toBeHidden();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Center']")).toBeHidden();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Edit']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Delete']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[data-bs-title='Unlink child']")).toBeVisible();
+                await expect(featToolbar.locator(".feature-toolbar button[title='Create feature']")).toBeHidden();
+            }
+
+            // change tab to inspect bird spots (1:n control)
+            await project.switchChildAttributeTable('natural_areas-birds_spots');
             // inspect 1:n layer related table
             let oneToNAttrTable = page.locator("#attribute-layer-table-natural_areas-birds_spots");
             await expect(oneToNAttrTable).toHaveCount(1);
@@ -178,7 +212,7 @@ test.describe('N to M relations',
             await expect(oneToNAttrTable.locator("tbody tr").nth(0).locator("td").nth(3)).toHaveText("Vignalie tower");
 
             // go to birds spots tab and check the unlinked record
-            await page.locator('#nav-tab-attribute-layer-birds_spots').click();
+            await project.switchAttributeTable('birds_spots');
             let birdsSpotsTable = page.locator("#attribute-layer-table-birds_spots");
 
             await expect(birdsSpotsTable.locator("tbody tr")).toHaveCount(5);
@@ -187,8 +221,7 @@ test.describe('N to M relations',
             // insert new bird associated with first area
 
             //back to natural areas panel first
-            await page.locator('#nav-tab-attribute-layer-natural_areas').click();
-
+            await project.switchAttributeTable('natural_areas');
             let addBirdsRequestPromise = page.waitForRequest(/lizmap\/edition\/editFeature/);
             await page.locator("#attribute-layer-main-natural_areas .edition-children-add-buttons button[value='birds']").click();
             let addBirdsRequest = await addBirdsRequestPromise;
@@ -213,7 +246,8 @@ test.describe('N to M relations',
             await page.locator("#lizmap-edition-message .btn-close").click();
 
             // check birds child table
-            await page.locator("#nav-tab-attribute-child-tab-natural_areas-birds").click();
+            await project.switchChildAttributeTable('natural_areas-birds');
+            //await page.locator("#nav-tab-attribute-child-tab-natural_areas-birds").click();
 
             await expect(nRelatedAttrTable.locator("tbody tr")).toHaveCount(4);
             await expect(nRelatedAttrTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
@@ -225,8 +259,33 @@ test.describe('N to M relations',
             await expect(nRelatedAttrTable.locator("tbody tr").nth(3).locator("td").nth(1)).toHaveText("9");
             await expect(nRelatedAttrTable.locator("tbody tr").nth(3).locator("td").nth(2)).toHaveText("Northern pintail");
 
+            datatablesRequestPromise = project.waitForDatatablesRequest();
+            await attrTable.locator("tbody tr").nth(1).click();
+            datatablesRequest = await datatablesRequestPromise;
+            datatablesResponse = await datatablesRequest.response();
+            responseExpect(datatablesResponse).toBeJson();
+
+            page.waitForTimeout(300);
+            // go to pivot table panel and look for the new inserted record
+            await project.switchChildAttributeTable('natural_areas-birds_areas');
+            await expect(pivotCardinalityTable.locator("tbody tr")).toHaveCount(4);
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("5");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("1");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(0).locator("td").nth(3)).toHaveText("2");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("6");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("3");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(1).locator("td").nth(3)).toHaveText("2");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("7");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("5");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(2).locator("td").nth(3)).toHaveText("2");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(3).locator("td").nth(1)).toHaveText("15");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(3).locator("td").nth(2)).toHaveText("9");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(3).locator("td").nth(3)).toHaveText("2");
+
+
             // go to birds panel and look for the new inserted record
-            await page.locator('#nav-tab-attribute-layer-birds').click();
+            await project.switchAttributeTable('birds')
+            //await page.locator('#nav-tab-attribute-layer-birds').click();
 
             let birdsTable = page.locator("#attribute-layer-table-birds");
             await expect(birdsTable.locator("tbody tr")).toHaveCount(9);
@@ -288,6 +347,36 @@ test.describe('N to M relations',
             await deleteBirdFeature;
 
             await expect(birdsTable.locator("tbody tr")).toHaveCount(8);
+            await project.switchAttributeTable('natural_areas');
+
+            datatablesRequestPromise = project.waitForDatatablesRequest();
+            await attrTable.locator("tbody tr").nth(1).click();
+            datatablesRequest = await datatablesRequestPromise;
+            datatablesResponse = await datatablesRequest.response();
+            responseExpect(datatablesResponse).toBeJson();
+
+            // check n:m relation on child natural areas table
+            await project.switchChildAttributeTable('natural_areas-birds');
+            await expect(nRelatedAttrTable.locator("tbody tr")).toHaveCount(3);
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("Greater flamingo");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("3");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("Purple heron");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("5");
+            await expect(nRelatedAttrTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("Eurasian teal");
+
+            // go to pivot table panel and look for deleted record
+            await project.switchChildAttributeTable('natural_areas-birds_areas');
+            await expect(pivotCardinalityTable.locator("tbody tr")).toHaveCount(3);
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("5");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("1");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(0).locator("td").nth(3)).toHaveText("2");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("6");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("3");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(1).locator("td").nth(3)).toHaveText("2");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("7");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("5");
+            await expect(pivotCardinalityTable.locator("tbody tr").nth(2).locator("td").nth(3)).toHaveText("2");
 
             // popup behavior
             await page.locator("#bottom-dock-window-buttons button.btn-bottomdock-clear").click()
@@ -336,11 +425,19 @@ test.describe('N to M relations',
             await expect(natAreaElements.nth(0).locator('.jforms-control-input')).toHaveText("1");
             await expect(natAreaElements.nth(1).locator('.jforms-control-input')).toHaveText("Étang du Galabert");
 
-            // inspect popup children
+            // inspect popup children - birds (n:m cardinality)
             let childrenBirds = popup.locator('.lizmapPopupChildren.birds .lizmapPopupSingleFeature');
             await expect(childrenBirds).toHaveCount(4);
 
-            // unlink a bird from popup
+            // inspect popup children - Pivot records (cardinality 1:n)
+            let childrenPivotRecords = popup.locator('.lizmapPopupChildren.birds_areas .lizmapPopupSingleFeature');
+            await expect(childrenPivotRecords).toHaveCount(4);
+
+            // inspect popup children - birds spots (1:n)
+            let childrenbirdsSpotsRecords = popup.locator('.lizmapPopupChildren.birds_spots .lizmapPopupSingleFeature');
+            await expect(childrenbirdsSpotsRecords).toHaveCount(2);
+
+            // unlink a bird from popup (n:m cardinality)
             page.once('dialog', dialog => {
                 expect(dialog.message()).toBe("Are you sure you want to unlink the selected feature from \"Natural areas\" layer?");
                 return dialog.accept();
@@ -354,6 +451,9 @@ test.describe('N to M relations',
             await unlinkPopupPivotFeature;
 
             await expect(childrenBirds.nth(0).locator(".lizmapPopupDiv")).toHaveCount(0);
+
+            // pivot popup should be updated too (1:n cardinality)
+            await expect(childrenPivotRecords.nth(0).locator(".lizmapPopupDiv")).toHaveCount(0);
 
             // add a new bird from natural areas popup
             let editFeatureRequestPromise = page.waitForRequest(/lizmap\/edition\/editFeature/);
@@ -382,7 +482,7 @@ test.describe('N to M relations',
 
             await page.waitForTimeout(500);
 
-            // inspect birds table in edition form
+            // inspect birds table in edition form (n:m cardinality)
             let editionFormBirdsTable = page.locator("#edition-table-natural_areas-birds");
 
             await expect(editionFormBirdsTable).toHaveCount(1);
@@ -395,6 +495,24 @@ test.describe('N to M relations',
             await expect(editionFormBirdsTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("Common tern");
             await expect(editionFormBirdsTable.locator("tbody tr").nth(3).locator("td").nth(1)).toHaveText("10");
             await expect(editionFormBirdsTable.locator("tbody tr").nth(3).locator("td").nth(2)).toHaveText("Common snipe");
+
+            // inspect pivot records table in edition form (1:n cardinality)
+            let editionFormPivotTable = page.locator("#edition-table-natural_areas-birds_areas");
+
+            await expect(editionFormPivotTable).toHaveCount(1);
+            await expect(editionFormPivotTable.locator("tbody tr")).toHaveCount(4);
+            await expect(editionFormPivotTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("1");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(0).locator("td").nth(3)).toHaveText("1");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("2");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("2");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(1).locator("td").nth(3)).toHaveText("1");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("3");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("6");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(2).locator("td").nth(3)).toHaveText("1");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(3).locator("td").nth(1)).toHaveText("16");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(3).locator("td").nth(2)).toHaveText("10");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(3).locator("td").nth(3)).toHaveText("1");
 
             // insert new bird with "create new feature" submit option, this should create the pivot record again
             // click on the add feature button
@@ -461,5 +579,26 @@ test.describe('N to M relations',
             await expect(editionFormBirdsTable.locator("tbody tr").nth(4).locator("td").nth(2)).toHaveText("Mute swan");
             await expect(editionFormBirdsTable.locator("tbody tr").nth(5).locator("td").nth(1)).toHaveText("12");
             await expect(editionFormBirdsTable.locator("tbody tr").nth(5).locator("td").nth(2)).toHaveText("Common shelduck");
+
+            // check pivot table (1:n cardinality)
+            await expect(editionFormPivotTable.locator("tbody tr")).toHaveCount(6);
+            await expect(editionFormPivotTable.locator("tbody tr").nth(0).locator("td").nth(1)).toHaveText("1");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(0).locator("td").nth(2)).toHaveText("1");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(0).locator("td").nth(3)).toHaveText("1");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(1).locator("td").nth(1)).toHaveText("2");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(1).locator("td").nth(2)).toHaveText("2");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(1).locator("td").nth(3)).toHaveText("1");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(2).locator("td").nth(1)).toHaveText("3");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(2).locator("td").nth(2)).toHaveText("6");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(2).locator("td").nth(3)).toHaveText("1");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(3).locator("td").nth(1)).toHaveText("16");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(3).locator("td").nth(2)).toHaveText("10");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(3).locator("td").nth(3)).toHaveText("1");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(4).locator("td").nth(1)).toHaveText("17");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(4).locator("td").nth(2)).toHaveText("11");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(4).locator("td").nth(3)).toHaveText("1");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(5).locator("td").nth(1)).toHaveText("18");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(5).locator("td").nth(2)).toHaveText("12");
+            await expect(editionFormPivotTable.locator("tbody tr").nth(5).locator("td").nth(3)).toHaveText("1");
         });
     });

--- a/tests/end2end/playwright/pages/project.js
+++ b/tests/end2end/playwright/pages/project.js
@@ -528,6 +528,15 @@ export class ProjectPage extends BasePage {
     }
 
     /**
+     * Switch to given child attribute table
+     * @param {string} tableName Name of the attribute table to visualize
+     * @returns {Promise<void>}
+     */
+    async switchChildAttributeTable(tableName){
+        await this.page.locator(`#nav-tab-attribute-child-tab-${tableName}`).click();
+    }
+
+    /**
      * Open search builder attribute table panel. Optionally can clear all criteria
      * @param {string}  name Name of the table
      * @param {boolean} clearAll Wheter to clear all conditions or not

--- a/tests/qgis-projects/tests/n_to_m_relations.qgs
+++ b/tests/qgis-projects/tests/n_to_m_relations.qgs
@@ -1,12 +1,12 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis saveUser="ubuntu" saveDateTime="2025-12-03T07:22:56" version="3.40.13-Bratislava" saveUserFull="Ubuntu" projectname="">
+<qgis version="3.40.10-Bratislava" saveDateTime="2026-05-08T08:22:25" projectname="" saveUser="riccardo" saveUserFull="Riccardo Beltrami">
   <homePath path=""/>
   <title></title>
   <transaction mode="Disabled"/>
   <projectFlags set="TrustStoredLayerStatistics"/>
   <projectCrs>
     <spatialrefsys nativeFormat="Wkt">
-      <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+      <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
       <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
       <srsid>3452</srsid>
       <srid>4326</srid>
@@ -30,38 +30,38 @@
       <geographicflag>false</geographicflag>
     </spatialrefsys>
   </verticalCrs>
-  <elevation-shading-renderer edl-distance-unit="0" hillshading-is-active="0" edl-strength="1000" light-azimuth="315" combined-method="0" light-altitude="45" is-active="0" edl-distance="0.5" edl-is-active="1" hillshading-z-factor="1" hillshading-is-multidirectional="0"/>
+  <elevation-shading-renderer hillshading-is-active="0" edl-strength="1000" is-active="0" combined-method="0" edl-distance="0.5" edl-distance-unit="0" light-azimuth="315" edl-is-active="1" hillshading-is-multidirectional="0" light-altitude="45" hillshading-z-factor="1"/>
   <layer-tree-group>
     <customproperties>
       <Option/>
     </customproperties>
-    <layer-tree-layer checked="Qt::Checked" expanded="1" legend_split_behavior="0" source="service='lizmapdb' sslmode=prefer key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)" name="natural_areas" legend_exp="" id="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" providerKey="" patch_size="-1,-1">
+    <layer-tree-layer legend_split_behavior="0" source="service='lizmapdb' key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)" checked="Qt::Checked" providerKey="postgres" expanded="0" patch_size="-1,-1" id="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" legend_exp="" name="natural_areas">
       <customproperties>
         <Option/>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer checked="Qt::Checked" expanded="1" legend_split_behavior="0" source="service='lizmapdb' sslmode=prefer key='id' checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;birds_spots&quot;" name="birds_spots" legend_exp="" id="birds_spots_00d594ce_5dea_4664_91c3_a6b831eab900" providerKey="" patch_size="-1,-1">
+    <layer-tree-layer legend_split_behavior="0" source="service='lizmapdb' key='id' checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;birds_spots&quot;" checked="Qt::Checked" providerKey="postgres" expanded="1" patch_size="-1,-1" id="birds_spots_00d594ce_5dea_4664_91c3_a6b831eab900" legend_exp="" name="birds_spots">
       <customproperties>
         <Option/>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer checked="Qt::Checked" expanded="1" legend_split_behavior="0" source="service='lizmapdb' sslmode=prefer key='id' checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;birds&quot;" name="birds" legend_exp="" id="birds_40695c7a_461f_4cba_ba7f_50a16b6524f5" providerKey="" patch_size="-1,-1">
+    <layer-tree-layer legend_split_behavior="0" source="service='lizmapdb' key='id' checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;birds&quot;" checked="Qt::Checked" providerKey="postgres" expanded="1" patch_size="-1,-1" id="birds_40695c7a_461f_4cba_ba7f_50a16b6524f5" legend_exp="" name="birds">
       <customproperties>
         <Option/>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer checked="Qt::Checked" expanded="1" legend_split_behavior="0" source="service='lizmapdb' sslmode=prefer key='id' checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;birds_areas&quot;" name="birds_areas" legend_exp="" id="birds_areas_41ed4da5_c0e4_4e56_bf5a_037606486f34" providerKey="" patch_size="-1,-1">
+    <layer-tree-layer legend_split_behavior="0" source="service='lizmapdb' key='id' checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;birds_areas&quot;" checked="Qt::Checked" providerKey="postgres" expanded="1" patch_size="-1,-1" id="birds_areas_41ed4da5_c0e4_4e56_bf5a_037606486f34" legend_exp="" name="birds_areas">
       <customproperties>
         <Option/>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-group expanded="1" checked="Qt::Checked" name="baselayers" groupLayer="">
+    <layer-tree-group mutually-exclusive="1" checked="Qt::Checked" expanded="1" groupLayer="" mutually-exclusive-child="0" name="baselayers">
       <customproperties>
         <Option type="Map">
-          <Option name="wmsShortName" value="baselayers" type="QString"/>
+          <Option type="QString" value="baselayers" name="wmsShortName"/>
         </Option>
       </customproperties>
-      <layer-tree-layer checked="Qt::Checked" expanded="1" legend_split_behavior="0" source="crs=EPSG:3857&amp;format&amp;type=xyz&amp;url=https://tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&amp;zmax=19&amp;zmin=0&amp;http-header:referer=" name="OpenStreetMap" legend_exp="" id="OpenStreetMap_83c66d00_e6d6_4407_b56a_3c600adb3c59" providerKey="" patch_size="-1,-1">
+      <layer-tree-layer legend_split_behavior="0" source="crs=EPSG:3857&amp;format&amp;type=xyz&amp;url=https://tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&amp;zmax=19&amp;zmin=0&amp;http-header:referer=" checked="Qt::Checked" providerKey="wms" expanded="1" patch_size="-1,-1" id="OpenStreetMap_83c66d00_e6d6_4407_b56a_3c600adb3c59" legend_exp="" name="OpenStreetMap">
         <customproperties>
           <Option/>
         </customproperties>
@@ -72,24 +72,83 @@
       <item>OpenStreetMap_83c66d00_e6d6_4407_b56a_3c600adb3c59</item>
     </custom-order>
   </layer-tree-group>
-  <snapping-settings enabled="0" tolerance="12" maxScale="0" mode="2" minScale="0" scaleDependencyMode="0" intersection-snapping="0" unit="1" self-snapping="0" type="1">
+  <snapping-settings intersection-snapping="0" enabled="0" maxScale="0" type="1" tolerance="12" self-snapping="0" mode="2" unit="1" minScale="0" scaleDependencyMode="0">
     <individual-layer-settings>
-      <layer-setting enabled="0" tolerance="12" units="1" maxScale="0" minScale="0" id="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" type="1"/>
+      <layer-setting enabled="0" maxScale="0" type="1" tolerance="12" id="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" minScale="0" units="1"/>
     </individual-layer-settings>
   </snapping-settings>
   <relations>
-    <relation referencedLayer="birds_40695c7a_461f_4cba_ba7f_50a16b6524f5" name="birds_to_birds_area" referencingLayer="birds_areas_41ed4da5_c0e4_4e56_bf5a_037606486f34" id="birds_area_bird_id_birds_4069_id" strength="Association">
+    <relation referencedLayer="birds_40695c7a_461f_4cba_ba7f_50a16b6524f5" id="birds_area_bird_id_birds_4069_id" referencingLayer="birds_areas_41ed4da5_c0e4_4e56_bf5a_037606486f34" strength="Association" name="birds_to_birds_area">
       <fieldRef referencingField="bird_id" referencedField="id"/>
     </relation>
-    <relation referencedLayer="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" name="areas_to_birds_areas" referencingLayer="birds_areas_41ed4da5_c0e4_4e56_bf5a_037606486f34" id="birds_area_natural_area_id_natural_ar_id" strength="Association">
+    <relation referencedLayer="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" id="birds_area_natural_area_id_natural_ar_id" referencingLayer="birds_areas_41ed4da5_c0e4_4e56_bf5a_037606486f34" strength="Association" name="areas_to_birds_areas">
       <fieldRef referencingField="natural_area_id" referencedField="id"/>
     </relation>
-    <relation referencedLayer="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" name="natural_spots" referencingLayer="birds_spots_00d594ce_5dea_4664_91c3_a6b831eab900" id="birds_spot_area_id_natural_ar_id" strength="Association">
+    <relation referencedLayer="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" id="birds_area_natural_area_id_natural_ar_id_1" referencingLayer="birds_areas_41ed4da5_c0e4_4e56_bf5a_037606486f34" strength="Association" name="areas_to_birds_areas_card">
+      <fieldRef referencingField="natural_area_id" referencedField="id"/>
+    </relation>
+    <relation referencedLayer="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" id="birds_spot_area_id_natural_ar_id" referencingLayer="birds_spots_00d594ce_5dea_4664_91c3_a6b831eab900" strength="Association" name="natural_spots">
       <fieldRef referencingField="area_id" referencedField="id"/>
     </relation>
   </relations>
   <polymorphicRelations/>
-  <main-annotation-layer autoRefreshMode="Disabled" legendPlaceholderImage="" maxScale="0" hasScaleBasedVisibilityFlag="0" minScale="0" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" type="annotation">
+  <mapcanvas annotationsVisible="1" name="theMapCanvas">
+    <units>degrees</units>
+    <extent>
+      <xmin>4.50752183533590323</xmin>
+      <ymin>43.33843327459011618</ymin>
+      <xmax>4.72770627483301364</xmax>
+      <ymax>43.46425295430275071</ymax>
+    </extent>
+    <rotation>0</rotation>
+    <destinationsrs>
+      <spatialrefsys nativeFormat="Wkt">
+        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+        <srsid>3452</srsid>
+        <srid>4326</srid>
+        <authid>EPSG:4326</authid>
+        <description>WGS 84</description>
+        <projectionacronym>longlat</projectionacronym>
+        <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+        <geographicflag>true</geographicflag>
+      </spatialrefsys>
+    </destinationsrs>
+    <rendermaptile>0</rendermaptile>
+    <expressionContextScope/>
+  </mapcanvas>
+  <projectModels/>
+  <legend updateDrawingOrder="true">
+    <legendlayer open="false" drawingOrder="-1" checked="Qt::Checked" showFeatureCount="0" name="natural_areas">
+      <filegroup open="false" hidden="false">
+        <legendlayerfile isInOverview="0" layerid="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" visible="1"/>
+      </filegroup>
+    </legendlayer>
+    <legendlayer open="true" drawingOrder="-1" checked="Qt::Checked" showFeatureCount="0" name="birds_spots">
+      <filegroup open="true" hidden="false">
+        <legendlayerfile isInOverview="0" layerid="birds_spots_00d594ce_5dea_4664_91c3_a6b831eab900" visible="1"/>
+      </filegroup>
+    </legendlayer>
+    <legendlayer open="true" drawingOrder="-1" checked="Qt::Checked" showFeatureCount="0" name="birds">
+      <filegroup open="true" hidden="false">
+        <legendlayerfile isInOverview="0" layerid="birds_40695c7a_461f_4cba_ba7f_50a16b6524f5" visible="1"/>
+      </filegroup>
+    </legendlayer>
+    <legendlayer open="true" drawingOrder="-1" checked="Qt::Checked" showFeatureCount="0" name="birds_areas">
+      <filegroup open="true" hidden="false">
+        <legendlayerfile isInOverview="0" layerid="birds_areas_41ed4da5_c0e4_4e56_bf5a_037606486f34" visible="1"/>
+      </filegroup>
+    </legendlayer>
+    <legendgroup open="true" checked="Qt::Checked" name="baselayers">
+      <legendlayer open="true" drawingOrder="-1" checked="Qt::Checked" showFeatureCount="0" name="OpenStreetMap">
+        <filegroup open="true" hidden="false">
+          <legendlayerfile isInOverview="0" layerid="OpenStreetMap_83c66d00_e6d6_4407_b56a_3c600adb3c59" visible="1"/>
+        </filegroup>
+      </legendlayer>
+    </legendgroup>
+  </legend>
+  <mapViewDocks/>
+  <main-annotation-layer autoRefreshMode="Disabled" maxScale="0" type="annotation" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" minScale="0">
     <id>Annotations_1b82beaa_5a0a_445e_b2ad_d7288106e20f</id>
     <datasource></datasource>
     <keywordList>
@@ -98,7 +157,7 @@
     <layername></layername>
     <srs>
       <spatialrefsys nativeFormat="Wkt">
-        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
         <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
         <srsid>3452</srsid>
         <srid>4326</srid>
@@ -150,7 +209,7 @@
     <paintEffect/>
   </main-annotation-layer>
   <projectlayers>
-    <maplayer legendPlaceholderImage="" maxScale="0" hasScaleBasedVisibilityFlag="0" minScale="1e+08" styleCategories="AllStyleCategories" autoRefreshEnabled="0" autoRefreshTime="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" type="raster">
+    <maplayer autoRefreshMode="Disabled" maxScale="0" type="raster" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" minScale="1e+08">
       <extent>
         <xmin>-20037508.34278924390673637</xmin>
         <ymin>-20037508.34278924763202667</ymin>
@@ -160,19 +219,19 @@
       <wgs84extent>
         <xmin>-180</xmin>
         <ymin>-85.05112877980660357</ymin>
-        <xmax>179.99999999999997158</xmax>
+        <xmax>180</xmax>
         <ymax>85.05112877980660357</ymax>
       </wgs84extent>
       <id>OpenStreetMap_83c66d00_e6d6_4407_b56a_3c600adb3c59</id>
       <datasource>crs=EPSG:3857&amp;format&amp;type=xyz&amp;url=https://tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&amp;zmax=19&amp;zmin=0&amp;http-header:referer=</datasource>
       <shortname>OpenStreetMap</shortname>
       <keywordList>
-        <value/>
+        <value></value>
       </keywordList>
       <layername>OpenStreetMap</layername>
       <srs>
         <spatialrefsys nativeFormat="Wkt">
-          <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+          <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
           <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
           <srsid>3857</srsid>
           <srid>3857</srid>
@@ -185,22 +244,23 @@
       </srs>
       <resourceMetadata>
         <identifier>OpenStreetMap tiles</identifier>
-        <parentidentifier/>
-        <language/>
+        <parentidentifier></parentidentifier>
+        <language></language>
         <type>dataset</type>
         <title>OpenStreetMap tiles</title>
         <abstract>OpenStreetMap is built by a community of mappers that contribute and maintain data about roads, trails, cafés, railway stations, and much more, all over the world.</abstract>
         <links>
-          <link url="https://www.openstreetmap.org/" name="Source" format="" description="" mimeType="" type="WWW:LINK" size=""/>
+          <link type="WWW:LINK" mimeType="" size="" url="https://www.openstreetmap.org/" description="" format="" name="Source"/>
         </links>
-        <fees/>
+        <dates/>
+        <fees></fees>
         <rights>Base map and data from OpenStreetMap and OpenStreetMap Foundation (CC-BY-SA). © https://www.openstreetmap.org and contributors.</rights>
         <license>Open Data Commons Open Database License (ODbL)</license>
         <license>Creative Commons Attribution-ShareAlike (CC-BY-SA)</license>
-        <encoding/>
+        <encoding></encoding>
         <crs>
           <spatialrefsys nativeFormat="Wkt">
-            <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
+            <wkt>PROJCRS["WGS 84 / Pseudo-Mercator",BASEGEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["Popular Visualisation Pseudo-Mercator",METHOD["Popular Visualisation Pseudo Mercator",ID["EPSG",1024]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",0,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Web mapping and visualisation."],AREA["World between 85.06°S and 85.06°N."],BBOX[-85.06,-180,85.06,180]],ID["EPSG",3857]]</wkt>
             <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs</proj4>
             <srsid>3857</srsid>
             <srid>3857</srid>
@@ -212,12 +272,12 @@
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial minx="-180" maxz="0" miny="-85.05112877980660357" minz="0" maxy="85.05112877980660357" crs="EPSG:4326" maxx="180" dimensions="2"/>
+          <spatial dimensions="2" maxx="180" maxy="85.05112877980660357" crs="EPSG:4326" miny="-85.05112877980660357" minz="0" minx="-180" maxz="0"/>
         </extent>
       </resourceMetadata>
       <provider>wms</provider>
       <noData>
-        <noDataList bandNo="1" useSrcNoData="0"/>
+        <noDataList useSrcNoData="0" bandNo="1"/>
       </noData>
       <map-layer-style-manager current="default">
         <map-layer-style name="default"/>
@@ -229,97 +289,97 @@
         <Searchable>0</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" fetchMode="0">
+      <temporal enabled="0" mode="0" fetchMode="0" bandNumber="1">
         <fixedRange>
-          <start/>
-          <end/>
+          <start></start>
+          <end></end>
         </fixedRange>
       </temporal>
-      <elevation enabled="0" zscale="1" band="1" symbology="Line" zoffset="0">
+      <elevation enabled="0" mode="RepresentsElevationSurface" zscale="1" band="1" zoffset="0" symbology="Line">
         <data-defined-properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
+            <Option type="QString" value="" name="name"/>
             <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data-defined-properties>
         <profileLineSymbol>
-          <symbol is_animated="0" frame_rate="10" name="" force_rhr="0" clip_to_extent="1" alpha="1" type="line">
+          <symbol type="line" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleLine">
+            <layer enabled="1" pass="0" id="{34c78775-fe04-401f-9548-e130dc33f430}" class="SimpleLine" locked="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" value="0" type="QString"/>
-                <Option name="capstyle" value="square" type="QString"/>
-                <Option name="customdash" value="5;2" type="QString"/>
-                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="customdash_unit" value="MM" type="QString"/>
-                <Option name="dash_pattern_offset" value="0" type="QString"/>
-                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
-                <Option name="draw_inside_polygon" value="0" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="line_color" value="164,113,88,255" type="QString"/>
-                <Option name="line_style" value="solid" type="QString"/>
-                <Option name="line_width" value="0.6" type="QString"/>
-                <Option name="line_width_unit" value="MM" type="QString"/>
-                <Option name="offset" value="0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="ring_filter" value="0" type="QString"/>
-                <Option name="trim_distance_end" value="0" type="QString"/>
-                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
-                <Option name="trim_distance_start" value="0" type="QString"/>
-                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
-                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
-                <Option name="use_custom_dash" value="0" type="QString"/>
-                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="square" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="164,113,88,255,rgb:0.64313725490196083,0.44313725490196076,0.34509803921568627,1" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.6" name="line_width"/>
+                <Option type="QString" value="MM" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileLineSymbol>
         <profileFillSymbol>
-          <symbol is_animated="0" frame_rate="10" name="" force_rhr="0" clip_to_extent="1" alpha="1" type="fill">
+          <symbol type="fill" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleFill">
+            <layer enabled="1" pass="0" id="{4cd3a2f2-dc9a-46a8-9f69-971e1b37e9f6}" class="SimpleFill" locked="0">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="color" value="164,113,88,255" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="offset" value="0,0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="outline_color" value="35,35,35,255" type="QString"/>
-                <Option name="outline_style" value="no" type="QString"/>
-                <Option name="outline_width" value="0.26" type="QString"/>
-                <Option name="outline_width_unit" value="MM" type="QString"/>
-                <Option name="style" value="solid" type="QString"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="164,113,88,255,rgb:0.64313725490196083,0.44313725490196076,0.34509803921568627,1" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="outline_color"/>
+                <Option type="QString" value="no" name="outline_style"/>
+                <Option type="QString" value="0.26" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -328,21 +388,22 @@
       </elevation>
       <customproperties>
         <Option type="Map">
-          <Option name="identify/format" value="Value" type="QString"/>
+          <Option type="QString" value="Value" name="identify/format"/>
         </Option>
       </customproperties>
+      <mapTip enabled="1"></mapTip>
       <pipe-data-defined-properties>
         <Option type="Map">
-          <Option name="name" value="" type="QString"/>
+          <Option type="QString" value="" name="name"/>
           <Option name="properties"/>
-          <Option name="type" value="collection" type="QString"/>
+          <Option type="QString" value="collection" name="type"/>
         </Option>
       </pipe-data-defined-properties>
       <pipe>
         <provider>
-          <resampling enabled="false" zoomedOutResamplingMethod="nearestNeighbour" maxOversampling="2" zoomedInResamplingMethod="nearestNeighbour"/>
+          <resampling enabled="false" maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" zoomedInResamplingMethod="nearestNeighbour"/>
         </provider>
-        <rasterrenderer alphaBand="-1" nodataColor="" band="1" opacity="1" type="singlebandcolordata">
+        <rasterrenderer type="singlebandcolordata" alphaBand="-1" nodataColor="" opacity="1" band="1">
           <rasterTransparency/>
           <minMaxOrigin>
             <limits>None</limits>
@@ -353,73 +414,74 @@
             <stdDevFactor>2</stdDevFactor>
           </minMaxOrigin>
         </rasterrenderer>
-        <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-        <huesaturation invertColors="0" colorizeStrength="100" saturation="0" colorizeRed="255" colorizeOn="0" grayscaleMode="0" colorizeBlue="128" colorizeGreen="128"/>
+        <brightnesscontrast contrast="0" brightness="0" gamma="1"/>
+        <huesaturation colorizeOn="0" saturation="0" colorizeRed="255" invertColors="0" colorizeStrength="100" grayscaleMode="0" colorizeGreen="128" colorizeBlue="128"/>
         <rasterresampler maxOversampling="2"/>
         <resamplingStage>resamplingFilter</resamplingStage>
       </pipe>
       <blendMode>0</blendMode>
     </maplayer>
-    <maplayer readOnly="0" wkbType="NoGeometry" legendPlaceholderImage="" maxScale="0" hasScaleBasedVisibilityFlag="0" minScale="1e+08" geometry="No geometry" styleCategories="AllStyleCategories" autoRefreshEnabled="0" autoRefreshTime="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" type="vector">
+    <maplayer autoRefreshMode="Disabled" maxScale="0" type="vector" wkbType="NoGeometry" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" geometry="No geometry" readOnly="0" minScale="1e+08">
       <id>birds_40695c7a_461f_4cba_ba7f_50a16b6524f5</id>
-      <datasource>service='lizmapdb' sslmode=prefer key='id' checkPrimaryKeyUnicity='1' table="tests_projects"."birds"</datasource>
+      <datasource>service='lizmapdb' key='id' checkPrimaryKeyUnicity='1' table="tests_projects"."birds"</datasource>
       <shortname>birds</shortname>
       <title>Birds</title>
       <keywordList>
-        <value/>
+        <value></value>
       </keywordList>
       <layername>birds</layername>
       <srs>
         <spatialrefsys nativeFormat="Wkt">
-          <wkt/>
-          <proj4/>
+          <wkt></wkt>
+          <proj4></proj4>
           <srsid>0</srsid>
           <srid>0</srid>
-          <authid/>
-          <description/>
-          <projectionacronym/>
-          <ellipsoidacronym/>
+          <authid></authid>
+          <description></description>
+          <projectionacronym></projectionacronym>
+          <ellipsoidacronym></ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
       <resourceMetadata>
-        <identifier/>
-        <parentidentifier/>
-        <language/>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
         <type>dataset</type>
-        <title/>
-        <abstract/>
+        <title></title>
+        <abstract></abstract>
         <contact>
-          <name/>
-          <organization/>
-          <position/>
-          <voice/>
-          <fax/>
-          <email/>
-          <role/>
+          <name></name>
+          <organization></organization>
+          <position></position>
+          <voice></voice>
+          <fax></fax>
+          <email></email>
+          <role></role>
         </contact>
         <links/>
-        <fees/>
-        <encoding/>
+        <dates/>
+        <fees></fees>
+        <encoding></encoding>
         <crs>
           <spatialrefsys nativeFormat="Wkt">
-            <wkt/>
-            <proj4/>
+            <wkt></wkt>
+            <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
-            <authid/>
-            <description/>
-            <projectionacronym/>
-            <ellipsoidacronym/>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
             <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial minx="0" maxz="0" miny="0" minz="0" maxy="0" crs="" maxx="0" dimensions="2"/>
+          <spatial dimensions="2" maxx="0" maxy="0" crs="" miny="0" minz="0" minx="0" maxz="0"/>
           <temporal>
             <period>
-              <start/>
-              <end/>
+              <start></start>
+              <end></end>
             </period>
           </temporal>
         </extent>
@@ -440,138 +502,138 @@
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" endExpression="" durationUnit="min" startField="" limitMode="0" accumulate="0" startExpression="" durationField="id" endField="" fixedDuration="0">
+      <temporal durationField="id" durationUnit="min" startExpression="" enabled="0" startField="" fixedDuration="0" endExpression="" limitMode="0" mode="0" accumulate="0" endField="">
         <fixedRange>
-          <start/>
-          <end/>
+          <start></start>
+          <end></end>
         </fixedRange>
       </temporal>
-      <elevation zscale="1" showMarkerSymbolInSurfacePlots="0" clamping="Terrain" symbology="Line" extrusion="0" zoffset="0" binding="Centroid" respectLayerSymbol="1" type="IndividualFeatures" extrusionEnabled="0">
+      <elevation binding="Centroid" extrusionEnabled="0" type="IndividualFeatures" extrusion="0" respectLayerSymbol="1" clamping="Terrain" showMarkerSymbolInSurfacePlots="0" zscale="1" zoffset="0" symbology="Line">
         <data-defined-properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
+            <Option type="QString" value="" name="name"/>
             <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data-defined-properties>
         <profileLineSymbol>
-          <symbol is_animated="0" frame_rate="10" name="" force_rhr="0" clip_to_extent="1" alpha="1" type="line">
+          <symbol type="line" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleLine">
+            <layer enabled="1" pass="0" id="{3195f6f1-8f32-427a-a103-d365504717fa}" class="SimpleLine" locked="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" value="0" type="QString"/>
-                <Option name="capstyle" value="square" type="QString"/>
-                <Option name="customdash" value="5;2" type="QString"/>
-                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="customdash_unit" value="MM" type="QString"/>
-                <Option name="dash_pattern_offset" value="0" type="QString"/>
-                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
-                <Option name="draw_inside_polygon" value="0" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="line_color" value="190,207,80,255" type="QString"/>
-                <Option name="line_style" value="solid" type="QString"/>
-                <Option name="line_width" value="0.6" type="QString"/>
-                <Option name="line_width_unit" value="MM" type="QString"/>
-                <Option name="offset" value="0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="ring_filter" value="0" type="QString"/>
-                <Option name="trim_distance_end" value="0" type="QString"/>
-                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
-                <Option name="trim_distance_start" value="0" type="QString"/>
-                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
-                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
-                <Option name="use_custom_dash" value="0" type="QString"/>
-                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="square" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="190,207,80,255,rgb:0.74509803921568629,0.81176470588235294,0.31372549019607843,1" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.6" name="line_width"/>
+                <Option type="QString" value="MM" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileLineSymbol>
         <profileFillSymbol>
-          <symbol is_animated="0" frame_rate="10" name="" force_rhr="0" clip_to_extent="1" alpha="1" type="fill">
+          <symbol type="fill" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleFill">
+            <layer enabled="1" pass="0" id="{0e65df81-8a76-4a6c-a7ac-069957dd8b41}" class="SimpleFill" locked="0">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="color" value="190,207,80,255" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="offset" value="0,0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="outline_color" value="136,148,57,255" type="QString"/>
-                <Option name="outline_style" value="solid" type="QString"/>
-                <Option name="outline_width" value="0.2" type="QString"/>
-                <Option name="outline_width_unit" value="MM" type="QString"/>
-                <Option name="style" value="solid" type="QString"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="190,207,80,255,rgb:0.74509803921568629,0.81176470588235294,0.31372549019607843,1" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="136,148,57,255,rgb:0.53333333333333333,0.58039215686274515,0.22352941176470589,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.2" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileFillSymbol>
         <profileMarkerSymbol>
-          <symbol is_animated="0" frame_rate="10" name="" force_rhr="0" clip_to_extent="1" alpha="1" type="marker">
+          <symbol type="marker" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleMarker">
+            <layer enabled="1" pass="0" id="{63b42bf7-822f-48e4-80ec-2c3808dd8ba6}" class="SimpleMarker" locked="0">
               <Option type="Map">
-                <Option name="angle" value="0" type="QString"/>
-                <Option name="cap_style" value="square" type="QString"/>
-                <Option name="color" value="190,207,80,255" type="QString"/>
-                <Option name="horizontal_anchor_point" value="1" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="name" value="diamond" type="QString"/>
-                <Option name="offset" value="0,0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="outline_color" value="136,148,57,255" type="QString"/>
-                <Option name="outline_style" value="solid" type="QString"/>
-                <Option name="outline_width" value="0.2" type="QString"/>
-                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="outline_width_unit" value="MM" type="QString"/>
-                <Option name="scale_method" value="diameter" type="QString"/>
-                <Option name="size" value="3" type="QString"/>
-                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="size_unit" value="MM" type="QString"/>
-                <Option name="vertical_anchor_point" value="1" type="QString"/>
+                <Option type="QString" value="0" name="angle"/>
+                <Option type="QString" value="square" name="cap_style"/>
+                <Option type="QString" value="190,207,80,255,rgb:0.74509803921568629,0.81176470588235294,0.31372549019607843,1" name="color"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="diamond" name="name"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="136,148,57,255,rgb:0.53333333333333333,0.58039215686274515,0.22352941176470589,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.2" name="outline_width"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="3" name="size"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="MM" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -580,82 +642,92 @@
       </elevation>
       <customproperties>
         <Option type="Map">
-          <Option name="dualview/previewExpressions" type="List">
-            <Option value="&quot;bird_name&quot;" type="QString"/>
+          <Option type="List" name="dualview/previewExpressions">
+            <Option type="QString" value="&quot;bird_name&quot;"/>
           </Option>
-          <Option name="embeddedWidgets/count" value="0" type="int"/>
-          <Option name="variableNames"/>
-          <Option name="variableValues"/>
+          <Option type="int" value="0" name="embeddedWidgets/count"/>
+          <Option type="invalid" name="variableNames"/>
+          <Option type="invalid" name="variableValues"/>
         </Option>
       </customproperties>
-      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
       <legend type="default-vector" showLabelLegend="0"/>
       <referencedLayers/>
       <fieldConfiguration>
-        <field configurationFlags="None" name="id">
+        <field configurationFlags="NoFlag" name="id">
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option name="IsMultiline" value="false" type="bool"/>
-                <Option name="UseHtml" value="false" type="bool"/>
+                <Option type="bool" value="false" name="IsMultiline"/>
+                <Option type="bool" value="false" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="bird_name">
+        <field configurationFlags="NoFlag" name="bird_name">
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option name="IsMultiline" value="false" type="bool"/>
-                <Option name="UseHtml" value="false" type="bool"/>
+                <Option type="bool" value="false" name="IsMultiline"/>
+                <Option type="bool" value="false" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="bird_scientific_name">
+        <field configurationFlags="NoFlag" name="bird_scientific_name">
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option name="IsMultiline" value="false" type="bool"/>
-                <Option name="UseHtml" value="false" type="bool"/>
+                <Option type="bool" value="false" name="IsMultiline"/>
+                <Option type="bool" value="false" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="id" field="id" index="0"/>
-        <alias name="Name" field="bird_name" index="1"/>
-        <alias name="Scientific name" field="bird_scientific_name" index="2"/>
+        <alias field="id" index="0" name="id"/>
+        <alias field="bird_name" index="1" name="Name"/>
+        <alias field="bird_scientific_name" index="2" name="Scientific name"/>
       </aliases>
+      <splitPolicies>
+        <policy policy="Duplicate" field="id"/>
+        <policy policy="Duplicate" field="bird_name"/>
+        <policy policy="Duplicate" field="bird_scientific_name"/>
+      </splitPolicies>
+      <duplicatePolicies>
+        <policy policy="Duplicate" field="id"/>
+        <policy policy="Duplicate" field="bird_name"/>
+        <policy policy="Duplicate" field="bird_scientific_name"/>
+      </duplicatePolicies>
       <defaults>
         <default expression="" field="id" applyOnUpdate="0"/>
         <default expression="" field="bird_name" applyOnUpdate="0"/>
         <default expression="" field="bird_scientific_name" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint unique_strength="1" constraints="3" field="id" exp_strength="0" notnull_strength="2"/>
-        <constraint unique_strength="0" constraints="0" field="bird_name" exp_strength="0" notnull_strength="0"/>
-        <constraint unique_strength="0" constraints="0" field="bird_scientific_name" exp_strength="0" notnull_strength="0"/>
+        <constraint field="id" unique_strength="1" notnull_strength="2" constraints="3" exp_strength="0"/>
+        <constraint field="bird_name" unique_strength="0" notnull_strength="0" constraints="0" exp_strength="0"/>
+        <constraint field="bird_scientific_name" unique_strength="0" notnull_strength="0" constraints="0" exp_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint desc="" exp="" field="id"/>
-        <constraint desc="" exp="" field="bird_name"/>
-        <constraint desc="" exp="" field="bird_scientific_name"/>
+        <constraint desc="" field="id" exp=""/>
+        <constraint desc="" field="bird_name" exp=""/>
+        <constraint desc="" field="bird_scientific_name" exp=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
-      <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column name="id" width="-1" hidden="0" type="field"/>
-          <column name="bird_name" width="-1" hidden="0" type="field"/>
-          <column name="bird_scientific_name" width="-1" hidden="0" type="field"/>
-          <column width="-1" hidden="1" type="actions"/>
+          <column width="-1" type="field" hidden="0" name="id"/>
+          <column width="-1" type="field" hidden="0" name="bird_name"/>
+          <column width="-1" type="field" hidden="0" name="bird_scientific_name"/>
+          <column width="-1" type="actions" hidden="1"/>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
@@ -663,10 +735,10 @@
         <fieldstyles/>
       </conditionalstyles>
       <storedexpressions/>
-      <editform tolerant="1"/>
+      <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
-      <editforminitfilepath/>
+      <editforminitfilepath></editforminitfilepath>
       <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
@@ -687,128 +759,129 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>tablayout</editorlayout>
       <attributeEditorForm>
-        <labelStyle labelColor="0,0,0,255" overrideLabelFont="0" overrideLabelColor="0">
-          <labelFont underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
+        <labelStyle overrideLabelColor="0" labelColor="" overrideLabelFont="0">
+          <labelFont strikethrough="0" italic="0" style="" description="Sans Serif,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
         </labelStyle>
-        <attributeEditorField name="id" index="0" showLabel="1">
-          <labelStyle labelColor="0,0,0,255" overrideLabelFont="0" overrideLabelColor="0">
-            <labelFont underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
+        <attributeEditorField showLabel="1" horizontalStretch="0" index="0" name="id" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+            <labelFont strikethrough="0" italic="0" style="" description="Sans,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
           </labelStyle>
         </attributeEditorField>
-        <attributeEditorField name="bird_name" index="1" showLabel="1">
-          <labelStyle labelColor="0,0,0,255" overrideLabelFont="0" overrideLabelColor="0">
-            <labelFont underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
+        <attributeEditorField showLabel="1" horizontalStretch="0" index="1" name="bird_name" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+            <labelFont strikethrough="0" italic="0" style="" description="Sans,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
           </labelStyle>
         </attributeEditorField>
-        <attributeEditorField name="bird_scientific_name" index="2" showLabel="1">
-          <labelStyle labelColor="0,0,0,255" overrideLabelFont="0" overrideLabelColor="0">
-            <labelFont underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
+        <attributeEditorField showLabel="1" horizontalStretch="0" index="2" name="bird_scientific_name" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+            <labelFont strikethrough="0" italic="0" style="" description="Sans,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
           </labelStyle>
         </attributeEditorField>
-        <attributeEditorRelation name="birds_area_bird_id_birds_4069_id" label="Associated areas" relationWidgetTypeId="relation_editor" relation="birds_area_bird_id_birds_4069_id" nmRelationId="birds_area_natural_area_id_natural_ar_id" showLabel="1" forceSuppressFormPopup="0">
-          <labelStyle labelColor="0,0,0,255" overrideLabelFont="0" overrideLabelColor="0">
-            <labelFont underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
+        <attributeEditorRelation relationWidgetTypeId="relation_editor" showLabel="1" relation="birds_area_bird_id_birds_4069_id" forceSuppressFormPopup="0" label="Associated areas" horizontalStretch="0" nmRelationId="birds_area_natural_area_id_natural_ar_id" name="birds_area_bird_id_birds_4069_id" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+            <labelFont strikethrough="0" italic="0" style="" description="Sans,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
           </labelStyle>
           <editor_configuration type="Map">
-            <Option name="allow_add_child_feature_with_no_geometry" value="false" type="bool"/>
-            <Option name="buttons" value="AllButtons" type="QString"/>
-            <Option name="show_first_feature" value="true" type="bool"/>
+            <Option type="bool" value="false" name="allow_add_child_feature_with_no_geometry"/>
+            <Option type="QString" value="AllButtons" name="buttons"/>
+            <Option type="bool" value="true" name="show_first_feature"/>
           </editor_configuration>
         </attributeEditorRelation>
       </attributeEditorForm>
       <editable>
-        <field name="bird_media" editable="1"/>
-        <field name="bird_name" editable="1"/>
-        <field name="bird_scientific_name" editable="1"/>
-        <field name="id" editable="0"/>
-        <field name="laying_number" editable="1"/>
+        <field editable="1" name="bird_media"/>
+        <field editable="1" name="bird_name"/>
+        <field editable="1" name="bird_scientific_name"/>
+        <field editable="0" name="id"/>
+        <field editable="1" name="laying_number"/>
       </editable>
       <labelOnTop>
-        <field name="bird_media" labelOnTop="0"/>
-        <field name="bird_name" labelOnTop="0"/>
-        <field name="bird_scientific_name" labelOnTop="0"/>
-        <field name="id" labelOnTop="0"/>
-        <field name="laying_number" labelOnTop="0"/>
+        <field labelOnTop="0" name="bird_media"/>
+        <field labelOnTop="0" name="bird_name"/>
+        <field labelOnTop="0" name="bird_scientific_name"/>
+        <field labelOnTop="0" name="id"/>
+        <field labelOnTop="0" name="laying_number"/>
       </labelOnTop>
       <reuseLastValue>
-        <field name="bird_media" reuseLastValue="0"/>
-        <field name="bird_name" reuseLastValue="0"/>
-        <field name="bird_scientific_name" reuseLastValue="0"/>
-        <field name="id" reuseLastValue="0"/>
-        <field name="laying_number" reuseLastValue="0"/>
+        <field reuseLastValue="0" name="bird_media"/>
+        <field reuseLastValue="0" name="bird_name"/>
+        <field reuseLastValue="0" name="bird_scientific_name"/>
+        <field reuseLastValue="0" name="id"/>
+        <field reuseLastValue="0" name="laying_number"/>
       </reuseLastValue>
       <dataDefinedFieldProperties/>
       <widgets>
         <widget name="birds_area_bird_id_birds_4069_id">
           <config type="Map">
-            <Option name="force-suppress-popup" value="false" type="bool"/>
-            <Option name="nm-rel" value="birds_area_natural_area_id_natural_ar_id" type="QString"/>
+            <Option type="bool" value="false" name="force-suppress-popup"/>
+            <Option type="QString" value="birds_area_natural_area_id_natural_ar_id" name="nm-rel"/>
           </config>
         </widget>
       </widgets>
       <previewExpression>"bird_name"</previewExpression>
-      <mapTip/>
+      <mapTip enabled="1"></mapTip>
     </maplayer>
-    <maplayer readOnly="0" wkbType="NoGeometry" legendPlaceholderImage="" maxScale="0" hasScaleBasedVisibilityFlag="0" minScale="1e+08" geometry="No geometry" styleCategories="AllStyleCategories" autoRefreshEnabled="0" autoRefreshTime="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" type="vector">
+    <maplayer autoRefreshMode="Disabled" maxScale="0" type="vector" wkbType="NoGeometry" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" geometry="No geometry" readOnly="0" minScale="1e+08">
       <id>birds_areas_41ed4da5_c0e4_4e56_bf5a_037606486f34</id>
-      <datasource>service='lizmapdb' sslmode=prefer key='id' checkPrimaryKeyUnicity='1' table="tests_projects"."birds_areas"</datasource>
+      <datasource>service='lizmapdb' key='id' checkPrimaryKeyUnicity='1' table="tests_projects"."birds_areas"</datasource>
       <shortname>birds_areas</shortname>
       <title>Area and birds</title>
       <keywordList>
-        <value/>
+        <value></value>
       </keywordList>
       <layername>birds_areas</layername>
       <srs>
         <spatialrefsys nativeFormat="Wkt">
-          <wkt/>
-          <proj4/>
+          <wkt></wkt>
+          <proj4></proj4>
           <srsid>0</srsid>
           <srid>0</srid>
-          <authid/>
-          <description/>
-          <projectionacronym/>
-          <ellipsoidacronym/>
+          <authid></authid>
+          <description></description>
+          <projectionacronym></projectionacronym>
+          <ellipsoidacronym></ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
       <resourceMetadata>
-        <identifier/>
-        <parentidentifier/>
-        <language/>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
         <type>dataset</type>
-        <title/>
-        <abstract/>
+        <title></title>
+        <abstract></abstract>
         <contact>
-          <name/>
-          <organization/>
-          <position/>
-          <voice/>
-          <fax/>
-          <email/>
-          <role/>
+          <name></name>
+          <organization></organization>
+          <position></position>
+          <voice></voice>
+          <fax></fax>
+          <email></email>
+          <role></role>
         </contact>
         <links/>
-        <fees/>
-        <encoding/>
+        <dates/>
+        <fees></fees>
+        <encoding></encoding>
         <crs>
           <spatialrefsys nativeFormat="Wkt">
-            <wkt/>
-            <proj4/>
+            <wkt></wkt>
+            <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
-            <authid/>
-            <description/>
-            <projectionacronym/>
-            <ellipsoidacronym/>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
             <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial minx="0" maxz="0" miny="0" minz="0" maxy="0" crs="" maxx="0" dimensions="2"/>
+          <spatial dimensions="2" maxx="0" maxy="0" crs="" miny="0" minz="0" minx="0" maxz="0"/>
           <temporal>
             <period>
-              <start/>
-              <end/>
+              <start></start>
+              <end></end>
             </period>
           </temporal>
         </extent>
@@ -829,138 +902,138 @@ def my_form_open(dialog, layer, feature):
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" endExpression="" durationUnit="min" startField="" limitMode="0" accumulate="0" startExpression="" durationField="" endField="" fixedDuration="0">
+      <temporal durationField="" durationUnit="min" startExpression="" enabled="0" startField="" fixedDuration="0" endExpression="" limitMode="0" mode="0" accumulate="0" endField="">
         <fixedRange>
-          <start/>
-          <end/>
+          <start></start>
+          <end></end>
         </fixedRange>
       </temporal>
-      <elevation zscale="1" showMarkerSymbolInSurfacePlots="0" clamping="Terrain" symbology="Line" extrusion="0" zoffset="0" binding="Centroid" respectLayerSymbol="1" type="IndividualFeatures" extrusionEnabled="0">
+      <elevation binding="Centroid" extrusionEnabled="0" type="IndividualFeatures" extrusion="0" respectLayerSymbol="1" clamping="Terrain" showMarkerSymbolInSurfacePlots="0" zscale="1" zoffset="0" symbology="Line">
         <data-defined-properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
+            <Option type="QString" value="" name="name"/>
             <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data-defined-properties>
         <profileLineSymbol>
-          <symbol is_animated="0" frame_rate="10" name="" force_rhr="0" clip_to_extent="1" alpha="1" type="line">
+          <symbol type="line" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleLine">
+            <layer enabled="1" pass="0" id="{10fe8197-c29a-4f3d-b69a-ab42f4136246}" class="SimpleLine" locked="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" value="0" type="QString"/>
-                <Option name="capstyle" value="square" type="QString"/>
-                <Option name="customdash" value="5;2" type="QString"/>
-                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="customdash_unit" value="MM" type="QString"/>
-                <Option name="dash_pattern_offset" value="0" type="QString"/>
-                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
-                <Option name="draw_inside_polygon" value="0" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="line_color" value="231,113,72,255" type="QString"/>
-                <Option name="line_style" value="solid" type="QString"/>
-                <Option name="line_width" value="0.6" type="QString"/>
-                <Option name="line_width_unit" value="MM" type="QString"/>
-                <Option name="offset" value="0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="ring_filter" value="0" type="QString"/>
-                <Option name="trim_distance_end" value="0" type="QString"/>
-                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
-                <Option name="trim_distance_start" value="0" type="QString"/>
-                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
-                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
-                <Option name="use_custom_dash" value="0" type="QString"/>
-                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="square" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="231,113,72,255,rgb:0.90588235294117647,0.44313725490196076,0.28235294117647058,1" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.6" name="line_width"/>
+                <Option type="QString" value="MM" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileLineSymbol>
         <profileFillSymbol>
-          <symbol is_animated="0" frame_rate="10" name="" force_rhr="0" clip_to_extent="1" alpha="1" type="fill">
+          <symbol type="fill" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleFill">
+            <layer enabled="1" pass="0" id="{74315aa6-85cc-44e2-b5df-c802d102f64e}" class="SimpleFill" locked="0">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="color" value="231,113,72,255" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="offset" value="0,0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="outline_color" value="165,81,51,255" type="QString"/>
-                <Option name="outline_style" value="solid" type="QString"/>
-                <Option name="outline_width" value="0.2" type="QString"/>
-                <Option name="outline_width_unit" value="MM" type="QString"/>
-                <Option name="style" value="solid" type="QString"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="231,113,72,255,rgb:0.90588235294117647,0.44313725490196076,0.28235294117647058,1" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="165,81,51,255,rgb:0.6470588235294118,0.31764705882352939,0.20000000000000001,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.2" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileFillSymbol>
         <profileMarkerSymbol>
-          <symbol is_animated="0" frame_rate="10" name="" force_rhr="0" clip_to_extent="1" alpha="1" type="marker">
+          <symbol type="marker" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleMarker">
+            <layer enabled="1" pass="0" id="{6e913b4a-df0b-4876-a125-384e3aa098a0}" class="SimpleMarker" locked="0">
               <Option type="Map">
-                <Option name="angle" value="0" type="QString"/>
-                <Option name="cap_style" value="square" type="QString"/>
-                <Option name="color" value="231,113,72,255" type="QString"/>
-                <Option name="horizontal_anchor_point" value="1" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="name" value="diamond" type="QString"/>
-                <Option name="offset" value="0,0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="outline_color" value="165,81,51,255" type="QString"/>
-                <Option name="outline_style" value="solid" type="QString"/>
-                <Option name="outline_width" value="0.2" type="QString"/>
-                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="outline_width_unit" value="MM" type="QString"/>
-                <Option name="scale_method" value="diameter" type="QString"/>
-                <Option name="size" value="3" type="QString"/>
-                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="size_unit" value="MM" type="QString"/>
-                <Option name="vertical_anchor_point" value="1" type="QString"/>
+                <Option type="QString" value="0" name="angle"/>
+                <Option type="QString" value="square" name="cap_style"/>
+                <Option type="QString" value="231,113,72,255,rgb:0.90588235294117647,0.44313725490196076,0.28235294117647058,1" name="color"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="diamond" name="name"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="165,81,51,255,rgb:0.6470588235294118,0.31764705882352939,0.20000000000000001,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.2" name="outline_width"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="3" name="size"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="MM" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -969,97 +1042,110 @@ def my_form_open(dialog, layer, feature):
       </elevation>
       <customproperties>
         <Option type="Map">
-          <Option name="dualview/previewExpressions" type="List">
-            <Option value="&quot;id&quot;" type="QString"/>
+          <Option type="List" name="dualview/previewExpressions">
+            <Option type="QString" value="&quot;id&quot;"/>
           </Option>
-          <Option name="embeddedWidgets/count" value="0" type="int"/>
-          <Option name="variableNames" type="invalid"/>
-          <Option name="variableValues" type="invalid"/>
+          <Option type="int" value="0" name="embeddedWidgets/count"/>
+          <Option type="invalid" name="variableNames"/>
+          <Option type="invalid" name="variableValues"/>
         </Option>
       </customproperties>
-      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
       <legend type="default-vector" showLabelLegend="0"/>
       <referencedLayers>
-        <relation referencedLayer="birds_40695c7a_461f_4cba_ba7f_50a16b6524f5" layerId="birds_40695c7a_461f_4cba_ba7f_50a16b6524f5" name="birds_to_birds_area" referencingLayer="birds_areas_41ed4da5_c0e4_4e56_bf5a_037606486f34" strength="Association" id="birds_area_bird_id_birds_4069_id" providerKey="postgres" layerName="birds" dataSource="service='lizmapdb' sslmode=prefer key='id' checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;birds&quot;">
+        <relation layerName="birds" providerKey="postgres" referencedLayer="birds_40695c7a_461f_4cba_ba7f_50a16b6524f5" layerId="birds_40695c7a_461f_4cba_ba7f_50a16b6524f5" dataSource="service='lizmapdb' key='id' checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;birds&quot;" id="birds_area_bird_id_birds_4069_id" referencingLayer="birds_areas_41ed4da5_c0e4_4e56_bf5a_037606486f34" strength="Association" name="birds_to_birds_area">
           <fieldRef referencingField="bird_id" referencedField="id"/>
         </relation>
-        <relation referencedLayer="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" layerId="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" name="areas_to_birds_areas" referencingLayer="birds_areas_41ed4da5_c0e4_4e56_bf5a_037606486f34" strength="Association" id="birds_area_natural_area_id_natural_ar_id" providerKey="postgres" layerName="natural_areas" dataSource="service='lizmapdb' sslmode=prefer key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)">
+        <relation layerName="natural_areas" providerKey="postgres" referencedLayer="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" layerId="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" dataSource="service='lizmapdb' key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)" id="birds_area_natural_area_id_natural_ar_id" referencingLayer="birds_areas_41ed4da5_c0e4_4e56_bf5a_037606486f34" strength="Association" name="areas_to_birds_areas">
+          <fieldRef referencingField="natural_area_id" referencedField="id"/>
+        </relation>
+        <relation layerName="natural_areas" providerKey="postgres" referencedLayer="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" layerId="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" dataSource="service='lizmapdb' key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)" id="birds_area_natural_area_id_natural_ar_id_1" referencingLayer="birds_areas_41ed4da5_c0e4_4e56_bf5a_037606486f34" strength="Association" name="areas_to_birds_areas_card">
           <fieldRef referencingField="natural_area_id" referencedField="id"/>
         </relation>
       </referencedLayers>
       <fieldConfiguration>
-        <field configurationFlags="None" name="id">
+        <field configurationFlags="NoFlag" name="id">
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option name="IsMultiline" value="false" type="bool"/>
-                <Option name="UseHtml" value="false" type="bool"/>
+                <Option type="bool" value="false" name="IsMultiline"/>
+                <Option type="bool" value="false" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="bird_id">
+        <field configurationFlags="NoFlag" name="bird_id">
           <editWidget type="Range">
             <config>
               <Option type="Map">
-                <Option name="AllowNull" value="true" type="bool"/>
-                <Option name="Max" value="2147483647" type="int"/>
-                <Option name="Min" value="-2147483648" type="int"/>
-                <Option name="Precision" value="0" type="int"/>
-                <Option name="Step" value="1" type="int"/>
-                <Option name="Style" value="SpinBox" type="QString"/>
+                <Option type="bool" value="true" name="AllowNull"/>
+                <Option type="int" value="2147483647" name="Max"/>
+                <Option type="int" value="-2147483648" name="Min"/>
+                <Option type="int" value="0" name="Precision"/>
+                <Option type="int" value="1" name="Step"/>
+                <Option type="QString" value="SpinBox" name="Style"/>
               </Option>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="natural_area_id">
+        <field configurationFlags="NoFlag" name="natural_area_id">
           <editWidget type="Range">
             <config>
               <Option type="Map">
-                <Option name="AllowNull" value="true" type="bool"/>
-                <Option name="Max" value="2147483647" type="int"/>
-                <Option name="Min" value="-2147483648" type="int"/>
-                <Option name="Precision" value="0" type="int"/>
-                <Option name="Step" value="1" type="int"/>
-                <Option name="Style" value="SpinBox" type="QString"/>
+                <Option type="bool" value="true" name="AllowNull"/>
+                <Option type="int" value="2147483647" name="Max"/>
+                <Option type="int" value="-2147483648" name="Min"/>
+                <Option type="int" value="0" name="Precision"/>
+                <Option type="int" value="1" name="Step"/>
+                <Option type="QString" value="SpinBox" name="Style"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="id" field="id" index="0"/>
-        <alias name="bird_id" field="bird_id" index="1"/>
-        <alias name="natural_area_id" field="natural_area_id" index="2"/>
+        <alias field="id" index="0" name="id"/>
+        <alias field="bird_id" index="1" name="bird_id"/>
+        <alias field="natural_area_id" index="2" name="natural_area_id"/>
       </aliases>
+      <splitPolicies>
+        <policy policy="Duplicate" field="id"/>
+        <policy policy="Duplicate" field="bird_id"/>
+        <policy policy="Duplicate" field="natural_area_id"/>
+      </splitPolicies>
+      <duplicatePolicies>
+        <policy policy="Duplicate" field="id"/>
+        <policy policy="Duplicate" field="bird_id"/>
+        <policy policy="Duplicate" field="natural_area_id"/>
+      </duplicatePolicies>
       <defaults>
         <default expression="" field="id" applyOnUpdate="0"/>
         <default expression="" field="bird_id" applyOnUpdate="0"/>
         <default expression="" field="natural_area_id" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint unique_strength="1" constraints="3" field="id" exp_strength="0" notnull_strength="1"/>
-        <constraint unique_strength="0" constraints="1" field="bird_id" exp_strength="0" notnull_strength="1"/>
-        <constraint unique_strength="0" constraints="1" field="natural_area_id" exp_strength="0" notnull_strength="1"/>
+        <constraint field="id" unique_strength="1" notnull_strength="1" constraints="3" exp_strength="0"/>
+        <constraint field="bird_id" unique_strength="0" notnull_strength="1" constraints="1" exp_strength="0"/>
+        <constraint field="natural_area_id" unique_strength="0" notnull_strength="1" constraints="1" exp_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint desc="" exp="" field="id"/>
-        <constraint desc="" exp="" field="bird_id"/>
-        <constraint desc="" exp="" field="natural_area_id"/>
+        <constraint desc="" field="id" exp=""/>
+        <constraint desc="" field="bird_id" exp=""/>
+        <constraint desc="" field="natural_area_id" exp=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
-      <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column name="id" width="-1" hidden="0" type="field"/>
-          <column name="bird_id" width="-1" hidden="0" type="field"/>
-          <column name="natural_area_id" width="-1" hidden="0" type="field"/>
-          <column width="-1" hidden="1" type="actions"/>
+          <column width="-1" type="field" hidden="0" name="id"/>
+          <column width="-1" type="field" hidden="0" name="bird_id"/>
+          <column width="-1" type="field" hidden="0" name="natural_area_id"/>
+          <column width="-1" type="actions" hidden="1"/>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
@@ -1067,10 +1153,10 @@ def my_form_open(dialog, layer, feature):
         <fieldstyles/>
       </conditionalstyles>
       <storedexpressions/>
-      <editform tolerant="1"/>
+      <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
-      <editforminitfilepath/>
+      <editforminitfilepath></editforminitfilepath>
       <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
@@ -1091,105 +1177,106 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>tablayout</editorlayout>
       <attributeEditorForm>
-        <labelStyle labelColor="0,0,0,255" overrideLabelFont="0" overrideLabelColor="0">
-          <labelFont underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
+        <labelStyle overrideLabelColor="0" labelColor="" overrideLabelFont="0">
+          <labelFont strikethrough="0" italic="0" style="" description="Sans Serif,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
         </labelStyle>
-        <attributeEditorField name="id" index="0" showLabel="1">
-          <labelStyle labelColor="0,0,0,255" overrideLabelFont="0" overrideLabelColor="0">
-            <labelFont underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
+        <attributeEditorField showLabel="1" horizontalStretch="0" index="0" name="id" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+            <labelFont strikethrough="0" italic="0" style="" description="Sans,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
           </labelStyle>
         </attributeEditorField>
-        <attributeEditorField name="bird_id" index="1" showLabel="1">
-          <labelStyle labelColor="0,0,0,255" overrideLabelFont="0" overrideLabelColor="0">
-            <labelFont underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
+        <attributeEditorField showLabel="1" horizontalStretch="0" index="1" name="bird_id" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+            <labelFont strikethrough="0" italic="0" style="" description="Sans,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
           </labelStyle>
         </attributeEditorField>
-        <attributeEditorField name="natural_area_id" index="2" showLabel="1">
-          <labelStyle labelColor="0,0,0,255" overrideLabelFont="0" overrideLabelColor="0">
-            <labelFont underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
+        <attributeEditorField showLabel="1" horizontalStretch="0" index="2" name="natural_area_id" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+            <labelFont strikethrough="0" italic="0" style="" description="Sans,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
           </labelStyle>
         </attributeEditorField>
       </attributeEditorForm>
       <editable>
-        <field name="bird_id" editable="1"/>
-        <field name="id" editable="1"/>
-        <field name="natural_area_id" editable="1"/>
+        <field editable="1" name="bird_id"/>
+        <field editable="1" name="id"/>
+        <field editable="1" name="natural_area_id"/>
       </editable>
       <labelOnTop>
-        <field name="bird_id" labelOnTop="0"/>
-        <field name="id" labelOnTop="0"/>
-        <field name="natural_area_id" labelOnTop="0"/>
+        <field labelOnTop="0" name="bird_id"/>
+        <field labelOnTop="0" name="id"/>
+        <field labelOnTop="0" name="natural_area_id"/>
       </labelOnTop>
       <reuseLastValue>
-        <field name="bird_id" reuseLastValue="0"/>
-        <field name="id" reuseLastValue="0"/>
-        <field name="natural_area_id" reuseLastValue="0"/>
+        <field reuseLastValue="0" name="bird_id"/>
+        <field reuseLastValue="0" name="id"/>
+        <field reuseLastValue="0" name="natural_area_id"/>
       </reuseLastValue>
       <dataDefinedFieldProperties/>
       <widgets/>
       <previewExpression>"id"</previewExpression>
-      <mapTip/>
+      <mapTip enabled="1"></mapTip>
     </maplayer>
-    <maplayer readOnly="0" wkbType="NoGeometry" legendPlaceholderImage="" maxScale="0" hasScaleBasedVisibilityFlag="0" minScale="1e+08" geometry="No geometry" styleCategories="AllStyleCategories" autoRefreshEnabled="0" autoRefreshTime="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" type="vector">
+    <maplayer autoRefreshMode="Disabled" maxScale="0" type="vector" wkbType="NoGeometry" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" geometry="No geometry" readOnly="0" minScale="1e+08">
       <id>birds_spots_00d594ce_5dea_4664_91c3_a6b831eab900</id>
-      <datasource>service='lizmapdb' sslmode=prefer key='id' checkPrimaryKeyUnicity='1' table="tests_projects"."birds_spots"</datasource>
+      <datasource>service='lizmapdb' key='id' checkPrimaryKeyUnicity='1' table="tests_projects"."birds_spots"</datasource>
       <shortname>birds_spots</shortname>
       <title>Bird sposts</title>
       <keywordList>
-        <value/>
+        <value></value>
       </keywordList>
       <layername>birds_spots</layername>
       <srs>
         <spatialrefsys nativeFormat="Wkt">
-          <wkt/>
-          <proj4/>
+          <wkt></wkt>
+          <proj4></proj4>
           <srsid>0</srsid>
           <srid>0</srid>
-          <authid/>
-          <description/>
-          <projectionacronym/>
-          <ellipsoidacronym/>
+          <authid></authid>
+          <description></description>
+          <projectionacronym></projectionacronym>
+          <ellipsoidacronym></ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
       <resourceMetadata>
-        <identifier/>
-        <parentidentifier/>
-        <language/>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
         <type>dataset</type>
-        <title/>
-        <abstract/>
+        <title></title>
+        <abstract></abstract>
         <contact>
-          <name/>
-          <organization/>
-          <position/>
-          <voice/>
-          <fax/>
-          <email/>
-          <role/>
+          <name></name>
+          <organization></organization>
+          <position></position>
+          <voice></voice>
+          <fax></fax>
+          <email></email>
+          <role></role>
         </contact>
         <links/>
-        <fees/>
-        <encoding/>
+        <dates/>
+        <fees></fees>
+        <encoding></encoding>
         <crs>
           <spatialrefsys nativeFormat="Wkt">
-            <wkt/>
-            <proj4/>
+            <wkt></wkt>
+            <proj4></proj4>
             <srsid>0</srsid>
             <srid>0</srid>
-            <authid/>
-            <description/>
-            <projectionacronym/>
-            <ellipsoidacronym/>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
             <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial minx="0" maxz="0" miny="0" minz="0" maxy="0" crs="" maxx="0" dimensions="2"/>
+          <spatial dimensions="2" maxx="0" maxy="0" crs="" miny="0" minz="0" minx="0" maxz="0"/>
           <temporal>
             <period>
-              <start/>
-              <end/>
+              <start></start>
+              <end></end>
             </period>
           </temporal>
         </extent>
@@ -1210,138 +1297,138 @@ def my_form_open(dialog, layer, feature):
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" endExpression="" durationUnit="min" startField="" limitMode="0" accumulate="0" startExpression="" durationField="" endField="" fixedDuration="0">
+      <temporal durationField="" durationUnit="min" startExpression="" enabled="0" startField="" fixedDuration="0" endExpression="" limitMode="0" mode="0" accumulate="0" endField="">
         <fixedRange>
-          <start/>
-          <end/>
+          <start></start>
+          <end></end>
         </fixedRange>
       </temporal>
-      <elevation zscale="1" showMarkerSymbolInSurfacePlots="0" clamping="Terrain" symbology="Line" extrusion="0" zoffset="0" binding="Centroid" respectLayerSymbol="1" type="IndividualFeatures" extrusionEnabled="0">
+      <elevation binding="Centroid" extrusionEnabled="0" type="IndividualFeatures" extrusion="0" respectLayerSymbol="1" clamping="Terrain" showMarkerSymbolInSurfacePlots="0" zscale="1" zoffset="0" symbology="Line">
         <data-defined-properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
+            <Option type="QString" value="" name="name"/>
             <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data-defined-properties>
         <profileLineSymbol>
-          <symbol is_animated="0" frame_rate="10" name="" force_rhr="0" clip_to_extent="1" alpha="1" type="line">
+          <symbol type="line" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleLine">
+            <layer enabled="1" pass="0" id="{fc4759f8-7d06-4abb-a946-de07b6e10ba3}" class="SimpleLine" locked="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" value="0" type="QString"/>
-                <Option name="capstyle" value="square" type="QString"/>
-                <Option name="customdash" value="5;2" type="QString"/>
-                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="customdash_unit" value="MM" type="QString"/>
-                <Option name="dash_pattern_offset" value="0" type="QString"/>
-                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
-                <Option name="draw_inside_polygon" value="0" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="line_color" value="133,182,111,255" type="QString"/>
-                <Option name="line_style" value="solid" type="QString"/>
-                <Option name="line_width" value="0.6" type="QString"/>
-                <Option name="line_width_unit" value="MM" type="QString"/>
-                <Option name="offset" value="0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="ring_filter" value="0" type="QString"/>
-                <Option name="trim_distance_end" value="0" type="QString"/>
-                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
-                <Option name="trim_distance_start" value="0" type="QString"/>
-                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
-                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
-                <Option name="use_custom_dash" value="0" type="QString"/>
-                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="square" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="133,182,111,255,rgb:0.52156862745098043,0.71372549019607845,0.43529411764705883,1" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.6" name="line_width"/>
+                <Option type="QString" value="MM" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileLineSymbol>
         <profileFillSymbol>
-          <symbol is_animated="0" frame_rate="10" name="" force_rhr="0" clip_to_extent="1" alpha="1" type="fill">
+          <symbol type="fill" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleFill">
+            <layer enabled="1" pass="0" id="{3f54db18-9c08-4399-96a5-ca4be2f21377}" class="SimpleFill" locked="0">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="color" value="133,182,111,255" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="offset" value="0,0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="outline_color" value="95,130,79,255" type="QString"/>
-                <Option name="outline_style" value="solid" type="QString"/>
-                <Option name="outline_width" value="0.2" type="QString"/>
-                <Option name="outline_width_unit" value="MM" type="QString"/>
-                <Option name="style" value="solid" type="QString"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="133,182,111,255,rgb:0.52156862745098043,0.71372549019607845,0.43529411764705883,1" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="95,130,79,255,rgb:0.37254901960784315,0.50980392156862742,0.30980392156862746,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.2" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileFillSymbol>
         <profileMarkerSymbol>
-          <symbol is_animated="0" frame_rate="10" name="" force_rhr="0" clip_to_extent="1" alpha="1" type="marker">
+          <symbol type="marker" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleMarker">
+            <layer enabled="1" pass="0" id="{40c6c62b-8e9e-4b4e-81c7-2da083bfebc2}" class="SimpleMarker" locked="0">
               <Option type="Map">
-                <Option name="angle" value="0" type="QString"/>
-                <Option name="cap_style" value="square" type="QString"/>
-                <Option name="color" value="133,182,111,255" type="QString"/>
-                <Option name="horizontal_anchor_point" value="1" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="name" value="diamond" type="QString"/>
-                <Option name="offset" value="0,0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="outline_color" value="95,130,79,255" type="QString"/>
-                <Option name="outline_style" value="solid" type="QString"/>
-                <Option name="outline_width" value="0.2" type="QString"/>
-                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="outline_width_unit" value="MM" type="QString"/>
-                <Option name="scale_method" value="diameter" type="QString"/>
-                <Option name="size" value="3" type="QString"/>
-                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="size_unit" value="MM" type="QString"/>
-                <Option name="vertical_anchor_point" value="1" type="QString"/>
+                <Option type="QString" value="0" name="angle"/>
+                <Option type="QString" value="square" name="cap_style"/>
+                <Option type="QString" value="133,182,111,255,rgb:0.52156862745098043,0.71372549019607845,0.43529411764705883,1" name="color"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="diamond" name="name"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="95,130,79,255,rgb:0.37254901960784315,0.50980392156862742,0.30980392156862746,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.2" name="outline_width"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="3" name="size"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="MM" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -1350,96 +1437,106 @@ def my_form_open(dialog, layer, feature):
       </elevation>
       <customproperties>
         <Option type="Map">
-          <Option name="dualview/previewExpressions" type="List">
-            <Option value="&quot;spot_name&quot;" type="QString"/>
+          <Option type="List" name="dualview/previewExpressions">
+            <Option type="QString" value="&quot;spot_name&quot;"/>
           </Option>
-          <Option name="embeddedWidgets/count" value="0" type="int"/>
-          <Option name="variableNames" type="invalid"/>
-          <Option name="variableValues" type="invalid"/>
+          <Option type="int" value="0" name="embeddedWidgets/count"/>
+          <Option type="invalid" name="variableNames"/>
+          <Option type="invalid" name="variableValues"/>
         </Option>
       </customproperties>
-      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
       <legend type="default-vector" showLabelLegend="0"/>
       <referencedLayers>
-        <relation referencedLayer="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" layerId="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" name="natural_spots" referencingLayer="birds_spots_00d594ce_5dea_4664_91c3_a6b831eab900" strength="Association" id="birds_spot_area_id_natural_ar_id" providerKey="postgres" layerName="natural_areas" dataSource="service='lizmapdb' sslmode=prefer key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)">
+        <relation layerName="natural_areas" providerKey="postgres" referencedLayer="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" layerId="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" dataSource="service='lizmapdb' key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)" id="birds_spot_area_id_natural_ar_id" referencingLayer="birds_spots_00d594ce_5dea_4664_91c3_a6b831eab900" strength="Association" name="natural_spots">
           <fieldRef referencingField="area_id" referencedField="id"/>
         </relation>
       </referencedLayers>
       <fieldConfiguration>
-        <field configurationFlags="None" name="id">
+        <field configurationFlags="NoFlag" name="id">
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option name="IsMultiline" value="false" type="bool"/>
-                <Option name="UseHtml" value="false" type="bool"/>
+                <Option type="bool" value="false" name="IsMultiline"/>
+                <Option type="bool" value="false" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="area_id">
+        <field configurationFlags="NoFlag" name="area_id">
           <editWidget type="RelationReference">
             <config>
               <Option type="Map">
-                <Option name="AllowAddFeatures" value="false" type="bool"/>
-                <Option name="AllowNULL" value="false" type="bool"/>
-                <Option name="MapIdentification" value="false" type="bool"/>
-                <Option name="OrderByValue" value="false" type="bool"/>
-                <Option name="ReadOnly" value="false" type="bool"/>
-                <Option name="ReferencedLayerDataSource" value="service='lizmapdb' sslmode=prefer key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)" type="QString"/>
-                <Option name="ReferencedLayerId" value="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" type="QString"/>
-                <Option name="ReferencedLayerName" value="natural_areas" type="QString"/>
-                <Option name="ReferencedLayerProviderKey" value="postgres" type="QString"/>
-                <Option name="Relation" value="birds_spot_area_id_natural_ar_id" type="QString"/>
-                <Option name="ShowForm" value="false" type="bool"/>
-                <Option name="ShowOpenFormButton" value="true" type="bool"/>
+                <Option type="bool" value="false" name="AllowAddFeatures"/>
+                <Option type="bool" value="false" name="AllowNULL"/>
+                <Option type="bool" value="false" name="MapIdentification"/>
+                <Option type="bool" value="false" name="OrderByValue"/>
+                <Option type="bool" value="false" name="ReadOnly"/>
+                <Option type="QString" value="service='lizmapdb' sslmode=prefer key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)" name="ReferencedLayerDataSource"/>
+                <Option type="QString" value="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" name="ReferencedLayerId"/>
+                <Option type="QString" value="natural_areas" name="ReferencedLayerName"/>
+                <Option type="QString" value="postgres" name="ReferencedLayerProviderKey"/>
+                <Option type="QString" value="birds_spot_area_id_natural_ar_id" name="Relation"/>
+                <Option type="bool" value="false" name="ShowForm"/>
+                <Option type="bool" value="true" name="ShowOpenFormButton"/>
               </Option>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="spot_name">
+        <field configurationFlags="NoFlag" name="spot_name">
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option name="IsMultiline" value="false" type="bool"/>
-                <Option name="UseHtml" value="false" type="bool"/>
+                <Option type="bool" value="false" name="IsMultiline"/>
+                <Option type="bool" value="false" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="Id" field="id" index="0"/>
-        <alias name="Area id" field="area_id" index="1"/>
-        <alias name="Spot name" field="spot_name" index="2"/>
+        <alias field="id" index="0" name="Id"/>
+        <alias field="area_id" index="1" name="Area id"/>
+        <alias field="spot_name" index="2" name="Spot name"/>
       </aliases>
+      <splitPolicies>
+        <policy policy="Duplicate" field="id"/>
+        <policy policy="Duplicate" field="area_id"/>
+        <policy policy="Duplicate" field="spot_name"/>
+      </splitPolicies>
+      <duplicatePolicies>
+        <policy policy="Duplicate" field="id"/>
+        <policy policy="Duplicate" field="area_id"/>
+        <policy policy="Duplicate" field="spot_name"/>
+      </duplicatePolicies>
       <defaults>
         <default expression="" field="id" applyOnUpdate="0"/>
         <default expression="" field="area_id" applyOnUpdate="0"/>
         <default expression="" field="spot_name" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint unique_strength="1" constraints="3" field="id" exp_strength="0" notnull_strength="1"/>
-        <constraint unique_strength="0" constraints="1" field="area_id" exp_strength="0" notnull_strength="1"/>
-        <constraint unique_strength="0" constraints="0" field="spot_name" exp_strength="0" notnull_strength="0"/>
+        <constraint field="id" unique_strength="1" notnull_strength="1" constraints="3" exp_strength="0"/>
+        <constraint field="area_id" unique_strength="0" notnull_strength="1" constraints="1" exp_strength="0"/>
+        <constraint field="spot_name" unique_strength="0" notnull_strength="0" constraints="0" exp_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint desc="" exp="" field="id"/>
-        <constraint desc="" exp="" field="area_id"/>
-        <constraint desc="" exp="" field="spot_name"/>
+        <constraint desc="" field="id" exp=""/>
+        <constraint desc="" field="area_id" exp=""/>
+        <constraint desc="" field="spot_name" exp=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
-      <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column name="id" width="-1" hidden="0" type="field"/>
-          <column name="area_id" width="-1" hidden="0" type="field"/>
-          <column name="spot_name" width="-1" hidden="0" type="field"/>
-          <column width="-1" hidden="1" type="actions"/>
+          <column width="-1" type="field" hidden="0" name="id"/>
+          <column width="-1" type="field" hidden="0" name="area_id"/>
+          <column width="-1" type="field" hidden="0" name="spot_name"/>
+          <column width="-1" type="actions" hidden="1"/>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
@@ -1447,10 +1544,10 @@ def my_form_open(dialog, layer, feature):
         <fieldstyles/>
       </conditionalstyles>
       <storedexpressions/>
-      <editform tolerant="1"/>
+      <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
-      <editforminitfilepath/>
+      <editforminitfilepath></editforminitfilepath>
       <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
@@ -1471,46 +1568,46 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>tablayout</editorlayout>
       <attributeEditorForm>
-        <labelStyle labelColor="0,0,0,255" overrideLabelFont="0" overrideLabelColor="0">
-          <labelFont underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
+        <labelStyle overrideLabelColor="0" labelColor="" overrideLabelFont="0">
+          <labelFont strikethrough="0" italic="0" style="" description="Sans Serif,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
         </labelStyle>
-        <attributeEditorField name="id" index="0" showLabel="1">
-          <labelStyle labelColor="0,0,0,255" overrideLabelFont="0" overrideLabelColor="0">
-            <labelFont underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
+        <attributeEditorField showLabel="1" horizontalStretch="0" index="0" name="id" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+            <labelFont strikethrough="0" italic="0" style="" description="Sans,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
           </labelStyle>
         </attributeEditorField>
-        <attributeEditorField name="area_id" index="1" showLabel="1">
-          <labelStyle labelColor="0,0,0,255" overrideLabelFont="0" overrideLabelColor="0">
-            <labelFont underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
+        <attributeEditorField showLabel="1" horizontalStretch="0" index="1" name="area_id" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+            <labelFont strikethrough="0" italic="0" style="" description="Sans,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
           </labelStyle>
         </attributeEditorField>
-        <attributeEditorField name="spot_name" index="2" showLabel="1">
-          <labelStyle labelColor="0,0,0,255" overrideLabelFont="0" overrideLabelColor="0">
-            <labelFont underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
+        <attributeEditorField showLabel="1" horizontalStretch="0" index="2" name="spot_name" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+            <labelFont strikethrough="0" italic="0" style="" description="Sans,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
           </labelStyle>
         </attributeEditorField>
       </attributeEditorForm>
       <editable>
-        <field name="area_id" editable="1"/>
-        <field name="id" editable="1"/>
-        <field name="spot_name" editable="1"/>
+        <field editable="1" name="area_id"/>
+        <field editable="1" name="id"/>
+        <field editable="1" name="spot_name"/>
       </editable>
       <labelOnTop>
-        <field name="area_id" labelOnTop="0"/>
-        <field name="id" labelOnTop="0"/>
-        <field name="spot_name" labelOnTop="0"/>
+        <field labelOnTop="0" name="area_id"/>
+        <field labelOnTop="0" name="id"/>
+        <field labelOnTop="0" name="spot_name"/>
       </labelOnTop>
       <reuseLastValue>
-        <field name="area_id" reuseLastValue="0"/>
-        <field name="id" reuseLastValue="0"/>
-        <field name="spot_name" reuseLastValue="0"/>
+        <field reuseLastValue="0" name="area_id"/>
+        <field reuseLastValue="0" name="id"/>
+        <field reuseLastValue="0" name="spot_name"/>
       </reuseLastValue>
       <dataDefinedFieldProperties/>
       <widgets/>
       <previewExpression>"spot_name"</previewExpression>
-      <mapTip/>
+      <mapTip enabled="1"></mapTip>
     </maplayer>
-    <maplayer simplifyAlgorithm="0" autoRefreshEnabled="0" simplifyMaxScale="1" autoRefreshTime="0" type="vector" symbologyReferenceScale="-1" maxScale="0" labelsEnabled="0" legendPlaceholderImage="" minScale="100000000" refreshOnNotifyMessage="" simplifyDrawingTol="1" wkbType="Polygon" hasScaleBasedVisibilityFlag="0" geometry="Polygon" simplifyLocal="0" styleCategories="AllStyleCategories" refreshOnNotifyEnabled="0" simplifyDrawingHints="1" readOnly="0">
+    <maplayer autoRefreshMode="Disabled" hasScaleBasedVisibilityFlag="0" simplifyMaxScale="1" labelsEnabled="0" maxScale="0" refreshOnNotifyEnabled="0" symbologyReferenceScale="-1" simplifyLocal="0" geometry="Polygon" legendPlaceholderImage="" simplifyDrawingTol="1" type="vector" wkbType="Polygon" styleCategories="AllStyleCategories" autoRefreshTime="0" simplifyAlgorithm="0" minScale="100000000" readOnly="0" simplifyDrawingHints="1" refreshOnNotifyMessage="">
       <extent>
         <xmin>4.58213930607160602</xmin>
         <ymin>43.35054476032322412</ymin>
@@ -1524,16 +1621,16 @@ def my_form_open(dialog, layer, feature):
         <ymax>43.45587426605017356</ymax>
       </wgs84extent>
       <id>natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813</id>
-      <datasource>service='lizmapdb' sslmode=prefer key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table="tests_projects"."natural_areas" (geom)</datasource>
+      <datasource>service='lizmapdb' key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table="tests_projects"."natural_areas" (geom)</datasource>
       <shortname>natural_areas</shortname>
       <title>Natural areas</title>
       <keywordList>
-        <value/>
+        <value></value>
       </keywordList>
       <layername>natural_areas</layername>
       <srs>
         <spatialrefsys nativeFormat="Wkt">
-          <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+          <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
           <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
           <srsid>3452</srsid>
           <srid>4326</srid>
@@ -1545,27 +1642,28 @@ def my_form_open(dialog, layer, feature):
         </spatialrefsys>
       </srs>
       <resourceMetadata>
-        <identifier/>
-        <parentidentifier/>
-        <language/>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
         <type>dataset</type>
-        <title/>
-        <abstract/>
+        <title></title>
+        <abstract></abstract>
         <contact>
-          <name/>
-          <organization/>
-          <position/>
-          <voice/>
-          <fax/>
-          <email/>
-          <role/>
+          <name></name>
+          <organization></organization>
+          <position></position>
+          <voice></voice>
+          <fax></fax>
+          <email></email>
+          <role></role>
         </contact>
         <links/>
-        <fees/>
-        <encoding/>
+        <dates/>
+        <fees></fees>
+        <encoding></encoding>
         <crs>
           <spatialrefsys nativeFormat="Wkt">
-            <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+            <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
             <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
             <srsid>3452</srsid>
             <srid>4326</srid>
@@ -1577,11 +1675,11 @@ def my_form_open(dialog, layer, feature):
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial minx="0" maxz="0" miny="0" minz="0" maxy="0" crs="EPSG:4326" maxx="0" dimensions="2"/>
+          <spatial dimensions="2" maxx="0" maxy="0" crs="EPSG:4326" miny="0" minz="0" minx="0" maxz="0"/>
           <temporal>
             <period>
-              <start/>
-              <end/>
+              <start></start>
+              <end></end>
             </period>
           </temporal>
         </extent>
@@ -1602,305 +1700,305 @@ def my_form_open(dialog, layer, feature):
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" endExpression="" durationUnit="min" startField="" limitMode="0" accumulate="0" startExpression="" durationField="" endField="" fixedDuration="0">
+      <temporal durationField="" durationUnit="min" startExpression="" enabled="0" startField="" fixedDuration="0" endExpression="" limitMode="0" mode="0" accumulate="0" endField="">
         <fixedRange>
-          <start/>
-          <end/>
+          <start></start>
+          <end></end>
         </fixedRange>
       </temporal>
-      <elevation zscale="1" showMarkerSymbolInSurfacePlots="0" clamping="Terrain" symbology="Line" extrusion="0" zoffset="0" binding="Centroid" respectLayerSymbol="1" type="IndividualFeatures" extrusionEnabled="0">
+      <elevation binding="Centroid" extrusionEnabled="0" type="IndividualFeatures" extrusion="0" respectLayerSymbol="1" clamping="Terrain" showMarkerSymbolInSurfacePlots="0" zscale="1" zoffset="0" symbology="Line">
         <data-defined-properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
+            <Option type="QString" value="" name="name"/>
             <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </data-defined-properties>
         <profileLineSymbol>
-          <symbol is_animated="0" frame_rate="10" name="" force_rhr="0" clip_to_extent="1" alpha="1" type="line">
+          <symbol type="line" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleLine">
+            <layer enabled="1" pass="0" id="{44cad848-0ddb-47d4-b55d-29c18d0638c7}" class="SimpleLine" locked="0">
               <Option type="Map">
-                <Option name="align_dash_pattern" value="0" type="QString"/>
-                <Option name="capstyle" value="square" type="QString"/>
-                <Option name="customdash" value="5;2" type="QString"/>
-                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="customdash_unit" value="MM" type="QString"/>
-                <Option name="dash_pattern_offset" value="0" type="QString"/>
-                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
-                <Option name="draw_inside_polygon" value="0" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="line_color" value="229,182,54,255" type="QString"/>
-                <Option name="line_style" value="solid" type="QString"/>
-                <Option name="line_width" value="0.6" type="QString"/>
-                <Option name="line_width_unit" value="MM" type="QString"/>
-                <Option name="offset" value="0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="ring_filter" value="0" type="QString"/>
-                <Option name="trim_distance_end" value="0" type="QString"/>
-                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
-                <Option name="trim_distance_start" value="0" type="QString"/>
-                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
-                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
-                <Option name="use_custom_dash" value="0" type="QString"/>
-                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="square" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="229,182,54,255,rgb:0.89803921568627454,0.71372549019607845,0.21176470588235294,1" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.6" name="line_width"/>
+                <Option type="QString" value="MM" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileLineSymbol>
         <profileFillSymbol>
-          <symbol is_animated="0" frame_rate="10" name="" force_rhr="0" clip_to_extent="1" alpha="1" type="fill">
+          <symbol type="fill" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleFill">
+            <layer enabled="1" pass="0" id="{095c8f8e-00eb-4109-a8f8-aa1cb8cb3c71}" class="SimpleFill" locked="0">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="color" value="229,182,54,255" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="offset" value="0,0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="outline_color" value="164,130,39,255" type="QString"/>
-                <Option name="outline_style" value="solid" type="QString"/>
-                <Option name="outline_width" value="0.2" type="QString"/>
-                <Option name="outline_width_unit" value="MM" type="QString"/>
-                <Option name="style" value="solid" type="QString"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="229,182,54,255,rgb:0.89803921568627454,0.71372549019607845,0.21176470588235294,1" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="164,130,39,255,rgb:0.64313725490196083,0.50980392156862742,0.15294117647058825,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.2" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileFillSymbol>
         <profileMarkerSymbol>
-          <symbol is_animated="0" frame_rate="10" name="" force_rhr="0" clip_to_extent="1" alpha="1" type="marker">
+          <symbol type="marker" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleMarker">
+            <layer enabled="1" pass="0" id="{65b37710-c39f-45f6-87e0-0f3266aeb832}" class="SimpleMarker" locked="0">
               <Option type="Map">
-                <Option name="angle" value="0" type="QString"/>
-                <Option name="cap_style" value="square" type="QString"/>
-                <Option name="color" value="229,182,54,255" type="QString"/>
-                <Option name="horizontal_anchor_point" value="1" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="name" value="diamond" type="QString"/>
-                <Option name="offset" value="0,0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="outline_color" value="164,130,39,255" type="QString"/>
-                <Option name="outline_style" value="solid" type="QString"/>
-                <Option name="outline_width" value="0.2" type="QString"/>
-                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="outline_width_unit" value="MM" type="QString"/>
-                <Option name="scale_method" value="diameter" type="QString"/>
-                <Option name="size" value="3" type="QString"/>
-                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="size_unit" value="MM" type="QString"/>
-                <Option name="vertical_anchor_point" value="1" type="QString"/>
+                <Option type="QString" value="0" name="angle"/>
+                <Option type="QString" value="square" name="cap_style"/>
+                <Option type="QString" value="229,182,54,255,rgb:0.89803921568627454,0.71372549019607845,0.21176470588235294,1" name="color"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="diamond" name="name"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="164,130,39,255,rgb:0.64313725490196083,0.50980392156862742,0.15294117647058825,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.2" name="outline_width"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="3" name="size"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="MM" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileMarkerSymbol>
       </elevation>
-      <renderer-v2 enableorderby="0" forceraster="0" attr="id" symbollevels="0" referencescale="-1" type="categorizedSymbol">
+      <renderer-v2 enableorderby="0" symbollevels="0" referencescale="-1" type="categorizedSymbol" attr="id" forceraster="0">
         <categories>
-          <category render="true" label="1" value="1" symbol="0" type="long"/>
-          <category render="true" label="2" value="2" symbol="1" type="long"/>
-          <category render="true" label="3" value="3" symbol="2" type="long"/>
-          <category render="true" label="" value="" symbol="3" type="string"/>
+          <category uuid="0" type="long" label="1" symbol="0" render="true" value="1"/>
+          <category uuid="1" type="long" label="2" symbol="1" render="true" value="2"/>
+          <category uuid="2" type="long" label="3" symbol="2" render="true" value="3"/>
+          <category uuid="3" type="string" label="" symbol="3" render="true" value=""/>
         </categories>
         <symbols>
-          <symbol is_animated="0" frame_rate="10" name="0" force_rhr="0" clip_to_extent="1" alpha="1" type="fill">
+          <symbol type="fill" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleFill">
+            <layer enabled="1" pass="0" id="{93209251-2141-495b-a7cb-8ae01aaa9ca1}" class="SimpleFill" locked="0">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="color" value="46,220,83,255" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="offset" value="0,0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="outline_color" value="35,35,35,255" type="QString"/>
-                <Option name="outline_style" value="solid" type="QString"/>
-                <Option name="outline_width" value="0.26" type="QString"/>
-                <Option name="outline_width_unit" value="MM" type="QString"/>
-                <Option name="style" value="solid" type="QString"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="46,220,83,255,rgb:0.1803921568627451,0.86274509803921573,0.32549019607843138,1" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.26" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol is_animated="0" frame_rate="10" name="1" force_rhr="0" clip_to_extent="1" alpha="1" type="fill">
+          <symbol type="fill" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="1">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleFill">
+            <layer enabled="1" pass="0" id="{7ac1311a-d402-47f1-9188-7fd068561f19}" class="SimpleFill" locked="0">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="color" value="236,177,28,255" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="offset" value="0,0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="outline_color" value="35,35,35,255" type="QString"/>
-                <Option name="outline_style" value="solid" type="QString"/>
-                <Option name="outline_width" value="0.26" type="QString"/>
-                <Option name="outline_width_unit" value="MM" type="QString"/>
-                <Option name="style" value="solid" type="QString"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="236,177,28,255,rgb:0.92549019607843142,0.69411764705882351,0.10980392156862745,1" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.26" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol is_animated="0" frame_rate="10" name="2" force_rhr="0" clip_to_extent="1" alpha="1" type="fill">
+          <symbol type="fill" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="2">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleFill">
+            <layer enabled="1" pass="0" id="{62ed713c-be81-451f-b82b-d34d99e47931}" class="SimpleFill" locked="0">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="color" value="127,151,211,255" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="offset" value="0,0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="outline_color" value="35,35,35,255" type="QString"/>
-                <Option name="outline_style" value="solid" type="QString"/>
-                <Option name="outline_width" value="0.26" type="QString"/>
-                <Option name="outline_width_unit" value="MM" type="QString"/>
-                <Option name="style" value="solid" type="QString"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="127,151,211,255,rgb:0.49803921568627452,0.59215686274509804,0.82745098039215681,1" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.26" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol is_animated="0" frame_rate="10" name="3" force_rhr="0" clip_to_extent="1" alpha="1" type="fill">
+          <symbol type="fill" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="3">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleFill">
+            <layer enabled="1" pass="0" id="{94f65594-73c0-428a-b85f-8aaa9bb16a98}" class="SimpleFill" locked="0">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="color" value="200,77,173,255" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="offset" value="0,0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="outline_color" value="35,35,35,255" type="QString"/>
-                <Option name="outline_style" value="solid" type="QString"/>
-                <Option name="outline_width" value="0.26" type="QString"/>
-                <Option name="outline_width_unit" value="MM" type="QString"/>
-                <Option name="style" value="solid" type="QString"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="200,77,173,255,rgb:0.78431372549019607,0.30196078431372547,0.67843137254901964,1" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.26" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
         <source-symbol>
-          <symbol is_animated="0" frame_rate="10" name="0" force_rhr="0" clip_to_extent="1" alpha="1" type="fill">
+          <symbol type="fill" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option type="QString" value="" name="name"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option type="QString" value="collection" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer pass="0" enabled="1" locked="0" class="SimpleFill">
+            <layer enabled="1" pass="0" id="{b2d80baf-86ea-46f5-bb6a-e7e8411a7067}" class="SimpleFill" locked="0">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="color" value="196,60,57,255" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="offset" value="0,0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="outline_color" value="35,35,35,255" type="QString"/>
-                <Option name="outline_style" value="solid" type="QString"/>
-                <Option name="outline_width" value="0.26" type="QString"/>
-                <Option name="outline_width_unit" value="MM" type="QString"/>
-                <Option name="style" value="solid" type="QString"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="196,60,57,255,rgb:0.7686274509803922,0.23529411764705882,0.22352941176470589,1" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.26" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -1908,144 +2006,195 @@ def my_form_open(dialog, layer, feature):
         </source-symbol>
         <rotation/>
         <sizescale/>
+        <data-defined-properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data-defined-properties>
       </renderer-v2>
+      <selection mode="Default">
+        <selectionColor invalid="1"/>
+        <selectionSymbol>
+          <symbol type="fill" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" pass="0" id="{bef8bdc5-5090-4f6d-9190-45967dfe302d}" class="SimpleFill" locked="0">
+              <Option type="Map">
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="0,0,255,255,rgb:0,0,1,1" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.26" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </selectionSymbol>
+      </selection>
       <customproperties>
         <Option type="Map">
-          <Option name="dualview/previewExpressions" type="List">
-            <Option value="natural_area_name" type="QString"/>
-            <Option value="&quot;natural_area_name&quot;" type="QString"/>
+          <Option type="List" name="dualview/previewExpressions">
+            <Option type="QString" value="natural_area_name"/>
+            <Option type="QString" value="&quot;natural_area_name&quot;"/>
           </Option>
-          <Option name="embeddedWidgets/count" value="0" type="int"/>
-          <Option name="variableNames" type="invalid"/>
-          <Option name="variableValues" type="invalid"/>
+          <Option type="int" value="0" name="embeddedWidgets/count"/>
+          <Option type="invalid" name="variableNames"/>
+          <Option type="invalid" name="variableValues"/>
         </Option>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-        <DiagramCategory width="15" spacing="5" showAxis="1" penAlpha="255" backgroundAlpha="255" enabled="0" penWidth="0" rotationOffset="270" minimumSize="0" lineSizeType="MM" spacingUnitScale="3x:0,0,0,0,0,0" spacingUnit="MM" barWidth="5" backgroundColor="#ffffff" scaleDependency="Area" direction="0" sizeType="MM" diagramOrientation="Up" sizeScale="3x:0,0,0,0,0,0" height="15" maxScaleDenominator="1e+08" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" scaleBasedVisibility="0" penColor="#000000" opacity="1" labelPlacementMethod="XHeight">
-          <fontProperties underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
-          <attribute label="" field="" color="#000000" colorOpacity="1"/>
+      <LinearlyInterpolatedDiagramRenderer lowerValue="0" upperWidth="5" diagramType="Histogram" classificationAttributeExpression="" attributeLegend="1" lowerWidth="0" upperHeight="5" upperValue="0" lowerHeight="0">
+        <DiagramCategory sizeType="MM" stackedDiagramMode="Horizontal" spacingUnitScale="3x:0,0,0,0,0,0" stackedDiagramSpacing="0" spacingUnit="MM" barWidth="5" minimumSize="0" maxScaleDenominator="1e+08" height="15" penAlpha="255" stackedDiagramSpacingUnit="MM" spacing="5" showAxis="1" backgroundColor="#ffffff" direction="0" lineSizeType="MM" minScaleDenominator="0" lineSizeScale="3x:0,0,0,0,0,0" diagramOrientation="Up" penWidth="0" labelPlacementMethod="XHeight" penColor="#000000" sizeScale="3x:0,0,0,0,0,0" stackedDiagramSpacingUnitScale="3x:0,0,0,0,0,0" scaleDependency="Area" rotationOffset="270" opacity="1" width="15" enabled="0" scaleBasedVisibility="0" backgroundAlpha="255">
+          <fontProperties strikethrough="0" italic="0" style="" description="Sans,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
+          <attribute colorOpacity="1" color="#000000" field="" label=""/>
           <axisSymbol>
-            <symbol is_animated="0" frame_rate="10" name="" force_rhr="0" clip_to_extent="1" alpha="1" type="line">
+            <symbol type="line" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" is_animated="0" name="">
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
-              <layer pass="0" enabled="1" locked="0" class="SimpleLine">
+              <layer enabled="1" pass="0" id="{2d7ebc3f-9658-4828-9d9e-0c5ae8651516}" class="SimpleLine" locked="0">
                 <Option type="Map">
-                  <Option name="align_dash_pattern" value="0" type="QString"/>
-                  <Option name="capstyle" value="square" type="QString"/>
-                  <Option name="customdash" value="5;2" type="QString"/>
-                  <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                  <Option name="customdash_unit" value="MM" type="QString"/>
-                  <Option name="dash_pattern_offset" value="0" type="QString"/>
-                  <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                  <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
-                  <Option name="draw_inside_polygon" value="0" type="QString"/>
-                  <Option name="joinstyle" value="bevel" type="QString"/>
-                  <Option name="line_color" value="35,35,35,255" type="QString"/>
-                  <Option name="line_style" value="solid" type="QString"/>
-                  <Option name="line_width" value="0.26" type="QString"/>
-                  <Option name="line_width_unit" value="MM" type="QString"/>
-                  <Option name="offset" value="0" type="QString"/>
-                  <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                  <Option name="offset_unit" value="MM" type="QString"/>
-                  <Option name="ring_filter" value="0" type="QString"/>
-                  <Option name="trim_distance_end" value="0" type="QString"/>
-                  <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                  <Option name="trim_distance_end_unit" value="MM" type="QString"/>
-                  <Option name="trim_distance_start" value="0" type="QString"/>
-                  <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                  <Option name="trim_distance_start_unit" value="MM" type="QString"/>
-                  <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
-                  <Option name="use_custom_dash" value="0" type="QString"/>
-                  <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option type="QString" value="0" name="align_dash_pattern"/>
+                  <Option type="QString" value="square" name="capstyle"/>
+                  <Option type="QString" value="5;2" name="customdash"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="customdash_unit"/>
+                  <Option type="QString" value="0" name="dash_pattern_offset"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                  <Option type="QString" value="0" name="draw_inside_polygon"/>
+                  <Option type="QString" value="bevel" name="joinstyle"/>
+                  <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="line_color"/>
+                  <Option type="QString" value="solid" name="line_style"/>
+                  <Option type="QString" value="0.26" name="line_width"/>
+                  <Option type="QString" value="MM" name="line_width_unit"/>
+                  <Option type="QString" value="0" name="offset"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="offset_unit"/>
+                  <Option type="QString" value="0" name="ring_filter"/>
+                  <Option type="QString" value="0" name="trim_distance_end"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                  <Option type="QString" value="0" name="trim_distance_start"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                  <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                  <Option type="QString" value="0" name="use_custom_dash"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
                 </Option>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" value="" type="QString"/>
+                    <Option type="QString" value="" name="name"/>
                     <Option name="properties"/>
-                    <Option name="type" value="collection" type="QString"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
               </layer>
             </symbol>
           </axisSymbol>
         </DiagramCategory>
-      </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings obstacle="0" zIndex="0" priority="0" linePlacementFlags="18" dist="0" placement="1" showAll="1">
+      </LinearlyInterpolatedDiagramRenderer>
+      <DiagramLayerSettings showAll="1" linePlacementFlags="18" placement="1" zIndex="0" dist="0" priority="0" obstacle="0">
         <properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
+            <Option type="QString" value="" name="name"/>
             <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
         <activeChecks/>
         <checkConfiguration type="Map">
-          <Option name="QgsGeometryGapCheck" type="Map">
-            <Option name="allowedGapsBuffer" value="0" type="double"/>
-            <Option name="allowedGapsEnabled" value="false" type="bool"/>
-            <Option name="allowedGapsLayer" value="" type="QString"/>
+          <Option type="Map" name="QgsGeometryGapCheck">
+            <Option type="double" value="0" name="allowedGapsBuffer"/>
+            <Option type="bool" value="false" name="allowedGapsEnabled"/>
+            <Option type="invalid" name="allowedGapsLayer"/>
           </Option>
         </checkConfiguration>
       </geometryOptions>
       <legend type="default-vector" showLabelLegend="0"/>
       <referencedLayers/>
       <fieldConfiguration>
-        <field configurationFlags="None" name="id">
+        <field configurationFlags="NoFlag" name="id">
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option name="IsMultiline" value="false" type="bool"/>
-                <Option name="UseHtml" value="false" type="bool"/>
+                <Option type="bool" value="false" name="IsMultiline"/>
+                <Option type="bool" value="false" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="natural_area_name">
+        <field configurationFlags="NoFlag" name="natural_area_name">
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option name="IsMultiline" value="false" type="bool"/>
-                <Option name="UseHtml" value="false" type="bool"/>
+                <Option type="bool" value="false" name="IsMultiline"/>
+                <Option type="bool" value="false" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="id" field="id" index="0"/>
-        <alias name="Natural area name" field="natural_area_name" index="1"/>
+        <alias field="id" index="0" name="id"/>
+        <alias field="natural_area_name" index="1" name="Natural area name"/>
       </aliases>
+      <splitPolicies>
+        <policy policy="Duplicate" field="id"/>
+        <policy policy="Duplicate" field="natural_area_name"/>
+      </splitPolicies>
+      <duplicatePolicies>
+        <policy policy="Duplicate" field="id"/>
+        <policy policy="Duplicate" field="natural_area_name"/>
+      </duplicatePolicies>
       <defaults>
         <default expression="" field="id" applyOnUpdate="0"/>
         <default expression="" field="natural_area_name" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint unique_strength="1" constraints="3" field="id" exp_strength="0" notnull_strength="1"/>
-        <constraint unique_strength="0" constraints="0" field="natural_area_name" exp_strength="0" notnull_strength="0"/>
+        <constraint field="id" unique_strength="1" notnull_strength="1" constraints="3" exp_strength="0"/>
+        <constraint field="natural_area_name" unique_strength="0" notnull_strength="0" constraints="0" exp_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint desc="" exp="" field="id"/>
-        <constraint desc="" exp="" field="natural_area_name"/>
+        <constraint desc="" field="id" exp=""/>
+        <constraint desc="" field="natural_area_name" exp=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
-      <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column name="id" width="-1" hidden="0" type="field"/>
-          <column name="natural_area_name" width="-1" hidden="0" type="field"/>
-          <column width="-1" hidden="1" type="actions"/>
+          <column width="-1" type="field" hidden="0" name="id"/>
+          <column width="-1" type="field" hidden="0" name="natural_area_name"/>
+          <column width="-1" type="actions" hidden="1"/>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
@@ -2053,10 +2202,10 @@ def my_form_open(dialog, layer, feature):
         <fieldstyles/>
       </conditionalstyles>
       <storedexpressions/>
-      <editform tolerant="1"/>
+      <editform tolerant="1"></editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
-      <editforminitfilepath/>
+      <editforminitfilepath></editforminitfilepath>
       <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
@@ -2077,69 +2226,88 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>tablayout</editorlayout>
       <attributeEditorForm>
-        <labelStyle labelColor="0,0,0,255" overrideLabelFont="0" overrideLabelColor="0">
-          <labelFont underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
+        <labelStyle overrideLabelColor="0" labelColor="" overrideLabelFont="0">
+          <labelFont strikethrough="0" italic="0" style="" description="Sans Serif,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
         </labelStyle>
-        <attributeEditorField name="id" index="0" showLabel="1">
-          <labelStyle labelColor="0,0,0,255" overrideLabelFont="0" overrideLabelColor="0">
-            <labelFont underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
+        <attributeEditorField showLabel="1" horizontalStretch="0" index="0" name="id" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+            <labelFont strikethrough="0" italic="0" style="" description="Noto Sans,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
           </labelStyle>
         </attributeEditorField>
-        <attributeEditorField name="natural_area_name" index="1" showLabel="1">
-          <labelStyle labelColor="0,0,0,255" overrideLabelFont="0" overrideLabelColor="0">
-            <labelFont underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
+        <attributeEditorField showLabel="1" horizontalStretch="0" index="1" name="natural_area_name" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+            <labelFont strikethrough="0" italic="0" style="" description="Noto Sans,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
           </labelStyle>
         </attributeEditorField>
-        <attributeEditorRelation name="birds_area_natural_area_id_natural_ar_id" label="Associated birds" relationWidgetTypeId="relation_editor" relation="birds_area_natural_area_id_natural_ar_id" nmRelationId="birds_area_bird_id_birds_4069_id" showLabel="1" forceSuppressFormPopup="0">
-          <labelStyle labelColor="0,0,0,255" overrideLabelFont="0" overrideLabelColor="0">
-            <labelFont underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
+        <attributeEditorRelation relationWidgetTypeId="relation_editor" showLabel="1" relation="birds_area_natural_area_id_natural_ar_id" forceSuppressFormPopup="0" label="Associated birds" horizontalStretch="0" nmRelationId="birds_area_bird_id_birds_4069_id" name="birds_area_natural_area_id_natural_ar_id" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+            <labelFont strikethrough="0" italic="0" style="" description="Noto Sans,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
           </labelStyle>
           <editor_configuration type="Map">
-            <Option name="allow_add_child_feature_with_no_geometry" value="false" type="bool"/>
-            <Option name="buttons" value="AllButtons" type="QString"/>
-            <Option name="show_first_feature" value="true" type="bool"/>
+            <Option type="bool" value="false" name="allow_add_child_feature_with_no_geometry"/>
+            <Option type="QString" value="AllButtons" name="buttons"/>
+            <Option type="invalid" name="filter_expression"/>
+            <Option type="bool" value="true" name="show_first_feature"/>
           </editor_configuration>
         </attributeEditorRelation>
-        <attributeEditorRelation name="birds_spot_area_id_natural_ar_id" label="spots" relationWidgetTypeId="relation_editor" relation="birds_spot_area_id_natural_ar_id" nmRelationId="" showLabel="1" forceSuppressFormPopup="0">
-          <labelStyle labelColor="0,0,0,255" overrideLabelFont="0" overrideLabelColor="0">
-            <labelFont underline="0" italic="0" description="Sans,9,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style=""/>
+        <attributeEditorRelation relationWidgetTypeId="relation_editor" showLabel="1" relation="birds_area_natural_area_id_natural_ar_id_1" forceSuppressFormPopup="0" label="card" horizontalStretch="0" nmRelationId="" name="birds_area_natural_area_id_natural_ar_id_1" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="" overrideLabelFont="0">
+            <labelFont strikethrough="0" italic="0" style="" description="Noto Sans,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
           </labelStyle>
           <editor_configuration type="Map">
-            <Option name="allow_add_child_feature_with_no_geometry" value="false" type="bool"/>
-            <Option name="buttons" value="AllButtons" type="QString"/>
-            <Option name="show_first_feature" value="true" type="bool"/>
+            <Option type="bool" value="false" name="allow_add_child_feature_with_no_geometry"/>
+            <Option type="QString" value="AllButtons" name="buttons"/>
+            <Option type="invalid" name="filter_expression"/>
+            <Option type="bool" value="true" name="show_first_feature"/>
+          </editor_configuration>
+        </attributeEditorRelation>
+        <attributeEditorRelation relationWidgetTypeId="relation_editor" showLabel="1" relation="birds_spot_area_id_natural_ar_id" forceSuppressFormPopup="0" label="spots" horizontalStretch="0" nmRelationId="" name="birds_spot_area_id_natural_ar_id" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+            <labelFont strikethrough="0" italic="0" style="" description="Noto Sans,9,-1,5,50,0,0,0,0,0" underline="0" bold="0"/>
+          </labelStyle>
+          <editor_configuration type="Map">
+            <Option type="bool" value="false" name="allow_add_child_feature_with_no_geometry"/>
+            <Option type="QString" value="AllButtons" name="buttons"/>
+            <Option type="invalid" name="filter_expression"/>
+            <Option type="bool" value="true" name="show_first_feature"/>
           </editor_configuration>
         </attributeEditorRelation>
       </attributeEditorForm>
       <editable>
-        <field name="id" editable="0"/>
-        <field name="natural_area_name" editable="1"/>
+        <field editable="0" name="id"/>
+        <field editable="1" name="natural_area_name"/>
       </editable>
       <labelOnTop>
-        <field name="id" labelOnTop="0"/>
-        <field name="natural_area_name" labelOnTop="0"/>
+        <field labelOnTop="0" name="id"/>
+        <field labelOnTop="0" name="natural_area_name"/>
       </labelOnTop>
       <reuseLastValue>
-        <field name="id" reuseLastValue="0"/>
-        <field name="natural_area_name" reuseLastValue="0"/>
+        <field reuseLastValue="0" name="id"/>
+        <field reuseLastValue="0" name="natural_area_name"/>
       </reuseLastValue>
       <dataDefinedFieldProperties/>
       <widgets>
         <widget name="birds_area_natural_area_id_natural_ar_id">
           <config type="Map">
-            <Option name="force-suppress-popup" value="false" type="bool"/>
-            <Option name="nm-rel" value="birds_area_bird_id_birds_4069_id" type="QString"/>
+            <Option type="bool" value="false" name="force-suppress-popup"/>
+            <Option type="QString" value="birds_area_bird_id_birds_4069_id" name="nm-rel"/>
+          </config>
+        </widget>
+        <widget name="birds_area_natural_area_id_natural_ar_id_1">
+          <config type="Map">
+            <Option type="bool" value="false" name="force-suppress-popup"/>
+            <Option type="invalid" name="nm-rel"/>
           </config>
         </widget>
         <widget name="birds_spot_area_id_natural_ar_id">
           <config type="Map">
-            <Option name="force-suppress-popup" value="false" type="bool"/>
-            <Option name="nm-rel" type="invalid"/>
+            <Option type="bool" value="false" name="force-suppress-popup"/>
+            <Option type="invalid" name="nm-rel"/>
           </config>
         </widget>
       </widgets>
       <previewExpression>natural_area_name</previewExpression>
-      <mapTip/>
+      <mapTip enabled="1"></mapTip>
     </maplayer>
   </projectlayers>
   <layerorder>
@@ -2231,6 +2399,7 @@ def my_form_open(dialog, layer, feature):
     </WFSTLayers>
     <WFSUrl type="QString"></WFSUrl>
     <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
+    <WMSAddLayerGroupsLegendGraphic type="bool">false</WMSAddLayerGroupsLegendGraphic>
     <WMSAddWktGeometry type="bool">false</WMSAddWktGeometry>
     <WMSContactMail type="QString"></WMSContactMail>
     <WMSContactOrganization type="QString"></WMSContactOrganization>
@@ -2262,6 +2431,7 @@ def my_form_open(dialog, layer, feature):
     <WMSServiceAbstract type="QString"></WMSServiceAbstract>
     <WMSServiceCapabilities type="bool">true</WMSServiceCapabilities>
     <WMSServiceTitle type="QString">n_to_m_relations</WMSServiceTitle>
+    <WMSSkipNameForGroup type="bool">false</WMSSkipNameForGroup>
     <WMSTileBuffer type="int">0</WMSTileBuffer>
     <WMSUrl type="QString"></WMSUrl>
     <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
@@ -2289,9 +2459,9 @@ def my_form_open(dialog, layer, feature):
   </properties>
   <dataDefinedServerProperties>
     <Option type="Map">
-      <Option name="name" value="" type="QString"/>
+      <Option type="QString" value="" name="name"/>
       <Option name="properties"/>
-      <Option name="type" value="collection" type="QString"/>
+      <Option type="QString" value="collection" name="type"/>
     </Option>
   </dataDefinedServerProperties>
   <visibility-presets/>
@@ -2314,9 +2484,9 @@ def my_form_open(dialog, layer, feature):
     </contact>
     <links/>
     <dates>
-      <date value="2023-11-27T09:09:04" type="Created"/>
+      <date type="Created" value="2023-11-27T09:09:04"/>
     </dates>
-    <author>Ubuntu</author>
+    <author>Riccardo Beltrami</author>
     <creation>2023-11-27T09:09:04</creation>
   </projectMetadata>
   <Annotations/>
@@ -2324,11 +2494,11 @@ def my_form_open(dialog, layer, feature):
   <mapViewDocks3D/>
   <Bookmarks/>
   <Sensors/>
-  <ProjectViewSettings UseProjectScales="0" rotation="0">
+  <ProjectViewSettings rotation="0" UseProjectScales="0">
     <Scales/>
-    <DefaultViewExtent ymax="43.46425295430275071" ymin="43.33843327459011618" xmin="4.50752183533590323" xmax="4.72770627483301364">
+    <DefaultViewExtent xmax="4.72770627483301364" ymin="43.31931361737888153" xmin="4.50752183533590323" ymax="43.48337261151398536">
       <spatialrefsys nativeFormat="Wkt">
-        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
         <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
         <srsid>3452</srsid>
         <srid>4326</srid>
@@ -2340,10 +2510,10 @@ def my_form_open(dialog, layer, feature):
       </spatialrefsys>
     </DefaultViewExtent>
   </ProjectViewSettings>
-  <ProjectStyleSettings colorModel="Rgb" DefaultSymbolOpacity="1" iccProfileId="attachment:///" RandomizeDefaultSymbolColor="1" projectStyleId="attachment:///EpDhzW_styles.db">
+  <ProjectStyleSettings RandomizeDefaultSymbolColor="1" projectStyleId="attachment:///QPiDeB_styles.db" colorModel="Rgb" DefaultSymbolOpacity="1" iccProfileId="attachment:///QGIS3-YUhxUC">
     <databases/>
   </ProjectStyleSettings>
-  <ProjectTimeSettings frameRate="1" timeStep="1" totalMovieFrames="100" timeStepUnit="h" cumulativeTemporalRange="0"/>
+  <ProjectTimeSettings timeStep="1" frameRate="1" timeStepUnit="h" cumulativeTemporalRange="0" totalMovieFrames="100"/>
   <ElevationProperties FilterInvertSlider="0">
     <terrainProvider type="flat">
       <TerrainProvider scale="1" offset="0"/>
@@ -2352,34 +2522,34 @@ def my_form_open(dialog, layer, feature):
   <ProjectDisplaySettings CoordinateType="MapCrs" CoordinateAxisOrder="Default">
     <BearingFormat id="bearing">
       <Option type="Map">
-        <Option name="decimal_separator" type="invalid"/>
-        <Option name="decimals" value="6" type="int"/>
-        <Option name="direction_format" value="0" type="int"/>
-        <Option name="rounding_type" value="0" type="int"/>
-        <Option name="show_plus" value="false" type="bool"/>
-        <Option name="show_thousand_separator" value="true" type="bool"/>
-        <Option name="show_trailing_zeros" value="false" type="bool"/>
-        <Option name="thousand_separator" type="invalid"/>
+        <Option type="invalid" name="decimal_separator"/>
+        <Option type="int" value="6" name="decimals"/>
+        <Option type="int" value="0" name="direction_format"/>
+        <Option type="int" value="0" name="rounding_type"/>
+        <Option type="bool" value="false" name="show_plus"/>
+        <Option type="bool" value="true" name="show_thousand_separator"/>
+        <Option type="bool" value="false" name="show_trailing_zeros"/>
+        <Option type="invalid" name="thousand_separator"/>
       </Option>
     </BearingFormat>
     <GeographicCoordinateFormat id="geographiccoordinate">
       <Option type="Map">
-        <Option name="angle_format" value="DecimalDegrees" type="QString"/>
-        <Option name="decimal_separator" type="invalid"/>
-        <Option name="decimals" value="6" type="int"/>
-        <Option name="rounding_type" value="0" type="int"/>
-        <Option name="show_leading_degree_zeros" value="false" type="bool"/>
-        <Option name="show_leading_zeros" value="false" type="bool"/>
-        <Option name="show_plus" value="false" type="bool"/>
-        <Option name="show_suffix" value="false" type="bool"/>
-        <Option name="show_thousand_separator" value="true" type="bool"/>
-        <Option name="show_trailing_zeros" value="false" type="bool"/>
-        <Option name="thousand_separator" type="invalid"/>
+        <Option type="QString" value="DecimalDegrees" name="angle_format"/>
+        <Option type="invalid" name="decimal_separator"/>
+        <Option type="int" value="6" name="decimals"/>
+        <Option type="int" value="0" name="rounding_type"/>
+        <Option type="bool" value="false" name="show_leading_degree_zeros"/>
+        <Option type="bool" value="false" name="show_leading_zeros"/>
+        <Option type="bool" value="false" name="show_plus"/>
+        <Option type="bool" value="false" name="show_suffix"/>
+        <Option type="bool" value="true" name="show_thousand_separator"/>
+        <Option type="bool" value="false" name="show_trailing_zeros"/>
+        <Option type="invalid" name="thousand_separator"/>
       </Option>
     </GeographicCoordinateFormat>
     <CoordinateCustomCrs>
       <spatialrefsys nativeFormat="Wkt">
-        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
         <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
         <srsid>3452</srsid>
         <srid>4326</srid>
@@ -2391,7 +2561,7 @@ def my_form_open(dialog, layer, feature):
       </spatialrefsys>
     </CoordinateCustomCrs>
   </ProjectDisplaySettings>
-  <ProjectGpsSettings autoCommitFeatures="0" destinationLayer="" autoAddTrackVertices="0" destinationFollowsActiveLayer="1">
+  <ProjectGpsSettings autoAddTrackVertices="0" autoCommitFeatures="0" destinationFollowsActiveLayer="1" destinationLayerName="natural_areas" destinationLayerSource="service='lizmapdb' key='id' estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=&quot;tests_projects&quot;.&quot;natural_areas&quot; (geom)" destinationLayer="natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813" destinationLayerProvider="postgres">
     <timeStampFields/>
   </ProjectGpsSettings>
 </qgis>

--- a/tests/qgis-projects/tests/n_to_m_relations.qgs.cfg
+++ b/tests/qgis-projects/tests/n_to_m_relations.qgs.cfg
@@ -1,16 +1,16 @@
 {
     "metadata": {
-        "qgis_desktop_version": 33415,
-        "lizmap_plugin_version_str": "4.4.9",
-        "lizmap_plugin_version": 40409,
-        "lizmap_web_client_target_version": 30900,
-        "lizmap_web_client_target_status": "Stable",
+        "qgis_desktop_version": 34010,
+        "lizmap_plugin_version_str": "4.5.9",
+        "lizmap_plugin_version": 40509,
+        "lizmap_web_client_target_version": 31100,
+        "lizmap_web_client_target_status": "Dev",
         "instance_target_url": "http://localhost:8130/",
         "instance_target_repository": "intranet"
     },
     "warnings": {},
     "debug": {
-        "total_time": 0.624
+        "total_time": 0.15100000000000002
     },
     "options": {
         "projection": {
@@ -77,6 +77,7 @@
             "popupSource": "form",
             "popupTemplate": "",
             "popupMaxFeatures": 10,
+            "children_lizmap_features_table": false,
             "popupDisplayChildren": "True",
             "popup_allow_download": true,
             "legend_image_option": "hide_at_startup",
@@ -111,6 +112,7 @@
             "popupSource": "auto",
             "popupTemplate": "",
             "popupMaxFeatures": 10,
+            "children_lizmap_features_table": false,
             "popupDisplayChildren": "False",
             "popup_allow_download": true,
             "legend_image_option": "hide_at_startup",
@@ -145,6 +147,7 @@
             "popupSource": "form",
             "popupTemplate": "",
             "popupMaxFeatures": 10,
+            "children_lizmap_features_table": false,
             "popupDisplayChildren": "True",
             "popup_allow_download": true,
             "legend_image_option": "hide_at_startup",
@@ -179,6 +182,7 @@
             "popupSource": "form",
             "popupTemplate": "",
             "popupMaxFeatures": 10,
+            "children_lizmap_features_table": false,
             "popupDisplayChildren": "False",
             "popup_allow_download": true,
             "legend_image_option": "hide_at_startup",
@@ -205,6 +209,7 @@
             "popupSource": "auto",
             "popupTemplate": "",
             "popupMaxFeatures": 10,
+            "children_lizmap_features_table": false,
             "popupDisplayChildren": "False",
             "popup_allow_download": true,
             "legend_image_option": "hide_at_startup",
@@ -238,6 +243,7 @@
             "popupSource": "auto",
             "popupTemplate": "",
             "popupMaxFeatures": 10,
+            "children_lizmap_features_table": false,
             "popupDisplayChildren": "False",
             "popup_allow_download": true,
             "legend_image_option": "hide_at_startup",

--- a/tests/units/classes/Project/Qgis/MapLayerTest.php
+++ b/tests/units/classes/Project/Qgis/MapLayerTest.php
@@ -1021,5 +1021,719 @@ class MapLayerTest extends TestCase
         $formControls = $layer->getFormControls();
         $this->assertNotNull($formControls);
         $this->assertCount(9, $formControls);
+
+        // attributeEditorForm
+        $xmlStr = '
+        <maplayer geometry="Polygon" refreshOnNotifyMessage="" simplifyDrawingTol="1" simplifyAlgorithm="0" type="vector" simplifyDrawingHints="1" minScale="100000000" styleCategories="AllStyleCategories" readOnly="0" refreshOnNotifyEnabled="0" wkbType="Polygon" autoRefreshMode="Disabled" labelsEnabled="0" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" symbologyReferenceScale="-1" legendPlaceholderImage="" simplifyMaxScale="1" maxScale="0" simplifyLocal="0">
+        <extent>
+          <xmin>4.58213930607160602</xmin>
+          <ymin>43.35054476032322412</ymin>
+          <xmax>4.64863080116274929</xmax>
+          <ymax>43.45587426605017356</ymax>
+        </extent>
+        <wgs84extent>
+          <xmin>4.58213930607160602</xmin>
+          <ymin>43.35054476032322412</ymin>
+          <xmax>4.64863080116274929</xmax>
+          <ymax>43.45587426605017356</ymax>
+        </wgs84extent>
+        <id>natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813</id>
+        <datasource>service="lizmapdb" key="id" estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity="1" table="tests_projects"."natural_areas" (geom)</datasource>
+        <shortname>natural_areas</shortname>
+        <title>Natural areas</title>
+        <keywordList>
+          <value></value>
+        </keywordList>
+        <layername>natural_areas</layername>
+        <srs>
+          <spatialrefsys nativeFormat="Wkt">
+            <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+            <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+            <srsid>3452</srsid>
+            <srid>4326</srid>
+            <authid>EPSG:4326</authid>
+            <description>WGS 84</description>
+            <projectionacronym>longlat</projectionacronym>
+            <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+            <geographicflag>true</geographicflag>
+          </spatialrefsys>
+        </srs>
+        <resourceMetadata>
+          <identifier></identifier>
+          <parentidentifier></parentidentifier>
+          <language></language>
+          <type>dataset</type>
+          <title></title>
+          <abstract></abstract>
+          <contact>
+            <name></name>
+            <organization></organization>
+            <position></position>
+            <voice></voice>
+            <fax></fax>
+            <email></email>
+            <role></role>
+          </contact>
+          <links/>
+          <dates/>
+          <fees></fees>
+          <encoding></encoding>
+          <crs>
+            <spatialrefsys nativeFormat="Wkt">
+              <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+              <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+              <srsid>3452</srsid>
+              <srid>4326</srid>
+              <authid>EPSG:4326</authid>
+              <description>WGS 84</description>
+              <projectionacronym>longlat</projectionacronym>
+              <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+              <geographicflag>true</geographicflag>
+            </spatialrefsys>
+          </crs>
+          <extent>
+            <spatial dimensions="2" maxy="0" maxx="0" crs="EPSG:4326" minx="0" miny="0" minz="0" maxz="0"/>
+            <temporal>
+              <period>
+                <start></start>
+                <end></end>
+              </period>
+            </temporal>
+          </extent>
+        </resourceMetadata>
+        <provider encoding="">postgres</provider>
+        <vectorjoins/>
+        <layerDependencies/>
+        <dataDependencies/>
+        <expressionfields/>
+        <map-layer-style-manager current="default">
+          <map-layer-style name="default"/>
+        </map-layer-style-manager>
+        <auxiliaryLayer/>
+        <metadataUrls/>
+        <flags>
+          <Identifiable>1</Identifiable>
+          <Removable>1</Removable>
+          <Searchable>1</Searchable>
+          <Private>0</Private>
+        </flags>
+        <temporal mode="0" durationUnit="min" fixedDuration="0" durationField="" limitMode="0" endField="" endExpression="" startField="" startExpression="" accumulate="0" enabled="0">
+          <fixedRange>
+            <start></start>
+            <end></end>
+          </fixedRange>
+        </temporal>
+        <elevation binding="Centroid" zscale="1" type="IndividualFeatures" zoffset="0" extrusionEnabled="0" extrusion="0" symbology="Line" clamping="Terrain" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0">
+          <data-defined-properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data-defined-properties>
+          <profileLineSymbol>
+            <symbol clip_to_extent="1" is_animated="0" type="line" alpha="1" name="" force_rhr="0" frame_rate="10">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer pass="0" class="SimpleLine" id="{44cad848-0ddb-47d4-b55d-29c18d0638c7}" enabled="1" locked="0">
+                <Option type="Map">
+                  <Option value="0" type="QString" name="align_dash_pattern"/>
+                  <Option value="square" type="QString" name="capstyle"/>
+                  <Option value="5;2" type="QString" name="customdash"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="customdash_unit"/>
+                  <Option value="0" type="QString" name="dash_pattern_offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+                  <Option value="0" type="QString" name="draw_inside_polygon"/>
+                  <Option value="bevel" type="QString" name="joinstyle"/>
+                  <Option value="229,182,54,255,rgb:0.89803921568627454,0.71372549019607845,0.21176470588235294,1" type="QString" name="line_color"/>
+                  <Option value="solid" type="QString" name="line_style"/>
+                  <Option value="0.6" type="QString" name="line_width"/>
+                  <Option value="MM" type="QString" name="line_width_unit"/>
+                  <Option value="0" type="QString" name="offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="offset_unit"/>
+                  <Option value="0" type="QString" name="ring_filter"/>
+                  <Option value="0" type="QString" name="trim_distance_end"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+                  <Option value="0" type="QString" name="trim_distance_start"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+                  <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+                  <Option value="0" type="QString" name="use_custom_dash"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </profileLineSymbol>
+          <profileFillSymbol>
+            <symbol clip_to_extent="1" is_animated="0" type="fill" alpha="1" name="" force_rhr="0" frame_rate="10">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer pass="0" class="SimpleFill" id="{095c8f8e-00eb-4109-a8f8-aa1cb8cb3c71}" enabled="1" locked="0">
+                <Option type="Map">
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+                  <Option value="229,182,54,255,rgb:0.89803921568627454,0.71372549019607845,0.21176470588235294,1" type="QString" name="color"/>
+                  <Option value="bevel" type="QString" name="joinstyle"/>
+                  <Option value="0,0" type="QString" name="offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="offset_unit"/>
+                  <Option value="164,130,39,255,rgb:0.64313725490196083,0.50980392156862742,0.15294117647058825,1" type="QString" name="outline_color"/>
+                  <Option value="solid" type="QString" name="outline_style"/>
+                  <Option value="0.2" type="QString" name="outline_width"/>
+                  <Option value="MM" type="QString" name="outline_width_unit"/>
+                  <Option value="solid" type="QString" name="style"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </profileFillSymbol>
+          <profileMarkerSymbol>
+            <symbol clip_to_extent="1" is_animated="0" type="marker" alpha="1" name="" force_rhr="0" frame_rate="10">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer pass="0" class="SimpleMarker" id="{65b37710-c39f-45f6-87e0-0f3266aeb832}" enabled="1" locked="0">
+                <Option type="Map">
+                  <Option value="0" type="QString" name="angle"/>
+                  <Option value="square" type="QString" name="cap_style"/>
+                  <Option value="229,182,54,255,rgb:0.89803921568627454,0.71372549019607845,0.21176470588235294,1" type="QString" name="color"/>
+                  <Option value="1" type="QString" name="horizontal_anchor_point"/>
+                  <Option value="bevel" type="QString" name="joinstyle"/>
+                  <Option value="diamond" type="QString" name="name"/>
+                  <Option value="0,0" type="QString" name="offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="offset_unit"/>
+                  <Option value="164,130,39,255,rgb:0.64313725490196083,0.50980392156862742,0.15294117647058825,1" type="QString" name="outline_color"/>
+                  <Option value="solid" type="QString" name="outline_style"/>
+                  <Option value="0.2" type="QString" name="outline_width"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="outline_width_unit"/>
+                  <Option value="diameter" type="QString" name="scale_method"/>
+                  <Option value="3" type="QString" name="size"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="size_unit"/>
+                  <Option value="1" type="QString" name="vertical_anchor_point"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </profileMarkerSymbol>
+        </elevation>
+        <renderer-v2 forceraster="0" symbollevels="0" type="categorizedSymbol" referencescale="-1" enableorderby="0" attr="id">
+          <categories>
+            <category label="1" value="1" type="long" symbol="0" uuid="0" render="true"/>
+            <category label="2" value="2" type="long" symbol="1" uuid="1" render="true"/>
+            <category label="3" value="3" type="long" symbol="2" uuid="2" render="true"/>
+            <category label="" value="" type="string" symbol="3" uuid="3" render="true"/>
+          </categories>
+          <symbols>
+            <symbol clip_to_extent="1" is_animated="0" type="fill" alpha="1" name="0" force_rhr="0" frame_rate="10">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer pass="0" class="SimpleFill" id="{93209251-2141-495b-a7cb-8ae01aaa9ca1}" enabled="1" locked="0">
+                <Option type="Map">
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+                  <Option value="46,220,83,255,rgb:0.1803921568627451,0.86274509803921573,0.32549019607843138,1" type="QString" name="color"/>
+                  <Option value="bevel" type="QString" name="joinstyle"/>
+                  <Option value="0,0" type="QString" name="offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="offset_unit"/>
+                  <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+                  <Option value="solid" type="QString" name="outline_style"/>
+                  <Option value="0.26" type="QString" name="outline_width"/>
+                  <Option value="MM" type="QString" name="outline_width_unit"/>
+                  <Option value="solid" type="QString" name="style"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+            <symbol clip_to_extent="1" is_animated="0" type="fill" alpha="1" name="1" force_rhr="0" frame_rate="10">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer pass="0" class="SimpleFill" id="{7ac1311a-d402-47f1-9188-7fd068561f19}" enabled="1" locked="0">
+                <Option type="Map">
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+                  <Option value="236,177,28,255,rgb:0.92549019607843142,0.69411764705882351,0.10980392156862745,1" type="QString" name="color"/>
+                  <Option value="bevel" type="QString" name="joinstyle"/>
+                  <Option value="0,0" type="QString" name="offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="offset_unit"/>
+                  <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+                  <Option value="solid" type="QString" name="outline_style"/>
+                  <Option value="0.26" type="QString" name="outline_width"/>
+                  <Option value="MM" type="QString" name="outline_width_unit"/>
+                  <Option value="solid" type="QString" name="style"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+            <symbol clip_to_extent="1" is_animated="0" type="fill" alpha="1" name="2" force_rhr="0" frame_rate="10">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer pass="0" class="SimpleFill" id="{62ed713c-be81-451f-b82b-d34d99e47931}" enabled="1" locked="0">
+                <Option type="Map">
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+                  <Option value="127,151,211,255,rgb:0.49803921568627452,0.59215686274509804,0.82745098039215681,1" type="QString" name="color"/>
+                  <Option value="bevel" type="QString" name="joinstyle"/>
+                  <Option value="0,0" type="QString" name="offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="offset_unit"/>
+                  <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+                  <Option value="solid" type="QString" name="outline_style"/>
+                  <Option value="0.26" type="QString" name="outline_width"/>
+                  <Option value="MM" type="QString" name="outline_width_unit"/>
+                  <Option value="solid" type="QString" name="style"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+            <symbol clip_to_extent="1" is_animated="0" type="fill" alpha="1" name="3" force_rhr="0" frame_rate="10">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer pass="0" class="SimpleFill" id="{94f65594-73c0-428a-b85f-8aaa9bb16a98}" enabled="1" locked="0">
+                <Option type="Map">
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+                  <Option value="200,77,173,255,rgb:0.78431372549019607,0.30196078431372547,0.67843137254901964,1" type="QString" name="color"/>
+                  <Option value="bevel" type="QString" name="joinstyle"/>
+                  <Option value="0,0" type="QString" name="offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="offset_unit"/>
+                  <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+                  <Option value="solid" type="QString" name="outline_style"/>
+                  <Option value="0.26" type="QString" name="outline_width"/>
+                  <Option value="MM" type="QString" name="outline_width_unit"/>
+                  <Option value="solid" type="QString" name="style"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </symbols>
+          <source-symbol>
+            <symbol clip_to_extent="1" is_animated="0" type="fill" alpha="1" name="0" force_rhr="0" frame_rate="10">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer pass="0" class="SimpleFill" id="{b2d80baf-86ea-46f5-bb6a-e7e8411a7067}" enabled="1" locked="0">
+                <Option type="Map">
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+                  <Option value="196,60,57,255,rgb:0.7686274509803922,0.23529411764705882,0.22352941176470589,1" type="QString" name="color"/>
+                  <Option value="bevel" type="QString" name="joinstyle"/>
+                  <Option value="0,0" type="QString" name="offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="offset_unit"/>
+                  <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+                  <Option value="solid" type="QString" name="outline_style"/>
+                  <Option value="0.26" type="QString" name="outline_width"/>
+                  <Option value="MM" type="QString" name="outline_width_unit"/>
+                  <Option value="solid" type="QString" name="style"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </source-symbol>
+          <rotation/>
+          <sizescale/>
+          <data-defined-properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data-defined-properties>
+        </renderer-v2>
+        <selection mode="Default">
+          <selectionColor invalid="1"/>
+          <selectionSymbol>
+            <symbol clip_to_extent="1" is_animated="0" type="fill" alpha="1" name="" force_rhr="0" frame_rate="10">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer pass="0" class="SimpleFill" id="{bef8bdc5-5090-4f6d-9190-45967dfe302d}" enabled="1" locked="0">
+                <Option type="Map">
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+                  <Option value="0,0,255,255,rgb:0,0,1,1" type="QString" name="color"/>
+                  <Option value="bevel" type="QString" name="joinstyle"/>
+                  <Option value="0,0" type="QString" name="offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="offset_unit"/>
+                  <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+                  <Option value="solid" type="QString" name="outline_style"/>
+                  <Option value="0.26" type="QString" name="outline_width"/>
+                  <Option value="MM" type="QString" name="outline_width_unit"/>
+                  <Option value="solid" type="QString" name="style"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </selectionSymbol>
+        </selection>
+        <customproperties>
+          <Option type="Map">
+            <Option type="List" name="dualview/previewExpressions">
+              <Option value="natural_area_name" type="QString"/>
+              <Option value="&quot;natural_area_name&quot;" type="QString"/>
+            </Option>
+            <Option value="0" type="int" name="embeddedWidgets/count"/>
+            <Option type="invalid" name="variableNames"/>
+            <Option type="invalid" name="variableValues"/>
+          </Option>
+        </customproperties>
+        <blendMode>0</blendMode>
+        <featureBlendMode>0</featureBlendMode>
+        <layerOpacity>1</layerOpacity>
+        <LinearlyInterpolatedDiagramRenderer attributeLegend="1" lowerHeight="0" upperHeight="5" upperWidth="5" diagramType="Histogram" lowerWidth="0" classificationAttributeExpression="" lowerValue="0" upperValue="0">
+          <DiagramCategory scaleBasedVisibility="0" backgroundAlpha="255" showAxis="1" diagramOrientation="Up" stackedDiagramMode="Horizontal" spacing="5" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" spacingUnit="MM" width="15" direction="0" barWidth="5" stackedDiagramSpacingUnitScale="3x:0,0,0,0,0,0" penAlpha="255" penColor="#000000" stackedDiagramSpacing="0" penWidth="0" sizeType="MM" rotationOffset="270" minScaleDenominator="0" opacity="1" sizeScale="3x:0,0,0,0,0,0" spacingUnitScale="3x:0,0,0,0,0,0" enabled="0" stackedDiagramSpacingUnit="MM" backgroundColor="#ffffff" height="15" minimumSize="0" maxScaleDenominator="1e+08" lineSizeType="MM">
+            <fontProperties description="Sans,9,-1,5,50,0,0,0,0,0" style="" underline="0" bold="0" italic="0" strikethrough="0"/>
+            <attribute label="" field="" color="#000000" colorOpacity="1"/>
+            <axisSymbol>
+              <symbol clip_to_extent="1" is_animated="0" type="line" alpha="1" name="" force_rhr="0" frame_rate="10">
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+                <layer pass="0" class="SimpleLine" id="{2d7ebc3f-9658-4828-9d9e-0c5ae8651516}" enabled="1" locked="0">
+                  <Option type="Map">
+                    <Option value="0" type="QString" name="align_dash_pattern"/>
+                    <Option value="square" type="QString" name="capstyle"/>
+                    <Option value="5;2" type="QString" name="customdash"/>
+                    <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+                    <Option value="MM" type="QString" name="customdash_unit"/>
+                    <Option value="0" type="QString" name="dash_pattern_offset"/>
+                    <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+                    <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+                    <Option value="0" type="QString" name="draw_inside_polygon"/>
+                    <Option value="bevel" type="QString" name="joinstyle"/>
+                    <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="line_color"/>
+                    <Option value="solid" type="QString" name="line_style"/>
+                    <Option value="0.26" type="QString" name="line_width"/>
+                    <Option value="MM" type="QString" name="line_width_unit"/>
+                    <Option value="0" type="QString" name="offset"/>
+                    <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                    <Option value="MM" type="QString" name="offset_unit"/>
+                    <Option value="0" type="QString" name="ring_filter"/>
+                    <Option value="0" type="QString" name="trim_distance_end"/>
+                    <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+                    <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+                    <Option value="0" type="QString" name="trim_distance_start"/>
+                    <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+                    <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+                    <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+                    <Option value="0" type="QString" name="use_custom_dash"/>
+                    <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+                  </Option>
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option value="" type="QString" name="name"/>
+                      <Option name="properties"/>
+                      <Option value="collection" type="QString" name="type"/>
+                    </Option>
+                  </data_defined_properties>
+                </layer>
+              </symbol>
+            </axisSymbol>
+          </DiagramCategory>
+        </LinearlyInterpolatedDiagramRenderer>
+        <DiagramLayerSettings linePlacementFlags="18" priority="0" zIndex="0" showAll="1" placement="1" dist="0" obstacle="0">
+          <properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </properties>
+        </DiagramLayerSettings>
+        <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+          <activeChecks/>
+          <checkConfiguration type="Map">
+            <Option type="Map" name="QgsGeometryGapCheck">
+              <Option value="0" type="double" name="allowedGapsBuffer"/>
+              <Option value="false" type="bool" name="allowedGapsEnabled"/>
+              <Option type="invalid" name="allowedGapsLayer"/>
+            </Option>
+          </checkConfiguration>
+        </geometryOptions>
+        <legend type="default-vector" showLabelLegend="0"/>
+        <referencedLayers/>
+        <fieldConfiguration>
+          <field configurationFlags="NoFlag" name="id">
+            <editWidget type="TextEdit">
+              <config>
+                <Option type="Map">
+                  <Option value="false" type="bool" name="IsMultiline"/>
+                  <Option value="false" type="bool" name="UseHtml"/>
+                </Option>
+              </config>
+            </editWidget>
+          </field>
+          <field configurationFlags="NoFlag" name="natural_area_name">
+            <editWidget type="TextEdit">
+              <config>
+                <Option type="Map">
+                  <Option value="false" type="bool" name="IsMultiline"/>
+                  <Option value="false" type="bool" name="UseHtml"/>
+                </Option>
+              </config>
+            </editWidget>
+          </field>
+        </fieldConfiguration>
+        <aliases>
+          <alias field="id" index="0" name="id"/>
+          <alias field="natural_area_name" index="1" name="Natural area name"/>
+        </aliases>
+        <splitPolicies>
+          <policy field="id" policy="Duplicate"/>
+          <policy field="natural_area_name" policy="Duplicate"/>
+        </splitPolicies>
+        <duplicatePolicies>
+          <policy field="id" policy="Duplicate"/>
+          <policy field="natural_area_name" policy="Duplicate"/>
+        </duplicatePolicies>
+        <defaults>
+          <default field="id" applyOnUpdate="0" expression=""/>
+          <default field="natural_area_name" applyOnUpdate="0" expression=""/>
+        </defaults>
+        <constraints>
+          <constraint field="id" unique_strength="1" notnull_strength="1" exp_strength="0" constraints="3"/>
+          <constraint field="natural_area_name" unique_strength="0" notnull_strength="0" exp_strength="0" constraints="0"/>
+        </constraints>
+        <constraintExpressions>
+          <constraint field="id" desc="" exp=""/>
+          <constraint field="natural_area_name" desc="" exp=""/>
+        </constraintExpressions>
+        <expressionfields/>
+        <attributeactions>
+          <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        </attributeactions>
+        <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+          <columns>
+            <column hidden="0" width="-1" type="field" name="id"/>
+            <column hidden="0" width="-1" type="field" name="natural_area_name"/>
+            <column hidden="1" width="-1" type="actions"/>
+          </columns>
+        </attributetableconfig>
+        <conditionalstyles>
+          <rowstyles/>
+          <fieldstyles/>
+        </conditionalstyles>
+        <storedexpressions/>
+        <editform tolerant="1"></editform>
+        <editforminit/>
+        <editforminitcodesource>0</editforminitcodesource>
+        <editforminitfilepath></editforminitfilepath>
+        <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+  """
+  QGIS forms can have a Python function that is called when the form is
+  opened.
+
+  Use this function to add extra logic to your forms.
+
+  Enter the name of the function in the "Python Init function"
+  field.
+  An example follows:
+  """
+  from qgis.PyQt.QtWidgets import QWidget
+
+  def my_form_open(dialog, layer, feature):
+      geom = feature.geometry()
+      control = dialog.findChild(QWidget, "MyLineEdit")
+  ]]></editforminitcode>
+        <featformsuppress>0</featformsuppress>
+        <editorlayout>tablayout</editorlayout>
+        <attributeEditorForm>
+          <labelStyle labelColor="" overrideLabelFont="0" overrideLabelColor="0">
+            <labelFont description="Sans Serif,9,-1,5,50,0,0,0,0,0" style="" underline="0" bold="0" italic="0" strikethrough="0"/>
+          </labelStyle>
+          <attributeEditorField showLabel="1" horizontalStretch="0" index="0" verticalStretch="0" name="id">
+            <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+              <labelFont description="Noto Sans,9,-1,5,50,0,0,0,0,0" style="" underline="0" bold="0" italic="0" strikethrough="0"/>
+            </labelStyle>
+          </attributeEditorField>
+          <attributeEditorField showLabel="1" horizontalStretch="0" index="1" verticalStretch="0" name="natural_area_name">
+            <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+              <labelFont description="Noto Sans,9,-1,5,50,0,0,0,0,0" style="" underline="0" bold="0" italic="0" strikethrough="0"/>
+            </labelStyle>
+          </attributeEditorField>
+          <attributeEditorRelation label="Associated birds" relation="birds_area_natural_area_id_natural_ar_id" showLabel="1" horizontalStretch="0" nmRelationId="birds_area_bird_id_birds_4069_id" verticalStretch="0" forceSuppressFormPopup="0" name="birds_area_natural_area_id_natural_ar_id" relationWidgetTypeId="relation_editor">
+            <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+              <labelFont description="Noto Sans,9,-1,5,50,0,0,0,0,0" style="" underline="0" bold="0" italic="0" strikethrough="0"/>
+            </labelStyle>
+            <editor_configuration type="Map">
+              <Option value="false" type="bool" name="allow_add_child_feature_with_no_geometry"/>
+              <Option value="AllButtons" type="QString" name="buttons"/>
+              <Option type="invalid" name="filter_expression"/>
+              <Option value="true" type="bool" name="show_first_feature"/>
+            </editor_configuration>
+          </attributeEditorRelation>
+          <attributeEditorRelation label="card" relation="birds_area_natural_area_id_natural_ar_id_1" showLabel="1" horizontalStretch="0" nmRelationId="" verticalStretch="0" forceSuppressFormPopup="0" name="birds_area_natural_area_id_natural_ar_id_1" relationWidgetTypeId="relation_editor">
+            <labelStyle labelColor="" overrideLabelFont="0" overrideLabelColor="0">
+              <labelFont description="Noto Sans,9,-1,5,50,0,0,0,0,0" style="" underline="0" bold="0" italic="0" strikethrough="0"/>
+            </labelStyle>
+            <editor_configuration type="Map">
+              <Option value="false" type="bool" name="allow_add_child_feature_with_no_geometry"/>
+              <Option value="AllButtons" type="QString" name="buttons"/>
+              <Option type="invalid" name="filter_expression"/>
+              <Option value="true" type="bool" name="show_first_feature"/>
+            </editor_configuration>
+          </attributeEditorRelation>
+          <attributeEditorRelation label="spots" relation="birds_spot_area_id_natural_ar_id" showLabel="1" horizontalStretch="0" nmRelationId="" verticalStretch="0" forceSuppressFormPopup="0" name="birds_spot_area_id_natural_ar_id" relationWidgetTypeId="relation_editor">
+            <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+              <labelFont description="Noto Sans,9,-1,5,50,0,0,0,0,0" style="" underline="0" bold="0" italic="0" strikethrough="0"/>
+            </labelStyle>
+            <editor_configuration type="Map">
+              <Option value="false" type="bool" name="allow_add_child_feature_with_no_geometry"/>
+              <Option value="AllButtons" type="QString" name="buttons"/>
+              <Option type="invalid" name="filter_expression"/>
+              <Option value="true" type="bool" name="show_first_feature"/>
+            </editor_configuration>
+          </attributeEditorRelation>
+        </attributeEditorForm>
+        <editable>
+          <field editable="0" name="id"/>
+          <field editable="1" name="natural_area_name"/>
+        </editable>
+        <labelOnTop>
+          <field labelOnTop="0" name="id"/>
+          <field labelOnTop="0" name="natural_area_name"/>
+        </labelOnTop>
+        <reuseLastValue>
+          <field name="id" reuseLastValue="0"/>
+          <field name="natural_area_name" reuseLastValue="0"/>
+        </reuseLastValue>
+        <dataDefinedFieldProperties/>
+        <widgets>
+          <widget name="birds_area_natural_area_id_natural_ar_id">
+            <config type="Map">
+              <Option value="false" type="bool" name="force-suppress-popup"/>
+              <Option value="birds_area_bird_id_birds_4069_id" type="QString" name="nm-rel"/>
+            </config>
+          </widget>
+          <widget name="birds_area_natural_area_id_natural_ar_id_1">
+            <config type="Map">
+              <Option value="false" type="bool" name="force-suppress-popup"/>
+              <Option type="invalid" name="nm-rel"/>
+            </config>
+          </widget>
+          <widget name="birds_spot_area_id_natural_ar_id">
+            <config type="Map">
+              <Option value="false" type="bool" name="force-suppress-popup"/>
+              <Option type="invalid" name="nm-rel"/>
+            </config>
+          </widget>
+        </widgets>
+        <previewExpression>natural_area_name</previewExpression>
+        <mapTip enabled="1"></mapTip>
+      </maplayer>
+        ';
+
+        $oXml = App\XmlTools::xmlReaderFromString($xmlStr);
+        $layer = Qgis\Layer\MapLayer::fromXmlReader($oXml);
+
+        $this->assertInstanceOf(Qgis\Layer\VectorLayer::class, $layer);
+        $this->assertCount(3, $layer->attributeEditorRelation);
+        $this->assertCount(2, $layer->attributeEditorField);
+
     }
 }

--- a/tests/units/classes/Project/Qgis/VectorLayerAttributeEditorFieldTest.php
+++ b/tests/units/classes/Project/Qgis/VectorLayerAttributeEditorFieldTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Lizmap\App;
+use Lizmap\Project\Qgis;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+class VectorLayerAttributeEditorFieldTest extends TestCase
+{
+    public function testFromXmlReader(): void
+    {
+        // simple field
+        $xmlStr = '
+        <attributeEditorField showLabel="1" horizontalStretch="0" index="1" verticalStretch="0" name="natural_area_name">
+            <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+            <labelFont description="Noto Sans,9,-1,5,50,0,0,0,0,0" style="" underline="0" bold="0" italic="0" strikethrough="0"/>
+            </labelStyle>
+        </attributeEditorField>
+        ';
+        $config = array(
+            'name' => 'natural_area_name',
+            'showLabel' => '1',
+        );
+        $oXml = App\XmlTools::xmlReaderFromString($xmlStr);
+        $field = Qgis\Layer\VectorLayerAttributeEditorField::fromXmlReader($oXml);
+
+        foreach ($config as $prop => $value) {
+            $this->assertEquals($value, $field->{$prop});
+        }
+    }
+}

--- a/tests/units/classes/Project/Qgis/VectorLayerAttributeEditorRelationTest.php
+++ b/tests/units/classes/Project/Qgis/VectorLayerAttributeEditorRelationTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use Lizmap\App;
+use Lizmap\Project\Qgis;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+class VectorLayerAttributeEditorRelationTest extends TestCase
+{
+    public function testFromXmlReader(): void
+    {
+        // 1:n relation
+        $xmlStr = '
+        <attributeEditorRelation label="card" relation="birds_area_natural_area_id_natural_ar_id_1" showLabel="1" horizontalStretch="0" nmRelationId="" verticalStretch="0" forceSuppressFormPopup="0" name="birds_area_natural_area_id_natural_ar_id_1" relationWidgetTypeId="relation_editor">
+            <labelStyle labelColor="" overrideLabelFont="0" overrideLabelColor="0">
+            <labelFont description="Noto Sans,9,-1,5,50,0,0,0,0,0" style="" underline="0" bold="0" italic="0" strikethrough="0"/>
+            </labelStyle>
+            <editor_configuration type="Map">
+            <Option value="false" type="bool" name="allow_add_child_feature_with_no_geometry"/>
+            <Option value="AllButtons" type="QString" name="buttons"/>
+            <Option type="invalid" name="filter_expression"/>
+            <Option value="true" type="bool" name="show_first_feature"/>
+            </editor_configuration>
+        </attributeEditorRelation>
+        ';
+        $config = array(
+            'label' => 'card',
+            'name' => 'birds_area_natural_area_id_natural_ar_id_1',
+            'relation' => 'birds_area_natural_area_id_natural_ar_id_1',
+            'nmRelationId' => '',
+            'showLabel' => '1',
+        );
+        $oXml = App\XmlTools::xmlReaderFromString($xmlStr);
+        $relation = Qgis\Layer\VectorLayerAttributeEditorRelation::fromXmlReader($oXml);
+
+        foreach ($config as $prop => $value) {
+            $this->assertEquals($value, $relation->{$prop});
+        }
+
+        $this->assertFalse($relation->isnmRelation());
+
+        // n:m relation
+        $xmlStr = '
+        <attributeEditorRelation label="Associated birds" relation="birds_area_natural_area_id_natural_ar_id" showLabel="1" horizontalStretch="0" nmRelationId="birds_area_bird_id_birds_4069_id" verticalStretch="0" forceSuppressFormPopup="0" name="birds_area_natural_area_id_natural_ar_id" relationWidgetTypeId="relation_editor">
+            <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+            <labelFont description="Noto Sans,9,-1,5,50,0,0,0,0,0" style="" underline="0" bold="0" italic="0" strikethrough="0"/>
+            </labelStyle>
+            <editor_configuration type="Map">
+            <Option value="false" type="bool" name="allow_add_child_feature_with_no_geometry"/>
+            <Option value="AllButtons" type="QString" name="buttons"/>
+            <Option type="invalid" name="filter_expression"/>
+            <Option value="true" type="bool" name="show_first_feature"/>
+            </editor_configuration>
+        </attributeEditorRelation>
+        ';
+        $config = array(
+            'label' => 'Associated birds',
+            'name' => 'birds_area_natural_area_id_natural_ar_id',
+            'relation' => 'birds_area_natural_area_id_natural_ar_id',
+            'nmRelationId' => 'birds_area_bird_id_birds_4069_id',
+            'showLabel' => '1',
+        );
+        $oXml = App\XmlTools::xmlReaderFromString($xmlStr);
+        $relation = Qgis\Layer\VectorLayerAttributeEditorRelation::fromXmlReader($oXml);
+
+        foreach ($config as $prop => $value) {
+            $this->assertEquals($value, $relation->{$prop});
+        }
+
+        $this->assertTrue($relation->isnmRelation());
+    }
+}

--- a/tests/units/classes/Project/Qgis/VectorLayerTest.php
+++ b/tests/units/classes/Project/Qgis/VectorLayerTest.php
@@ -3273,5 +3273,761 @@ control = dialog.findChild(QWidget, "MyLineEdit")
         $this->assertTrue($layerToKeyArray['constraints']['website']['exp']);
         $this->assertEquals('left( "website", 4) = \'http\'', $layerToKeyArray['constraints']['website']['exp_value']);
         $this->assertEquals('Web site URL must start with \'http\'', $layerToKeyArray['constraints']['website']['exp_desc']);
+
+        // getAttributeEditorRelationConfiguration
+        $xmlStr = '
+        <maplayer geometry="Polygon" refreshOnNotifyMessage="" simplifyDrawingTol="1" simplifyAlgorithm="0" type="vector" simplifyDrawingHints="1" minScale="100000000" styleCategories="AllStyleCategories" readOnly="0" refreshOnNotifyEnabled="0" wkbType="Polygon" autoRefreshMode="Disabled" labelsEnabled="0" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" symbologyReferenceScale="-1" legendPlaceholderImage="" simplifyMaxScale="1" maxScale="0" simplifyLocal="0">
+        <extent>
+          <xmin>4.58213930607160602</xmin>
+          <ymin>43.35054476032322412</ymin>
+          <xmax>4.64863080116274929</xmax>
+          <ymax>43.45587426605017356</ymax>
+        </extent>
+        <wgs84extent>
+          <xmin>4.58213930607160602</xmin>
+          <ymin>43.35054476032322412</ymin>
+          <xmax>4.64863080116274929</xmax>
+          <ymax>43.45587426605017356</ymax>
+        </wgs84extent>
+        <id>natural_areas_5f5587de_ddf8_4740_a724_00bcdf518813</id>
+        <datasource>service="lizmapdb" key="id" estimatedmetadata=true srid=4326 type=Polygon checkPrimaryKeyUnicity="1" table="tests_projects"."natural_areas" (geom)</datasource>
+        <shortname>natural_areas</shortname>
+        <title>Natural areas</title>
+        <keywordList>
+          <value></value>
+        </keywordList>
+        <layername>natural_areas</layername>
+        <srs>
+          <spatialrefsys nativeFormat="Wkt">
+            <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+            <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+            <srsid>3452</srsid>
+            <srid>4326</srid>
+            <authid>EPSG:4326</authid>
+            <description>WGS 84</description>
+            <projectionacronym>longlat</projectionacronym>
+            <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+            <geographicflag>true</geographicflag>
+          </spatialrefsys>
+        </srs>
+        <resourceMetadata>
+          <identifier></identifier>
+          <parentidentifier></parentidentifier>
+          <language></language>
+          <type>dataset</type>
+          <title></title>
+          <abstract></abstract>
+          <contact>
+            <name></name>
+            <organization></organization>
+            <position></position>
+            <voice></voice>
+            <fax></fax>
+            <email></email>
+            <role></role>
+          </contact>
+          <links/>
+          <dates/>
+          <fees></fees>
+          <encoding></encoding>
+          <crs>
+            <spatialrefsys nativeFormat="Wkt">
+              <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],MEMBER["World Geodetic System 1984 (G2296)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+              <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+              <srsid>3452</srsid>
+              <srid>4326</srid>
+              <authid>EPSG:4326</authid>
+              <description>WGS 84</description>
+              <projectionacronym>longlat</projectionacronym>
+              <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+              <geographicflag>true</geographicflag>
+            </spatialrefsys>
+          </crs>
+          <extent>
+            <spatial dimensions="2" maxy="0" maxx="0" crs="EPSG:4326" minx="0" miny="0" minz="0" maxz="0"/>
+            <temporal>
+              <period>
+                <start></start>
+                <end></end>
+              </period>
+            </temporal>
+          </extent>
+        </resourceMetadata>
+        <provider encoding="">postgres</provider>
+        <vectorjoins/>
+        <layerDependencies/>
+        <dataDependencies/>
+        <expressionfields/>
+        <map-layer-style-manager current="default">
+          <map-layer-style name="default"/>
+        </map-layer-style-manager>
+        <auxiliaryLayer/>
+        <metadataUrls/>
+        <flags>
+          <Identifiable>1</Identifiable>
+          <Removable>1</Removable>
+          <Searchable>1</Searchable>
+          <Private>0</Private>
+        </flags>
+        <temporal mode="0" durationUnit="min" fixedDuration="0" durationField="" limitMode="0" endField="" endExpression="" startField="" startExpression="" accumulate="0" enabled="0">
+          <fixedRange>
+            <start></start>
+            <end></end>
+          </fixedRange>
+        </temporal>
+        <elevation binding="Centroid" zscale="1" type="IndividualFeatures" zoffset="0" extrusionEnabled="0" extrusion="0" symbology="Line" clamping="Terrain" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0">
+          <data-defined-properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data-defined-properties>
+          <profileLineSymbol>
+            <symbol clip_to_extent="1" is_animated="0" type="line" alpha="1" name="" force_rhr="0" frame_rate="10">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer pass="0" class="SimpleLine" id="{44cad848-0ddb-47d4-b55d-29c18d0638c7}" enabled="1" locked="0">
+                <Option type="Map">
+                  <Option value="0" type="QString" name="align_dash_pattern"/>
+                  <Option value="square" type="QString" name="capstyle"/>
+                  <Option value="5;2" type="QString" name="customdash"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="customdash_unit"/>
+                  <Option value="0" type="QString" name="dash_pattern_offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+                  <Option value="0" type="QString" name="draw_inside_polygon"/>
+                  <Option value="bevel" type="QString" name="joinstyle"/>
+                  <Option value="229,182,54,255,rgb:0.89803921568627454,0.71372549019607845,0.21176470588235294,1" type="QString" name="line_color"/>
+                  <Option value="solid" type="QString" name="line_style"/>
+                  <Option value="0.6" type="QString" name="line_width"/>
+                  <Option value="MM" type="QString" name="line_width_unit"/>
+                  <Option value="0" type="QString" name="offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="offset_unit"/>
+                  <Option value="0" type="QString" name="ring_filter"/>
+                  <Option value="0" type="QString" name="trim_distance_end"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+                  <Option value="0" type="QString" name="trim_distance_start"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+                  <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+                  <Option value="0" type="QString" name="use_custom_dash"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </profileLineSymbol>
+          <profileFillSymbol>
+            <symbol clip_to_extent="1" is_animated="0" type="fill" alpha="1" name="" force_rhr="0" frame_rate="10">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer pass="0" class="SimpleFill" id="{095c8f8e-00eb-4109-a8f8-aa1cb8cb3c71}" enabled="1" locked="0">
+                <Option type="Map">
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+                  <Option value="229,182,54,255,rgb:0.89803921568627454,0.71372549019607845,0.21176470588235294,1" type="QString" name="color"/>
+                  <Option value="bevel" type="QString" name="joinstyle"/>
+                  <Option value="0,0" type="QString" name="offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="offset_unit"/>
+                  <Option value="164,130,39,255,rgb:0.64313725490196083,0.50980392156862742,0.15294117647058825,1" type="QString" name="outline_color"/>
+                  <Option value="solid" type="QString" name="outline_style"/>
+                  <Option value="0.2" type="QString" name="outline_width"/>
+                  <Option value="MM" type="QString" name="outline_width_unit"/>
+                  <Option value="solid" type="QString" name="style"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </profileFillSymbol>
+          <profileMarkerSymbol>
+            <symbol clip_to_extent="1" is_animated="0" type="marker" alpha="1" name="" force_rhr="0" frame_rate="10">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer pass="0" class="SimpleMarker" id="{65b37710-c39f-45f6-87e0-0f3266aeb832}" enabled="1" locked="0">
+                <Option type="Map">
+                  <Option value="0" type="QString" name="angle"/>
+                  <Option value="square" type="QString" name="cap_style"/>
+                  <Option value="229,182,54,255,rgb:0.89803921568627454,0.71372549019607845,0.21176470588235294,1" type="QString" name="color"/>
+                  <Option value="1" type="QString" name="horizontal_anchor_point"/>
+                  <Option value="bevel" type="QString" name="joinstyle"/>
+                  <Option value="diamond" type="QString" name="name"/>
+                  <Option value="0,0" type="QString" name="offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="offset_unit"/>
+                  <Option value="164,130,39,255,rgb:0.64313725490196083,0.50980392156862742,0.15294117647058825,1" type="QString" name="outline_color"/>
+                  <Option value="solid" type="QString" name="outline_style"/>
+                  <Option value="0.2" type="QString" name="outline_width"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="outline_width_unit"/>
+                  <Option value="diameter" type="QString" name="scale_method"/>
+                  <Option value="3" type="QString" name="size"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="size_unit"/>
+                  <Option value="1" type="QString" name="vertical_anchor_point"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </profileMarkerSymbol>
+        </elevation>
+        <renderer-v2 forceraster="0" symbollevels="0" type="categorizedSymbol" referencescale="-1" enableorderby="0" attr="id">
+          <categories>
+            <category label="1" value="1" type="long" symbol="0" uuid="0" render="true"/>
+            <category label="2" value="2" type="long" symbol="1" uuid="1" render="true"/>
+            <category label="3" value="3" type="long" symbol="2" uuid="2" render="true"/>
+            <category label="" value="" type="string" symbol="3" uuid="3" render="true"/>
+          </categories>
+          <symbols>
+            <symbol clip_to_extent="1" is_animated="0" type="fill" alpha="1" name="0" force_rhr="0" frame_rate="10">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer pass="0" class="SimpleFill" id="{93209251-2141-495b-a7cb-8ae01aaa9ca1}" enabled="1" locked="0">
+                <Option type="Map">
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+                  <Option value="46,220,83,255,rgb:0.1803921568627451,0.86274509803921573,0.32549019607843138,1" type="QString" name="color"/>
+                  <Option value="bevel" type="QString" name="joinstyle"/>
+                  <Option value="0,0" type="QString" name="offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="offset_unit"/>
+                  <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+                  <Option value="solid" type="QString" name="outline_style"/>
+                  <Option value="0.26" type="QString" name="outline_width"/>
+                  <Option value="MM" type="QString" name="outline_width_unit"/>
+                  <Option value="solid" type="QString" name="style"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+            <symbol clip_to_extent="1" is_animated="0" type="fill" alpha="1" name="1" force_rhr="0" frame_rate="10">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer pass="0" class="SimpleFill" id="{7ac1311a-d402-47f1-9188-7fd068561f19}" enabled="1" locked="0">
+                <Option type="Map">
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+                  <Option value="236,177,28,255,rgb:0.92549019607843142,0.69411764705882351,0.10980392156862745,1" type="QString" name="color"/>
+                  <Option value="bevel" type="QString" name="joinstyle"/>
+                  <Option value="0,0" type="QString" name="offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="offset_unit"/>
+                  <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+                  <Option value="solid" type="QString" name="outline_style"/>
+                  <Option value="0.26" type="QString" name="outline_width"/>
+                  <Option value="MM" type="QString" name="outline_width_unit"/>
+                  <Option value="solid" type="QString" name="style"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+            <symbol clip_to_extent="1" is_animated="0" type="fill" alpha="1" name="2" force_rhr="0" frame_rate="10">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer pass="0" class="SimpleFill" id="{62ed713c-be81-451f-b82b-d34d99e47931}" enabled="1" locked="0">
+                <Option type="Map">
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+                  <Option value="127,151,211,255,rgb:0.49803921568627452,0.59215686274509804,0.82745098039215681,1" type="QString" name="color"/>
+                  <Option value="bevel" type="QString" name="joinstyle"/>
+                  <Option value="0,0" type="QString" name="offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="offset_unit"/>
+                  <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+                  <Option value="solid" type="QString" name="outline_style"/>
+                  <Option value="0.26" type="QString" name="outline_width"/>
+                  <Option value="MM" type="QString" name="outline_width_unit"/>
+                  <Option value="solid" type="QString" name="style"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+            <symbol clip_to_extent="1" is_animated="0" type="fill" alpha="1" name="3" force_rhr="0" frame_rate="10">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer pass="0" class="SimpleFill" id="{94f65594-73c0-428a-b85f-8aaa9bb16a98}" enabled="1" locked="0">
+                <Option type="Map">
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+                  <Option value="200,77,173,255,rgb:0.78431372549019607,0.30196078431372547,0.67843137254901964,1" type="QString" name="color"/>
+                  <Option value="bevel" type="QString" name="joinstyle"/>
+                  <Option value="0,0" type="QString" name="offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="offset_unit"/>
+                  <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+                  <Option value="solid" type="QString" name="outline_style"/>
+                  <Option value="0.26" type="QString" name="outline_width"/>
+                  <Option value="MM" type="QString" name="outline_width_unit"/>
+                  <Option value="solid" type="QString" name="style"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </symbols>
+          <source-symbol>
+            <symbol clip_to_extent="1" is_animated="0" type="fill" alpha="1" name="0" force_rhr="0" frame_rate="10">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer pass="0" class="SimpleFill" id="{b2d80baf-86ea-46f5-bb6a-e7e8411a7067}" enabled="1" locked="0">
+                <Option type="Map">
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+                  <Option value="196,60,57,255,rgb:0.7686274509803922,0.23529411764705882,0.22352941176470589,1" type="QString" name="color"/>
+                  <Option value="bevel" type="QString" name="joinstyle"/>
+                  <Option value="0,0" type="QString" name="offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="offset_unit"/>
+                  <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+                  <Option value="solid" type="QString" name="outline_style"/>
+                  <Option value="0.26" type="QString" name="outline_width"/>
+                  <Option value="MM" type="QString" name="outline_width_unit"/>
+                  <Option value="solid" type="QString" name="style"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </source-symbol>
+          <rotation/>
+          <sizescale/>
+          <data-defined-properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data-defined-properties>
+        </renderer-v2>
+        <selection mode="Default">
+          <selectionColor invalid="1"/>
+          <selectionSymbol>
+            <symbol clip_to_extent="1" is_animated="0" type="fill" alpha="1" name="" force_rhr="0" frame_rate="10">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer pass="0" class="SimpleFill" id="{bef8bdc5-5090-4f6d-9190-45967dfe302d}" enabled="1" locked="0">
+                <Option type="Map">
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+                  <Option value="0,0,255,255,rgb:0,0,1,1" type="QString" name="color"/>
+                  <Option value="bevel" type="QString" name="joinstyle"/>
+                  <Option value="0,0" type="QString" name="offset"/>
+                  <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                  <Option value="MM" type="QString" name="offset_unit"/>
+                  <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+                  <Option value="solid" type="QString" name="outline_style"/>
+                  <Option value="0.26" type="QString" name="outline_width"/>
+                  <Option value="MM" type="QString" name="outline_width_unit"/>
+                  <Option value="solid" type="QString" name="style"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </selectionSymbol>
+        </selection>
+        <customproperties>
+          <Option type="Map">
+            <Option type="List" name="dualview/previewExpressions">
+              <Option value="natural_area_name" type="QString"/>
+              <Option value="&quot;natural_area_name&quot;" type="QString"/>
+            </Option>
+            <Option value="0" type="int" name="embeddedWidgets/count"/>
+            <Option type="invalid" name="variableNames"/>
+            <Option type="invalid" name="variableValues"/>
+          </Option>
+        </customproperties>
+        <blendMode>0</blendMode>
+        <featureBlendMode>0</featureBlendMode>
+        <layerOpacity>1</layerOpacity>
+        <LinearlyInterpolatedDiagramRenderer attributeLegend="1" lowerHeight="0" upperHeight="5" upperWidth="5" diagramType="Histogram" lowerWidth="0" classificationAttributeExpression="" lowerValue="0" upperValue="0">
+          <DiagramCategory scaleBasedVisibility="0" backgroundAlpha="255" showAxis="1" diagramOrientation="Up" stackedDiagramMode="Horizontal" spacing="5" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" spacingUnit="MM" width="15" direction="0" barWidth="5" stackedDiagramSpacingUnitScale="3x:0,0,0,0,0,0" penAlpha="255" penColor="#000000" stackedDiagramSpacing="0" penWidth="0" sizeType="MM" rotationOffset="270" minScaleDenominator="0" opacity="1" sizeScale="3x:0,0,0,0,0,0" spacingUnitScale="3x:0,0,0,0,0,0" enabled="0" stackedDiagramSpacingUnit="MM" backgroundColor="#ffffff" height="15" minimumSize="0" maxScaleDenominator="1e+08" lineSizeType="MM">
+            <fontProperties description="Sans,9,-1,5,50,0,0,0,0,0" style="" underline="0" bold="0" italic="0" strikethrough="0"/>
+            <attribute label="" field="" color="#000000" colorOpacity="1"/>
+            <axisSymbol>
+              <symbol clip_to_extent="1" is_animated="0" type="line" alpha="1" name="" force_rhr="0" frame_rate="10">
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option value="" type="QString" name="name"/>
+                    <Option name="properties"/>
+                    <Option value="collection" type="QString" name="type"/>
+                  </Option>
+                </data_defined_properties>
+                <layer pass="0" class="SimpleLine" id="{2d7ebc3f-9658-4828-9d9e-0c5ae8651516}" enabled="1" locked="0">
+                  <Option type="Map">
+                    <Option value="0" type="QString" name="align_dash_pattern"/>
+                    <Option value="square" type="QString" name="capstyle"/>
+                    <Option value="5;2" type="QString" name="customdash"/>
+                    <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+                    <Option value="MM" type="QString" name="customdash_unit"/>
+                    <Option value="0" type="QString" name="dash_pattern_offset"/>
+                    <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+                    <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+                    <Option value="0" type="QString" name="draw_inside_polygon"/>
+                    <Option value="bevel" type="QString" name="joinstyle"/>
+                    <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="line_color"/>
+                    <Option value="solid" type="QString" name="line_style"/>
+                    <Option value="0.26" type="QString" name="line_width"/>
+                    <Option value="MM" type="QString" name="line_width_unit"/>
+                    <Option value="0" type="QString" name="offset"/>
+                    <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                    <Option value="MM" type="QString" name="offset_unit"/>
+                    <Option value="0" type="QString" name="ring_filter"/>
+                    <Option value="0" type="QString" name="trim_distance_end"/>
+                    <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+                    <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+                    <Option value="0" type="QString" name="trim_distance_start"/>
+                    <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+                    <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+                    <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+                    <Option value="0" type="QString" name="use_custom_dash"/>
+                    <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+                  </Option>
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option value="" type="QString" name="name"/>
+                      <Option name="properties"/>
+                      <Option value="collection" type="QString" name="type"/>
+                    </Option>
+                  </data_defined_properties>
+                </layer>
+              </symbol>
+            </axisSymbol>
+          </DiagramCategory>
+        </LinearlyInterpolatedDiagramRenderer>
+        <DiagramLayerSettings linePlacementFlags="18" priority="0" zIndex="0" showAll="1" placement="1" dist="0" obstacle="0">
+          <properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </properties>
+        </DiagramLayerSettings>
+        <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+          <activeChecks/>
+          <checkConfiguration type="Map">
+            <Option type="Map" name="QgsGeometryGapCheck">
+              <Option value="0" type="double" name="allowedGapsBuffer"/>
+              <Option value="false" type="bool" name="allowedGapsEnabled"/>
+              <Option type="invalid" name="allowedGapsLayer"/>
+            </Option>
+          </checkConfiguration>
+        </geometryOptions>
+        <legend type="default-vector" showLabelLegend="0"/>
+        <referencedLayers/>
+        <fieldConfiguration>
+          <field configurationFlags="NoFlag" name="id">
+            <editWidget type="TextEdit">
+              <config>
+                <Option type="Map">
+                  <Option value="false" type="bool" name="IsMultiline"/>
+                  <Option value="false" type="bool" name="UseHtml"/>
+                </Option>
+              </config>
+            </editWidget>
+          </field>
+          <field configurationFlags="NoFlag" name="natural_area_name">
+            <editWidget type="TextEdit">
+              <config>
+                <Option type="Map">
+                  <Option value="false" type="bool" name="IsMultiline"/>
+                  <Option value="false" type="bool" name="UseHtml"/>
+                </Option>
+              </config>
+            </editWidget>
+          </field>
+        </fieldConfiguration>
+        <aliases>
+          <alias field="id" index="0" name="id"/>
+          <alias field="natural_area_name" index="1" name="Natural area name"/>
+        </aliases>
+        <splitPolicies>
+          <policy field="id" policy="Duplicate"/>
+          <policy field="natural_area_name" policy="Duplicate"/>
+        </splitPolicies>
+        <duplicatePolicies>
+          <policy field="id" policy="Duplicate"/>
+          <policy field="natural_area_name" policy="Duplicate"/>
+        </duplicatePolicies>
+        <defaults>
+          <default field="id" applyOnUpdate="0" expression=""/>
+          <default field="natural_area_name" applyOnUpdate="0" expression=""/>
+        </defaults>
+        <constraints>
+          <constraint field="id" unique_strength="1" notnull_strength="1" exp_strength="0" constraints="3"/>
+          <constraint field="natural_area_name" unique_strength="0" notnull_strength="0" exp_strength="0" constraints="0"/>
+        </constraints>
+        <constraintExpressions>
+          <constraint field="id" desc="" exp=""/>
+          <constraint field="natural_area_name" desc="" exp=""/>
+        </constraintExpressions>
+        <expressionfields/>
+        <attributeactions>
+          <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        </attributeactions>
+        <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+          <columns>
+            <column hidden="0" width="-1" type="field" name="id"/>
+            <column hidden="0" width="-1" type="field" name="natural_area_name"/>
+            <column hidden="1" width="-1" type="actions"/>
+          </columns>
+        </attributetableconfig>
+        <conditionalstyles>
+          <rowstyles/>
+          <fieldstyles/>
+        </conditionalstyles>
+        <storedexpressions/>
+        <editform tolerant="1"></editform>
+        <editforminit/>
+        <editforminitcodesource>0</editforminitcodesource>
+        <editforminitfilepath></editforminitfilepath>
+        <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+  """
+  QGIS forms can have a Python function that is called when the form is
+  opened.
+
+  Use this function to add extra logic to your forms.
+
+  Enter the name of the function in the "Python Init function"
+  field.
+  An example follows:
+  """
+  from qgis.PyQt.QtWidgets import QWidget
+
+  def my_form_open(dialog, layer, feature):
+      geom = feature.geometry()
+      control = dialog.findChild(QWidget, "MyLineEdit")
+  ]]></editforminitcode>
+        <featformsuppress>0</featformsuppress>
+        <editorlayout>tablayout</editorlayout>
+        <attributeEditorForm>
+          <labelStyle labelColor="" overrideLabelFont="0" overrideLabelColor="0">
+            <labelFont description="Sans Serif,9,-1,5,50,0,0,0,0,0" style="" underline="0" bold="0" italic="0" strikethrough="0"/>
+          </labelStyle>
+          <attributeEditorField showLabel="1" horizontalStretch="0" index="0" verticalStretch="0" name="id">
+            <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+              <labelFont description="Noto Sans,9,-1,5,50,0,0,0,0,0" style="" underline="0" bold="0" italic="0" strikethrough="0"/>
+            </labelStyle>
+          </attributeEditorField>
+          <attributeEditorField showLabel="1" horizontalStretch="0" index="1" verticalStretch="0" name="natural_area_name">
+            <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+              <labelFont description="Noto Sans,9,-1,5,50,0,0,0,0,0" style="" underline="0" bold="0" italic="0" strikethrough="0"/>
+            </labelStyle>
+          </attributeEditorField>
+          <attributeEditorRelation label="Associated birds" relation="birds_area_natural_area_id_natural_ar_id" showLabel="1" horizontalStretch="0" nmRelationId="birds_area_bird_id_birds_4069_id" verticalStretch="0" forceSuppressFormPopup="0" name="birds_area_natural_area_id_natural_ar_id" relationWidgetTypeId="relation_editor">
+            <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+              <labelFont description="Noto Sans,9,-1,5,50,0,0,0,0,0" style="" underline="0" bold="0" italic="0" strikethrough="0"/>
+            </labelStyle>
+            <editor_configuration type="Map">
+              <Option value="false" type="bool" name="allow_add_child_feature_with_no_geometry"/>
+              <Option value="AllButtons" type="QString" name="buttons"/>
+              <Option type="invalid" name="filter_expression"/>
+              <Option value="true" type="bool" name="show_first_feature"/>
+            </editor_configuration>
+          </attributeEditorRelation>
+          <attributeEditorRelation label="card" relation="birds_area_natural_area_id_natural_ar_id_1" showLabel="1" horizontalStretch="0" nmRelationId="" verticalStretch="0" forceSuppressFormPopup="0" name="birds_area_natural_area_id_natural_ar_id_1" relationWidgetTypeId="relation_editor">
+            <labelStyle labelColor="" overrideLabelFont="0" overrideLabelColor="0">
+              <labelFont description="Noto Sans,9,-1,5,50,0,0,0,0,0" style="" underline="0" bold="0" italic="0" strikethrough="0"/>
+            </labelStyle>
+            <editor_configuration type="Map">
+              <Option value="false" type="bool" name="allow_add_child_feature_with_no_geometry"/>
+              <Option value="AllButtons" type="QString" name="buttons"/>
+              <Option type="invalid" name="filter_expression"/>
+              <Option value="true" type="bool" name="show_first_feature"/>
+            </editor_configuration>
+          </attributeEditorRelation>
+          <attributeEditorRelation label="spots" relation="birds_spot_area_id_natural_ar_id" showLabel="1" horizontalStretch="0" nmRelationId="" verticalStretch="0" forceSuppressFormPopup="0" name="birds_spot_area_id_natural_ar_id" relationWidgetTypeId="relation_editor">
+            <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+              <labelFont description="Noto Sans,9,-1,5,50,0,0,0,0,0" style="" underline="0" bold="0" italic="0" strikethrough="0"/>
+            </labelStyle>
+            <editor_configuration type="Map">
+              <Option value="false" type="bool" name="allow_add_child_feature_with_no_geometry"/>
+              <Option value="AllButtons" type="QString" name="buttons"/>
+              <Option type="invalid" name="filter_expression"/>
+              <Option value="true" type="bool" name="show_first_feature"/>
+            </editor_configuration>
+          </attributeEditorRelation>
+        </attributeEditorForm>
+        <editable>
+          <field editable="0" name="id"/>
+          <field editable="1" name="natural_area_name"/>
+        </editable>
+        <labelOnTop>
+          <field labelOnTop="0" name="id"/>
+          <field labelOnTop="0" name="natural_area_name"/>
+        </labelOnTop>
+        <reuseLastValue>
+          <field name="id" reuseLastValue="0"/>
+          <field name="natural_area_name" reuseLastValue="0"/>
+        </reuseLastValue>
+        <dataDefinedFieldProperties/>
+        <widgets>
+          <widget name="birds_area_natural_area_id_natural_ar_id">
+            <config type="Map">
+              <Option value="false" type="bool" name="force-suppress-popup"/>
+              <Option value="birds_area_bird_id_birds_4069_id" type="QString" name="nm-rel"/>
+            </config>
+          </widget>
+          <widget name="birds_area_natural_area_id_natural_ar_id_1">
+            <config type="Map">
+              <Option value="false" type="bool" name="force-suppress-popup"/>
+              <Option type="invalid" name="nm-rel"/>
+            </config>
+          </widget>
+          <widget name="birds_spot_area_id_natural_ar_id">
+            <config type="Map">
+              <Option value="false" type="bool" name="force-suppress-popup"/>
+              <Option type="invalid" name="nm-rel"/>
+            </config>
+          </widget>
+        </widgets>
+        <previewExpression>natural_area_name</previewExpression>
+        <mapTip enabled="1"></mapTip>
+      </maplayer>
+        ';
+
+        $oXml = App\XmlTools::xmlReaderFromString($xmlStr);
+        $layer = Qgis\Layer\MapLayer::fromXmlReader($oXml);
+
+        $this->assertNotNull($layer->attributeEditorField);
+        $this->assertNotNull($layer->attributeEditorRelation);
+
+        // n:m relation
+        $config = array(
+            'label' => 'Associated birds',
+            'name' => 'birds_area_natural_area_id_natural_ar_id',
+            'relation' => 'birds_area_natural_area_id_natural_ar_id',
+            'nmRelationId' => 'birds_area_bird_id_birds_4069_id',
+            'showLabel' => '1',
+        );
+
+        $editorRelation = $layer->getAttributeEditorRelationConfiguration('birds_area_natural_area_id_natural_ar_id');
+        foreach ($config as $prop => $value) {
+            $this->assertEquals($value, $editorRelation->{$prop});
+        }
+
+        // 1:n with pivot table
+        $config = array(
+            'label' => 'card',
+            'name' => 'birds_area_natural_area_id_natural_ar_id_1',
+            'relation' => 'birds_area_natural_area_id_natural_ar_id_1',
+            'nmRelationId' => '',
+            'showLabel' => '1',
+        );
+
+        $editorRelation = $layer->getAttributeEditorRelationConfiguration('birds_area_natural_area_id_natural_ar_id_1');
+        foreach ($config as $prop => $value) {
+            $this->assertEquals($value, $editorRelation->{$prop});
+        }
+
+        // 1:n birds
+        $config = array(
+            'label' => 'spots',
+            'name' => 'birds_spot_area_id_natural_ar_id',
+            'relation' => 'birds_spot_area_id_natural_ar_id',
+            'nmRelationId' => '',
+            'showLabel' => '1',
+        );
+
+        $editorRelation = $layer->getAttributeEditorRelationConfiguration('birds_spot_area_id_natural_ar_id');
+        $this->assertNotNull($editorRelation);
+
+        // raltion does not exists
+        $editorRelation = $layer->getAttributeEditorRelationConfiguration('invalid');
+        $this->assertNull($editorRelation);
     }
 }

--- a/tests/units/classes/Project/QgisProjectTest.php
+++ b/tests/units/classes/Project/QgisProjectTest.php
@@ -59,7 +59,7 @@ class QgisProjectTest extends TestCase
                     'previewField' => 'fid',
                     'relationName' => 'fk_father_child_relation',
                     'relationId' => 'child_laye_father_id_father_lay_ref_id_1',
-
+                    'nmRelation' => false,
                 ),
             ),
             'pivot' => array(),


### PR DESCRIPTION
When setting up an `n` to `m` relation in QGIS form, users can select the type of table to display in the Drag and Drop layout (pivot or m-table) by toggling on the `cardinality` option.

<img width="975" height="543" alt="image" src="https://github.com/user-attachments/assets/56152ef9-8e93-4a5e-863b-45b70e2434bf" />

This option is translated into the QGIS project file in the `nmRelationId` attribute of the `attributeEditorRelation` element.

Lizmap now also relies on this property to detect which table should be displayed.

**NOTES**
- Controls for whether to display a many-to-many relationship have been strengthened
- I also added the `vectorLayerAttributeEditorField` class, although it isn't used in this development. It can still be a good starting point if you want to make more use of the information in the `attributeEditorForm`.

**MOST IMPORTANT**
Adding/removing records directly from the pivot table remains discouraged IMHO, but there are cases where the pivot also contains additional information that a user might want to update.

Funded by Etra
