### PR TITLE
Fix PHP: Since guzzlehttp/psr7 2.11: Passing a non-uppercase HTTP method is deprecated

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisExpressionUtils.class.php
+++ b/lizmap/modules/lizmap/classes/qgisExpressionUtils.class.php
@@ -433,7 +433,7 @@ class qgisExpressionUtils
 
         // Request evaluate constraint expressions
         $url = Proxy::constructUrl($params, lizmap::getServices());
-        $options = array('method' => 'post');
+        $options = array('method' => 'POST');
         list($data, $mime, $code) = Proxy::getRemoteData($url, $options);
 
         // Check data from request
@@ -494,7 +494,7 @@ class qgisExpressionUtils
         }
         $url = Proxy::constructUrl($merged_params, lizmap::getServices());
         // Use POST method as the expressions can be heavy (polygon filter)
-        $options = array('method' => 'post');
+        $options = array('method' => 'POST');
         list($data, $mime, $code) = Proxy::getRemoteData($url, $options);
 
         // Check data from request

--- a/lizmap/modules/lizmap/controllers/osm.classic.php
+++ b/lizmap/modules/lizmap/controllers/osm.classic.php
@@ -48,7 +48,7 @@ class osmCtrl extends jController
 
         $url .= http_build_query($params);
         list($content, $mime, $code) = Proxy::getRemoteData($url, array(
-            'method' => 'get',
+            'method' => 'GET',
             'referer' => jUrl::getFull('view~default:index'),
         ));
 

--- a/lizmap/modules/lizmap/lib/Request/OGCRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/OGCRequest.php
@@ -299,7 +299,7 @@ abstract class OGCRequest
         $options = array();
         if ($this->requestXml !== null) {
             $options = array(
-                'method' => 'post',
+                'method' => 'POST',
                 'body' => $this->requestXml,
             );
             $headers = array_merge(
@@ -307,7 +307,7 @@ abstract class OGCRequest
                 $headers,
             );
         } elseif ($post) {
-            $options = array('method' => 'post');
+            $options = array('method' => 'POST');
         }
         $options['headers'] = $headers;
 

--- a/lizmap/modules/lizmap/lib/Request/Proxy.php
+++ b/lizmap/modules/lizmap/lib/Request/Proxy.php
@@ -264,11 +264,11 @@ class Proxy
             // support of deprecated parameters
             if ($options !== null) {
                 $options = array(
-                    'method' => $method,
+                    'method' => strtoupper($method),
                     'proxyHttpBackend' => $options,
                 );
             } else {
-                $options = array('method' => $method);
+                $options = array('method' => strtoupper($method));
             }
             if ($debug !== null) {
                 $options['debug'] = $debug;
@@ -277,7 +277,7 @@ class Proxy
 
         $services = self::getServices();
         $options = array_merge(array(
-            'method' => 'get',
+            'method' => 'GET',
             'referer' => '',
             'headers' => array(),
             'proxyHttpBackend' => $services->proxyHttpBackend,
@@ -285,7 +285,7 @@ class Proxy
             'body' => '',
         ), $options);
 
-        $options['method'] = strtolower($options['method']);
+        $options['method'] = strtoupper($options['method']);
 
         return $options;
     }
@@ -316,7 +316,10 @@ class Proxy
      */
     protected static function buildHeaders($url, $options)
     {
-        if ($options['method'] == 'post' || $options['method'] == 'put') {
+        if ($options['method']) {
+            $options['method'] = strtoupper($options['method']);
+        }
+        if (in_array($options['method'], array('POST', 'PUT'))) {
             if ($options['body'] == '') {
                 $options['headers']['Content-type'] = 'application/x-www-form-urlencoded';
                 $content = explode('?', $url);
@@ -425,7 +428,7 @@ class Proxy
 
         // Create request
         $request = new Request(
-            $options['method'],
+            strtoupper($options['method']),
             $url,
             $options['headers'],
             $options['body'],
@@ -507,7 +510,7 @@ class Proxy
      *
      * @return array{0: string, 1: string, 2: int, 3: array} Array containing data (0: string), mime type (1: string), HTTP code (2: int) and headers
      */
-    public static function getRemoteData($url, $options = null, $debug = null, $method = 'get')
+    public static function getRemoteData($url, $options = null, $debug = null, $method = 'GET')
     {
         $options = self::buildOptions($options, $method, $debug);
         $response = self::sendRequest($url, $options);
@@ -537,7 +540,7 @@ class Proxy
      */
     public static function getRemoteDataAsStream($url, $options = null)
     {
-        $options = self::buildOptions($options, 'get', null);
+        $options = self::buildOptions($options, 'GET', null);
         $options['stream'] = true;
 
         $response = self::sendRequest($url, $options);

--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -1330,7 +1330,7 @@ class WMSRequest extends OGCRequest
         }
 
         // Get data from the map server: use POST to avoid too long URLS
-        $options = array('method' => 'post');
+        $options = array('method' => 'POST');
         list($data, $mime, $code) = Proxy::getRemoteData(
             Proxy::constructUrl($params, $this->services),
             $options

--- a/tests/units/classes/Request/ProxyTest.php
+++ b/tests/units/classes/Request/ProxyTest.php
@@ -156,7 +156,7 @@ class ProxyTest extends TestCase
             'referer' => 'referer',
         );
         $expectedStr = array(
-            'method' => 'post',
+            'method' => 'POST',
             'referer' => '',
             'headers' => array(),
             'proxyHttpBackend' => 'proxyHttp',
@@ -164,7 +164,7 @@ class ProxyTest extends TestCase
             'body' => '',
         );
         $expectedNull = array(
-            'method' => 'post',
+            'method' => 'POST',
             'referer' => '',
             'headers' => array(),
             'proxyHttpBackend' => 'proxy',
@@ -172,7 +172,7 @@ class ProxyTest extends TestCase
             'body' => '',
         );
         $expectedArray = array(
-            'method' => 'post',
+            'method' => 'POST',
             'referer' => 'referer',
             'headers' => array(),
             'proxyHttpBackend' => 'proxy',


### PR DESCRIPTION
guzzlehttp/psr7 3.0 preserves method casing and will no longer uppercase it. Normalize the method before constructing or modifying requests if uppercase is required.
