### PR TITLE
Fix/Hide form filter export button without export permission

### DIFF
--- a/CHANGELOG-3.9.md
+++ b/CHANGELOG-3.9.md
@@ -43,6 +43,7 @@ with some extra keywords: backend, tests, test, translation, funders, important
 * Map - WMS baselayers from QGIS layers now proxy through QGIS Server
 * UI - Popup: place children features tables inside drag-and-drop relation
 * UI - Geolocation error
+* Filter - Hide the form filter panel export button when the user is not allowed to export the layer (#6642)
 
 ### Tests
 

--- a/assets/src/legacy/filter.js
+++ b/assets/src/legacy/filter.js
@@ -138,6 +138,13 @@ var lizLayerFilterTool = function () {
                 var layerName = getConfig[0];
                 globalThis['filterConfigData'].layerName = layerName;
 
+                // Only show the export button when the user is allowed to export this layer.
+                // Permission is computed server-side into attributeLayers.export_enabled (see #6642).
+                var layerExportEnabled = ('attributeLayers' in lizMap.config)
+                    && (layerName in lizMap.config.attributeLayers)
+                    && lizMap.config.attributeLayers[layerName].export_enabled == 'True';
+                $('#liz-filter-export').toggle(!!layerExportEnabled);
+
                 // Remove previous field inputs
                 $('div.liz-filter-field-box').remove();
 


### PR DESCRIPTION
The export button in the form filter panel was rendered solely based on ODS format availability, ignoring the layer export permissions that are already computed server-side into attributeLayers.export_enabled.

Toggle the button visibility per selected layer so it is hidden for users not allowed to export that layer, consistent with the attribute table.

Fixes #6642

