### PR TITLE
[BUGFIX] Keep the form filter of the other layers

### DIFF
--- a/assets/src/legacy/filter.js
+++ b/assets/src/legacy/filter.js
@@ -145,23 +145,30 @@ var lizLayerFilterTool = function () {
                     && lizMap.config.attributeLayers[layerName].export_enabled == 'True';
                 $('#liz-filter-export').toggle(!!layerExportEnabled);
 
-                // Remove previous field inputs
-                $('div.liz-filter-field-box').remove();
+                // Hide the field inputs of the other layers. They are kept in the
+                // DOM so that their state, and therefore their filter, is preserved
+                // when the user comes back to them.
+                $('#filter div.tree > div[id^="filter-field-order"]').hide();
 
-                // Get html and add it
+                // Get html and add it, or show it back when already built
                 getLayerFilterForm();
 
                 // Limit dock size
                 adaptLayerFilterSize();
 
+                // This layer may already be filtered, from a previous visit of
+                // its form. Restore that filter as the current one.
+                var layerFilter = getFilterForLayer(layerId);
+                globalThis['filterConfigData'].filter = layerFilter ? layerFilter : undefined;
+
                 // Get Feature count
-                getFeatureCount();
+                getFeatureCount(layerFilter);
 
                 // Set default zoom extent setZoomExtent
                 // Only if first query works
                 // Which means PHP spatialite extension is activated
                 if ($('#liz-filter-zoom').is(":visible")) {
-                    setZoomExtent();
+                    setZoomExtent(layerFilter);
                 }
             }
 
