### PR TITLE
Fix WFS/filter selection: translate all geometry operators to PostGIS

### DIFF
--- a/lizmap/modules/filter/classes/filterDatasource.class.php
+++ b/lizmap/modules/filter/classes/filterDatasource.class.php
@@ -82,10 +82,8 @@ class filterDatasource
 
             return null;
         }
-        $filter = str_replace('intersects', 'ST_Intersects', $filter);
-        $filter = str_replace('geom_from_gml', 'ST_GeomFromGML', $filter);
 
-        return str_replace('$geometry', '"'.$this->datasource->geocol.'"', $filter);
+        return SqlTools::translateExpressionToPostgis($filter, $this->datasource->geocol);
     }
 
     /**

--- a/lizmap/modules/lizmap/lib/App/SqlTools.php
+++ b/lizmap/modules/lizmap/lib/App/SqlTools.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * SQL tools for Lizmap.
+ *
+ * @author    3liz
+ * @copyright 2026 3liz
+ *
+ * @see      http://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
 namespace Lizmap\App;
 
 class SqlTools
@@ -23,6 +34,23 @@ class SqlTools
     );
 
     /**
+     * QGIS geometry predicate functions mapped to their PostGIS ST_* equivalents.
+     *
+     * These are the operators offered by the selection tool and the filter form.
+     *
+     * @var array<string, string>
+     */
+    public const GEOMETRY_PREDICATES = array(
+        'intersects' => 'ST_Intersects',
+        'contains' => 'ST_Contains',
+        'within' => 'ST_Within',
+        'crosses' => 'ST_Crosses',
+        'overlaps' => 'ST_Overlaps',
+        'touches' => 'ST_Touches',
+        'disjoint' => 'ST_Disjoint',
+    );
+
+    /**
      * Validate an expression filter.
      *
      * @param string $filter The expression filter to validate
@@ -35,5 +63,31 @@ class SqlTools
         $pattern = '#'.implode('|', array_map(fn ($w): string => preg_quote($w, '#'), static::$blockSqlWords)).'#i';
 
         return array(!preg_match($pattern, $filter, $block_items), $block_items);
+    }
+
+    /**
+     * Translate a QGIS expression filter into a PostGIS compatible SQL filter.
+     *
+     * Rewrites the geometry predicate functions used by the selection tool and
+     * the filter form (intersects, contains, within, crosses, overlaps, touches,
+     * disjoint) to their PostGIS ST_* equivalents, translates geom_from_gml() and
+     * replaces the $geometry variable with the given geometry column.
+     *
+     * The predicate name is matched case-insensitively and only when followed by
+     * an opening parenthesis, so plain text and column names are left untouched.
+     *
+     * @param string $filter         The QGIS expression filter
+     * @param string $geometryColumn The layer geometry column name
+     *
+     * @return string The PostGIS compatible filter
+     */
+    public static function translateExpressionToPostgis(string $filter, string $geometryColumn): string
+    {
+        foreach (self::GEOMETRY_PREDICATES as $qgisFunction => $postgisFunction) {
+            $filter = preg_replace('/\b'.$qgisFunction.'\s*\(/i', $postgisFunction.'(', $filter);
+        }
+        $filter = str_replace('geom_from_gml', 'ST_GeomFromGML', $filter);
+
+        return str_replace('$geometry', '"'.$geometryColumn.'"', $filter);
     }
 }

--- a/lizmap/modules/lizmap/lib/Request/WFSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WFSRequest.php
@@ -1156,10 +1156,8 @@ class WFSRequest extends OGCRequest
 
             return false;
         }
-        $vfilter = str_replace('intersects', 'ST_Intersects', $filter);
-        $vfilter = str_replace('geom_from_gml', 'ST_GeomFromGML', $vfilter);
 
