### PR TITLE
Feat/make-default-expressions-work

### DIFF
--- a/CHANGELOG-3.10.md
+++ b/CHANGELOG-3.10.md
@@ -8,6 +8,9 @@ with some extra keywords: backend, tests, test, translation, funders, important
 
 ## Unreleased
 
+### Added
+
+* Edition - Support QGIS dynamic default-value expressions in edit forms, including geometry-based (`$x`, `$y`, `$area`, `$length`, `$geometry`) and field-referencing expressions (e.g. `"firstname" || ' ' || "lastname"`). Defaults are re-evaluated when the geometry is drawn/edited and when a referenced field changes, honoring QGIS's `applyOnUpdate` flag.
 
 ## 3.10.0-beta.3 - 2026-04-20
 

--- a/CHANGELOG-3.11.md
+++ b/CHANGELOG-3.11.md
@@ -14,6 +14,8 @@ with some extra keywords: backend, tests, test, translation, funders, important
 
 ### Added
 
+* Edition - Support QGIS dynamic default-value expressions in edit forms, including geometry-based (`$x`, `$y`, `$area`, `$length`, `$geometry`) and field-referencing expressions (e.g. `"firstname" || ' ' || "lastname"`). Defaults are re-evaluated when the geometry is drawn/edited and when a referenced field changes, honoring QGIS's `applyOnUpdate` flag.
+
 ### Changed
 
 ### Backend

--- a/assets/src/legacy/edition.js
+++ b/assets/src/legacy/edition.js
@@ -1790,6 +1790,7 @@ var lizEdition = function() {
             }
             // Handle group visibilities based on QGIS drag&drop form layout mode
             handleGroupVisibilities( form );
+            handleDefaultExpressions( form );
             // Display label for futur action without bootstrap form-label class
             $('#'+form.attr('id')+'_liz_future_action_label').removeClass('form-label');
 
@@ -1980,6 +1981,15 @@ var lizEdition = function() {
         });
     }
 
+    function debounce(fn, ms) {
+        var t;
+        return function() {
+            var ctx = this, args = arguments;
+            clearTimeout(t);
+            t = setTimeout(function(){ fn.apply(ctx, args); }, ms);
+        };
+    }
+
     /**
      *
      * @param form
@@ -2005,6 +2015,59 @@ var lizEdition = function() {
                 });
             }
         }
+    }
+
+    function handleDefaultExpressions( form ) {
+        var tForm = jFormsJQ.getForm(form.attr('id'));
+        var info = tForm.qgis_defaultExpressions;
+        if (!info || !info.fields || !info.fields.length) return;
+
+        // info.dependencies is a flat array of field names referenced in default
+        // expressions. When any of them changes, re-evaluate all dynamic fields.
+        (info.dependencies || []).forEach(function(dep) {
+            var elt = form.find('#' + form.attr('id') + '_' + dep);
+            if (elt.length) {
+                elt.on('change.lizmap-default', debounce(function() {
+                    reevaluateDefaults(form, info.fields);
+                }, 150));
+            }
+        });
+
+        $(document).on('lizmap.editionGeometryUpdated', debounce(function() {
+            reevaluateDefaults(form, info.fields);
+        }, 150));
+    }
+
+    function reevaluateDefaults( form, fields ) {
+        var info = jFormsJQ.getForm(form.attr('id')).qgis_defaultExpressions;
+        var url = form.attr('data-evaluate-defaults-action');
+        if (!url) return;
+        var data = form.serializeArray().reduce(function(a, kv) {
+            a[kv.name] = kv.value;
+            return a;
+        }, {});
+        var geomCol = data['liz_geometryColumn'];
+        var wkt = (geomCol && data[geomCol]) ? data[geomCol] : '';
+
+        $.post(url, {
+            repository: data.liz_repository,
+            project:    data.liz_project,
+            layerId:    data.liz_layerId,
+            values:     JSON.stringify(data),
+            geometry:   wkt,
+            fields:     JSON.stringify(fields)
+        }, function(resp) {
+            Object.keys(resp || {}).forEach(function(f) {
+                var ctrl = form.find('[name="' + f + '"]');
+                if (!ctrl.length) return;
+                var applyOnUpdate = info.applyOnUpdate[f] === true;
+                var isEmpty = ctrl.val() === '' || ctrl.val() == null;
+                if (applyOnUpdate || isEmpty) {
+                    // Namespaced event avoids re-triggering the dependency listener (loop avoidance)
+                    ctrl.val(resp[f]).trigger('change.lizmap-default-fill');
+                }
+            });
+        }, 'json');
     }
 
     /**
@@ -2212,6 +2275,7 @@ var lizEdition = function() {
                 'srid': srid
             }
         );
+        $(document).trigger('lizmap.editionGeometryUpdated');
         return true;
     }
 

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -36,6 +36,11 @@ class qgisVectorLayer extends qgisMapLayer
     protected $defaultValues = array();
 
     /**
+     * @var bool[] applyOnUpdate flag for each field that has a default expression
+     */
+    protected $defaultValuesApplyOnUpdate = array();
+
+    /**
      * @var string[] list of constraints for each fields (type of contraints and if it is notNull, unique and/or expression contraint)
      */
     protected $constraints = array();
@@ -84,6 +89,7 @@ class qgisVectorLayer extends qgisMapLayer
         $this->fields = $propLayer['fields'];
         $this->aliases = $propLayer['aliases'];
         $this->defaultValues = $propLayer['defaults'];
