### PR TITLE
Fix/honor external wms toggle

### DIFF
--- a/assets/src/modules/action/Symbology.js
+++ b/assets/src/modules/action/Symbology.js
@@ -32,8 +32,11 @@ export async function updateLayerTreeLayersSymbology(treeLayers, method=HttpRequ
 
     if (method.toUpperCase() == HttpRequestMethods.GET) {
         for (const treeLayer of treeLayers) {
-            // Check if this is an external WMS layer using the backend flag
-            const isExternalWMS = treeLayer.layerConfig?.externalWmsToggle;
+            // Check if this is a WMS layer using the backend flag: WMS layers
+            // need a PNG legend because a JSON GetLegendGraphic returns empty
+            // icons. This is independent of the direct-access (externalWmsToggle)
+            // option, so cascaded WMS layers still get a proper legend.
+            const isExternalWMS = treeLayer.layerConfig?.wmsLayer;
 
             if (isExternalWMS) {
                 // For external WMS layers, use GetLegendGraphic URL directly as DOM element src

--- a/assets/src/modules/config/Layer.js
+++ b/assets/src/modules/config/Layer.js
@@ -47,6 +47,7 @@ const optionalProperties = {
     'mutuallyExclusive': {type: 'boolean', default: false},
     'externalWmsToggle': {type: 'boolean', default: false},
     'externalAccess': {type: 'object'},
+    'wmsLayer': {type: 'boolean', default: false},
 };
 
 /**
@@ -360,6 +361,15 @@ export class LayerConfig extends BaseObjectConfig {
      */
     get externalAccess() {
         return this._externalAccess;
+    }
+
+    /**
+     * The layer is served by a WMS provider: its legend must be requested as a
+     * PNG image because a JSON GetLegendGraphic returns empty icons (layer only)
+     * @type {boolean}
+     */
+    get wmsLayer() {
+        return this._wmsLayer;
     }
 }
 

--- a/lizmap/modules/lizmap/lib/Project/Project.php
+++ b/lizmap/modules/lizmap/lib/Project/Project.php
@@ -2086,14 +2086,30 @@ class Project
                                 && !array_key_exists('crs', $layerDatasource)) {
                                 $layerDatasource['crs'] = 'EPSG:3857';
                             }
-                            // Set externalWmsToggle for:
-                            // 1. WMS layers (no 'type' field or type='wms')
-                            // 2. xyz/wmts layers with EPSG:3857 CRS (preserves original functionality)
-                            if ((!array_key_exists('type', $layerDatasource) || $layerDatasource['type'] == 'wms')
-                                || (array_key_exists('type', $layerDatasource) && $layerDatasource['crs'] == 'EPSG:3857')) {
-                                $obj->externalWmsToggle = 'True';
+                            // Flag every WMS layer so the client renders its legend as a PNG
+                            // image: a JSON GetLegendGraphic returns empty icons for WMS layers
+                            // (see #5934). This is independent of the direct-access option below.
+                            $obj->wmsLayer = true;
+                            // Honor the project configuration for direct WMS access.
+                            // The Lizmap plugin writes externalWmsToggle in the CFG when the
+                            // user enables "get images directly from the WMS server" for a
+                            // layer. Only expose the datasource for direct client access when
+                            // that option is enabled; otherwise the layer keeps cascading
+                            // through QGIS Server (required e.g. to reproject a WMS server that
+                            // only serves its native CRS). Forcing it on for every raster WMS
+                            // layer overrode the user's choice (regression, see #5934 fix).
+                            $directAccessRequested = property_exists($obj, 'externalWmsToggle')
+                                && filter_var($obj->externalWmsToggle, FILTER_VALIDATE_BOOLEAN);
+                            // Preserve original behavior for xyz/WMTS tile layers in EPSG:3857:
+                            // these have no plugin toggle but must be fetched by the client.
+                            $isEpsg3857Tiles = array_key_exists('type', $layerDatasource)
+                                && (($layerDatasource['crs'] ?? '') == 'EPSG:3857');
+                            if ($directAccessRequested || $isEpsg3857Tiles) {
+                                if ($isEpsg3857Tiles) {
+                                    $obj->externalWmsToggle = 'True';
+                                }
+                                $obj->externalAccess = $layerDatasource;
                             }
-                            $obj->externalAccess = $layerDatasource;
                         }
                     }
                 }

