### PR TITLE
fix(search): resolve relative nominatim URL against the page URL

### DIFF
--- a/assets/src/modules/Search.js
+++ b/assets/src/modules/Search.js
@@ -225,7 +225,7 @@ export default class Search {
         const searchQuery = document.getElementById('search-query').value;
         switch (searchConfig.service) {
             case 'nominatim': {
-                const nominatimUrl = new URL(service);
+                const nominatimUrl = new URL(service, window.location.href);
                 nominatimUrl.searchParams.set('query', searchQuery);
                 nominatimUrl.searchParams.set('bbox', extent.toBBOX());
                 Utils.fetchJSON(nominatimUrl.toString()).then(data => {


### PR DESCRIPTION
The jQuery->vanilla refactor (6284d4530) passes the server-generated nominatim endpoint, a root-relative path (/index.php/lizmap/osm/nominatim), to the URL constructor. new URL() throws on a relative URL without a base, so external nominatim search crashes with "URL constructor: ... is not a valid URL" and never fires the request. jQuery $.get previously accepted the relative path.

Pass window.location.origin as the base so the path resolves. IGN uses an absolute URL and is unaffected.
