### PR TITLE
Action - add actionStarted event

### DIFF
--- a/assets/src/modules/Action.js
+++ b/assets/src/modules/Action.js
@@ -419,6 +419,21 @@ export default class Action {
         options['mapExtent'] = WKTformat.writeGeometry(fromExtent(viewExtent), projOptions);
         options['mapCenter'] = WKTformat.writeGeometry(new Point(viewCenter), projOptions);
 
+        /**
+         * Lizmap event to allow other scripts to process the data if needed
+         * @event actionStarted
+         * @property {Objects} action Current action object
+         * @property {string} layerId Layer ID of the current layer
+         * @property {string} featureId Feature ID of the current feature
+         */
+        this._lizmap3.events.triggerEvent("actionStarted",
+            {
+                'action': action,
+                'layerId': layerId,
+                'featureId': featureId
+            }
+        );
+
         // Request action and get data
         let url = actionConfigData.url;
         try {


### PR DESCRIPTION
Useful to display a message or run code just after the user triggered the action.

Example:
```javascript
lizMap.events.on({

    actionStarted: function(e) {
        console.log('Action start')
    },
    
    actionResultReceived: function(e) {
        console.log('Action received')
    }
});
``` 

Funded by 3Liz