--- a/tests/end2end/playwright/external_wms_toggle.spec.js
+++ b/tests/end2end/playwright/external_wms_toggle.spec.js
@@ -1,0 +1,111 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+/**
+ * Regression suite: the per-layer "get images directly from the WMS server"
+ * option (externalWmsToggle) must be honored by getProjectConfig.
+ *
+ * Background
+ * ----------
+ * LWC used to force `externalWmsToggle = 'True'` and inject `externalAccess`
+ * for every unauthenticated raster WMS layer, overriding the plugin's choice.
+ * That prevented a WMS layer from cascading through QGIS Server (needed e.g.
+ * to reproject a WMS server that only serves its native CRS) and made the
+ * browser send cross-origin GetMap requests that failed with ORB.
+ *
+ * Expected behavior after the fix:
+ *   - direct client access (externalAccess) is exposed only when the layer
+ *     opted in (externalWmsToggle truthy in the CFG) or for EPSG:3857 tiles;
+ *   - a WMS layer with the toggle OFF has no externalAccess and cascades;
+ *   - every WMS layer is still flagged `wmsLayer: true` so its legend renders
+ *     as a PNG (a JSON GetLegendGraphic returns empty icons for WMS layers).
+ *
+ * Projects used
+ * -------------
+ *   - testsrepository / base_layers_user_defined
+ *       "WMS grouped external": plain WMS, plugin toggle written as "False"
+ *   - testsrepository / external_wms_layer
+ *       "png": external WMS, plugin toggle written as "True"
+ */
+
+test.describe('External WMS toggle honored in getProjectConfig @requests @readonly', () => {
+
+    // -----------------------------------------------------------------------
+    // Toggle OFF — the layer must cascade through QGIS Server (no direct access)
+    // -----------------------------------------------------------------------
+    test.describe('Plugin toggle OFF — cascaded', () => {
+        /** @type {object} */
+        let config;
+
+        test.beforeAll(async ({ request }) => {
+            const params = new URLSearchParams({
+                repository: 'testsrepository',
+                project: 'base_layers_user_defined',
+            });
+            const response = await request.get(
+                `/index.php/lizmap/service/getProjectConfig?${params}`
+            );
+            expect(response.ok()).toBeTruthy();
+            config = await response.json();
+        });
+
+        test('externalWmsToggle "False" is not overridden to "True"', () => {
+            const layer = config.layers['WMS grouped external'];
+            expect(layer, 'Layer "WMS grouped external" must exist').toBeDefined();
+            // The CFG declares the toggle off; the backend must not force it on.
+            expect(layer.externalWmsToggle).not.toBe('True');
+        });
+
+        test('no externalAccess is injected, so the layer cascades', () => {
+            const layer = config.layers['WMS grouped external'];
+            expect(
+                layer.externalAccess,
+                'externalAccess must be absent when the toggle is off (layer cascades through QGIS Server)'
+            ).toBeUndefined();
+        });
+
+        test('the cascaded WMS layer is still flagged wmsLayer for PNG legend rendering', () => {
+            const layer = config.layers['WMS grouped external'];
+            expect(
+                layer.wmsLayer,
+                'wmsLayer must be true so the legend renders as PNG even when tiles cascade'
+            ).toBe(true);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // Toggle ON — the layer keeps direct client access
+    // -----------------------------------------------------------------------
+    test.describe('Plugin toggle ON — direct access', () => {
+        /** @type {object} */
+        let config;
+
+        test.beforeAll(async ({ request }) => {
+            const params = new URLSearchParams({
+                repository: 'testsrepository',
+                project: 'external_wms_layer',
+            });
+            const response = await request.get(
+                `/index.php/lizmap/service/getProjectConfig?${params}`
+            );
+            expect(response.ok()).toBeTruthy();
+            config = await response.json();
+        });
+
+        test('externalWmsToggle "True" is kept and externalAccess is exposed', () => {
+            const layer = config.layers['png'];
+            expect(layer, 'Layer "png" must exist').toBeDefined();
+            expect(layer.externalWmsToggle).toBe('True');
+            expect(
+                layer.externalAccess,
+                'externalAccess must be present when the toggle is on'
+            ).toBeDefined();
+            expect(layer.externalAccess.url).toContain('liz.lizmap.com');
+        });
+
+        test('the direct-access WMS layer is also flagged wmsLayer', () => {
+            const layer = config.layers['png'];
+            expect(layer.wmsLayer).toBe(true);
+        });
+    });
+});

--- a/tests/end2end/playwright/external_wmts_layer.spec.js
+++ b/tests/end2end/playwright/external_wmts_layer.spec.js
@@ -106,8 +106,9 @@ test.describe('External WMTS layer — getProjectConfig @requests @readonly', ()
         expect(wmsGroupedLayer, 'Layer "WMS grouped external" must exist in config').toBeDefined();
         // This WMS layer's URL has no 'wmts' token in host/path/service param, so
         // the PHP detection must NOT set externalAccess.type = 'wmts'.
-        // (Note: PHP sets externalWmsToggle = 'True' for all external WMS layers —
-        // the plugin's 'False' value in the .cfg is overridden at runtime.)
+        // (The per-layer externalWmsToggle is now honored: a WMS layer whose
+        // plugin toggle is off gets no externalAccess and cascades through QGIS
+        // Server. See external_wms_toggle.spec.js for that behavior.)
         if (wmsGroupedLayer.externalAccess) {
             expect(wmsGroupedLayer.externalAccess.type).not.toBe('wmts');
         }


### PR DESCRIPTION
`getProjectConfig` unconditionally set `externalWmsToggle='True' `and `externalAccess` for every unauthenticated raster WMS layer, overriding the per-layer "get images directly from the WMS server" option written to the CFG by the plugin. WMS layers could no longer cascade through QGIS Server: 
For example, a server that only serves its native CRS could not be reprojected, and the browser issued cross-origin GetMap requests that failed with `OpaqueResponseBlocking`.

Direct client access is now exposed only when the CFG opts in
(externalWmsToggle truthy) or for xyz/WMTS EPSG:3857 tile layers.

To keep external-WMS legends working independently of tile routing, a
dedicated wmsLayer flag now drives PNG legend rendering for every WMS layer,
so cascaded (toggle-off) WMS layers still get a proper legend instead of
empty JSON GetLegendGraphic icons.