### PR TITLE
[CI] Speed up e2e: shard Playwright tests across isolated jobs (~27min → ~13min)

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -206,7 +206,7 @@ jobs:
           success() ||
           steps.test-playwright-requests.outcome != 'success'
         run: |
-          npx playwright test --grep @readonly --grep-invert @requests ${{ env.PLAYWRIGHT_OPTIONS }}
+          npx playwright test --grep @readonly --grep-invert @requests ${{ env.PLAYWRIGHT_OPTIONS }} --workers=4
 
       - name: Prepare the database diff from Playwright "@readonly" tests
         if: |

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -266,7 +266,7 @@ jobs:
           steps.test-playwright-requests.outcome != 'success' ||
           steps.test-playwright-read-only.outcome != 'success' )
         run: |
-          npx playwright test --workers 1 --grep-invert "(?=.*@write|.*@readonly)" ${{ env.PLAYWRIGHT_OPTIONS }}
+          npx playwright test --workers 4 --grep-invert "(?=.*@write|.*@readonly)" ${{ env.PLAYWRIGHT_OPTIONS }}
 
       - name: Run Playwright tests tagged "@write"
         id: test-playwright-write

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -214,7 +214,7 @@ jobs:
           success() ||
           steps.test-playwright-requests.outcome != 'success'
         run: |
-          npx playwright test --grep @readonly --grep-invert @requests ${{ env.PLAYWRIGHT_OPTIONS }} --workers=4 --shard=${{ matrix.shard }}/3
+          npx playwright test --grep @readonly --grep-invert @requests ${{ env.PLAYWRIGHT_OPTIONS }} --workers=2 --shard=${{ matrix.shard }}/3
 
       - name: Prepare the database diff from Playwright "@readonly" tests
         if: |

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   end2end:
-    name: "E2E QGIS ${{ matrix.qgis-server }} PG ${{ matrix.pg-postgis }} PHP ${{ matrix.php }}"
+    name: "E2E ${{ matrix.name }} shard ${{ matrix.shard }}/3 (QGIS ${{ matrix.qgis-server }} PG ${{ matrix.pg-postgis }} PHP ${{ matrix.php }})"
     permissions:
       issues: write
       pull-requests: write
@@ -23,6 +23,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Each (name x shard) pair is an independent job with its own isolated
+        # docker stack (own PostgreSQL), so sharding the @write / no-tag tests
+        # across shards is race-free. The per-config fields (php, pg, qgis...)
+        # are attached to every shard of a given name via the include entries.
+        name: ["LEGACY", "STABLE", "BLEEDING_EDGE"]
+        shard: [1, 2, 3]
         include:
           - name: "LEGACY"
             php: "8.2"
@@ -154,6 +160,8 @@ jobs:
           npm ci
 
       - name: Run BATS tests
+        # BATS tests are shard-independent; run them once per config (first shard).
+        if: matrix.shard == 1
         working-directory: ./
         run: |
           npm run bats
@@ -194,7 +202,7 @@ jobs:
         # GetFeature with a polygon filter), which flaked. Serial execution
         # removes the contention and costs only a few extra seconds.
         run: |
-          npx playwright test --grep "(?=.*@requests)(?=.*@readonly)" ${{ env.PLAYWRIGHT_OPTIONS }} --workers=1
+          npx playwright test --grep "(?=.*@requests)(?=.*@readonly)" ${{ env.PLAYWRIGHT_OPTIONS }} --workers=1 --shard=${{ matrix.shard }}/3
 
       - name: Run Playwright tests tagged "@readonly"
         id: test-playwright-read-only
@@ -206,7 +214,7 @@ jobs:
           success() ||
           steps.test-playwright-requests.outcome != 'success'
         run: |
-          npx playwright test --grep @readonly --grep-invert @requests ${{ env.PLAYWRIGHT_OPTIONS }} --workers=4
+          npx playwright test --grep @readonly --grep-invert @requests ${{ env.PLAYWRIGHT_OPTIONS }} --workers=4 --shard=${{ matrix.shard }}/3
 
       - name: Prepare the database diff from Playwright "@readonly" tests
         if: |
@@ -235,7 +243,7 @@ jobs:
           steps.test-playwright-read-only.outcome != 'success'
         uses: actions/upload-artifact@master
         with:
-          name: ${{ matrix.name }}-DB-diff-read-only
+          name: ${{ matrix.name }}-shard${{ matrix.shard }}-DB-diff-read-only
           if-no-files-found: 'ignore'
           path: |
             ${{ github.workspace }}/tests/qgis-projects/tests/tests_dataset.patch
@@ -266,7 +274,7 @@ jobs:
           steps.test-playwright-requests.outcome != 'success' ||
           steps.test-playwright-read-only.outcome != 'success' )
         run: |
-          npx playwright test --workers 1 --grep-invert "(?=.*@write|.*@readonly)" ${{ env.PLAYWRIGHT_OPTIONS }}
+          npx playwright test --config playwright.serial.config.ts --workers 1 --grep-invert "(?=.*@write|.*@readonly)" ${{ env.PLAYWRIGHT_OPTIONS }} --shard=${{ matrix.shard }}/3
 
       - name: Run Playwright tests tagged "@write"
         id: test-playwright-write
@@ -281,7 +289,7 @@ jobs:
           steps.test-playwright-read-only.outcome != 'success' ||
           steps.test-playwright-no-tag.outcome != 'success' )
         run: |
-          npx playwright test --workers 1 --grep @write ${{ env.PLAYWRIGHT_OPTIONS }}
+          npx playwright test --config playwright.serial.config.ts --workers 1 --grep @write ${{ env.PLAYWRIGHT_OPTIONS }} --shard=${{ matrix.shard }}/3
 
       - name: Debug
         if: always()
