### PR TITLE
[CI] Pin e2e QGIS Lizmap Server plugin to 2.14.1

### DIFF
--- a/tests/add_server_plugins.sh
+++ b/tests/add_server_plugins.sh
@@ -18,7 +18,11 @@ fi
 echo "QGIS Server Lizmap and WfsOutputExtension plugins"
 echo "Loading from $(cat $QGIS_PLUGIN_MANAGER_SOURCES_FILE)"
 qgis-plugin-manager update
-qgis-plugin-manager install -f "Lizmap server"
+# Pinned to 2.14.1: releases 2.15.0/2.15.1 (2026-07-27) throw a server error (HTTP 500) on the
+# GetFeatureInfo(FILTER=..., with_maptip=true) request used to fetch embedded relation children,
+# breaking the popup children display (see e2e embedded-relation.spec.js).
+# Unpin once https://github.com/3liz/qgis-lizmap-server-plugin ships a fix for this regression.
+qgis-plugin-manager install -f "Lizmap server"==2.14.1
 qgis-plugin-manager install -f wfsOutputExtension
 qgis-plugin-manager install -f atlasprint
 


### PR DESCRIPTION
## Summary

The e2e workflow has been failing since ~2026-07-27 18:00 UTC ([run 30344907345](https://github.com/3liz/lizmap-web-client/actions/runs/30344907345) and several before it), consistently on:

- `embedded-relation.spec.js` › "Visualize popup for embedded layers": `.lizmapPopupChildren .lizmapPopupSingleFeature` count expected `2`, got `0`, across STABLE (QGIS 3.40), LEGACY (QGIS 3.40) and BLEEDING_EDGE (QGIS 3.44) shards alike.

**Root cause**: `tests/add_server_plugins.sh` installs the "Lizmap server" QGIS Server plugin unpinned (`qgis-plugin-manager install -f "Lizmap server"`), i.e. always the latest release. That plugin shipped **2.15.0** on 2026-07-27 17:35 UTC and **2.15.1** shortly after — right when e2e started failing on every environment simultaneously (same regression regardless of QGIS/PG/PHP version rules out a lizmap-web-client-side cause).

Digging into the CI artifacts (docker/nginx logs + `echoproxy.log`) for the failing run shows the client-side flow is correct: it issues a `GetFeatureInfo` request with `FILTER=child_layer:"father_id" = '1'` and `with_maptip=true` (the mechanism used to fetch embedded relation children server-side), and QGIS Server returns **HTTP 500** for that specific request — before, that same request returned the popup HTML with the children. This points to a regression in the plugin's GetFeatureInfo/maptip XML processing, which was substantially rewritten in the same release window. The bug lives in https://github.com/3liz/qgis-lizmap-server-plugin, not in this repository.

The one other failure in that run (`popup.spec.js` › "Check lizmap feature toolbar", a dataviz visibility timeout in a single BLEEDING_EDGE shard) doesn't reproduce in the other failing runs and looks like an unrelated one-off timing flake.

## Fix

Pin the e2e Docker stack to the last known-good plugin release (`2.14.1`) instead of "latest", so CI isn't at the mercy of upstream plugin regressions. Unpin once the plugin repo ships a fix.

## Test plan

- [ ] e2e workflow (triggered by this PR) goes green, in particular `embedded-relation.spec.js`