### PR TITLE
[BUGFIX] Show the "deactivate current filter" button with the form filter

### DIFF
--- a/assets/src/legacy/filter.js
+++ b/assets/src/legacy/filter.js
@@ -1013,6 +1013,10 @@ var lizLayerFilterTool = function () {
                 if (filterMethod == 'simple') {
                     // Use a simple filter only for the getmap and other WMS/WFS queries
                     lizMap.triggerLayerFilter(layerName, filter);
+
+                    // Show the "deactivate current filter" button in the layer switcher
+                    lizMap.lizmapLayerFilterActive = layerName;
+                    $('#layerActionUnfilter').toggle(true);
                 } else {
                     // Get the filtered features fids
                     var pkField = lizMap.config.attributeLayers[layerName]['primaryKey'];
@@ -1076,6 +1080,12 @@ var lizLayerFilterTool = function () {
                 if (filterMethod == 'simple') {
                     // Use a simple filter only for the getmap and other WMS/WFS queries
                     lizMap.deactivateMaplayerFilter(layerName);
+
+                    // Hide the "deactivate current filter" button in the layer switcher
+                    if (lizMap.lizmapLayerFilterActive === layerName) {
+                        lizMap.lizmapLayerFilterActive = null;
+                    }
+                    $('#layerActionUnfilter').toggle((lizMap.lizmapLayerFilterActive !== null));
 
                     // Refresh plots
                     lizMap.events.triggerEvent("layerFilterParamChanged",

--- a/tests/end2end/playwright/form-filter.spec.js
+++ b/tests/end2end/playwright/form-filter.spec.js
@@ -99,4 +99,32 @@ test.describe('Form filter', () => {
         await expect(page.locator('#ui-id-2 .ui-menu-item')).toHaveCount(1);
         await expect(page.locator('#ui-id-2 .ui-menu-item div')).toHaveText('monuments');
     });
+
+    test('Deactivate filter button shows up with the "simple" filter method', async ({ page }) => {
+        // Force the 'simple' filtering method (bypasses the attribute table code path)
+        // https://github.com/3liz/lizmap-web-client/issues/6775
+        await page.evaluate(() => { globalThis['filterConfigData'].filterMethod = 'simple'; });
+
+        const unfilterButton = page.locator('#layerActionUnfilter');
+
+        // The "Deactivate current filter" button lives in the layer switcher dock,
+        // opening it switches away from the filter dock (docks are mutually exclusive)
+        await page.locator('#button-switcher').click();
+        await expect(unfilterButton).toBeHidden();
+
+        // Re-open the filter dock to apply the filter
+        await page.locator('#button-filter').click();
+        await page.locator('#liz-filter-field-test_filter').selectOption('_uvres_d_art_et_monuments_de_l_espace_urbain');
+        await expect(page.locator('#liz-filter-item-layer-total-count')).toHaveText('1');
+
+        // Bug #6775: this button stayed hidden before the fix
+        await page.locator('#button-switcher').click();
+        await expect(unfilterButton).toBeVisible();
+
+        await unfilterButton.click();
+        await expect(unfilterButton).toBeHidden();
+
+        await page.locator('#button-filter').click();
+        await expect(page.locator('#liz-filter-item-layer-total-count')).toHaveText('4');
+    });
 });


### PR DESCRIPTION
## Problem

Fixes #6775.

The "Deactivate current filter" button (`#layerActionUnfilter`, in the layer switcher dock) does not show up when the filter is applied from the form filter panel, while it does show up when the filter comes from the attribute table or the selection.

## Root cause

The button's visibility is driven solely by the `lizMap.lizmapLayerFilterActive` global, and it was toggled in a single place: `attributeTable.js` (`updateLayer()`). That code is only reached by the **"full"** filtering path, which builds the filter from a list of feature ids.

The form filter panel picks its method in `getFilterMethod()` (`filter.js`): it defaults to **"simple"**, and only uses "full" when the layer has an attribute table config with a single-column primary key. The "simple" path applies a WMS/WFS expression filter via `lizMap.triggerLayerFilter()` / `lizMap.deactivateMaplayerFilter()` (`map.js`), which never touched `lizmapLayerFilterActive` nor the button.

## Fix

The button state is now updated in the two `'simple'` branches of `filter.js`.

The low-level `map.js` helpers are **deliberately left untouched**: `timemanager.js` calls `triggerLayerFilter()` on every time step, so updating the button there would make it flicker while the Time Manager plays.

Nothing else was needed — clicking the button already worked once visible: it triggers `layerfeatureremovefilter`, which `attributeTable.js` already handles to clear the map filter (`exp_filter`/`filtertoken`/`filter` + `expressionFilter`) and `filter.js` already handles to reset the form fields.

## Test

Added a Playwright test in `form-filter.spec.js`.

The existing `form_filter` fixture has single-column primary keys on both layers, so `getFilterMethod()` always resolves to `"full"` there — which is why the existing tests never covered this. The new test forces the `"simple"` path with `filterConfigData.filterMethod = 'simple'`, the extension point already documented in `filter.js` for project custom scripts, so the existing tests on that fixture keep exercising `"full"` unchanged.

Verified locally: the new test fails on `expect(unfilterButton).toBeVisible()` without the fix, and passes with it.

Note: `Form filter with combobox` fails on my local stack because of an echo-proxy setup issue in `getEchoRequestParams`; it fails identically on a clean `master`, so it is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)