@@ -178,8 +185,15 @@ var lizLayerFilterTool = function () {
                 for (var o in globalThis['filterConfig']) {
                     var field_item = globalThis['filterConfig'][o];
                     if ('title' in field_item && field_item.layerId == layerId) {
+                        var fieldContainerId = 'filter-field-order' + String(field_item.order);
+                        // The field has already been built: only show it back,
+                        // its current value and filter are preserved
+                        if (document.getElementById(fieldContainerId)) {
+                            $('#' + fieldContainerId).show();
+                            continue;
+                        }
                         formFilterLayersSorted.push(field_item);
-                        $("#filter div.tree").append('<div id="filter-field-order' + String(field_item.order) + '"></div>');
+                        $("#filter div.tree").append('<div id="' + fieldContainerId + '"></div>');
                     }
                 }
 
@@ -979,14 +993,13 @@ var lizLayerFilterTool = function () {
 
 
             /**
-             * Compute the global filter to pass to the layer
-             * and apply it to the map and other tools
-             *
+             * Compute the filter of a layer by combining the filter
+             * of each of its form fields. Returns an empty string when the
+             * layer is not filtered.
+             * @param layerId
+             * @returns {string} The layer filter
              */
-            function activateFilter() {
-                var layerId = globalThis['filterConfigData'].layerId;
-                var layerName = globalThis['filterConfigData'].layerName;
-
+            function getFilterForLayer(layerId) {
                 var afilter = [];
                 for (var o in globalThis['filterConfig']) {
                     var field_item = globalThis['filterConfig'][o];
@@ -996,14 +1009,26 @@ var lizLayerFilterTool = function () {
                 }
 
                 // We use AND clause between fields
-                var filter = afilter.join(' AND ');
+                return afilter.join(' AND ');
+            }
+
+            /**
+             * Compute the global filter to pass to the layer
+             * and apply it to the map and other tools
+             *
+             */
+            function activateFilter() {
+                var layerId = globalThis['filterConfigData'].layerId;
+                var layerName = globalThis['filterConfigData'].layerName;
+
+                var filter = getFilterForLayer(layerId);
 
                 // Deactivate the filter if it is empty.
                 // It can occur when the user unchecks the only checkbox
                 // which was checked before,
                 // or resetted the field input with the reset button
                 // when only this field filter was active
-                if (afilter.length == 0 || filter.trim() == '') {
+                if (filter.trim() == '') {
                     deactivateFilter();
                     return true;
                 }
@@ -1531,7 +1556,8 @@ var lizLayerFilterTool = function () {
 
             // Listen to the layer selector changes
             $('#liz-filter-layer-selector').change(function () {
-                deactivateFilter();
+                // The filter of the layer we are leaving is kept, so that several
+                // layers can be filtered at the same time
                 globalThis['filterConfigData'].layerId = $(this).val();
                 launchLayerFilterTool($(this).val());
             });

--- a/tests/end2end/playwright/form-filter.spec.js
+++ b/tests/end2end/playwright/form-filter.spec.js
@@ -99,4 +99,34 @@ test.describe('Form filter', () => {
         await expect(page.locator('#ui-id-2 .ui-menu-item')).toHaveCount(1);
         await expect(page.locator('#ui-id-2 .ui-menu-item div')).toHaveText('monuments');
     });
+
+    test('Filtering a second layer keeps the filter on the first one', async ({ page }) => {
+        // https://github.com/3liz/lizmap-web-client/issues/6772
+        const PARENT = 'form filter (à)';
+        const CHILD = 'form_filter_child_bus_stops';
+        const expFilter = (layer) => page.evaluate(
+            (l) => lizMap.config.layers[l]?.request_params?.exp_filter ?? null,
+            layer,
+        );
+
+        // Filter the first layer
+        await page.locator('#liz-filter-field-test_filter').selectOption('_uvres_d_art_et_monuments_de_l_espace_urbain');
+        await expect(page.locator('#liz-filter-item-layer-total-count')).toHaveText('1');
+        await expect.poll(() => expFilter(PARENT)).toBeTruthy();
+
+        // Switch the filter panel to the second layer, then filter it too
+        await page.locator('#liz-filter-layer-selector').selectOption(CHILD);
+        // Pick the first real value (index 0 is the empty " --- " entry)
+        await page.locator('#liz-filter-field-child_label').selectOption({ index: 1 });
+        await expect.poll(() => expFilter(CHILD)).toBeTruthy();
+
+        // Bug #6772: switching layers used to reset the first layer's filter
+        expect(await expFilter(PARENT)).toBeTruthy();
+
+        // Coming back to the first layer shows its filter again, the form
+        // fields are kept in the DOM instead of being rebuilt from scratch
+        await page.locator('#liz-filter-layer-selector').selectOption(PARENT);
+        await expect(page.locator('#liz-filter-field-test_filter')).toHaveValue('_uvres_d_art_et_monuments_de_l_espace_urbain');
+        await expect(page.locator('#liz-filter-item-layer-total-count')).toHaveText('1');
+    });
 });

--- a/tests/qgis-projects/tests/form_filter.qgs.cfg
+++ b/tests/qgis-projects/tests/form_filter.qgs.cfg
@@ -197,6 +197,15 @@
             "end_field": "id",
             "order": 2,
             "provider": "postgres"
+        },
+        "3": {
+            "layerId": "form_filter_child_bus_stops_127f4642_a441_45cc_aa49_687900fb96c8",
+            "title": "child_label",
+            "type": "uniquevalues",
+            "field": "label",
+            "format": "select",
+            "order": 3,
+            "provider": "postgres"
         }
     }
 }


### PR DESCRIPTION
## Problem

Fixes #6772.

With a form filter active on layer A, selecting layer B in the form filter panel immediately reset the filter on layer A, while both layers can legitimately be filtered at the same time.

## Root cause

The layer selector handler called `deactivateFilter()` before switching:

```js
$('#liz-filter-layer-selector').change(function () {
    deactivateFilter();   // <-- drops the filter of the layer being left
    globalThis['filterConfigData'].layerId = $(this).val();
    launchLayerFilterTool($(this).val());
});
```

At that point `filterConfigData.layerName` still pointed at layer A, so it was A's filter that got removed.

## Fix

The layer being left keeps its filter.

To stay consistent, the field inputs of a layer are no longer removed from the DOM when switching layer (`$('div.liz-filter-field-box').remove()`), they are hidden and shown back on return. That preserves their value — and therefore the filter they produce — without having to serialize and restore the state of each of the four field types (none of the builders restored a user value: `uniquevalues` rebuilt the select with ` --- ` selected, date/numeric reset to the full `min`/`max` range, text to `""`).

`filterConfigData.filter` is recomputed for the newly selected layer, and the feature count and zoom extent are now requested with it, so the panel reflects the filter actually applied to that layer instead of showing the unfiltered count.

The per-layer filter computation is extracted into `getFilterForLayer()` and reused by `activateFilter()`.

Note this does not change the single `lizmapLayerFilterActive` global, so the ambiguity raised in [this comment](https://github.com/3liz/lizmap-web-client/issues/6772#issuecomment-4329436169) about which layer the layer-switcher unfilter button applies to when several layers are filtered is out of scope here.

## Test

Added a Playwright test in `form-filter.spec.js` asserting that filtering a second layer keeps the first layer's `exp_filter`, and that coming back to the first layer still shows its selected value and its filtered feature count.

The `form_filter` test project had a form filter on only one of its two layers, so the layer selector had a single entry and this could not be covered. A form filter on `form_filter_child_bus_stops` is added to the fixture (9 lines in the `.cfg`); the default selected layer is unchanged, so the existing tests keep exercising the same layer.

Verified locally: the new test fails on the parent `exp_filter` assertion without the fix (it is `null`) and passes with it.

Unrelated pre-existing local failures, identical on a clean `master`: `Form filter with combobox` (echo proxy not set up on my stack) and the four `Key/value in attribute table` tests in `key_value_mapping.spec.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)