### PR TITLE
[Backport release_3_10] Fix geometry type case mismatch in zoomToGeometryOrExtent function

### DIFF
--- a/assets/src/modules/map.js
+++ b/assets/src/modules/map.js
@@ -1185,9 +1185,10 @@ export default class map extends olMap {
         const geometryType = geometryOrExtent.getType?.();
         if (geometryType && (this._initialConfig.options.max_scale_lines_polygons || this._initialConfig.options.max_scale_points)) {
             let maxScale;
-            if (['Polygon', 'Linestring', 'MultiPolygon', 'MultiLinestring'].includes(geometryType)){
+            // Compare lowerCase geometry type
+            if (['polygon', 'linestring', 'multipolygon', 'multilinestring'].includes(geometryType.toLowerCase())){
                 maxScale = this._initialConfig.options.max_scale_lines_polygons;
-            } else if (['Point', 'MultiPoint'].includes(geometryType)){
+            } else if (['point', 'multipoint'].includes(geometryType.toLowerCase())){
                 maxScale = this._initialConfig.options.max_scale_points;
             }
             const resolution = Utils.getResolutionFromScale(


### PR DESCRIPTION
Backport #6877
 **Authored by:** @Elioooooott 