### PR TITLE
[CI] retry all curl errors when checking QGIS Server status in e2e wo…

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -105,6 +105,7 @@ jobs:
             --user 'admin:admin' \
             --retry 30 \
             --retry-delay 5 \
+            --retry-all-errors \
             -N \
             "http://localhost:8130/index.php/view/app/metadata" \
             -o /tmp/test-qgis-server.json


### PR DESCRIPTION
…rkflow

The nginx container can refuse/reset the first connection right after it starts, before it is actually ready to serve requests. curl's --retry only covers timeouts and HTTP 5xx codes, not low-level connection errors like "Connection reset by peer" (exit code 56), so the check failed immediately instead of retrying.
