### PR TITLE
UI/bs5 polish

### DIFF
--- a/assets/src/components/SelectionTool.js
+++ b/assets/src/components/SelectionTool.js
@@ -162,14 +162,14 @@ export default class SelectionTool extends HTMLElement {
                     ></lizmap-digitizing>
                 <div class="selectiontool-buffer">
                     <label><span>${lizDict['selectiontool.toolbar.buffer']}</span>
-                        <div class="input-append">
+                        <div class="input-group input-group-sm">
                             <input
                                 type="number"
                                 min="0"
-                                class="form-control form-control-sm"
+                                class="form-control"
                                 .value="${mainLizmap.selectionTool.bufferValue}"
                                 @input=${(event) => mainLizmap.selectionTool.bufferValue = parseInt(event.target.value)}
-                                ><span class="add-on">m</span>
+                                ><span class="input-group-text">m</span>
                         </div>
                     </label>
                 </div>

--- a/assets/src/legacy/filter.js
+++ b/assets/src/legacy/filter.js
@@ -226,7 +226,7 @@ var lizLayerFilterTool = function () {
                 html += '">';
                 var flabel = field_item.title;
                 html += '<span style="font-weight:bold;">' + flabel + '</span>';
-                html += '<button class="btn btn-primary btn-sm pull-right liz-filter-reset-field" title="' + lizDict['filter.btn.reset.title'] + '" value="' + field_item.order + '">x</button>';
+                html += '<button class="btn btn-primary btn-sm pull-right liz-filter-reset-field" title="' + lizDict['filter.btn.reset.title'] + '" value="' + field_item.order + '"><i class="icon-remove icon-white"></i></button>';
                 html += '<p>';
 
                 return html;

--- a/lizmap/www/assets/css/filter.css
+++ b/lizmap/www/assets/css/filter.css
@@ -73,6 +73,13 @@ ul.ui-autocomplete.ui-menu {
 
 
 /*
+form filter: keep the reset button clear of the field title
+*/
+button.liz-filter-reset-field {
+  margin-left: 8px;
+}
+
+/*
 form filter: restrict the height of the combo box list filter view
 */
 div.liz-filter-field-box p {
@@ -81,6 +88,7 @@ div.liz-filter-field-box p {
   overflow-y: scroll;
   padding-left: 5px;
   clear: both;
+  margin-top: 8px;
 }
 
 div.liz-filter-field-box p label {

--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -2210,7 +2210,7 @@ lizmap-print .flex {
 #switcher-layers-actions div.btn-group > ul{
   left:auto;
   right:0;
-  max-height:90px;
+  max-height:300px;
   overflow-y:auto;
 }
 
@@ -3538,7 +3538,7 @@ img {
 /* Its icon is taller than the legacy icons in the neighbouring expand/collapse
    buttons; trim the vertical padding so all three buttons share the same height. */
 #theme-selector .btn {
-  --bs-btn-padding-y: 0.125rem;
+  --bs-btn-padding-y: 0.15rem;
 }
 
 /* Geolocation */

--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -19,6 +19,19 @@
   background-repeat:no-repeat
 }
 
+/* Icon-only buttons: the embedded sprite icon is a fixed size, so the button
+   must hug it instead of inheriting Bootstrap 5's text-button padding and 1.5
+   line-height (which made these buttons look oversized after the BS5 upgrade). */
+.btn:has(> [class^="icon-"]:only-child),
+.btn:has(> [class*=" icon-"]:only-child) {
+  --bs-btn-line-height: 1;
+  --bs-btn-padding-y: 0.25rem;
+  --bs-btn-padding-x: 0.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .icon-glass {
   background-position:0 0
 }
@@ -1880,6 +1893,16 @@ transform: none !important;
   padding-right:0.2em;
 }
 
+/* Space the draw button away from the layer selector above it. */
+#edition-creation #edition-draw {
+  margin-top: 6px;
+}
+
+/* Space the DXF export button away from the options above it. */
+lizmap-dxfexport .dxfexport-actions {
+  margin-top: 10px;
+}
+
 /* Right Dock */
 #right-dock {
   display: none;
@@ -3509,6 +3532,12 @@ img {
   height: 18px;
   background-size: auto 18px;
   background-position: -422px -5px;
+}
+
+/* Its icon is taller than the legacy icons in the neighbouring expand/collapse
+   buttons; trim the vertical padding so all three buttons share the same height. */
+#theme-selector .btn {
+  --bs-btn-padding-y: 0.125rem;
 }
 
 /* Geolocation */

--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -22,11 +22,12 @@
 /* Icon-only buttons: the embedded sprite icon is a fixed size, so the button
    must hug it instead of inheriting Bootstrap 5's text-button padding and 1.5
    line-height (which made these buttons look oversized after the BS5 upgrade). */
-.btn:has(> [class^="icon-"]:only-child),
-.btn:has(> [class*=" icon-"]:only-child) {
+.btn:not(.hide):has(> [class^="icon-"]:only-child),
+.btn:not(.hide):has(> [class*=" icon-"]:only-child) {
   --bs-btn-line-height: 1;
   --bs-btn-padding-y: 0.25rem;
   --bs-btn-padding-x: 0.25rem;
+
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -2109,6 +2109,7 @@ lizmap-print .flex {
   margin :  0;
   text-shadow: none;
   display:inline;
+  font-size: 12px;
 }
 
 .ui-autocomplete.ui-menu {
@@ -3828,6 +3829,11 @@ lizmap-treeview label {
   flex-grow: 1;
   margin: 0;
   display: inline;
+}
+
+/* Layer and group titles were noticeably smaller than surrounding UI text. */
+lizmap-treeview .node label {
+  font-size: 15px;
 }
 
 lizmap-treeview li.not-visible > div input[type="checkbox"],


### PR DESCRIPTION
Fixes/polishes several minor UI flaws
a) regarding buttonsizes (introduced by BS5)
b) font sizes
c) margins

**1. Legend (font size of layer names + Theme-Switcher/Expand/Collapse buttons):**
Before:
<img width="364" height="434" alt="Old_legend" src="https://github.com/user-attachments/assets/393fa4df-c090-478b-87c6-fe3fadc09d2c" />

After:
<img width="417" height="430" alt="New_legend" src="https://github.com/user-attachments/assets/dad8d2c3-91b8-4aa6-b39a-56144ac92a8a" />

**Edition (added margin, button size)**
Before:
<img width="235" height="229" alt="Old_Edition" src="https://github.com/user-attachments/assets/249b57a0-96c5-4314-abb3-fb9b3dc1f16a" />

After:
<img width="260" height="227" alt="New_Edition" src="https://github.com/user-attachments/assets/ea298103-6b5b-44ff-951c-4854dfc4a83b" />

**Filter (Margin before "X" button + below + button size)**
Before:
<img width="356" height="487" alt="Old_Filter" src="https://github.com/user-attachments/assets/15ade7a6-c8e3-4f39-bc4b-7fe25bd4f874" />

After:
<img width="372" height="420" alt="New_Filter" src="https://github.com/user-attachments/assets/f7a7503f-1a56-4a9f-bf1e-5977300248ce" />

**Selection-Tool PopUp (Button sizes)**
Before:
<img width="496" height="444" alt="Old_SelectionTool" src="https://github.com/user-attachments/assets/81a46f1b-ba3a-4082-a52a-a658f51ae729" />

After:
<img width="526" height="381" alt="New_Selection" src="https://github.com/user-attachments/assets/1d8ce213-1f02-4f27-a1df-81f8eac39956" />

**Locate by Layer (font size)**
New:
<img width="269" height="233" alt="New_LocationByLayer" src="https://github.com/user-attachments/assets/6dc1517c-61b3-4bbe-8717-2b8e18640936" />


**Theme Selector (List shows now up to ~10 selectable themes, depending on the overall Layer-List )** 
Fixes #6406
<img width="411" height="301" alt="grafik" src="https://github.com/user-attachments/assets/b05026da-1f53-446e-8693-f62ea8eca400" />