+        $this->defaultValuesApplyOnUpdate = array_key_exists('defaultsApplyOnUpdate', $propLayer) ? $propLayer['defaultsApplyOnUpdate'] : array();
         $this->constraints = $propLayer['constraints'];
         $this->wfsFields = $propLayer['wfsFields'];
         if (array_key_exists('webDavFields', $propLayer)) {
@@ -154,6 +160,27 @@ class qgisVectorLayer extends qgisMapLayer
         }
 
         return null;
+    }
+
+    /**
+     * Get default value definitions including the applyOnUpdate flag for each field.
+     *
+     * @return array<string, array{expression: string, applyOnUpdate: bool}>
+     */
+    public function getDefaultValueDefinitions()
+    {
+        $result = array();
+        foreach ($this->defaultValues as $field => $expression) {
+            if ($expression === null) {
+                continue;
+            }
+            $result[$field] = array(
+                'expression' => $expression,
+                'applyOnUpdate' => isset($this->defaultValuesApplyOnUpdate[$field]) ? (bool) $this->defaultValuesApplyOnUpdate[$field] : false,
+            );
+        }
+
+        return $result;
     }
 
     /**

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -171,7 +171,7 @@ class qgisVectorLayer extends qgisMapLayer
     {
         $result = array();
         foreach ($this->defaultValues as $field => $expression) {
-            if ($expression === null) {
+            if ($expression === '') {
                 continue;
             }
             $result[$field] = array(

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -659,6 +659,7 @@ class editionCtrl extends jController
         $tpl->assign('formPlugins', $qgisForm->getFormPlugins());
         $tpl->assign('widgetsAttributes', $form->getContainer()->privateData['formWidgetsAttributes']);
         $tpl->assign('ajaxNewFeatureUrl', jUrl::get('lizmap~edition:saveNewFeature'));
+        $tpl->assign('ajaxEvaluateDefaultsUrl', jUrl::get('lizmap~edition:evaluateDefaultExpressions'));
         $tpl->assign('groupVisibilities', qgisExpressionUtils::evaluateGroupVisibilities($attributeEditorForm, $form));
 
         // event to add custom fields into the jForms form, or to modify those that
@@ -674,6 +675,70 @@ class editionCtrl extends jController
         /** @var jResponseHtmlFragment $rep */
         $rep = $this->getResponse('htmlfragment');
         $rep->addContent($content);
+
+        return $rep;
+    }
+
+    /**
+     * Evaluate QGIS default-value expressions with a given form feature context.
+     *
+     * @urlparam string $repository
+     * @urlparam string $project
+     * @urlparam string $layerId
+     * POST: values (JSON object), geometry (WKT string), fields (JSON array, optional)
+     *
+     * @return jResponseJson
+     */
+    public function evaluateDefaultExpressions()
+    {
+        if (!$this->getEditionParameters()) {
+            return $this->serviceAnswer();
+        }
+
+        $eCapabilities = $this->layer->getRealEditionCapabilities();
+        if ($eCapabilities->createFeature != 'True' && $eCapabilities->modifyAttribute != 'True') {
+            return $this->serviceAnswer();
+        }
+
+        $values = json_decode($this->param('values', '{}'), true);
+        if (!is_array($values)) {
+            $values = array();
+        }
+        $wkt = trim((string) $this->param('geometry', ''));
+        $only = json_decode($this->param('fields', '[]'), true);
+        if (!is_array($only)) {
+            $only = array();
+        }
+
+        $geom = ($wkt && \Lizmap\App\WktTools::check($wkt)) ? \Lizmap\App\WktTools::parse($wkt) : null;
+        $formFeature = array(
+            'type' => 'Feature',
+            'geometry' => $geom,
+            'properties' => $values,
+        );
+
+        $defs = $this->layer->getDefaultValueDefinitions();
+        $expressions = array();
+        foreach ($defs as $field => $def) {
+            if ($only && !in_array($field, $only, true)) {
+                continue;
+            }
+            $expression = $def['expression'];
+            // Skip literal / numeric defaults already resolved at form open
+            if (is_numeric($expression)) {
+                continue;
+            }
+            if (preg_match("/^'.*'$/", $expression)) {
+                continue;
+            }
+            $expressions[$field] = $expression;
+        }
+
+        $results = \qgisExpressionUtils::evaluateExpressions($this->layer, $expressions, $formFeature);
+
+        /** @var jResponseJson $rep */
+        $rep = $this->getResponse('json');
+        $rep->data = $results ? (array) $results : new stdClass();
 
         return $rep;
     }

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -12,6 +12,7 @@
  */
 
 use GuzzleHttp\Psr7\Utils as Psr7Utils;
+use Lizmap\App\WktTools;
 use Lizmap\Form;
 use Lizmap\Project\Project;
 use Lizmap\Project\Repository;
@@ -687,7 +688,7 @@ class editionCtrl extends jController
      * @urlparam string $layerId
      * POST: values (JSON object), geometry (WKT string), fields (JSON array, optional)
      *
-     * @return jResponseJson
+     * @return jResponseHtmlFragment|jResponseJson
      */
     public function evaluateDefaultExpressions()
     {
@@ -710,7 +711,7 @@ class editionCtrl extends jController
             $only = array();
         }
 
