### PR TITLE
fix: remove leftover Bootstrap tab classes from dataviz dock templates

### DIFF
--- a/lizmap/modules/dataviz/templates/dataviz_bottomdock.tpl
+++ b/lizmap/modules/dataviz/templates/dataviz_bottomdock.tpl
@@ -1,17 +1,12 @@
-<div class="tabbable">
-  <div class="tab-content" id="dataviz-container">
+<div id="dataviz-container">
 
-    <div class="tab-pane active bottom-content" id="dataviz-main" >
+  <div id="dataviz-dock-title">{@dataviz~dataviz.dock.title@}</div>
 
-        <div id="dataviz-content" class="{$theme}">
-        </div>
+  <div id="dataviz-main" class="bottom-content">
 
-    </div>
+      <div id="dataviz-content" class="{$theme}">
+      </div>
 
   </div>
-
-  <ul id="dataviz-tabs" class="nav nav-tabs" role="tablist">
-    <li id="nav-tab-dataviz-main" class="nav-item" role="presentation"><a class="nav-link active" href="#dataviz-main" data-bs-toggle="tab" role="tab">{@dataviz~dataviz.dock.title@}</a></li>
-  </ul>
 
 </div>

--- a/lizmap/modules/dataviz/templates/dataviz_rightdock.tpl
+++ b/lizmap/modules/dataviz/templates/dataviz_rightdock.tpl
@@ -1,12 +1,9 @@
-<div class="tabbable">
-  <div class="tab-content" id="dataviz-container">
+<div id="dataviz-container">
 
-    <div class="tab-pane active bottom-content" id="dataviz-main" >
+  <div id="dataviz-main" class="bottom-content">
 
-        <div id="dataviz-content" class="{$theme}">
-        </div>
-
-    </div>
+      <div id="dataviz-content" class="{$theme}">
+      </div>
 
   </div>
 

--- a/lizmap/modules/dataviz/templates/dataviz_rightdock.tpl
+++ b/lizmap/modules/dataviz/templates/dataviz_rightdock.tpl
@@ -1,5 +1,7 @@
 <div id="dataviz-container">
 
+  <div id="dataviz-dock-title">{@dataviz~dataviz.dock.title@}</div>
+
   <div id="dataviz-main" class="bottom-content">
 
       <div id="dataviz-content" class="{$theme}">

--- a/lizmap/www/assets/css/dataviz/dataviz.css
+++ b/lizmap/www/assets/css/dataviz/dataviz.css
@@ -48,9 +48,7 @@ Toolbar buttons
 }
 
 /* Title "Dataviz" of the bottom dock */
-#nav-tab-dataviz-main > a{
-    background: none !important;
-    border: none;
+#dataviz-dock-title {
     color: var(--color-text-primary);
     margin-top: 10px;
     font-weight: 500;
@@ -132,11 +130,6 @@ TABS AND GROUPS
     border-bottom: 3px solid var(--color-contrasted-elements);
     color: var(--color-text-primary);
     cursor: auto;
-}
-
-/* In bottom-dock, do not use a thick border bottom */
-#bottom-dock #nav-tab-dataviz-main > a {
-  border: none;
 }
 
 #dataviz div.tab-pane {

--- a/lizmap/www/assets/css/dataviz/dataviz.css
+++ b/lizmap/www/assets/css/dataviz/dataviz.css
@@ -47,7 +47,7 @@ Toolbar buttons
     font-size: 0.8em;
 }
 
-/* Title "Dataviz" of the bottom dock */
+/* Title "Dataviz" of the bottom-dock/right-dock panel */
 #dataviz-dock-title {
     color: var(--color-text-primary);
     margin-top: 10px;

--- a/lizmap/www/assets/css/map.css
+++ b/lizmap/www/assets/css/map.css
@@ -1107,7 +1107,7 @@ ul.nav.nav-tabs {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='white' class='bi bi-arrow-left-square' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M15 2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2zM0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2zm11.5 5.5a.5.5 0 0 1 0 1H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5H11.5z'/%3E%3C/svg%3E");
 }
 
-#right-dock div.tabbable {
+#right-dock #dataviz-container {
   height: 100%;
   margin-top: 5px;
 }
@@ -2027,7 +2027,7 @@ lizmap-dxfexport .dxfexport-actions {
   z-index:1099;
 }
 
-#right-dock > .tabbable{
+#right-dock > #dataviz-container{
   margin-right: 5px;
   margin-left: 5px;
 }


### PR DESCRIPTION
dataviz_bottomdock.tpl and dataviz_rightdock.tpl wrapped their single, never-multiplying pane in a full tabbable/tab-content/tab-pane + nav-tabs structure inherited from an old BS2->BS5 migration patch, even though the dataviz.js bundle never toggles between panes there (unlike the attribute table panel, which genuinely adds tabs dynamically). Replaced with plain divs, keeping the static "Dataviz" title in the bottom dock, and updated the CSS selectors that targeted the removed classes accordingly.
