### PR TITLE
[Backport release_3_9] JS dependencies update ol, proj4, line-split and dotenv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1299,12 +1299,14 @@
       }
     },
     "node_modules/@turf/bbox": {
-      "version": "7.3.4",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.5.tgz",
+      "integrity": "sha512-oG1ya/HtBjAIg4TimbWx+nOYPbY0bCvt82Bq8tm6sBw3qqtbOyRSfDz79Sq90TnH7DXJprJ1qnVGKNtZ6jemfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
-        "@turf/meta": "7.3.4",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -1313,12 +1315,14 @@
       }
     },
     "node_modules/@turf/distance": {
-      "version": "7.3.4",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.5.tgz",
+      "integrity": "sha512-uQAC63zg/l91KUxzfhqio7Ii3+UXTrPOVJScIdRj6EO6+9XHI4kC+AdyIS4cPAv14sZfJLIBxzMnzcGrss+kEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
-        "@turf/invariant": "7.3.4",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -1327,13 +1331,15 @@
       }
     },
     "node_modules/@turf/geojson-rbush": {
-      "version": "7.3.4",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/geojson-rbush/-/geojson-rbush-7.3.5.tgz",
+      "integrity": "sha512-30/hQqc+ErnlcavvDdxGfgm8VtsJDEzSYpf3mPqYxOyI976l49T6+1jCQD5xKswml6o8zZAaTSe6ZcSKF+SCNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@turf/bbox": "7.3.4",
-        "@turf/helpers": "7.3.4",
-        "@turf/meta": "7.3.4",
+        "@turf/bbox": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "rbush": "^3.0.1",
         "tslib": "^2.8.1"
@@ -1343,7 +1349,9 @@
       }
     },
     "node_modules/@turf/helpers": {
-      "version": "7.3.4",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1355,11 +1363,13 @@
       }
     },
     "node_modules/@turf/invariant": {
-      "version": "7.3.4",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
+        "@turf/helpers": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -1368,11 +1378,13 @@
       }
     },
     "node_modules/@turf/line-intersect": {
-      "version": "7.3.4",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.3.5.tgz",
+      "integrity": "sha512-2Cl4oPsjaDdfIwz/5IRDdG2fNdfp3W6atICm81vnzl/GwURoVP+CLjXJ64QWWzpzIbgX2XprJQTmamByDt5MDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
+        "@turf/helpers": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "sweepline-intersections": "^1.5.0",
         "tslib": "^2.8.1"
@@ -1382,13 +1394,15 @@
       }
     },
     "node_modules/@turf/line-segment": {
-      "version": "7.3.4",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-7.3.5.tgz",
+      "integrity": "sha512-TM1aCu7utM6fllAEHO8PNqBJZ/uoFJVNp2A0YI7FyWN928hPbacsvNtLeVz/Kq1ZbeqQ1ZIKRxo9FdVjaj8hGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
-        "@turf/invariant": "7.3.4",
-        "@turf/meta": "7.3.4",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -1397,19 +1411,21 @@
       }
     },
     "node_modules/@turf/line-split": {
-      "version": "7.3.4",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-7.3.5.tgz",
+      "integrity": "sha512-GEuy+LdbbaqtYjHk/i1G8sK51wfCdPqTO8uH0dJZ6WlcIcZQfRcKKI4ksFm7NkVyfmw8gXWbpMJD8lO380GFBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@turf/bbox": "7.3.4",
-        "@turf/geojson-rbush": "7.3.4",
-        "@turf/helpers": "7.3.4",
-        "@turf/invariant": "7.3.4",
-        "@turf/line-intersect": "7.3.4",
-        "@turf/line-segment": "7.3.4",
-        "@turf/meta": "7.3.4",
-        "@turf/nearest-point-on-line": "7.3.4",
-        "@turf/truncate": "7.3.4",
+        "@turf/bbox": "7.3.5",
+        "@turf/geojson-rbush": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@turf/line-segment": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/nearest-point-on-line": "7.3.5",
+        "@turf/truncate": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -1418,11 +1434,13 @@
       }
     },
     "node_modules/@turf/meta": {
-      "version": "7.3.4",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
+        "@turf/helpers": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -1431,14 +1449,16 @@
       }
     },
     "node_modules/@turf/nearest-point-on-line": {
-      "version": "7.3.4",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.3.5.tgz",
+      "integrity": "sha512-MZn6OkEFZpjS6BNUANfqiHMIbQSivu7TNji3a+OAIrnPJ71vp8cbz0N2aVEa5M7I8ipvxoxAPIV3eqg3h280Vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@turf/distance": "7.3.4",
-        "@turf/helpers": "7.3.4",
-        "@turf/invariant": "7.3.4",
-        "@turf/meta": "7.3.4",
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -1447,12 +1467,14 @@
       }
     },
     "node_modules/@turf/truncate": {
-      "version": "7.3.4",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.3.5.tgz",
+      "integrity": "sha512-Qx2iv3KIqKuDAUduMfaJ5fFegEWBeRve5zePalRevS16bMUqEX+jnKPK9fWGyUuPqT61qP1Kybz0PTWPbUbljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@turf/helpers": "7.3.4",
-        "@turf/meta": "7.3.4",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -1533,6 +1555,8 @@
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1670,12 +1694,14 @@
       }
     },
     "node_modules/@zarrita/storage": {
-      "version": "0.1.4",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.2.0.tgz",
+      "integrity": "sha512-855ZXqtnds7spnT8vNvD+MXa3QExP1m2GqShe8yt7uZXHnQLgJHgkpVwFjE1B0KDDRO0ki09hmk6OboTaIfPsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "reference-spec-reader": "^0.2.0",
-        "unzipit": "1.4.3"
+        "unzipit": "2.0.0"
       }
     },
     "node_modules/accepts": {
@@ -2743,7 +2769,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.3.1",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -3296,7 +3324,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4728,6 +4758,8 @@
     },
     "node_modules/numcodecs": {
       "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.3.2.tgz",
+      "integrity": "sha512-6YSPnmZgg0P87jnNhi3s+FVLOcIn3y+1CTIgUulA3IdASzK9fJM87sUFkpyA+be9GibGRaST2wCgkD+6U+fWKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4756,16 +4788,18 @@
       "license": "MIT"
     },
     "node_modules/ol": {
-      "version": "10.8.0",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-10.9.0.tgz",
+      "integrity": "sha512-svbbgVQUmEHaKpLQ8kRySojs59Brvgl2zYIrqG9eQNXGfsbi55rQasZIDpwpQzDL6OlzrUb0H4hQaiX9wDoGmA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/rbush": "4.0.0",
         "earcut": "^3.0.0",
-        "geotiff": "^3.0.2",
+        "geotiff": "^3.0.5 || ^3.1.0-beta.0",
         "pbf": "4.0.1",
         "rbush": "^4.0.0",
-        "zarrita": "^0.6.0"
+        "zarrita": "^0.7.1"
       },
       "funding": {
         "type": "opencollective",
@@ -4799,17 +4833,6 @@
       "license": "MIT",
       "dependencies": {
         "quickselect": "^3.0.0"
-      }
-    },
-    "node_modules/ol/node_modules/zarrita": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.6.2.tgz",
-      "integrity": "sha512-8IV+2bWt5yiHNVK9GVEVK1tscpqDcJj8iz5cIKFOiWiWYUsK4V5njgMtnpkvKu6L7K+Og6zUShd8f+dwb6LvTA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@zarrita/storage": "^0.1.4",
-        "numcodecs": "^0.3.2"
       }
     },
     "node_modules/on-finished": {
@@ -5233,12 +5256,14 @@
       "license": "MIT"
     },
     "node_modules/proj4": {
-      "version": "2.20.4",
+      "version": "2.20.8",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.8.tgz",
+      "integrity": "sha512-1C8sfT4xY4PAPwk0MroFBTGF4R4bzDXdmPQTGYVLsoNssrZ9odzObxS2dTeGBty8jW8KO7h16C1Hs2JP+ctfFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "mgrs": "1.0.0",
-        "wkt-parser": "^1.5.3"
+        "wkt-parser": "^1.5.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ahocevar"
@@ -5346,6 +5371,8 @@
     },
     "node_modules/quickselect": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
       "dev": true,
       "license": "ISC"
     },
