### PR TITLE
Actions - Add the ability to send dynamic parameters from JavaScript

### DIFF
--- a/assets/src/modules/Action.js
+++ b/assets/src/modules/Action.js
@@ -375,7 +375,7 @@ export default class Action {
      * @param {string} wkt - An optional geometry in WKT format and project EPSG:4326
      * @returns {boolean} - If the action was successful
      */
-    async runLizmapAction(actionName, scope = this.Scopes.Feature, layerId = null, featureId = null, wkt = null) {
+    async runLizmapAction(actionName, scope = this.Scopes.Feature, layerId = null, featureId = null, wkt = null, options = null) {
         if (!this.hasActions) {
             return false;
         }
@@ -404,11 +404,16 @@ export default class Action {
         }
 
         // Set the request parameters
-        let options = {
+        let parameters = {
             "layerId": layerId,
             "featureId": featureId,
             "name": actionName,
             "wkt": wkt
+        };
+
+        // add options to parameters
+        if (options) {
+            parameters['options'] = options
         };
 
         const viewExtent = this._map.getView().calculateExtent();
@@ -416,8 +421,8 @@ export default class Action {
 
         // We add the map extent and center
         // as WKT geometries
-        options['mapExtent'] = WKTformat.writeGeometry(fromExtent(viewExtent), projOptions);
-        options['mapCenter'] = WKTformat.writeGeometry(new Point(viewCenter), projOptions);
+        parameters['mapExtent'] = WKTformat.writeGeometry(fromExtent(viewExtent), projOptions);
+        parameters['mapCenter'] = WKTformat.writeGeometry(new Point(viewCenter), projOptions);
 
         /**
          * Lizmap event to allow other scripts to process the data if needed
@@ -442,7 +447,7 @@ export default class Action {
                 headers: {
                     'Content-Type': 'application/json;charset=utf-8'
                 },
-                body: JSON.stringify(options)
+                body: JSON.stringify(parameters)
             });
 
             // Parse the data

--- a/lizmap/modules/action/controllers/service.classic.php
+++ b/lizmap/modules/action/controllers/service.classic.php
@@ -164,7 +164,6 @@ class serviceCtrl extends jController
 
         // Compute the parameters to pass to the PostgreSQL action function
         // depending on the scope and given parameters
-        $data = array();
         $action_params = array(
             'lizmap_repository' => $repository,
             'lizmap_project' => $project,
@@ -192,23 +191,58 @@ class serviceCtrl extends jController
             $action_params['feature_id'] = $featureId;
         }
 
-        // Get the additional options from the JSON config file
-        // Not for any requests parameters !!!
-        foreach ($action->options as $k => $v) {
-            $action_params[$k] = $v;
+        // Run the action
+        $i = 1;
+        $sqlParts = array();
+        $sqlValues = array();
+        foreach ($action_params as $key => $value) {
+            $caster = ($key == 'feature_id') ? 'integer' : 'text';
+            $sqlParts[] = "'{$key}', (\${$i})::{$caster}";
+            $sqlValues[] = $value;
+            ++$i;
         }
 
-        // Run the action
-        $sql = "SELECT lizmap_get_data('";
-        $sql .= json_encode($action_params);
-        $sql .= "') AS data";
+        // Get the additional options from the JSON config file
+        // We need to be cautious with this values as they are sent from the client
+        $options = $this->param('options');
+        foreach ($action->options as $key => $config_value) {
+            $sqlParts[] = "'{$key}', (\${$i})::text";
+            $sqlValues[] = $options[$key] ?: $config_value;
+            ++$i;
+        }
 
+        $sql = '
+            SELECT public.lizmap_get_data(
+                json_build_object(
+                '.implode(",\n", $sqlParts).'
+                )
+            ) AS data
+        ';
+        jLog::log(
+            "SQL =
+            {$sql}"
+        );
+
+        // Prepare returned data
+        $resultset = null;
+
+        // Start SQL transaction
+        $cnx->beginTransaction();
+
+        // Run the lizmap_get_data function with a prepared statement
+        // to avoid SQL injections
+        // $sql = "SELECT json_build_object('un', $1::text, 'deux', $2::text)";
         try {
-            $res = $cnx->query($sql);
-            foreach ($res as $r) {
-                $data = json_decode($r->data);
+            $resultset = $cnx->prepare($sql);
+            $execute = $resultset->execute($sqlValues);
+            if ($resultset && $resultset->id() === false) {
+                $errorCode = $cnx->errorCode();
+
+                throw new Exception($errorCode);
             }
+            $cnx->commit();
         } catch (Exception $e) {
+            $cnx->rollback();
             jLog::log(
                 'Error in project '.$repository.'/'.$project.', layer '.$layerId.', '.
                 'while running the action with the PostgreSQL query : '.$sql.' → '.$e->getMessage(),
@@ -220,6 +254,14 @@ class serviceCtrl extends jController
             );
 
             return $this->error($errors);
+        }
+        $data = array();
+        if ($resultset !== null) {
+            foreach ($resultset as $r) {
+                if ($r->data) {
+                    $data = json_decode($r->data);
+                }
+            }
         }
 
         // Send response

--- a/lizmap/modules/action/controllers/service.classic.php
+++ b/lizmap/modules/action/controllers/service.classic.php
@@ -1,5 +1,6 @@
 <?php
 
+use Lizmap\ActionQuery\ActionQuery;
 use Lizmap\App\WktTools;
 use Lizmap\Project\UnknownLizmapProjectException;
 
@@ -162,106 +163,35 @@ class serviceCtrl extends jController
             }
         }
 
-        // Compute the parameters to pass to the PostgreSQL action function
-        // depending on the scope and given parameters
-        $action_params = array(
-            'lizmap_repository' => $repository,
-            'lizmap_project' => $project,
-            'action_name' => $actionName,
-            'action_scope' => $scope,
-            'layer_name' => null,
-            'layer_schema' => null,
-            'layer_table' => null,
-            'feature_id' => null,
-            'map_center' => $mapCenter,
-            'map_extent' => $mapExtent,
-            'wkt' => $wkt,
+        // Build and run the action query
+        $actionQuery = new ActionQuery($cnx, $repository, $project, $layerId, lizmap::getAppContext());
+
+        $action_params = $actionQuery->buildParams(
+            $actionName,
+            $scope,
+            $qgisLayer,
+            $featureId,
+            $wkt,
+            $mapCenter,
+            $mapExtent
         );
-
-        // Add the user login
-        $action_params['user_login'] = (jAuth::isConnected()) ? jAuth::getUserSession()->login : 'anonymous';
-
-        // If the scope is layer or feature, add the layer parameters
-        if ($qgisLayer && in_array($scope, array('layer', 'feature'))) {
-            $layerName = $qgisLayer->getName();
-            $layerDatasource = $qgisLayer->getDatasourceParameters();
-            $action_params['layer_name'] = str_replace("'", "''", $layerName);
-            $action_params['layer_schema'] = $layerDatasource->schema;
-            $action_params['layer_table'] = $layerDatasource->tablename;
-            $action_params['feature_id'] = $featureId;
-        }
-
-        // Run the action
-        $i = 1;
-        $sqlParts = array();
-        $sqlValues = array();
-        foreach ($action_params as $key => $value) {
-            $caster = ($key == 'feature_id') ? 'integer' : 'text';
-            $sqlParts[] = "'{$key}', (\${$i})::{$caster}";
-            $sqlValues[] = $value;
-            ++$i;
-        }
 
         // Get the additional options from the JSON config file
-        // We need to be cautious with this values as they are sent from the client
-        $options = $this->param('options');
-        foreach ($action->options as $key => $config_value) {
-            $sqlParts[] = "'{$key}', (\${$i})::text";
-            $sqlValues[] = $options[$key] ?: $config_value;
-            ++$i;
-        }
+        // We need to be cautious with these values as they are sent from the client
+        $options = $this->param('options') ?? array();
+        list($sql, $sqlValues) = $actionQuery->buildSql($action_params, $action, $options);
 
-        $sql = '
-            SELECT public.lizmap_get_data(
-                json_build_object(
-                '.implode(",\n", $sqlParts).'
-                )
-            ) AS data
-        ';
-        jLog::log(
-            "SQL =
-            {$sql}"
-        );
+        jLog::log("SQL =\n{$sql}");
 
-        // Prepare returned data
-        $resultset = null;
-
-        // Start SQL transaction
-        $cnx->beginTransaction();
-
-        // Run the lizmap_get_data function with a prepared statement
-        // to avoid SQL injections
-        // $sql = "SELECT json_build_object('un', $1::text, 'deux', $2::text)";
         try {
-            $resultset = $cnx->prepare($sql);
-            $execute = $resultset->execute($sqlValues);
-            if ($resultset && $resultset->id() === false) {
-                $errorCode = $cnx->errorCode();
-
-                throw new Exception($errorCode);
-            }
-            $cnx->commit();
+            $data = $actionQuery->execute($sql, $sqlValues);
         } catch (Exception $e) {
-            $cnx->rollback();
-            jLog::log(
-                'Error in project '.$repository.'/'.$project.', layer '.$layerId.', '.
-                'while running the action with the PostgreSQL query : '.$sql.' → '.$e->getMessage(),
-                'lizmapadmin'
-            );
             $errors = array(
                 'title' => 'An error occurred while processing the request',
                 'detail' => 'Please contact the GIS administrator to look to the administrator logs.',
             );
 
             return $this->error($errors);
-        }
-        $data = array();
-        if ($resultset !== null) {
-            foreach ($resultset as $r) {
-                if ($r->data) {
-                    $data = json_decode($r->data);
-                }
-            }
         }
 
         // Send response

--- a/lizmap/modules/filter/classes/filterDatasource.class.php
+++ b/lizmap/modules/filter/classes/filterDatasource.class.php
@@ -1,5 +1,7 @@
 <?php
 
+use Lizmap\App\SqlTools;
+
 /**
  * Manage and give access to lizmap configuration.
  *
@@ -25,20 +27,6 @@ class filterDatasource
     private $lproj;
     private $config;
     private $data;
-
-    protected $blockSqlWords = array(
-        ';',
-        'select',
-        'delete',
-        'insert',
-        'update',
-        'drop',
-        'alter',
-        '--',
-        'truncate',
-        'vacuum',
-        'create',
-    );
 
     public function __construct($repository, $project, $layerId)
     {
@@ -87,9 +75,9 @@ class filterDatasource
         if ($this->provider != 'postgres') {
             $filter = str_replace(' ILIKE ', ' LIKE ', $filter);
         }
-        $block_items = array();
 
-        if (preg_match('#'.implode('|', $this->blockSqlWords).'#i', $filter, $block_items)) {
+        [$validFilter, $block_items] = SqlTools::validateExpressionFilter($filter);
+        if (!$validFilter) {
             jLog::log('The EXP_FILTER param contains dangerous chars : '.implode(', ', $block_items), 'lizmapadmin');
 
             return null;

--- a/lizmap/modules/lizmap/lib/ActionQuery/ActionQuery.php
+++ b/lizmap/modules/lizmap/lib/ActionQuery/ActionQuery.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Lizmap\ActionQuery;
+
+use Lizmap\App\AppContextInterface;
+use Lizmap\App\SqlTools;
+
+class ActionQuery
+{
+    /** @var \jDbConnection */
+    private $cnx;
+    private AppContextInterface $appContext;
+
+    private string $repository;
+    private string $project;
+    private string $layerId;
+
+    public function __construct($cnx, string $repository, string $project, string $layerId, AppContextInterface $appContext)
+    {
+        $this->cnx = $cnx;
+        $this->repository = $repository;
+        $this->project = $project;
+        $this->layerId = $layerId;
+        $this->appContext = $appContext;
+    }
+
+    /**
+     * Build the parameter array passed as a JSON object to lizmap_get_data.
+     *
+     * @param string                $scope     project|layer|feature
+     * @param null|\qgisVectorLayer $qgisLayer
+     * @param int|string            $featureId
+     *
+     * @return array<string, null|int|string>
+     */
+    public function buildParams(
+        string $actionName,
+        string $scope,
+        $qgisLayer,
+        $featureId,
+        string $wkt,
+        string $mapCenter,
+        string $mapExtent
+    ): array {
+        $params = array(
+            'lizmap_repository' => $this->repository,
+            'lizmap_project' => $this->project,
+            'action_name' => $actionName,
+            'action_scope' => $scope,
+            'layer_name' => null,
+            'layer_schema' => null,
+            'layer_table' => null,
+            'feature_id' => null,
+            'map_center' => $mapCenter,
+            'map_extent' => $mapExtent,
+            'wkt' => $wkt,
+        );
+
+        $params['user_login'] = $this->appContext->userIsConnected() ? $this->appContext->getUserSession()->login : 'anonymous';
+
+        if ($qgisLayer && in_array($scope, array('layer', 'feature'))) {
+            $layerDatasource = $qgisLayer->getDatasourceParameters();
+            $params['layer_name'] = $qgisLayer->getName();
+            $params['layer_schema'] = $layerDatasource->schema;
+            $params['layer_table'] = $layerDatasource->tablename;
+            $params['feature_id'] = $featureId;
+        }
+
+        return $params;
+    }
+
+    /**
+     * Build the SQL string and the ordered values list for the prepared statement.
+     *
+     * @param array<string, null|int|string> $params        Output of buildParams()
+     * @param object                         $action        Action config object (must expose ->options)
+     * @param array<string, mixed>           $clientOptions Options sent by the client
+     *
+     * @return array{0: string, 1: list<mixed>} [$sql, $sqlValues]
+     */
+    public function buildSql(array $params, object $action, array $clientOptions): array
+    {
+        $i = 1;
+        $sqlParts = array();
+        $sqlValues = array();
+
+        foreach ($params as $key => $value) {
+            $caster = ($key === 'feature_id') ? 'integer' : 'text';
+            $sqlParts[] = "'{$key}', (\${$i})::{$caster}";
+            $sqlValues[] = $value;
+            ++$i;
+        }
+
+        foreach ($action->options as $key => $configValue) {
+            $sqlParts[] = "'{$key}', (\${$i})::text";
+            $clientValue = $clientOptions[$key] ?? '';
+            [$validFilter, $block_items] = SqlTools::validateExpressionFilter($clientValue);
+            if ($clientValue && $validFilter) {
+                $sqlValues[] = $clientValue;
+            } else {
+                $this->appContext->logMessage(
+                    'Choose the config value because the client option param contains dangerous chars : '.implode(', ', $block_items),
+                    'lizmapadmin'
+                );
+                $sqlValues[] = $configValue;
+            }
+            ++$i;
+        }
+
+        $sql = '
+            SELECT public.lizmap_get_data(
+                json_build_object(
+                '.implode(",\n", $sqlParts).'
+                )
+            ) AS data
+        ';
+
+        return array($sql, $sqlValues);
+    }
+
+    /**
+     * Execute the prepared statement inside a transaction and return the decoded data.
+     *
+     * @param list<mixed> $sqlValues
+     *
+     * @return mixed Decoded JSON data returned by lizmap_get_data
+     *
+     * @throws \Exception on query failure (after rollback + log)
+     */
+    public function execute(string $sql, array $sqlValues)
+    {
+        $this->cnx->beginTransaction();
+
+        try {
+            $resultset = $this->cnx->prepare($sql);
+            $resultset->execute($sqlValues);
+            if ($resultset->id() === false) {
+                throw new \Exception($this->cnx->errorCode());
+            }
+            $this->cnx->commit();
+        } catch (\Exception $e) {
+            $this->cnx->rollback();
+            $this->appContext->logMessage(
+                'Error in project '.$this->repository.'/'.$this->project.
+                ', layer '.$this->layerId.
+                ', while running the action with the PostgreSQL query : '.$sql.' → '.$e->getMessage(),
+                'lizmapadmin'
+            );
+
+            throw $e;
+        }
+
+        $data = array();
+        foreach ($resultset as $r) {
+            if ($r->data) {
+                $data = json_decode($r->data);
+            }
+        }
+
+        return $data;
+    }
+}

--- a/lizmap/modules/lizmap/lib/App/SqlTools.php
+++ b/lizmap/modules/lizmap/lib/App/SqlTools.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Lizmap\App;
+
+class SqlTools
+{
+    protected static $blockSqlWords = array(
+        ';',
+        'select',
+        'delete',
+        'insert',
+        'update',
+        'drop',
+        'alter',
+        '--',
+        'truncate',
+        'vacuum',
+        'create',
+        'reindex',
+        'grant',
+        'revoke',
+        '/*',
+    );
+
+    /**
+     * Validate an expression filter.
+     *
+     * @param string $filter The expression filter to validate
+     *
+     * @return array{0: bool, 1: list<string>} returns if the expression does not contains dangerous chars, and the list of blocked items
+     */
+    public static function validateExpressionFilter(string $filter): array
+    {
+        $block_items = array();
+        $pattern = '#'.implode('|', array_map(fn ($w): string => preg_quote($w, '#'), static::$blockSqlWords)).'#i';
+
+        return array(!preg_match($pattern, $filter, $block_items), $block_items);
+    }
+}

--- a/lizmap/modules/lizmap/lib/Request/WFSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WFSRequest.php
@@ -13,6 +13,8 @@
 
 namespace Lizmap\Request;
 
+use Lizmap\App\SqlTools;
+
 /**
  * @see https://en.wikipedia.org/wiki/Web_Feature_Service.
  */
@@ -45,23 +47,6 @@ class WFSRequest extends OGCRequest
      * @var string[] the fields to select
      */
     protected $selectFields = array();
-
-    /**
-     * @var string[] words blocked in SQL queries
-     */
-    protected $blockSqlWords = array(
-        ';',
-        'select',
-        'delete',
-        'insert',
-        'update',
-        'drop',
-        'alter',
-        '--',
-        'truncate',
-        'vacuum',
-        'create',
-    );
 
     /**
      * @var array<string, string> Generic GetFeature request parameters
@@ -654,11 +639,20 @@ class WFSRequest extends OGCRequest
             $expFilter = '$id IN ('.implode(', ', $pks).')';
         }
 
-        if ($expFilter && $this->validateExpressionFilter($expFilter)) {
-            return $expFilter;
+        if (!$expFilter) {
+            return '';
+        }
+        [$validFilter, $block_items] = SqlTools::validateExpressionFilter($expFilter);
+        if (!$validFilter) {
+            $this->appContext->logMessage(
+                'The EXP_FILTER param contains dangerous chars : '.implode(', ', $block_items),
+                'lizmapadmin'
+            );
+
+            return '';
         }
 
-        return '';
+        return $expFilter;
     }
 
     /**
@@ -1145,25 +1139,6 @@ class WFSRequest extends OGCRequest
     }
 
     /**
-     * Validate an expression filter.
-     *
-     * @param string $filter The expression filter to validate
-     *
-     * @return bool returns if the expression does not contains dangerous chars
-     */
-    protected function validateExpressionFilter(string $filter): bool
-    {
-        $block_items = array();
-        if (preg_match('#'.implode('|', $this->blockSqlWords).'#i', $filter, $block_items)) {
-            $this->appContext->logMessage('The EXP_FILTER param contains dangerous chars : '.implode(', ', $block_items), 'lizmadmin');
-
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
      * Parses and validate a filter for postgresql.
      *
      * @param string $filter The filter to parse
@@ -1172,7 +1147,13 @@ class WFSRequest extends OGCRequest
      */
     protected function validateFilter(string $filter): false|string
     {
-        if (!$this->validateExpressionFilter($filter)) {
+        [$validFilter, $block_items] = SqlTools::validateExpressionFilter($filter);
+        if (!$validFilter) {
+            $this->appContext->logMessage(
+                'The EXP_FILTER param contains dangerous chars : '.implode(', ', $block_items),
+                'lizmapadmin'
+            );
+
             return false;
         }
         $vfilter = str_replace('intersects', 'ST_Intersects', $filter);

--- a/tests/units/classes/Action/ActionQueryTest.php
+++ b/tests/units/classes/Action/ActionQueryTest.php
@@ -1,0 +1,293 @@
+<?php
+
+use Lizmap\ActionQuery\ActionQuery;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+class ActionQueryTest extends TestCase
+{
+    // =========================================================
+    // Helpers
+    // =========================================================
+
+    /**
+     * Fake DB connection that does nothing. Enough for tests that only call
+     * buildParams() or buildSql(), which never touch the connection.
+     */
+    private function makeActionQuery(): ActionQuery
+    {
+        return new ActionQuery($this->fakeCnx(), 'repo', 'proj', '', new ContextForTests());
+    }
+
+    private function fakeCnx(): object
+    {
+        return new class() {
+            public function beginTransaction(): void {}
+
+            public function commit(): void {}
+
+            public function rollback(): void {}
+
+            public function errorCode(): string
+            {
+                return '';
+            }
+
+            public function prepare(string $sql): object
+            {
+                return new class() implements Iterator {
+                    private int $pos = 0;
+
+                    public function execute(array $v): void {}
+
+                    public function id(): int
+                    {
+                        return 1;
+                    }
+
+                    public function current(): mixed
+                    {
+                        return (object) array('data' => '[]');
+                    }
+
+                    public function key(): int
+                    {
+                        return 0;
+                    }
+
+                    public function next(): void
+                    {
+                        ++$this->pos;
+                    }
+
+                    public function rewind(): void
+                    {
+                        $this->pos = 0;
+                    }
+
+                    public function valid(): bool
+                    {
+                        return false; // no rows
+                    }
+                };
+            }
+        };
+    }
+
+    /**
+     * Minimal layer stub.
+     */
+    private function fakeLayer(string $name, string $schema = 'public', string $table = 'mytable'): object
+    {
+        return new class($name, $schema, $table) {
+            public function __construct(
+                private string $name,
+                private string $schema,
+                private string $table,
+            ) {}
+
+            public function getName(): string
+            {
+                return $this->name;
+            }
+
+            public function getDatasourceParameters(): object
+            {
+                return (object) array('schema' => $this->schema, 'tablename' => $this->table);
+            }
+        };
+    }
+
+    // =========================================================
+    // buildParams()
+    // =========================================================
+
+    public function testBuildParamsBaseFieldsAreSet(): void
+    {
+        $aq = $this->makeActionQuery();
+
+        $params = $aq->buildParams('myaction', 'scope', null, null, 'WKT', 'CENTER', 'EXTENT');
+
+        $this->assertEquals('repo', $params['lizmap_repository']);
+        $this->assertEquals('proj', $params['lizmap_project']);
+        $this->assertEquals('myaction', $params['action_name']);
+        $this->assertEquals('scope', $params['action_scope']);
+        $this->assertEquals('WKT', $params['wkt']);
+        $this->assertEquals('CENTER', $params['map_center']);
+        $this->assertEquals('EXTENT', $params['map_extent']);
+        // jAuth not connected in test env -> falls back to anonymous
+        $this->assertEquals('anonymous', $params['user_login']);
+    }
+
+    public function testBuildParamsProjectScopeIgnoresLayer(): void
+    {
+        $aq = $this->makeActionQuery();
+        $layer = $this->fakeLayer('MyLayer');
+
+        // Even when a layer is passed, scope=project must leave layer fields null
+        $params = $aq->buildParams('act', 'project', $layer, 42, '', '', '');
+
+        $this->assertNull($params['layer_name']);
+        $this->assertNull($params['layer_schema']);
+        $this->assertNull($params['layer_table']);
+        $this->assertNull($params['feature_id']);
+    }
+
+    public function testBuildParamsLayerScopeFillsLayerInfo(): void
+    {
+        $aq = $this->makeActionQuery();
+        $layer = $this->fakeLayer('MyLayer', 'myschema', 'mytable');
+
+        $params = $aq->buildParams('act', 'layer', $layer, null, '', '', '');
+
+        $this->assertEquals('MyLayer', $params['layer_name']);
+        $this->assertEquals('myschema', $params['layer_schema']);
+        $this->assertEquals('mytable', $params['layer_table']);
+    }
+
+    public function testBuildParamsFeatureScopeIncludesFeatureId(): void
+    {
+        $aq = $this->makeActionQuery();
+        $layer = $this->fakeLayer('MyLayer');
+
+        $params = $aq->buildParams('act', 'feature', $layer, 99, '', '', '');
+
+        $this->assertEquals(99, $params['feature_id']);
+    }
+
+    // public function testBuildParamsLayerNameSingleQuoteIsDoubled(): void
+    // {
+    //     $aq = $this->makeActionQuery();
+    //     $layer = $this->fakeLayer("L'île"); // single quote in name
+
+    //     $params = $aq->buildParams('act', 'layer', $layer, null, '', '', '');
+
+    //     // SQL-safe escaping: ' → ''
+    //     $this->assertEquals("L''île", $params['layer_name']);
+    // }
+
+    // =========================================================
+    // buildSql()
+    // =========================================================
+
+    public function testBuildSqlStructureContainsLizmapGetData(): void
+    {
+        $aq = $this->makeActionQuery();
+
+        [$sql] = $aq->buildSql(array('lizmap_repository' => 'repo'), (object) array('options' => array()), array());
+
+        $this->assertStringContainsString('public.lizmap_get_data', $sql);
+        $this->assertStringContainsString('json_build_object', $sql);
+    }
+
+    public function testBuildSqlFeatureIdCastAsInteger(): void
+    {
+        $aq = $this->makeActionQuery();
+        // feature_id key should be integer
+        $params = array('feature_id' => 42);
+
+        [$sql] = $aq->buildSql($params, (object) array('options' => array()), array());
+
+        $this->assertStringContainsString("'feature_id', (\$1)::integer", $sql);
+    }
+
+    public function testBuildSqlTextParamCastAsText(): void
+    {
+        $aq = $this->makeActionQuery();
+        $params = array('layer_name' => 'MyLayer');
+
+        [$sql] = $aq->buildSql($params, (object) array('options' => array()), array());
+
+        $this->assertStringContainsString("'layer_name', (\$1)::text", $sql);
+    }
+
+    public function testBuildSqlPlaceholderIndexIncrements(): void
+    {
+        $aq = $this->makeActionQuery();
+        $params = array('layer_name' => 'foo', 'feature_id' => 5);
+
+        [$sql] = $aq->buildSql($params, (object) array('options' => array()), array());
+
+        $this->assertStringContainsString('$1', $sql);
+        $this->assertStringContainsString('$2', $sql);
+        $this->assertStringNotContainsString('$3', $sql);
+    }
+
+    public function testBuildSqlValuesMatchParamsInOrder(): void
+    {
+        $aq = $this->makeActionQuery();
+        $params = array('lizmap_repository' => 'repo', 'lizmap_project' => 'proj');
+
+        [, $values] = $aq->buildSql($params, (object) array('options' => array()), array());
+
+        $this->assertSame(array('repo', 'proj'), $values);
+    }
+
+    public function testBuildSqlTotalValuesCountEqualsParamsPlusOptions(): void
+    {
+        $aq = $this->makeActionQuery();
+        $params = array('lizmap_repository' => 'repo', 'feature_id' => 1);
+        $action = (object) array('options' => array('filter_a' => 'default_a', 'filter_b' => 'default_b'));
+        $clientOptions = array('filter_a' => 'val_a', 'filter_b' => 'val_b');
+
+        [, $values] = $aq->buildSql($params, $action, $clientOptions);
+
+        $this->assertCount(4, $values); // 2 params + 2 options
+    }
+
+    public function testBuildSqlValidClientOptionOverridesConfigDefault(): void
+    {
+        $aq = $this->makeActionQuery();
+        $action = (object) array('options' => array('my_filter' => 'default_value'));
+        $clientOptions = array('my_filter' => 'client_value');
+
+        [, $values] = $aq->buildSql(array(), $action, $clientOptions);
+
+        $this->assertEquals('client_value', $values[0]);
+    }
+
+    public function testBuildSqlEmptyClientOptionFallsBackToConfigDefault(): void
+    {
+        $aq = $this->makeActionQuery();
+        $action = (object) array('options' => array('my_filter' => 'safe_default'));
+        $clientOptions = array('my_filter' => '');
+
+        [, $values] = $aq->buildSql(array(), $action, $clientOptions);
+
+        $this->assertEquals('safe_default', $values[0]);
+    }
+
+    public static function sqlInjectionProvider(): array
+    {
+        return array(
+            'semicolon' => array('; DROP TABLE users; --'),
+            'select statement' => array('select * from users'),
+            'delete statement' => array('delete from users'),
+            'update statement' => array('update users set x=1'),
+            'comment block open' => array('/* comment */'),
+            'double dash' => array('-- comment'),
+            'truncate' => array('truncate table users'),
+        );
+    }
+
+    #[DataProvider('sqlInjectionProvider')]
+    public function testBuildSqlInjectionAttemptFallsBackToConfigDefault(string $maliciousInput): void
+    {
+        $aq = $this->makeActionQuery();
+        $action = (object) array('options' => array('my_filter' => 'safe_default'));
+        $clientOptions = array('my_filter' => $maliciousInput);
+
+        [, $values] = $aq->buildSql(array(), $action, $clientOptions);
+
+        $this->assertEquals(
+            'safe_default',
+            $values[0],
+            "Malicious input «{$maliciousInput}» should have been rejected",
+        );
+    }
+}

--- a/tests/units/classes/App/SqlToolsTest.php
+++ b/tests/units/classes/App/SqlToolsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use Lizmap\App\SqlTools;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+class SqlToolsTest extends TestCase
+{
+    public static function getValidateExpressionFilterData()
+    {
+        return array(
+            array(';', false),
+            array('select * from test', false),
+            array('delete table', false),
+            array('insert ', false),
+            array('update ', false),
+            array('drop ', false),
+            array('alter ', false),
+            array('--', false),
+            array('truncate ', false),
+            array('vacuum ', false),
+            array('create ', false),
+            array('grant ', false),
+            array('revoke ', false),
+            array('selectoioio', false),
+            array('test intersects other test', true),
+            array('test geom_from_gml other test', true),
+            array('test intersects $geometry', true),
+            array('$id IN (1)', true),
+            array('$id IN (1, 2)', true),
+            array('"id" IN (1)', true),
+            array('"id" IN (1, 2)', true),
+            array('"id" IN (\'test\')', true),
+            array('("foo" = \'test\' AND "id" = 55)', true),
+            array('("foo" = \'test\' AND "id" = 55) OR ("foo" = \'bar\' AND "id" = 44)', true),
+            array('("foo" = \'test\' AND "id" = 55) OR ("foo" = \'bar\' AND "id" = 44); -- SELECT * FROM jlx_user', false),
+        );
+    }
+
+    #[DataProvider('getValidateExpressionFilterData')]
+    public function testValidateExpressionFilter($filter, $expectedResult): void
+    {
+        [$valid, $blocked] = SqlTools::validateExpressionFilter($filter);
+        $this->assertEquals($expectedResult, $valid);
+    }
+}

--- a/tests/units/classes/Request/WFSRequestTest.php
+++ b/tests/units/classes/Request/WFSRequestTest.php
@@ -129,6 +129,7 @@ class WFSRequestTest extends TestCase
     public function testGetFeatureIdFilterExp($featureid, $typename, $expectedExpFilter, $layerOptions): void
     {
         $wfs = new WFSRequestForTests();
+        $wfs->appContext = new ContextForTests();
         $qgisLayer = new LayerWFSForTests();
         if ($layerOptions) {
             if (array_key_exists('provider', $layerOptions)) {
@@ -234,7 +235,7 @@ class WFSRequestTest extends TestCase
         $wfs->appContext = new ContextForTests();
         $sql = $wfs->getBboxSqlForTests($params);
         $bboxDesc = isset($params['bbox']) ? $params['bbox'] : '(none)';
-        $srsDesc  = isset($params['srsname']) ? $params['srsname'] : '(none)';
+        $srsDesc = isset($params['srsname']) ? $params['srsname'] : '(none)';
         $this->assertEquals(
             $expectedSql,
             $sql,
@@ -405,49 +406,6 @@ class WFSRequestTest extends TestCase
         $this->assertEquals($expectedSql, $result);
     }
 
-    public static function getValidateExpressionFilterData()
-    {
-        return array(
-            array(';', false),
-            array('select', false),
-            array('delete', false),
-            array('insert', false),
-            array('update', false),
-            array('drop', false),
-            array('alter', false),
-            array('--', false),
-            array('truncate', false),
-            array('vacuum', false),
-            array('create', false),
-            array('selectoioio', false),
-            array('test intersects other test', true),
-            array('test geom_from_gml other test', true),
-            array('test intersects $geometry', true),
-            array('$id IN (1)', true),
-            array('$id IN (1, 2)', true),
-            array('"id" IN (1)', true),
-            array('"id" IN (1, 2)', true),
-            array('"id" IN (\'test\')', true),
-            array('("foo" = \'test\' AND "id" = 55)', true),
-            array('("foo" = \'test\' AND "id" = 55) OR ("foo" = \'bar\' AND "id" = 44)', true),
-            array('("foo" = \'test\' AND "id" = 55) OR ("foo" = \'bar\' AND "id" = 44); -- SELECT * FROM jlx_user', false),
-        );
-    }
-
-    /**
-     * @dataProvider getValidateExpressionFilterData
-     *
-     * @param mixed $filter
-     * @param mixed $expectedResult
-     */
-    #[DataProvider('getValidateExpressionFilterData')]
-    public function testValidateExpressionFilter($filter, $expectedResult): void
-    {
-        $wfs = new WFSRequestForTests();
-        $wfs->appContext = new ContextForTests();
-        $this->assertEquals($expectedResult, $wfs->validateExpressionFilterForTests($filter));
-    }
-
     public static function getValidateFilterData()
     {
         return array(
@@ -527,8 +485,13 @@ class WFSRequestTest extends TestCase
         $wfs->datasource = (object) array('key' => 'id', 'geocol' => 'geom');
         $wfs->selectFields = array('"id"');
 
-        $sql = $wfs->setGeojsonSqlForTests('SELECT "id", "geom" AS "geosource" FROM mytable',
-            new jDbConnectionForTests(), 'my_layer', 'geom', $outputSrid);
+        $sql = $wfs->setGeojsonSqlForTests(
+            'SELECT "id", "geom" AS "geosource" FROM mytable',
+            new jDbConnectionForTests(),
+            'my_layer',
+            'geom',
+            $outputSrid
+        );
 
         $this->assertStringContainsString(
             $expectedGeomTransform,

--- a/tests/units/testslib/WFSRequestForTests.php
+++ b/tests/units/testslib/WFSRequestForTests.php
@@ -51,11 +51,6 @@ class WFSRequestForTests extends WFSRequest
         return $this->getQueryOrder($cnx, $params, $wfsFields);
     }
 
-    public function validateExpressionFilterForTests($filter)
-    {
-        return $this->validateExpressionFilter($filter);
-    }
-
     public function validateFilterForTests($filter)
     {
         return $this->validateFilter($filter);


### PR DESCRIPTION
Allow passing custom options (e.g. `buffer_size`) to Lizmap actions via the `options` argument of `runLizmapAction`. These options can be set dynamically from a JS custom form or any JS function.

Example:
```javascript
lizMap.mainLizmap.action.runLizmapAction(
    "project_map_center_buffer", // actionId
    'project',                   // scope
    null,                        // layerId
    null,                        // featureId
    null,                        // wkt
    {"buffer_size": 2000}        // options
);
``` 

Funded by 3Liz
