### PR TITLE
[CI] Add PHP 8.5 to the test matrices

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -41,7 +41,7 @@ jobs:
             qgis-server: "3.40"
             update-projects: "FALSE"
           - name: "BLEEDING_EDGE"
-            php: "8.4"
+            php: "8.5"
             pg-postgis: "18-3"
             qgis-server: "3.44"
             update-projects: "TRUE"

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -51,10 +51,11 @@ jobs:
       PLAYWRIGHT_JSON_OUTPUT_DIR: ${{ github.workspace }}/tests/end2end/playwright-report
       PLAYWRIGHT_OPTIONS: --project=end2end
       FORCE_COLOR: true
+      DOCKERHUB_TOKEN_SET: ${{ secrets.DOCKERHUB_TOKEN != '' }}
     steps:
 
       - name: Login to Docker Hub
-        if: ${{ github.secret_source == 'Actions' && secrets.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.secret_source == 'Actions' && env.DOCKERHUB_TOKEN_SET == 'true' }}
         uses: docker/login-action@v4
         env:
           ACTIONS_STEP_DEBUG: true

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
 
       - name: Login to Docker Hub
-        if: ${{ github.secret_source == 'Actions' }}
+        if: ${{ github.secret_source == 'Actions' && secrets.DOCKERHUB_TOKEN != '' }}
         uses: docker/login-action@v4
         env:
           ACTIONS_STEP_DEBUG: true

--- a/.github/workflows/php-stan.yml
+++ b/.github/workflows/php-stan.yml
@@ -25,6 +25,7 @@ jobs:
           - php-version: '8.2'
           - php-version: '8.3'
           - php-version: '8.4'
+          - php-version: '8.5'
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,8 @@ jobs:
             php-unit: "12.5.8"
           - php-version: "8.4"
             php-unit: "12.5.8"
+          - php-version: "8.5"
+            php-unit: "12.5.8"
     steps:
 
       - name: Check out repository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - release_3_*
+  workflow_dispatch:
 
 env:
   PHP_VERSION: "8.1"


### PR DESCRIPTION
## Summary
- Add PHP 8.5 to the PHP-Unit matrix (tests.yml) and the PHPStan matrix (php-stan.yml)
- Bump the e2e BLEEDING_EDGE job (e2e_tests.yml) from PHP 8.4 to PHP 8.5
- Make `tests.yml` dispatchable manually (workflow_dispatch), and make the Docker Hub login step in e2e_tests.yml skip gracefully when DOCKERHUB_TOKEN isn't set (org secret unavailable on forks), instead of failing with "Password required"

## Test plan
- [ ] Unit tests (PHP 8.5) pass
- [ ] PHPStan (PHP 8.5) passes
- [ ] e2e tests (BLEEDING_EDGE / PHP 8.5) pass