@@ -5381,6 +5408,8 @@
     },
     "node_modules/rbush": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5426,6 +5455,8 @@
     },
     "node_modules/reference-spec-reader": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
+      "integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6357,6 +6388,8 @@
     },
     "node_modules/sweepline-intersections": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz",
+      "integrity": "sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6463,6 +6496,8 @@
     },
     "node_modules/tinyqueue": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
       "dev": true,
       "license": "ISC"
     },
@@ -6591,14 +6626,13 @@
       }
     },
     "node_modules/unzipit": {
-      "version": "1.4.3",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-2.0.0.tgz",
+      "integrity": "sha512-DVeVIWUZCAQPNzm5sB0hpsG1GygTTdBnzNtYYEpInkttx5evkyqRgZi6rTczoySqp8hO5jHVKzrH0f23X8FZLg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "uzip-module": "^1.0.2"
-      },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/uri-js": {
@@ -6633,11 +6667,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/uzip-module": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -6858,9 +6887,14 @@
       "license": "MIT"
     },
     "node_modules/wkt-parser": {
-      "version": "1.5.4",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.5.5.tgz",
+      "integrity": "sha512-/zMYi94/7D7fxcOSlVmWn6vnOMj3Gq5d1xvVjaYOS9n6h0qOJ4I7YYVxBWYcH1vq9+suhqzXkn05Yx47zQNUIA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ahocevar"
+      }
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
@@ -7121,6 +7155,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zarrita": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.7.3.tgz",
+      "integrity": "sha512-wChTQ1Ox75INoQCzKAfLWAfB70JJ4KjdW8Sz5x4ZWrFB4Dw+YZdnxHTL0xSdsrB9EmKSeK7fS1Y+I2ibhfGbkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@zarrita/storage": "^0.2.0",
+        "numcodecs": "^0.3.2"
       }
     },
     "node_modules/zstddec": {


### PR DESCRIPTION
| package          | from   | to     |
|------------------|--------|--------|
| @turf/line-split |  7.3.4 |  7.3.5 |
| dotenv           | 17.3.1 | 17.4.2 |
| ol               | 10.8.0 | 10.9.0 |
| proj4            | 2.20.4 | 2.20.8 |