@@ -303,7 +311,7 @@ jobs:
           steps.test-playwright-write.outcome != 'success' )
         uses: actions/upload-artifact@master
         with:
-          name: ${{ matrix.name }}-screenshots-readonly
+          name: ${{ matrix.name }}-shard${{ matrix.shard }}-screenshots-readonly
           if-no-files-found: 'ignore'
           path: |
             ${{ github.workspace }}/tests/end2end/test-results/
@@ -328,11 +336,13 @@ jobs:
           title: All Playwright tests ${{ matrix.NAME }}
           failed-report: true
           # pull-request-report: true
-          pull-request: true
+          # With sharding there are 9 jobs; keep the per-job summary but do not
+          # post one PR comment per shard (too noisy).
+          pull-request: false
           # annotate: false
           update-comment: true
           overwrite-comment: false
-          comment-tag: '${{ github.workflow }}-${{ github.job }}'
+          comment-tag: '${{ github.workflow }}-${{ github.job }}-${{ matrix.name }}-shard${{ matrix.shard }}'
 
       - name: Upload test results
         if: |
@@ -344,7 +354,7 @@ jobs:
         uses: actions/upload-artifact@master
         with:
           if-no-files-found: 'ignore'
-          name: ${{ matrix.name }}-playwright-report
+          name: ${{ matrix.name }}-shard${{ matrix.shard }}-playwright-report
           path: ${{ github.workspace }}/tests/end2end/playwright-report
 
       - name: Export some logs to files
@@ -361,7 +371,7 @@ jobs:
         uses: actions/upload-artifact@master
         if: always()
         with:
-          name: ${{ matrix.name }}-E2E-all-logs
+          name: ${{ matrix.name }}-shard${{ matrix.shard }}-E2E-all-logs
           path: |
             /tmp/e2e/
 

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -266,7 +266,7 @@ jobs:
           steps.test-playwright-requests.outcome != 'success' ||
           steps.test-playwright-read-only.outcome != 'success' )
         run: |
-          npx playwright test --workers 4 --grep-invert "(?=.*@write|.*@readonly)" ${{ env.PLAYWRIGHT_OPTIONS }}
+          npx playwright test --workers 1 --grep-invert "(?=.*@write|.*@readonly)" ${{ env.PLAYWRIGHT_OPTIONS }}
 
       - name: Run Playwright tests tagged "@write"
         id: test-playwright-write

--- a/tests/end2end/playwright.serial.config.ts
+++ b/tests/end2end/playwright.serial.config.ts
@@ -1,0 +1,12 @@
+// Config used for the sharded serial test runs (@write and no-tag tests).
+//
+// These tests mutate data and may depend on state left by the previous test
+// in the same spec file. With `fullyParallel: false`, Playwright shards at the
+// whole-file level (never splitting a file across shards), so each isolated
+// docker stack always runs a spec file's tests together and in order.
+import baseConfig from './playwright.config';
+
+export default {
+    ...baseConfig,
+    fullyParallel: false,
+};


### PR DESCRIPTION
## Objectif

Réduire **drastiquement** le wall-clock des tests end2end Playwright (~25-27 min).

## Analyse (baseline, run #29569006019)

Sur ~27 min, ~22 min d'exécution de tests, dominée par des runs **sérialisés (`workers=1`) n'utilisant qu'1 cœur sur 4** :

| Phase | Durée | Workers |
|---|---|---|
| Setup + docker build | ~4 min | - |
| `@readonly` | 6-7 min | 2 |
| no-tag (mute des données) | 7m48 | 1 |
| `@write` | 6m37 | 1 |

## Expériences (mesurées sur la CI)

1. **`@readonly` 2→4 workers** : vert mais gain sous-linéaire (~2min) + flakiness accrue (plafond CPU, runner 4 vCPU). Insuffisant.
2. **no-tag 1→4 workers** : ❌ échec dur → non parallélisable dans un stack partagé (races DB : edition-form, maps-management, admin-qgis-projects… mutent des données malgré l'absence de tag).
3. **Sharding en jobs isolés** ✅ → retenu.

## Solution : sharding sur jobs à DB isolée

Chaque paire **(config × shard)** est un job indépendant avec **son propre stack docker (PostgreSQL isolé)** → sharder les tests `@write`/no-tag qui mutent des données est **sans race**.

- **3 configs × 3 shards = 9 jobs parallèles.**
- `@readonly`/`@requests` : sharding niveau test (lecture seule) ; **2 workers/shard** (le parallélisme vient déjà des shards — inutile de saturer le CPU).
- `@write`/no-tag : nouvelle `tests/end2end/playwright.serial.config.ts` (`fullyParallel:false`) → sharding **par fichier entier** (vérifié : aucun `.spec.js` scindé entre shards), préservant l'ordre/état intra-fichier.
- BATS une fois (shard 1) ; artefacts nommés par shard ; pas de commentaire PR par shard.

## Résultat validé (run #29615007573)

**9/9 verts**, wall-clock (job le plus lent) : **~13 min** contre **27m20** en baseline → **~−50 %**.

| | Baseline | Sharding |
|---|---|---|
| Wall-clock (job le + lent) | 27m20 | **~13 min** |
| Jobs parallèles | 3 | 9 |

Les runs sériels shardés (`@write`, no-tag) tournent à **0 flaky**. Un test lourd pré-existant flaky (`print.spec.js › Print requests with redlining`, timeout 90s) a épuisé ses retries une fois puis passé au rerun — indépendant du sharding (étape no-tag à workers=1, inchangée).

**Compromis** : 3→9 jobs (setup docker dupliqué) → *runner-minutes* ~×1.5-2 en échange d'un wall-clock ~divisé par 2. Plancher restant = setup ~4 min/job ; plus de shards = rendement décroissant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)