### PR TITLE
fix(map): close measure & geolocation minidocks via native click

### DIFF
--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -795,9 +795,8 @@ window.lizMap = function() {
 
         if (('geolocation' in configOptions)
       && configOptions['geolocation'] == 'True'){
-            $('#geolocation button.btn-geolocation-close').click(function () {
-                $('#button-geolocation').click();
-                return false;
+            document.querySelector('#geolocation button.btn-geolocation-close').addEventListener('click', () => {
+                document.getElementById('button-geolocation').click();
             });
         }
 
@@ -1940,8 +1939,8 @@ window.lizMap = function() {
             }
         });
 
-        $('#measure-stop').click(function(){
-            $('#button-measure').click();
+        document.getElementById('measure-stop').addEventListener('click', () => {
+            document.getElementById('button-measure').click();
         });
 
         return measureControls;


### PR DESCRIPTION
The #mapmenu .nav click handler was refactored to native addEventListener, but the X buttons on the measure (#measure-stop) and geolocation (.btn-geolocation-close) minidocks still triggered the toggle via jQuery .click(). jQuery's .trigger()/.click() does not dispatch a real DOM event to native listeners, so the close became a silent no-op. Switch both handlers to native addEventListener + HTMLElement.click().
