### PR TITLE
PHP: Update Guzzle to version 8 because of Psr7 version 3

### DIFF
--- a/lizmap/composer.json
+++ b/lizmap/composer.json
@@ -13,7 +13,7 @@
     "jelix/ldapdao-module": "~2.2.4",
     "proj4php/proj4php": "~2.0.0",
     "violet/streaming-json-encoder": "^1.1.5",
-    "guzzlehttp/guzzle": "^7.7.0",
+    "guzzlehttp/guzzle": "^8.0.0",
     "halaxa/json-machine": "^1.1",
     "kevinrob/guzzle-cache-middleware": "^7.0",
     "psr/log": "2.*"

--- a/lizmap/composer.json
+++ b/lizmap/composer.json
@@ -13,9 +13,9 @@
     "jelix/ldapdao-module": "~2.2.4",
     "proj4php/proj4php": "~2.0.0",
     "violet/streaming-json-encoder": "^1.1.5",
-    "guzzlehttp/guzzle": "^7.7.0",
+    "guzzlehttp/guzzle": "^8.0.0",
     "halaxa/json-machine": "^1.1",
-    "kevinrob/guzzle-cache-middleware": "^7.0",
+    "kevinrob/guzzle-cache-middleware": "^8.0",
     "psr/log": "2.*"
   },
   "minimum-stability": "stable",


### PR DESCRIPTION
Guzzle 8 adjusted `guzzlehttp/psr7` version constraint to `^3.0` 
This fixed *Since guzzlehttp/psr7 2.11: Passing int to MessageInterface::withHeader() is deprecated; guzzlehttp/psr7 3.0 requires string|string[].*