### PR TITLE
fix(edition): persist read-only QGIS default-value expressions on save

### DIFF
--- a/CHANGELOG-3.10.md
+++ b/CHANGELOG-3.10.md
@@ -8,6 +8,10 @@ with some extra keywords: backend, tests, test, translation, funders, important
 
 ## Unreleased
 
+### Fixed
+
+* Edition - Persist dynamic default-value expressions on read-only fields (e.g. `$x`, `round($length, 2)`), which were evaluated but not saved
+
 ## 3.10.0-rc.1 - 2026-05-28
 
 ### Funders

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -830,13 +830,25 @@ class editionCtrl extends jController
         // And get returned primary key values
         $pkvals = null;
         if ($check) {
+            // Recompute dynamic defaults server-side: read-only controls don't
+            // receive their value from the request, so persist it here.
+            $appliedDefaults = $qgisForm->applyDynamicDefaultsBeforeSave();
+
             // Check if featureId is null to get all controls or only modified controls
             if ($this->featureId == null) {
                 // Save to database with all controls
                 $pkvals = $qgisForm->saveToDb($feature, $form->getControls());
             } else {
                 // Save to database with modified controls
-                $pkvals = $qgisForm->saveToDb($feature, $form->getModifiedControls());
+                $modifiedControls = $form->getModifiedControls();
+                // Persist applied defaults even if the user didn't touch them.
+                foreach ($appliedDefaults as $appliedRef) {
+                    $appliedCtrl = $form->getControl($appliedRef);
+                    if ($appliedCtrl !== null) {
+                        $modifiedControls[$appliedRef] = $appliedCtrl;
+                    }
+                }
+                $pkvals = $qgisForm->saveToDb($feature, $modifiedControls);
             }
         }
 

--- a/lizmap/modules/lizmap/lib/Form/QgisForm.php
+++ b/lizmap/modules/lizmap/lib/Form/QgisForm.php
@@ -717,6 +717,52 @@ class QgisForm implements QgisFormControlsInterface
     }
 
     /**
+     * Re-evaluate dynamic default expressions server-side and inject them before save.
+     *
+     * Read-only controls are skipped by jForms::initFromRequest(), so a value
+     * filled client-side is dropped. Recompute it here, like QGIS at commit time.
+     * Fill policy: insert fills empty fields only; update only applyOnUpdate ones.
+     *
+     * Must run after jForms::initFromRequest().
+     *
+     * @return string[] field references whose value was set (to persist on update)
+     */
+    public function applyDynamicDefaultsBeforeSave()
+    {
+        if (!$this->dbFieldsInfo || !$this->dynamicDefaultExpressions) {
+            return array();
+        }
+
+        $form = $this->form;
+        // Non-empty featureId means update, like saveToDb().
+        $isUpdate = (bool) $this->featureId;
+        $evaluated = $this->evaluateDefaultExpressions($this->dynamicDefaultExpressions);
+
+        $applied = array();
+        foreach ($evaluated as $ref => $value) {
+            $applyOnUpdate = isset($this->defaultApplyOnUpdateMap[$ref])
+                && $this->defaultApplyOnUpdateMap[$ref] === true;
+
+            if ($isUpdate) {
+                if (!$applyOnUpdate) {
+                    continue;
+                }
+            } else {
+                // Don't overwrite a value the user entered.
+                $cur = $form->getData($ref);
+                if (!($cur === '' || $cur === array())) {
+                    continue;
+                }
+            }
+
+            $form->setData($ref, $value);
+            $applied[] = $ref;
+        }
+
+        return $applied;
+    }
+
+    /**
      * Set the form controls data from the database value.
      *
      * @param mixed $feature


### PR DESCRIPTION
Read-only form controls never receive their value from the request: jFormsBase::initFromRequest() skips them on purpose, so a dynamic default (e.g. \ or round(\, 2)) rendered into a non-editable widget was filled client-side for display but silently dropped on save, persisting NULL instead.

Re-evaluate the dynamic default expressions server-side just before saving, using the posted geometry and field values as context, and inject the result into the form data. This mirrors QGIS Desktop, which evaluates such defaults at commit time regardless of widget editability.

Fill policy: on insert, only fill fields left empty; on update, only re-evaluate fields flagged applyOnUpdate. Applied fields are added to the controls persisted on update so they are written even when untouched.
