### PR TITLE
fix: remove leftover Bootstrap tab classes from bottom-dock template

### DIFF
--- a/assets/src/legacy/map.js
+++ b/assets/src/legacy/map.js
@@ -3592,7 +3592,9 @@ window.lizMap = function() {
                 const parentElement = linkClicked.parentElement;
                 const wasActive = parentElement.classList.contains('active');
 
-                const dockContentSelector = dockType == 'minidock' ? '#mini-dock-content > div' : `#${dockType}-content > div`;
+                const dockContentSelector = dockType == 'minidock' ? '#mini-dock-content > div'
+                    : dockType == 'bottomdock' ? '#bottom-dock-content > div'
+                    : `#${dockType}-content > div`;
                 const dockEvent = dockType == 'right-dock' ? 'rightdock' : dockType;
 
                 // Manage the active docks othe same type that is not the current target
@@ -3618,11 +3620,6 @@ window.lizMap = function() {
 
                 return false;
             });
-
-            // hide mini-dock if no tool is active
-            if ($('#mapmenu ul li.nav-minidock.active').length == 0) {
-                $('#mini-dock-content > .tab-pane.active').removeClass('active');
-            }
 
             // Toggle menu visibility
             $('#menuToggle').click(function(){

--- a/lizmap/modules/view/templates/map_bottomdock.tpl
+++ b/lizmap/modules/view/templates/map_bottomdock.tpl
@@ -1,7 +1,7 @@
-    <div class="tabbable tabs-below">
-      <div id="bottom-dock-content" class="tab-content">
+    <div>
+      <div id="bottom-dock-content">
       {foreach $dockable as $dock}
-        <div class="tab-pane{if $dock->order==1} active{/if}" id="{$dock->id}">
+        <div {if $dock->order!=1}class="hide"{/if} id="{$dock->id}">
           {$dock->fetchContent()}
         </div>
       {/foreach}


### PR DESCRIPTION
map_bottomdock.tpl was the only outer dock template still wrapping its panels in Bootstrap's tabbable/tab-content/tab-pane/active classes, unlike dock/mini-dock/right-dock which already switched to the plain .hide convention driven by vanilla JS. This caused the bottom-dock "hide sibling panes" step to rely on a wrong #bottomdock-content selector (real id is #bottom-dock-content) and let Bootstrap's .tab-content>.active rule outrank the .hide utility class, so a docked popup and the attribute table could end up shown at the same time.

Funded by 3liz
