### PR TITLE
Fix/permalink basemap

### DIFF
--- a/assets/src/modules/Permalink.js
+++ b/assets/src/modules/Permalink.js
@@ -138,6 +138,12 @@ export default class Permalink {
             }, ['map.state.changed']
         );
 
+        // Refresh hash parameters when the selected base layer changes
+        mainLizmap.state.baseLayers.addListener(
+            () => this._updatePermalinkParameters(),
+            ['baselayers.selection.changed']
+        );
+
         mainLizmap.state.rootMapGroup.addListener(
             (ev) => {
                 const evtStyleChange = ev.type.indexOf("style.changed") >= 0;
@@ -659,7 +665,16 @@ export default class Permalink {
             mainLizmap.state.layersAndGroupsCollection.groups.reverse() // reverse groups array to get from leaf to root
         );
 
-        const [extent4326, itemsInURL, stylesInURL, opacitiesInURL, symbologyInUrl] = this._getPermalinkValues();
+        const [extent4326, itemsInURL, stylesInURL, opacitiesInURL, symbologyInUrl, baseLayerInURL] = this._getPermalinkValues();
+
+        // Restore the selected base layer, if any is stored in the permalink
+        if (baseLayerInURL) {
+            const baseLayerName = decodeURIComponent(baseLayerInURL);
+            const baseLayersState = mainLizmap.state.baseLayers;
+            if (baseLayersState.baseLayerNames.includes(baseLayerName)) {
+                baseLayersState.selectedBaseLayerName = baseLayerName;
+            }
+        }
 
         if (setExtent
             && extent4326
@@ -707,7 +722,7 @@ export default class Permalink {
      */
     _getPermalinkValues(){
         if (this._shortLinkPermalink) {
-            let permalinkValues = Array(4);
+            let permalinkValues = Array(6);
             try {
                 let currentPermalink = this.currentPermalinkProperties;
                 if (currentPermalink) {
@@ -717,6 +732,7 @@ export default class Permalink {
                         currentPermalink.styles ?? null,
                         currentPermalink.opacities ?? null,
                         currentPermalink.symbology ?? null,
+                        currentPermalink.baselayer ?? null,
                     ]
                 }
             } catch(e){
@@ -725,7 +741,11 @@ export default class Permalink {
 
             return permalinkValues;
         } else {
-            return window.location.hash.substring(1).split('|').map(part => part.split(','));
+            // Classic hash format: bbox|layers|styles|opacities|baselayer
+            // (symbology is only used with short link permalinks)
+            const parts = window.location.hash.substring(1).split('|').map(part => part.split(','));
+            const baseLayer = (parts[4] && parts[4][0]) ? parts[4][0] : null;
+            return [parts[0], parts[1] ?? null, parts[2] ?? null, parts[3] ?? null, null, baseLayer];
         }
     }
 
@@ -838,16 +858,30 @@ export default class Permalink {
             }
         }
 
-        if (itemsVisibility.length) {
-            hash += '|' + itemsVisibility.join();
-        }
+        // Currently selected base layer (may be null when no base layer is defined)
+        const selectedBaseLayerName = mainLizmap.state.baseLayers.selectedBaseLayerName;
 
-        if (itemsStyle.length) {
-            hash += '|' + itemsStyle.join();
-        }
+        if (selectedBaseLayerName) {
+            // The base layer is stored as the last (5th) segment of the hash.
+            // Always emit the layers/styles/opacities segments (even when empty)
+            // so the base layer keeps a fixed position and stays readable when
+            // no overlay layer is visible.
+            hash += '|' + itemsVisibility.join()
+                 +  '|' + itemsStyle.join()
+                 +  '|' + itemsOpacity.join()
+                 +  '|' + encodeURIComponent(selectedBaseLayerName);
+        } else {
+            if (itemsVisibility.length) {
+                hash += '|' + itemsVisibility.join();
+            }
 
-        if (itemsOpacity.length) {
-            hash += '|' + itemsOpacity.join();
+            if (itemsStyle.length) {
+                hash += '|' + itemsStyle.join();
+            }
+
+            if (itemsOpacity.length) {
+                hash += '|' + itemsOpacity.join();
+            }
         }
 
         // Saved new hash
@@ -861,6 +895,7 @@ export default class Permalink {
             if (itemsStyle.length) hashParams.styles = itemsStyle;
             if (itemsOpacity.length) hashParams.opacities = itemsOpacity;
             if (itemsSymbology.length) hashParams.symbology = itemsSymbology;
+            if (selectedBaseLayerName) hashParams.baselayer = encodeURIComponent(selectedBaseLayerName);
 
             this.currentPermalinkProperties = {repository: repository, project: project, plink: hashParams};
         }

--- a/tests/end2end/playwright/permalink-baselayer.spec.js
+++ b/tests/end2end/playwright/permalink-baselayer.spec.js
@@ -1,0 +1,96 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+import { gotoMap, reloadMap, playwrightTestFile } from './globals';
+import { ProjectPage } from './pages/project';
+
+/**
+ * Dedicated coverage for storing/restoring the selected base layer in a
+ * permalink (the share link / geobookmark hash). The `base_layers` project
+ * defines several base layers (`osm-mapnik` is the startup one), so we can
+ * switch to another one and check it survives a permalink round-trip.
+ */
+test.describe('Permalink base layer @readonly', () => {
+
+    test.beforeEach(async ({ page }) => {
+        // Force automatic permalink so the URL hash reflects the map state
+        await page.route('**/service/getProjectConfig*', async route => {
+            const response = await route.fetch();
+            const json = await response.json();
+            json.options['automatic_permalink'] = true;
+            await route.fulfill({ response, json });
+        });
+
+        // Mock OpenStreetMap tiles (default base layer) with a transparent tile
+        // so the test does not depend on the external OSM tile server.
+        await page.route('https://tile.openstreetmap.org/*/*/*.png', async route => {
+            await route.fulfill({
+                path: playwrightTestFile('mock', 'transparent_tile.png')
+            });
+        });
+    });
+
+    test.afterEach(async ({ page }) => {
+        await page.unroute('**/service/getProjectConfig*');
+        await page.unroute('https://tile.openstreetmap.org/*/*/*.png');
+    });
+
+    test('Selected base layer is stored in the hash and restored on reload', async ({ page }) => {
+        const project = new ProjectPage(page, 'base_layers');
+        await project.open();
+
+        // Startup base layer
+        await expect(project.baseLayerSelect).toHaveValue('osm-mapnik');
+
+        // Switch to the empty base layer
+        await project.baseLayerSelect.selectOption('empty');
+        await expect(project.baseLayerSelect).toHaveValue('empty');
+
+        // The base layer is written as the last segment of the permalink hash
+        let hash = decodeURIComponent(new URL(page.url()).hash);
+        await expect(hash.length).toBeGreaterThan(0);
+        await expect(hash.split('|').pop()).toBe('empty');
+
+        // Reload: the empty base layer must be restored from the hash
+        await reloadMap(page);
+        await expect(project.baseLayerSelect).toHaveValue('empty');
+
+        // Switch to a project base layer and check the round-trip again
+        await project.baseLayerSelect.selectOption('quartiers_baselayer');
+        await expect(project.baseLayerSelect).toHaveValue('quartiers_baselayer');
+
+        hash = decodeURIComponent(new URL(page.url()).hash);
+        await expect(hash.split('|').pop()).toBe('quartiers_baselayer');
+
+        await reloadMap(page);
+        await expect(project.baseLayerSelect).toHaveValue('quartiers_baselayer');
+    });
+
+    test('Base layer from a shared permalink URL is applied on load', async ({ page }) => {
+        const baseUrl = '/index.php/view/map?repository=testsrepository&project=base_layers';
+        const bbox = '3.7980645260916805,43.59756940064654,3.904383263124536,43.672963842067254';
+        // Classic hash format: bbox|layers|styles|opacities|baselayer
+        // (empty layers/styles/opacities: only the base layer is shared)
+        const url = baseUrl + '#' + bbox + '||||quartiers_baselayer';
+
+        // No overlay layer is visible, so no GetLegendGraphic is expected
+        await gotoMap(url, page, true, 0, false);
+
+        const project = new ProjectPage(page, 'base_layers');
+        // The shared base layer must be selected, not the project startup one
+        await expect(project.baseLayerSelect).toHaveValue('quartiers_baselayer');
+    });
+
+    test('Unknown base layer in the hash is ignored (falls back to startup)', async ({ page }) => {
+        const baseUrl = '/index.php/view/map?repository=testsrepository&project=base_layers';
+        const bbox = '3.7980645260916805,43.59756940064654,3.904383263124536,43.672963842067254';
+        const url = baseUrl + '#' + bbox + '||||does_not_exist';
+
+        await gotoMap(url, page, true, 0, false);
+
+        // No error and the startup base layer stays selected
+        await expect(page.locator('p.error-msg')).toHaveCount(0);
+        const project = new ProjectPage(page, 'base_layers');
+        await expect(project.baseLayerSelect).toHaveValue('osm-mapnik');
+    });
+
+});


### PR DESCRIPTION
The permalink/geobookmark stored bbox, layer visibility, styles and opacities but never the selected base layer. When a permalink or geobookmark was loaded, the base layer fell back to the project's startup base layer, ignoring the one that was active when the link was created.

Store the selected base layer name in the permalink (as a 5th hash segment "bbox|layers|styles|opacities|baselayer" in classic mode, and as a "baselayer" property in short link mode) and restore it on load via baseLayers.selectedBaseLayerName. Also refresh the permalink when the base layer selection changes, so base-layer-only changes are captured. Old permalinks without a base layer segment keep working unchanged.