-        return str_replace('$geometry', '"'.$this->datasource->geocol.'"', $vfilter);
+        return SqlTools::translateExpressionToPostgis($filter, $this->datasource->geocol);
     }
 
     /**

--- a/tests/units/classes/App/SqlToolsTest.php
+++ b/tests/units/classes/App/SqlToolsTest.php
@@ -48,4 +48,38 @@ class SqlToolsTest extends TestCase
         [$valid, $blocked] = SqlTools::validateExpressionFilter($filter);
         $this->assertEquals($expectedResult, $valid);
     }
+
+    public static function getTranslateExpressionToPostgisData()
+    {
+        return array(
+            // Every geometry predicate offered by the selection tool must be
+            // translated to its PostGIS ST_* equivalent, not only "intersects".
+            array('intersects($geometry, geom_from_gml(\'g\'))', 'geom', 'ST_Intersects("geom", ST_GeomFromGML(\'g\'))'),
+            array('contains($geometry, geom_from_gml(\'g\'))', 'geom', 'ST_Contains("geom", ST_GeomFromGML(\'g\'))'),
+            array('within($geometry, geom_from_gml(\'g\'))', 'geom', 'ST_Within("geom", ST_GeomFromGML(\'g\'))'),
+            array('crosses($geometry, geom_from_gml(\'g\'))', 'geom', 'ST_Crosses("geom", ST_GeomFromGML(\'g\'))'),
+            array('overlaps($geometry, geom_from_gml(\'g\'))', 'geom', 'ST_Overlaps("geom", ST_GeomFromGML(\'g\'))'),
+            array('touches($geometry, geom_from_gml(\'g\'))', 'geom', 'ST_Touches("geom", ST_GeomFromGML(\'g\'))'),
+            array('disjoint($geometry, geom_from_gml(\'g\'))', 'geom', 'ST_Disjoint("geom", ST_GeomFromGML(\'g\'))'),
+            // Operators are matched case-insensitively and tolerate whitespace before "(".
+            array('INTERSECTS ($geometry, geom_from_gml(\'g\'))', 'geom', 'ST_Intersects("geom", ST_GeomFromGML(\'g\'))'),
+            // A predicate combined with another expression must keep both parts.
+            array('"field" > 3 AND within($geometry, geom_from_gml(\'g\'))', 'the_geom', '"field" > 3 AND ST_Within("the_geom", ST_GeomFromGML(\'g\'))'),
+            // A bare word that is not a function call must be left untouched.
+            array('"name" = \'it intersects here\'', 'geom', '"name" = \'it intersects here\''),
+        );
+    }
+
+    /**
+     * @dataProvider getTranslateExpressionToPostgisData
+     *
+     * @param mixed $filter
+     * @param mixed $geometryColumn
+     * @param mixed $expected
+     */
+    #[DataProvider('getTranslateExpressionToPostgisData')]
+    public function testTranslateExpressionToPostgis($filter, $geometryColumn, $expected): void
+    {
+        $this->assertEquals($expected, SqlTools::translateExpressionToPostgis($filter, $geometryColumn));
+    }
 }

--- a/tests/units/classes/Request/WFSRequestTest.php
+++ b/tests/units/classes/Request/WFSRequestTest.php
@@ -411,9 +411,22 @@ class WFSRequestTest extends TestCase
         return array(
             array('select', false),
             array('selectoioio', false),
-            array('test intersects other test', 'test ST_Intersects other test'),
             array('test geom_from_gml other test', 'test ST_GeomFromGML other test'),
-            array('test intersects $geometry', 'test ST_Intersects "column"'),
+            // Every geometry predicate offered by the selection tool must be
+            // translated to its PostGIS ST_* equivalent, not only "intersects".
+            array('intersects($geometry, geom_from_gml(\'g\'))', 'ST_Intersects("column", ST_GeomFromGML(\'g\'))'),
+            array('contains($geometry, geom_from_gml(\'g\'))', 'ST_Contains("column", ST_GeomFromGML(\'g\'))'),
+            array('within($geometry, geom_from_gml(\'g\'))', 'ST_Within("column", ST_GeomFromGML(\'g\'))'),
+            array('crosses($geometry, geom_from_gml(\'g\'))', 'ST_Crosses("column", ST_GeomFromGML(\'g\'))'),
+            array('overlaps($geometry, geom_from_gml(\'g\'))', 'ST_Overlaps("column", ST_GeomFromGML(\'g\'))'),
+            array('touches($geometry, geom_from_gml(\'g\'))', 'ST_Touches("column", ST_GeomFromGML(\'g\'))'),
+            array('disjoint($geometry, geom_from_gml(\'g\'))', 'ST_Disjoint("column", ST_GeomFromGML(\'g\'))'),
+            // Operators are matched case-insensitively and tolerate whitespace before "(".
+            array('INTERSECTS ($geometry, geom_from_gml(\'g\'))', 'ST_Intersects("column", ST_GeomFromGML(\'g\'))'),
+            // A predicate combined with another expression must keep both parts.
+            array('"field" > 3 AND within($geometry, geom_from_gml(\'g\'))', '"field" > 3 AND ST_Within("column", ST_GeomFromGML(\'g\'))'),
+            // A bare word that is not a function call must be left untouched.
+            array('"name" = \'it intersects here\'', '"name" = \'it intersects here\''),
         );
     }
 


### PR DESCRIPTION
The selection tool and the filter form let the user pick any of the QGIS geometry predicates (intersects, contains, within, crosses, overlaps, touches, disjoint). On the direct PostgreSQL query path the expression filter is rewritten to SQL, but only "intersects" was mapped to its ST_* function. Every other operator was passed through verbatim, producing invalid SQL (e.g. within(...) instead of ST_Within(...)), so the query failed and the selection returned nothing on PostGIS layers.

Rewrite the translation to map all seven predicates to their PostGIS equivalents, matching the function name case-insensitively and only when followed by "(" so plain text and column names are left untouched. The same fix is applied to the filter module which shared the incomplete mapping.