### PR TITLE
[GA] E2E: launched @readonly if QGIS Server is available

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -211,8 +211,9 @@ jobs:
           CRTF_JSON_FILE: playwright-tagged-readonly.json
           PLAYWRIGHT_JSON_OUTPUT_NAME: tests-results-readonly.json
         if: |
-          success() ||
-          steps.test-playwright-requests.outcome != 'success'
+          steps.qgis-server-status.outcome == 'success' &&
+          ( success() ||
+          steps.test-playwright-requests.outcome != 'success' )
         run: |
           npx playwright test --grep @readonly --grep-invert @requests ${{ env.PLAYWRIGHT_OPTIONS }} --workers=2 --shard=${{ matrix.shard }}/3
 


### PR DESCRIPTION
Launched Playwright end2end tests only if QGIS Server is available.