### PR TITLE
[BUGFIX] Time manager: keep the filter already set on the layer

### DIFF
--- a/assets/src/legacy/timemanager.js
+++ b/assets/src/legacy/timemanager.js
@@ -63,6 +63,10 @@ var lizTimemanager = function() {
             var filter = null;
             var tmAnimationTimer;
             var tmCurrentDate;
+            // Filter each controlled layer already had when the time manager was
+            // opened, by layer name. The date filter is combined with it, instead
+            // of replacing it.
+            var tmBaseFilters = {};
             var tmStartDate = -Infinity; // lower bound of when values
             var tmEndDate = Infinity; // upper value of when values
 
@@ -83,6 +87,16 @@ var lizTimemanager = function() {
 
                 // hourglass
                 //$('#loading').dialog('open');
+
+                // Keep the filter the layers may already have, e.g. set from the
+                // form filter, so that the date filter is combined with it (#6773)
+                tmBaseFilters = {};
+                for (var tmLayer in config.timemanagerLayers) {
+                    var tmLayerRequestParams = config.layers[tmLayer]?.['request_params'];
+                    if (tmLayerRequestParams?.['exp_filter']) {
+                        tmBaseFilters[tmLayer] = tmLayerRequestParams['exp_filter'];
+                    }
+                }
 
                 // Get min and max timestamps from layers
                 var minTime = Infinity, maxTime = -Infinity ;
@@ -352,6 +366,15 @@ var lizTimemanager = function() {
                 // Set filter for each vector layer
                 for (var l in config.timemanagerLayers){
                     filter = buildDateFilter(config.timemanagerLayers[l], lowerBoundary, upperBoundary);
+
+                    // Combine the date filter with the filter the layer already had,
+                    // otherwise the time manager would drop it (#6773)
+                    if (tmBaseFilters[l]) {
+                        filter = filter
+                            ? '( ' + tmBaseFilters[l] + ' ) AND ' + filter
+                            : tmBaseFilters[l];
+                    }
+
                     lizMap.triggerLayerFilter(l, filter);
                 }
             }
@@ -516,6 +539,14 @@ var lizTimemanager = function() {
             function unFilterTimeLayers() {
                 // Remove filter
                 for(var layerName in lizMap.config.timemanagerLayers){
+                    // The layer was already filtered before the time manager was
+                    // opened: only remove the date part, by restoring that filter.
+                    // `triggerLayerFilter` refreshes plots and popups on its own.
+                    if (tmBaseFilters[layerName]) {
+                        lizMap.triggerLayerFilter(layerName, tmBaseFilters[layerName]);
+                        continue;
+                    }
+
                     lizMap.deactivateMaplayerFilter(layerName);
                     // Refresh plots and popups
                     lizMap.config.layers[layerName]['request_params']['filtertoken'] = null;
@@ -527,6 +558,7 @@ var lizTimemanager = function() {
                         }
                     );
                 }
+                tmBaseFilters = {};
             }
 
             /**

--- a/tests/end2end/playwright/time-manager.spec.js
+++ b/tests/end2end/playwright/time-manager.spec.js
@@ -371,5 +371,42 @@ test.describe('Time Manager @readonly', () => {
         responseExpect(getMapNoFilterResponse).toBeImagePng();
     });
 
+    test('Keeps the filter already set on the layer', async ({ page }) => {
+        // https://github.com/3liz/lizmap-web-client/issues/6773
+        const project = new ProjectPage(page, 'time_manager');
+        await project.open();
+
+        // Filter the layer with the form filter, keeping the features with gid <= 2
+        await page.locator('#button-filter').click();
+        let getFilterTokenRequestPromise = project.waitForGetFilterTokenRequest();
+        await page.locator('#liz-filter-field-max-numericgid').fill('2');
+        // The numeric field applies its filter on `change`, which `fill()` alone
+        // does not trigger on a number input
+        await page.locator('#liz-filter-field-max-numericgid').dispatchEvent('change');
+
+        // The form filter is applied on its own
+        let getFilterTokenRequest = await getFilterTokenRequestPromise;
+        expect(decodeURIComponent(getFilterTokenRequest.postData() ?? '')).toContain('"gid"');
+
+        // Opening the time manager applies its date filter
+        getFilterTokenRequestPromise = project.waitForGetFilterTokenRequest();
+        await page.locator('#button-timemanager').click();
+        getFilterTokenRequest = await getFilterTokenRequestPromise;
+        const timeFilter = decodeURIComponent(getFilterTokenRequest.postData() ?? '');
+
+        expect(timeFilter).toContain('"test_date"');
+        // Bug #6773: the filter already set on the layer used to be replaced,
+        // so the time manager had no visible effect on the filtered features
+        expect(timeFilter).toContain('"gid"');
+
+        // Closing the time manager restores the filter of the layer alone
+        getFilterTokenRequestPromise = project.waitForGetFilterTokenRequest();
+        await page.locator('.btn-timemanager-clear').click();
+        getFilterTokenRequest = await getFilterTokenRequestPromise;
+        const restoredFilter = decodeURIComponent(getFilterTokenRequest.postData() ?? '');
+
+        expect(restoredFilter).toContain('"gid"');
+        expect(restoredFilter).not.toContain('"test_date"');
+    });
 
 });

--- a/tests/qgis-projects/tests/time_manager.qgs.cfg
+++ b/tests/qgis-projects/tests/time_manager.qgs.cfg
@@ -124,5 +124,15 @@
         },
         "layers": []
     },
-    "formFilterLayers": {}
+    "formFilterLayers": {
+        "0": {
+            "layerId": "time_manager_f272466b_c160_439c_bb9b_6c4b8c5ff74d",
+            "title": "gid",
+            "type": "numeric",
+            "start_field": "gid",
+            "end_field": "gid",
+            "order": 0,
+            "provider": "postgres"
+        }
+    }
 }


### PR DESCRIPTION
## Problem

Fixes #6773.

When a controlled layer already has a filter — typically set from the form filter — the time manager and that filter do not compose: the date range never restricts the features that the layer filter selected.

## Root cause

`setLayersFilter()` passed only its own date filter:

```js
filter = buildDateFilter(config.timemanagerLayers[l], lowerBoundary, upperBoundary);
lizMap.triggerLayerFilter(l, filter);
```

`lizMap.triggerLayerFilter()` *replaces* `request_params.exp_filter` on the layer, so the filter already applied was dropped at the first date step. Symmetrically, closing the time manager called `deactivateMaplayerFilter()`, wiping the layer filter along with the date one.

Reproduced with a form filter keeping `gid <= 2`: the GETFILTERTOKEN sent when opening the time manager contained only `"test_date"` conditions, the `"gid"` condition was gone.

## Fix

The filter each controlled layer has when the time manager is opened is captured in `tmBaseFilters` and combined with the date filter of every step. Closing the time manager restores that filter instead of clearing the layer, so only the date part is removed.

When the layer had no filter, the filter string is byte-for-byte unchanged, which keeps the existing (quite precise) GETFILTERTOKEN assertions in `time-manager.spec.js` and `time-manager-years.spec.js` valid.

**Known limitation:** the base filter is captured when the time manager is opened, so changing the form filter while the time manager is running is not picked up until it is reopened. Handling that properly needs the layer filters to be tracked per origin rather than as a single `exp_filter` string, which is a larger change.

## Test

Added a test in `time-manager.spec.js`: it filters the layer with the form filter, then asserts the time manager's GETFILTERTOKEN carries both the `"gid"` and the `"test_date"` conditions, and that closing the time manager restores the `"gid"` condition alone.

The `time_manager` test project had `formFilterLayers: {}`, so no layer filter could coexist with the date filter; a numeric form filter on `gid` is added to the fixture.

Verified locally: without the fix the test fails on the `"gid"` assertion (the filter contains only `"test_date"`), and passes with it.

Unrelated pre-existing local failures, identical on a clean `master` on my QGIS 3.44 stack: `Manual play`, `Let's play` and `Auto play uses full ISO dates in filter` (my stack resolves the time frame type to months, showing `January 2007` where the tests expect `2007`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)