### PR TITLE
[Backport release_3_9] Bump fast-uri from 3.1.0 to 3.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3223,7 +3223,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Backport #6807
 **Authored by:** @dependabot[bot]