### PR TITLE
[Bugfix] Searchbuilder: key-value description to string

### DIFF
--- a/assets/src/legacy/attributeTable.js
+++ b/assets/src/legacy/attributeTable.js
@@ -1895,7 +1895,7 @@ var lizAttributeTable = function() {
                                             const options = Object.keys(keyValues)
                                                             .map((k) => {return {id:k, description:keyValues[k] ?? ''}})
                                                             .filter((o) => detail &&
-                                                                o.description.toLowerCase().includes(detail.toLowerCase()));
+                                                                o.description.toString().toLowerCase().includes(detail.toString().toLowerCase()));
                                             // set component options list
                                             typeahead.options = options;
                                         })


### PR DESCRIPTION
It takes into account cases where the layer's `keyValue` configuration has a numeric type description.

Related to https://github.com/3liz/lizmap-web-client/pull/6572

Funded by Faunalia