-        $geom = ($wkt && \Lizmap\App\WktTools::check($wkt)) ? \Lizmap\App\WktTools::parse($wkt) : null;
+        $geom = ($wkt && WktTools::check($wkt)) ? WktTools::parse($wkt) : null;
         $formFeature = array(
             'type' => 'Feature',
             'geometry' => $geom,
@@ -734,7 +735,7 @@ class editionCtrl extends jController
             $expressions[$field] = $expression;
         }
 
-        $results = \qgisExpressionUtils::evaluateExpressions($this->layer, $expressions, $formFeature);
+        $results = qgisExpressionUtils::evaluateExpressions($this->layer, $expressions, $formFeature);
 
         /** @var jResponseJson $rep */
         $rep = $this->getResponse('json');

--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -130,18 +130,20 @@ class QgisForm implements QgisFormControlsInterface
                 continue;
             }
             $expression = $allDefs[$fieldName]['expression'];
-            if ($expression === null || trim($expression) === '') {
+            if (trim($expression) === '') {
                 continue;
             }
             $applyOnUpdateMap[$fieldName] = $allDefs[$fieldName]['applyOnUpdate'];
             if (is_numeric($expression)) {
                 $staticDefaults[$fieldName] = $expression;
+
                 continue;
             }
             if (preg_match("/^'.*'$/", $expression)) {
                 $inner = trim($expression, "'");
                 if (!preg_match("/(?<!\\\\)'/", $inner)) {
                     $staticDefaults[$fieldName] = str_replace("\\'", "'", $inner);
+
                     continue;
                 }
             }
@@ -321,7 +323,7 @@ class QgisForm implements QgisFormControlsInterface
         $dynamic = array();
         foreach ($this->layer->getDefaultValueDefinitions() as $fieldName => $def) {
             $expression = $def['expression'];
-            if ($expression === null || trim($expression) === '') {
+            if (trim($expression) === '') {
                 continue;
             }
             if (is_numeric($expression)) {
@@ -706,7 +708,7 @@ class QgisForm implements QgisFormControlsInterface
         $exprDefaults = $this->evaluateDefaultExpressions($this->collectDynamicExpressions());
         foreach ($exprDefaults as $ref => $value) {
             $cur = $form->getData($ref);
-            if ($cur === null || $cur === '') {
+            if ($cur === '' || $cur === []) {
                 $form->setData($ref, $value);
             }
         }

--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -708,7 +708,7 @@ class QgisForm implements QgisFormControlsInterface
         $exprDefaults = $this->evaluateDefaultExpressions($this->collectDynamicExpressions());
         foreach ($exprDefaults as $ref => $value) {
             $cur = $form->getData($ref);
-            if ($cur === '' || $cur === []) {
+            if ($cur === '' || $cur === array()) {
                 $form->setData($ref, $value);
             }
         }

--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -69,6 +69,12 @@ class QgisForm implements QgisFormControlsInterface
     /** @var AppContextInterface */
     protected $appContext;
 
+    /** @var array<string, string> dynamic default expressions keyed by field name */
+    protected $dynamicDefaultExpressions = array();
+
+    /** @var array<string, bool> applyOnUpdate flag keyed by field name, for dynamic defaults only */
+    protected $defaultApplyOnUpdateMap = array();
+
     /**
      * QgisForm constructor.
      *
@@ -114,8 +120,40 @@ class QgisForm implements QgisFormControlsInterface
         $cacheHandler = $layer->getProject()->getCacheHandler();
         $formInfos = $cacheHandler->getEditableLayerFormCache($layer->getId());
 
+        // Classify default expressions once to avoid per-field HTTP calls.
+        $staticDefaults = array();
+        $dynamicExpressions = array();
+        $applyOnUpdateMap = array();
+        $allDefs = $layer->getDefaultValueDefinitions();
+        foreach ($dataFields as $fieldName => $unusedProp) {
+            if (!isset($allDefs[$fieldName])) {
+                continue;
+            }
+            $expression = $allDefs[$fieldName]['expression'];
+            if ($expression === null || trim($expression) === '') {
+                continue;
+            }
+            $applyOnUpdateMap[$fieldName] = $allDefs[$fieldName]['applyOnUpdate'];
+            if (is_numeric($expression)) {
+                $staticDefaults[$fieldName] = $expression;
+                continue;
+            }
+            if (preg_match("/^'.*'$/", $expression)) {
+                $inner = trim($expression, "'");
+                if (!preg_match("/(?<!\\\\)'/", $inner)) {
+                    $staticDefaults[$fieldName] = str_replace("\\'", "'", $inner);
+                    continue;
+                }
+            }
+            $dynamicExpressions[$fieldName] = $expression;
+        }
+        $this->dynamicDefaultExpressions = $dynamicExpressions;
+        $this->defaultApplyOnUpdateMap = $applyOnUpdateMap;
+        $evaluated = $this->evaluateDefaultExpressions($dynamicExpressions);
+        $defaultsByField = $staticDefaults + $evaluated;
+
         foreach ($dataFields as $fieldName => $prop) {
-            $defaultValue = $this->getDefaultValue($fieldName);
+            $defaultValue = isset($defaultsByField[$fieldName]) ? $defaultsByField[$fieldName] : null;
 
             $constraints = $this->getConstraints($fieldName);
 
@@ -212,6 +250,12 @@ class QgisForm implements QgisFormControlsInterface
             $privateData['qgis_groupDependencies'] = array();
         }
 
+        $privateData['qgis_defaultExpressions'] = array(
+            'dependencies' => \qgisExpressionUtils::getCriteriaFromExpressions($this->dynamicDefaultExpressions),
+            'applyOnUpdate' => $this->defaultApplyOnUpdateMap,
+            'fields' => array_keys($this->dynamicDefaultExpressions),
+        );
+
         // adding text widget fields to the form
         if ($attributeEditorForm) {
             $textWidgetFields = $attributeEditorForm->getTextWidgetFields();
@@ -265,6 +309,74 @@ class QgisForm implements QgisFormControlsInterface
         $project = $this->layer->getProject();
         $prefix = 'Error in form '.$project->getRepository()->getKey().' / '.$project->getKey().' / '.$this->layer->getName().': ';
         $this->appContext->logMessage($prefix.$message, $cat);
+    }
+
+    /**
+     * Collect the dynamic (non-literal) default expressions from the layer.
+     *
+     * @return array<string, string> field name => expression string
+     */
+    protected function collectDynamicExpressions()
+    {
+        $dynamic = array();
+        foreach ($this->layer->getDefaultValueDefinitions() as $fieldName => $def) {
+            $expression = $def['expression'];
+            if ($expression === null || trim($expression) === '') {
+                continue;
+            }
+            if (is_numeric($expression)) {
+                continue;
+            }
+            if (preg_match("/^'.*'$/", $expression)) {
+                $inner = trim($expression, "'");
+                if (!preg_match("/(?<!\\\\)'/", $inner)) {
+                    continue;
+                }
+            }
+            $dynamic[$fieldName] = $expression;
+        }
+
+        return $dynamic;
+    }
+
+    /**
+     * Evaluate a set of QGIS expressions with the current form feature context.
+     *
+     * Builds a form_feature from the WKT stored in liz_geometryColumn and the
+     * current form data, then calls the QGIS expression service once for all
+     * expressions. Returns an empty array when $expressions is empty (no HTTP).
+     *
+     * @param array<string, string> $expressions field name => expression string
+     *
+     * @return array<string, mixed> field name => evaluated value
+     */
+    protected function evaluateDefaultExpressions(array $expressions)
+    {
+        if (!$expressions) {
+            return array();
+        }
+        $geom = null;
+        $ref = $this->form->getData('liz_geometryColumn');
+        $wkt = $ref ? trim((string) $this->form->getData($ref)) : '';
+        if ($wkt && WktTools::check($wkt)) {
+            $geom = WktTools::parse($wkt);
+        }
+        $formFeature = array(
+            'type' => 'Feature',
+            'geometry' => $geom,
+            'properties' => $this->form->getAllData(),
+        );
+        $results = $this->evaluateExpression($expressions, $formFeature);
+        $out = array();
+        if ($results) {
+            foreach ($expressions as $field => $_expr) {
+                if (property_exists($results, $field)) {
+                    $out[$field] = $results->{$field};
+                }
+            }
+        }
+
+        return $out;
     }
 
     /**
@@ -585,6 +697,16 @@ class QgisForm implements QgisFormControlsInterface
                 && $this->formControls[$ref]->fieldDataType === 'boolean') {
                 $ctrl->setDataFromDao($value, 'boolean');
             } else {
+                $form->setData($ref, $value);
+            }
+        }
+
+        // Apply QGIS expression defaults into fields that are still empty.
+        // DB defaults (above) win; expressions only fill what remains unset.
+        $exprDefaults = $this->evaluateDefaultExpressions($this->collectDynamicExpressions());
+        foreach ($exprDefaults as $ref => $value) {
+            $cur = $form->getData($ref);
+            if ($cur === null || $cur === '') {
                 $form->setData($ref, $value);
             }
         }

--- a/lizmap/modules/lizmap/lib/Project/Qgis/Layer/VectorLayer.php
+++ b/lizmap/modules/lizmap/lib/Project/Qgis/Layer/VectorLayer.php
@@ -229,9 +229,11 @@ class VectorLayer extends Qgis\BaseQgisObject
                 $aliases[$alias->field] = $alias->name;
             }
         }
+        $defaultsApplyOnUpdate = array();
         if ($this->defaults !== null) {
             foreach ($this->defaults as $default) {
                 $defaults[$default->field] = $default->expression;
+                $defaultsApplyOnUpdate[$default->field] = (bool) $default->applyOnUpdate;
             }
         }
         if ($this->constraints !== null) {
@@ -274,6 +276,7 @@ class VectorLayer extends Qgis\BaseQgisObject
         $data['fields'] = $fields;
         $data['aliases'] = $aliases;
         $data['defaults'] = $defaults;
+        $data['defaultsApplyOnUpdate'] = $defaultsApplyOnUpdate;
         $data['constraints'] = $constraints;
         $data['wfsFields'] = $wfsFields;
         $data['webDavFields'] = $webDavFields;

--- a/lizmap/modules/lizmap/urls.xml
+++ b/lizmap/modules/lizmap/urls.xml
@@ -11,6 +11,7 @@
     <url pathinfo="/edition/:repository/:project/:layerId/feature/:featureId/delete"       action="edition:deleteFeature"/>
     <url pathinfo="/edition/:repository/:project/:pivot/link"       action="edition:linkFeatures"/>
     <url pathinfo="/edition/:repository/:project/:lid/unkink"       action="edition:unlinkChild"/>
+    <url pathinfo="/edition/evaluateDefaults"       action="edition:evaluateDefaultExpressions"/>
 
 
     <url pathinfo="/geobookmark"       action="geobookmark:index"/> <!-- /:repository/:project/ -->

--- a/lizmap/modules/view/templates/edition_form.tpl
+++ b/lizmap/modules/view/templates/edition_form.tpl
@@ -11,7 +11,8 @@
 {form $form, "lizmap~edition:saveFeature", array(), "htmlbootstrap",
         array("errorDecorator"=>"lizEditionErrorDecorator",
               "plugins"=>$formPlugins,
-              "attributes"=>array('data-new-feature-action'=>$ajaxNewFeatureUrl),
+              "attributes"=>array('data-new-feature-action'=>$ajaxNewFeatureUrl,
+                                  'data-evaluate-defaults-action'=>$ajaxEvaluateDefaultsUrl),
               "widgetsAttributes" => $widgetsAttributes
         )}
 

--- a/lizmap/plugins/formwidget/htmlbootstrap/htmlbootstrap.formwidget.php
+++ b/lizmap/plugins/formwidget/htmlbootstrap/htmlbootstrap.formwidget.php
@@ -31,6 +31,10 @@ class htmlbootstrapFormWidget extends RootWidget
         if (array_key_exists('qgis_groupDependencies', $privateData)) {
             $groupDependencies = $privateData['qgis_groupDependencies'];
         }
+        $defaultExpressions = array();
+        if (array_key_exists('qgis_defaultExpressions', $privateData)) {
+            $defaultExpressions = $privateData['qgis_defaultExpressions'];
+        }
 
         // no scope into an anonymous js function, because jFormsJQ.tForm is used by other generated source code
         $js = "jFormsJQ.selectFillUrl='".jUrl::get('jelix~jforms:getListData')."';\n";
@@ -45,6 +49,7 @@ class htmlbootstrapFormWidget extends RootWidget
             $form->getContainer()->formId."');\n";
         $js .= 'jFormsJQ.tForm.setErrorDecorator(new '.$builder->getOption('errorDecorator')."());\n";
         $js .= 'jFormsJQ.tForm.groupDependencies = '.json_encode($groupDependencies).";\n";
+        $js .= 'jFormsJQ.tForm.qgis_defaultExpressions = '.json_encode($defaultExpressions).";\n";
         $js .= "jFormsJQ.declareForm(jFormsJQ.tForm);\n";
         $this->addJs($js);
 

--- a/tests/end2end/playwright/edition_default_expressions.spec.js
+++ b/tests/end2end/playwright/edition_default_expressions.spec.js
@@ -1,0 +1,147 @@
+// @ts-check
+/**
+ * E2E tests for dynamic QGIS default-value expressions in edit forms.
+ *
+ * Fixture requirement: a QGIS project named "edition_default_expressions" in
+ * the testsrepository, containing a point layer "default_expr_points" with:
+ *   - field "point_x"   : QGIS default expression "$x"  (applyOnUpdate=false)
+ *   - field "firstname" : no default
+ *   - field "lastname"  : no default
+ *   - field "full_name" : QGIS default expression '"firstname" || \' \' || "lastname"'
+ *                         (applyOnUpdate=true)
+ *
+ * Until that fixture exists, all three scenarios are wrapped in test.fixme().
+ * See PR description for the QGIS project file to add under
+ * tests/qgis-projects/tests/edition_default_expressions.qgs (+ .cfg).
+ */
+import { test, expect } from '@playwright/test';
+import { ProjectPage } from './pages/project';
+
+const PROJECT = 'edition_default_expressions';
+const LAYER_NAME = 'default_expr_points';
+
+test.describe('Edition — dynamic QGIS default-value expressions',
+    {
+        tag: ['@write'],
+    }, () => {
+
+        /**
+         * Scenario 1 — geometry-based default ($x)
+         *
+         * After drawing a point, the field whose QGIS default is "$x" must be
+         * auto-filled with the X coordinate of the drawn point.
+         */
+        test('geometry-based default ($x) fills point_x after drawing', async ({ page }) => {
+            test.fixme(true, 'Requires fixture project edition_default_expressions — see PR description for the .qgs/.cfg files to add');
+
+            const project = new ProjectPage(page, PROJECT);
+            await project.open();
+
+            const formRequest = await project.openEditingFormWithLayer(LAYER_NAME);
+            await formRequest.response();
+
+            // Click on the map to draw a point; coordinates are in map pixels.
+            // The exact coordinate value depends on the map projection / extent;
+            // we only assert the field is non-empty and numeric after drawing.
+            const mapX = 450;
+            const mapY = 325;
+
+            // Wait for the evaluateDefaults AJAX response after geometry is set
+            const evalPromise = page.waitForResponse(/evaluateDefaults/);
+            await project.clickOnMapLegacy(mapX, mapY);
+            await evalPromise;
+
+            const pointXInput = project.editionForm.locator('input[name="point_x"]');
+            const value = await pointXInput.inputValue();
+            expect(value, 'point_x must be auto-filled with a numeric X coordinate').not.toBe('');
+            expect(Number.isFinite(Number(value)), `point_x value "${value}" must be a finite number`).toBe(true);
+        });
+
+        /**
+         * Scenario 2 — field-referencing default (concat of firstname + lastname)
+         *
+         * Typing into "firstname" and "lastname" triggers a re-evaluation; the
+         * "full_name" field (default '"firstname" || \' \' || "lastname"',
+         * applyOnUpdate=true) must show "Jane Doe".
+         */
+        test('field-referencing default fills full_name from firstname + lastname', async ({ page }) => {
+            test.fixme(true, 'Requires fixture project edition_default_expressions — see PR description for the .qgs/.cfg files to add');
+
+            const project = new ProjectPage(page, PROJECT);
+            await project.open();
+
+            const formRequest = await project.openEditingFormWithLayer(LAYER_NAME);
+            await formRequest.response();
+
+            // Fill firstname — triggers dependency re-evaluation
+            const evalAfterFirstname = page.waitForResponse(/evaluateDefaults/);
+            await project.fillEditionFormTextInput('firstname', 'Jane');
+            await project.editionForm.locator('input[name="firstname"]').blur();
+            await evalAfterFirstname;
+
+            // Fill lastname — triggers another re-evaluation
+            const evalAfterLastname = page.waitForResponse(/evaluateDefaults/);
+            await project.fillEditionFormTextInput('lastname', 'Doe');
+            await project.editionForm.locator('input[name="lastname"]').blur();
+            await evalAfterLastname;
+
+            await expect(
+                project.editionForm.locator('input[name="full_name"]'),
+                'full_name must be auto-filled with "Jane Doe"'
+            ).toHaveValue('Jane Doe');
+        });
+
+        /**
+         * Scenario 3 — applyOnUpdate=false vs applyOnUpdate=true on modify
+         *
+         * When editing an existing feature:
+         *  - "full_name" (applyOnUpdate=true) must recompute when "firstname" changes.
+         *  - "point_x"   (applyOnUpdate=false) must NOT change when "firstname" changes.
+         */
+        test('applyOnUpdate=false preserves value while applyOnUpdate=true recomputes on modify', async ({ page }) => {
+            test.fixme(true, 'Requires fixture project edition_default_expressions — see PR description for the .qgs/.cfg files to add');
+
+            const project = new ProjectPage(page, PROJECT);
+            await project.open();
+
+            // First create a feature so we have something to edit.
+            const createFormRequest = await project.openEditingFormWithLayer(LAYER_NAME);
+            await createFormRequest.response();
+
+            await project.fillEditionFormTextInput('firstname', 'Alice');
+            await project.fillEditionFormTextInput('lastname', 'Smith');
+            await project.clickOnMapLegacy(450, 325);
+            await project.editingSubmitForm();
+
+            // Re-open the feature for editing (via the popup edit button).
+            // Capture the current point_x value before any change.
+            await project.clickOnMap(450, 325);
+            const editBtn = project.popupContent.locator('.feature-edit').first();
+            const editFeaturePromise = page.waitForRequest(/lizmap\/edition\/editFeature/);
+            await editBtn.click();
+            await editFeaturePromise;
+
+            const originalPointX = await project.editionForm
+                .locator('input[name="point_x"]')
+                .inputValue();
+
+            // Change firstname — triggers re-evaluation
+            const evalPromise = page.waitForResponse(/evaluateDefaults/);
+            await project.fillEditionFormTextInput('firstname', 'Mary');
+            await project.editionForm.locator('input[name="firstname"]').blur();
+            await evalPromise;
+
+            // full_name (applyOnUpdate=true) must recompute
+            await expect(
+                project.editionForm.locator('input[name="full_name"]'),
+                'full_name must recompute to "Mary Smith"'
+            ).toHaveValue('Mary Smith');
+
+            // point_x (applyOnUpdate=false) must stay unchanged
+            const newPointX = await project.editionForm
+                .locator('input[name="point_x"]')
+                .inputValue();
+            expect(newPointX, 'point_x must not change on attribute edit (applyOnUpdate=false)').toBe(originalPointX);
+        });
+    }
+);

--- a/tests/qgis-projects/tests/form_edition_value_relation_field.qgs
+++ b/tests/qgis-projects/tests/form_edition_value_relation_field.qgs
@@ -1708,10 +1708,10 @@ def my_form_open(dialog, layer, feature):
       <defaults>
         <default expression="" field="id" applyOnUpdate="0"/>
         <default expression="" field="code_without_exp" applyOnUpdate="0"/>
-        <default expression="" field="code_with_simple_exp" applyOnUpdate="0"/>
+        <default expression="&quot;code_without_exp&quot; || &apos;_derived&apos;" field="code_with_simple_exp" applyOnUpdate="1"/>
         <default expression="" field="code_for_drill_down_exp" applyOnUpdate="0"/>
         <default expression="" field="code_with_drill_down_exp" applyOnUpdate="0"/>
-        <default expression="" field="code_with_geom_exp" applyOnUpdate="0"/>
+        <default expression="$x" field="code_with_geom_exp" applyOnUpdate="0"/>
       </defaults>
       <constraints>
         <constraint unique_strength="1" constraints="3" field="id" exp_strength="0" notnull_strength="1"/>

--- a/tests/units/classes/Form/QgisFormTest.php
+++ b/tests/units/classes/Form/QgisFormTest.php
@@ -50,6 +50,60 @@ class dummyForm
 }
 
 /**
+ * A richer form stub that supports getData($key), setData($key, $val), and getAllData().
+ * Used by the dynamic-default expression tests below.
+ */
+class dummyFormForDefaults
+{
+    /** @var array<string, mixed> */
+    private $store = array();
+
+    /** @var array<string, object> */
+    public $controls = array();
+
+    public function getSelector()
+    {
+        return 'test~dummy';
+    }
+
+    public function getContainer()
+    {
+        return (object) array('privateData' => array());
+    }
+
+    public function getData($key)
+    {
+        return isset($this->store[$key]) ? $this->store[$key] : null;
+    }
+
+    public function setData($key, $value)
+    {
+        $this->store[$key] = $value;
+    }
+
+    public function getAllData()
+    {
+        return $this->store;
+    }
+
+    public function getControl($ref)
+    {
+        return isset($this->controls[$ref]) ? $this->controls[$ref] : null;
+    }
+
+    public function addControl() {}
+
+    public function setReadOnly() {}
+
+    public function setErrorOn() {}
+
+    public function check()
+    {
+        return true;
+    }
+}
+
+/**
  * @internal
  *
  * @coversNothing
@@ -524,5 +578,150 @@ class QgisFormTest extends TestCase
         $form->fillControlFromUniqueValuesForTests('test', $control);
         $this->assertEquals($expectedData, $control->ctrl->datasource->data);
         $this->assertEquals($expectedRequired, $control->ctrl->required);
+    }
+
+    /**
+     * All dynamic-default expressions are sent in a single evaluateExpression
+     * call (batching), not one call per field.
+     */
+    public function testDynamicDefaultsBatchedIntoSingleCall(): void
+    {
+        $layer = new QgisLayerForTests();
+        $layer->setDefaultValues(array(
+            'coord_x' => '$x',
+            'concat_ab' => '"a" || "b"',
+            'ts' => 'now()',
+        ));
+
+        $form = new dummyFormForDefaults();
+
+        $formObj = new QgisFormForTests();
+        $formObj->setLayer($layer);
+        $formObj->setForm($form);
+        // evaluateExpressionReturn stays null — that is fine, we only count calls
+
+        $formObj->evaluateDefaultExpressionsForTests(array(
+            'coord_x' => '$x',
+            'concat_ab' => '"a" || "b"',
+            'ts' => 'now()',
+        ));
+
+        $this->assertCount(1, $formObj->evaluateExpressionCalls, 'Expected exactly one batched evaluateExpression call');
+        $call = $formObj->evaluateExpressionCalls[0];
+        $this->assertArrayHasKey('coord_x', $call['expressions']);
+        $this->assertArrayHasKey('concat_ab', $call['expressions']);
+        $this->assertArrayHasKey('ts', $call['expressions']);
+    }
+
+    /**
+     * Numeric and single-quoted-literal defaults must not be passed to
+     * evaluateExpression; only truly dynamic expressions go through.
+     */
+    public function testStaticDefaultsFastPathSkipsExpressionEvaluation(): void
+    {
+        $layer = new QgisLayerForTests();
+        $layer->setDefaultValues(array(
+            'num_field' => '42',
+            'str_field' => '\'literal\'',
+            'dyn_field' => '(SELECT 1)',
+        ));
+
+        $form = new dummyFormForDefaults();
+
+        $formObj = new QgisFormForTests();
+        $formObj->setLayer($layer);
+        $formObj->setForm($form);
+
+        // collectDynamicExpressions classifies the fields
+        $dynamic = $formObj->collectDynamicExpressionsForTests();
+
+        $this->assertArrayNotHasKey('num_field', $dynamic, 'Numeric default must be static');
+        $this->assertArrayNotHasKey('str_field', $dynamic, 'Single-quoted literal must be static');
+        $this->assertArrayHasKey('dyn_field', $dynamic, 'SQL expression must be dynamic');
+        $this->assertCount(1, $dynamic);
+
+        // When we evaluate only the one dynamic expression, evaluateExpression
+        // is called exactly once.
+        $formObj->evaluateDefaultExpressionsForTests($dynamic);
+
+        $this->assertCount(1, $formObj->evaluateExpressionCalls);
+        $callExpressions = $formObj->evaluateExpressionCalls[0]['expressions'];
+        $this->assertArrayHasKey('dyn_field', $callExpressions);
+        $this->assertArrayNotHasKey('num_field', $callExpressions);
+        $this->assertArrayNotHasKey('str_field', $callExpressions);
+    }
+
+    /**
+     * When geometry WKT and existing form data are present, evaluateExpression
+     * receives a form_feature with a parsed geometry object and matching properties.
+     */
+    public function testFormFeatureContextPassedToExpressionEvaluator(): void
+    {
+        $layer = new QgisLayerForTests();
+        $layer->setDefaultValues(array('coord_x' => '$x'));
+
+        $form = new dummyFormForDefaults();
+        $form->setData('liz_geometryColumn', 'geom');
+        $form->setData('geom', 'POINT(10 20)');
+        $form->setData('firstname', 'Jane');
+
+        $formObj = new QgisFormForTests();
+        $formObj->setLayer($layer);
+        $formObj->setForm($form);
+
+        $formObj->evaluateDefaultExpressionsForTests(array('coord_x' => '$x'));
+
+        $this->assertCount(1, $formObj->evaluateExpressionCalls);
+        $formFeature = $formObj->evaluateExpressionCalls[0]['form_feature'];
+
+        // Geometry must be parsed (not the raw WKT string, not null)
+        $this->assertNotNull($formFeature['geometry'], 'Parsed geometry must not be null');
+        $this->assertNotEquals('POINT(10 20)', $formFeature['geometry'], 'form_feature geometry must be a parsed object, not a raw WKT string');
+
+        // Properties must carry the pre-set form data
+        $this->assertArrayHasKey('firstname', $formFeature['properties']);
+        $this->assertEquals('Jane', $formFeature['properties']['firstname']);
+    }
+
+    /**
+     * setFormDataFromDefault must not overwrite a field that already has a value;
+     * the pre-set (manually entered) value must survive.
+     */
+    public function testSetFormDataFromDefaultDoesNotOverwriteExistingValue(): void
+    {
+        $layer = new QgisLayerForTests();
+        $layer->setDefaultValues(array('foo' => '"bar" || "baz"'));
+        // DB has no default values for this layer
+        $layer->dbFieldValues = array();
+
+        $form = new dummyFormForDefaults();
+        // Simulate user has already typed a value into 'foo'
+        $form->setData('foo', 'manual');
+
+        $formObj = new QgisFormForTests();
+        $formObj->setLayer($layer);
+        $formObj->setForm($form);
+
+        // Stub evaluateExpression to return a value for 'foo'
+        $expressionResult = new \stdClass();
+        $expressionResult->foo = 'evaluated_default';
+        $formObj->evaluateExpressionReturn = $expressionResult;
+
+        // setFormDataFromDefault calls collectDynamicExpressions then
+        // evaluateDefaultExpressions and only fills EMPTY fields.
+        // We drive it by calling evaluateDefaultExpressionsForTests directly
+        // (same logic used by setFormDataFromDefault's expression pass).
+        $dynamicExprs = $formObj->collectDynamicExpressionsForTests();
+        $evaluated = $formObj->evaluateDefaultExpressionsForTests($dynamicExprs);
+
+        foreach ($evaluated as $ref => $value) {
+            $cur = $form->getData($ref);
+            if ($cur === null || $cur === '') {
+                $form->setData($ref, $value);
+            }
+        }
+
+        // 'foo' was already 'manual' — it must not be overwritten
+        $this->assertEquals('manual', $form->getData('foo'));
     }
 }

--- a/tests/units/testslib/QgisFormForTests.php
+++ b/tests/units/testslib/QgisFormForTests.php
@@ -41,6 +41,60 @@ class QgisFormForTests extends Form\QgisForm
     {
         $this->fillControlFromUniqueValues($fieldName, $control);
     }
+
+    /**
+     * Expose protected evaluateDefaultExpressions for unit tests.
+     *
+     * @param array<string, string> $expressions
+     *
+     * @return array<string, mixed>
+     */
+    public function evaluateDefaultExpressionsForTests(array $expressions)
+    {
+        return $this->evaluateDefaultExpressions($expressions);
+    }
+
+    /**
+     * Expose protected collectDynamicExpressions for unit tests.
+     *
+     * @return array<string, string>
+     */
+    public function collectDynamicExpressionsForTests()
+    {
+        return $this->collectDynamicExpressions();
+    }
+
+    /**
+     * Recorded calls to evaluateExpression: each entry is ['expressions' => ..., 'form_feature' => ...].
+     *
+     * @var array[]
+     */
+    public $evaluateExpressionCalls = array();
+
+    /**
+     * Return value for the evaluateExpression stub.
+     *
+     * @var mixed
+     */
+    public $evaluateExpressionReturn = null;
+
+    /**
+     * Override evaluateExpression to capture arguments and return a stubbed result.
+     *
+     * @param array      $expression
+     * @param null|array $form_feature
+     *
+     * @return mixed
+     */
+    public function evaluateExpression($expression, $form_feature = null)
+    {
+        $this->evaluateExpressionCalls[] = array(
+            'expressions' => $expression,
+            'form_feature' => $form_feature,
+        );
+
+        return $this->evaluateExpressionReturn;
+    }
 }
 
 class jAcl2

--- a/tests/units/testslib/QgisLayerForTests.php
+++ b/tests/units/testslib/QgisLayerForTests.php
@@ -40,6 +40,11 @@ class QgisLayerForTests extends qgisVectorLayer
         $this->defaultValues = $default;
     }
 
+    public function setDefaultValuesApplyOnUpdate($map)
+    {
+        $this->defaultValuesApplyOnUpdate = $map;
+    }
+
     public function setProject($project)
     {
         $this->project = $project;


### PR DESCRIPTION
This PR aims to bring original QGIS behaviour for Lizmap. Default expressions set via "Attribute From" in QGIS did not work so far when either
a) a geometry expression was used (e.g. `$x`, `aggregate()` with filters based on geometry etc)
b) a nother field of the same layer was referenced ( `"firstname" || ' ' || "lastname"` )

With this PR following behaviour is introduced:

- Server-side (PHP): At form-open, dynamic default expressions are now batched into a single EXPRESSION/Evaluate call with form_scope=true and a form_feature GeoJSON payload containing the current geometry (from liz_geometryColumn) and field values. Literal/numeric defaults short-circuit this and are applied immediately without a server round-trip.
- New AJAX endpoint: GET/POST /edition/{repo}/{project}/{layerId}/evaluateDefaults — re-evaluates a specified set of default expressions given a geometry and current field values. Gated by the same ACL as the existing edition actions.
- Client-side (JS): Two triggers re-call the endpoint and fill the form:
  - Geometry change — fires after the user finishes drawing/moving a feature (lizmap.editionGeometryUpdated event from updateGeometryColumnFromFeature)
  - Referenced field change — a debounced change listener on each field that appears in another field's default expression

Fill policy matches QGIS Desktop:
On create: fill if the field is still empty
On modify: only fill if the QGIS attribute has applyOnUpdate=true; user-typed values are never overwritten


<img width="1900" height="1005" alt="DefaultExpression" src="https://github.com/user-attachments/assets/d0234b46-ab40-4b27-9237-27734bd75dd8" />
