### PR TITLE
log key for login should not contain folder

### DIFF
--- a/lizmap/modules/lizmap/classes/lizmapLog.listener.php
+++ b/lizmap/modules/lizmap/classes/lizmapLog.listener.php
@@ -20,7 +20,8 @@ class lizmapLogListener extends jEventListener
     public function onAuthCanLogin($event)
     {
         $key = 'login';
-        $entrypointFile = str_replace('/', '', $_SERVER['SCRIPT_NAME']);
+        $entrypointFile = basename($_SERVER['SCRIPT_NAME']);
+        // assuming file end with .php ...
         $entrypoint = substr($entrypointFile, 0, -4);
         // entry point other than admin are provided by other module (webdav, ...), use different log key
         if ($entrypoint != 'admin') {


### PR DESCRIPTION
Login event are logged on a dedcicated table if this feature is enabled
But since various entry point can performe login (webddav for instance) the code was checking the entrypoint file name

When lizmap installation is on an URL with subfolder (ie `https://domain/cartes/` the log is filled with folder name : 

<img width="457" height="567" alt="Screenshot 2026-06-25 at 11-30-43 Administration" src="https://github.com/user-attachments/assets/4ef3c381-7d1c-4323-a109-6b8370099fd6" /> 

The pr fix the behaviour : classical admin login will be showned as `login` , other entrypoint login will be prefixed by entry point name
Ticket : #

Funded by 3Liz
