### PR TITLE
Fix undefined property readOnly in checkboxes_htmlbootstrap widget

### DIFF
--- a/lizmap/plugins/formwidget/checkboxes_htmlbootstrap/checkboxes_htmlbootstrap.formwidget.php
+++ b/lizmap/plugins/formwidget/checkboxes_htmlbootstrap/checkboxes_htmlbootstrap.formwidget.php
@@ -27,7 +27,7 @@ class checkboxes_htmlbootstrapFormWidget extends checkboxes_htmlFormWidget
     {
         $attr = $this->getControlAttributes();
         $value = $this->getValue();
-        $ro = $this->ctrl->readOnly;
+        $ro = $this->ctrl->isReadOnly();
 
         $attr['name'] = $this->ctrl->ref.'[]';
         unset($attr['title']);


### PR DESCRIPTION
outputControl() read the read-only state as `$this->ctrl->readOnly`, but jFormsControl has no such property: the state is held by the form's data container and exposed through jFormsControl::isReadOnly(), which delegates to jFormsDataContainer::isReadOnly($ref). The only `$readOnly` in Jelix is a protected array on jFormsDataContainer.

Under PHP 8 this emitted "Undefined property
jFormsControlCheckboxes::$readOnly" on every render of a ValueRelation field with AllowMulti, and left $ro null, so the widget added `jforms-required` to read-only controls and never added `jforms-readonly` to any of them.

Use isReadOnly(), matching Lizmap\Form\WidgetTrait::getCSSClass(), which builds the same class list correctly.

