### PR TITLE
[Backport release_3_9] Fix/e2e flaky tests

### DIFF
--- a/assets/src/legacy/edition.js
+++ b/assets/src/legacy/edition.js
@@ -602,9 +602,31 @@ var lizEdition = function() {
                 continue;
             }
 
-            olLayer.getSource().changed();
+            redrawLayerSource(olLayer.getSource());
         }
         return redrawnLayerIds;
+    }
+
+    /**
+     * Ask an OpenLayers source to fetch its data again.
+     *
+     * `source.changed()` is not enough for the WMS sources: it drops the image
+     * OpenLayers keeps, but the new request has the very same URL, so the browser
+     * answers it from its own cache and the map still shows the feature as it was
+     * before the edition. Changing a parameter makes the URL unique, which is the
+     * only way to be sure the layer is really redrawn.
+     * @param {object} source The OpenLayers source of the layer to redraw
+     */
+    function redrawLayerSource(source) {
+        if (typeof source.updateParams === 'function') {
+            // WMS sources (ImageWMS, TileWMS): QGIS Server ignores unknown parameters
+            source.updateParams({ 'LIZMAP_REDRAW': Date.now() });
+        } else if (typeof source.refresh === 'function') {
+            // Vector sources: refresh() clears the loaded features and reloads them
+            source.refresh();
+        } else {
+            source.changed();
+        }
     }
 
     /**

--- a/assets/src/modules/Permalink.js
+++ b/assets/src/modules/Permalink.js
@@ -19,6 +19,8 @@ export default class Permalink {
         // Used to behave differently when hash is changed
         // programmatically or by users in URL
         this._ignoreHashChange = false;
+        // True while a permalink is being applied to the map
+        this._applyingPermalink = false;
         // Store the build or received hash
         this._hash = '';
         this._extent4326 = [0, 0, 0, 0, 0];
@@ -174,7 +176,21 @@ export default class Permalink {
         }
 
         this._hash = ''+window.location.hash;
+        // Hold the fragment while the whole permalink is applied, see
+        // _writeURLFragment()
+        this._applyingPermalink = true;
+        try {
+            this._applyPermalink(setExtent);
+        } finally {
+            this._applyingPermalink = false;
+        }
+    }
 
+    /**
+     * Applies the values of the current permalink to the map
+     * @param {boolean} setExtent - whether set the map extent or not
+     */
+    _applyPermalink(setExtent) {
         // items are layers then groups from leaf to root
         const items = mainLizmap.state.layersAndGroupsCollection.layers.concat(
             mainLizmap.state.layersAndGroupsCollection.groups.reverse() // reverse groups array to get from leaf to root
@@ -273,6 +289,13 @@ export default class Permalink {
     _writeURLFragment() {
         // Don't write initial permalink if waiting for first theme to be applied
         if (this._suspendInitialWrite) {
+            return;
+        }
+        // Don't write while a permalink is being applied: setting the extent
+        // dispatches "map.state.changed", which lands here before the layers have
+        // been restored, and the fragment would then be rewritten from a half
+        // applied state - silently replacing the permalink being opened.
+        if (this._applyingPermalink) {
             return;
         }
 

--- a/tests/docker-conf/nginx-default.conf
+++ b/tests/docker-conf/nginx-default.conf
@@ -1,4 +1,16 @@
 # Nginx configuration
+
+# The wildcard "Access-Control-Allow-Origin" is only needed by swagger, which calls
+# the admin API through api.php. It must NOT be sent on the other entry points:
+# a repository configured with "accessControlAllowOrigin" makes Lizmap answer with
+# the allowed origin itself, and two "Access-Control-Allow-Origin" headers are
+# rejected by browsers ("header contains multiple values, but only one is allowed"),
+# which broke the CORS end2end tests. An empty value makes nginx skip add_header.
+map $uri $lizmap_cors_wildcard {
+    ~^/api\.php  '*';
+    default      '';
+}
+
 server {
     listen 80;
     listen 443 ssl;
@@ -32,7 +44,7 @@ server {
        fastcgi_pass lizmap:9000;
 
        # Allow swagger to test admin's API
-       add_header 'Access-Control-Allow-Origin' '*' always;
+       add_header 'Access-Control-Allow-Origin' $lizmap_cors_wildcard always;
        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE';
        add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type';
 

--- a/tests/end2end/playwright/attribute-table.spec.js
+++ b/tests/end2end/playwright/attribute-table.spec.js
@@ -919,9 +919,13 @@ test.describe('Attribute table linking @write', () => {
         getFeatureResponse = await getFeatureRequest.response();
         responseExpect(getFeatureResponse).toBeGeoJson();
 
-        // Select the children_layer feature: 2
-        await expect(project.attributeTableHtml(childLayerName).locator(`tbody tr[id="1"] button.feature-select`)).toBeVisible();
-        await project.attributeTableHtml(childLayerName).locator(`tbody tr[id="1"] button.feature-select`).click();
+        // Select the children_layer feature: 2, the one unlinked above. Feature 1
+        // was selected instead, so the test linked it to parent 1 while leaving
+        // feature 2 without a parent: the test dataset was left modified and the
+        // "@readonly" tests expecting feature 1 to be a child of parent 2 (see
+        // feature-toolbar.spec.js) failed on the next run against the same database.
+        await expect(project.attributeTableHtml(childLayerName).locator(`tbody tr[id="2"] button.feature-select`)).toBeVisible();
+        await project.attributeTableHtml(childLayerName).locator(`tbody tr[id="2"] button.feature-select`).click();
 
         // back to the parent_layer attribute table
         await expect(tableHtml).toBeHidden();

--- a/tests/end2end/playwright/cors.spec.js
+++ b/tests/end2end/playwright/cors.spec.js
@@ -1,29 +1,53 @@
 import { test, expect } from '@playwright/test';
 
+/**
+ * Collect the errors reported by the browser (console + failed requests).
+ * `testInfo.stderr` used to be asserted here, but it only carries what the Node
+ * test process writes on stderr: it stays undefined, so the assertion could
+ * never tell whether the browser blocked the request.
+ * @param {import('@playwright/test').Page} page the page to watch
+ * @returns {string[]} the collected error messages, filled while the page runs
+ */
+function collectBrowserErrors(page) {
+    /** @type {string[]} */
+    const errors = [];
+    page.on('console', message => {
+        if (message.type() === 'error') {
+            errors.push(message.text());
+        }
+    });
+    page.on('pageerror', error => errors.push(error.message));
+    page.on('requestfailed', request =>
+        errors.push(`${request.url()} ${request.failure()?.errorText ?? ''}`));
+    return errors;
+}
+
 test.describe('CORS',
     {
         tag: ['@localonly'],
     }, () => {
 
-        test('send authorized request', async function ({ page }, testInfo) {
-            test.skip(process.env.CI, 'Not working on GH Action');
+        test('send authorized request', async function ({ page }) {
+            test.skip(!!process.env.CI, 'Not working on GH Action');
+            const errors = collectBrowserErrors(page);
             await page.goto('http://othersite.local:8130');
             await page.locator('#launch-request').click();
             await expect(page.locator('#status')).toHaveText('200');
             await expect(page.locator('#response')).not.toBeEmpty();
-            expect(testInfo.stderr).toHaveLength(0);
-
+            expect(errors).toEqual([]);
         });
 
 
-        test('send unauthorized request', async function ({ page }, testInfo) {
-            test.skip(process.env.CI, 'Not working on GH Action');
+        test('send unauthorized request', async function ({ page }) {
+            test.skip(!!process.env.CI, 'Not working on GH Action');
+            const errors = collectBrowserErrors(page);
             await page.goto(
                 'http://othersite.local:8130');
             await page.locator('#launch-request-bad').click();
             await expect(page.locator('#status_bad')).toBeEmpty();
             await expect(page.locator('#response_bad')).toBeEmpty();
-            expect(testInfo.stderr).not.toBe('');
+            // The browser must have refused to hand the response over to the page
+            await expect.poll(() => errors.join('\n')).toContain('CORS');
         });
 
     });

--- a/tests/end2end/playwright/export-data.spec.js
+++ b/tests/end2end/playwright/export-data.spec.js
@@ -366,6 +366,11 @@ test.describe('Export data @readonly', () => {
     });
 });
 
+// NOTE: do not put "@readonly" in this describe title. `--grep` matches the full
+// title, so it used to select the "@write" tests below for the parallel @readonly
+// run as well: they change the export permissions of `testsrepository` while the
+// other tests read them, which made this file (and other @readonly specs) fail
+// randomly. They now only run in the serial @write partition.
 test.describe('Layer export permissions ACL', () => {
     // single_wms_points -> export enabled for group_a users
     // single_wms_points_group -> export enabled, no groups specified, inherith export permission from repository level
@@ -445,42 +450,55 @@ test.describe('Layer export permissions ACL', () => {
             // open maps management page
             await adminPage.openPage('Maps management');
 
-            // set layer export permissions
-            await adminPage.modifyRepository('testsrepository');
-            await adminPage.uncheckAllExportPermission();
-            await adminPage.setLayerExportPermission(enabled_groups);
-            await adminPage.page.getByRole('button', { name: 'Save' }).click();
+            // The permissions are restored in the `finally` block: without it a
+            // failure in the middle of the test left `testsrepository` with the
+            // export permissions of this case, breaking every following test.
+            try {
+                // set layer export permissions
+                await adminPage.modifyRepository('testsrepository');
+                await adminPage.uncheckAllExportPermission();
+                await adminPage.setLayerExportPermission(enabled_groups);
+                await adminPage.page.getByRole('button', { name: 'Save' }).click();
 
-            // login with specific user
-            let userContext;
-            if (login !== '__anonymous') {
-                userContext = await browser.newContext({storageState: getAuthStorageStatePath(login)});
-            } else {
-                userContext = await browser.newContext();
+                // login with specific user
+                let userContext;
+                if (login !== '__anonymous') {
+                    userContext = await browser.newContext({storageState: getAuthStorageStatePath(login)});
+                } else {
+                    userContext = await browser.newContext();
+                }
+                const userPage = await userContext.newPage();
+
+                // go to project page
+                const project = new ProjectPage(userPage, 'enable_export_acl');
+                await project.open();
+
+                // check layer export capabilities for logged in user
+                for(const layerObj of expected){
+                    let getFeatureRequest = await project.openAttributeTable(layerObj.layer);
+                    let getFeatureResponse = await getFeatureRequest.response();
+                    responseExpect(getFeatureResponse).toBeGeoJson();
+                    // Scope to the current layer's action bar: the global selector
+                    // also matched a previously opened layer's action bar that had
+                    // not been removed yet, making the count flaky.
+                    await expect(project.attributeTableActionBar(layerObj.layer).locator('.export-formats')).toHaveCount(layerObj.onPage);
+                    await project.closeAttributeTable();
+                }
+            } finally {
+                // reset layer export permissions. Start from the repository list
+                // again: the test may have failed while the form was open. Errors
+                // here must not hide the failure that led us to this block.
+                try {
+                    await page.goto('admin.php');
+                    await adminPage.openPage('Maps management');
+                    await adminPage.modifyRepository('testsrepository');
+                    await adminPage.resetLayerExportPermission();
+
+                    await adminPage.page.getByRole('button', { name: 'Save' }).click();
+                } catch (resetError) {
+                    console.error('Could not restore the export permissions:', resetError);
+                }
             }
-            const userPage = await userContext.newPage();
-
-            // go to project page
-            const project = new ProjectPage(userPage, 'enable_export_acl');
-            await project.open();
-
-            // check layer export capabilities for logged in user
-            for(const layerObj of expected){
-                let getFeatureRequest = await project.openAttributeTable(layerObj.layer);
-                let getFeatureResponse = await getFeatureRequest.response();
-                responseExpect(getFeatureResponse).toBeGeoJson();
-                // Scope to the current layer's action bar: the global selector
-                // also matched a previously opened layer's action bar that had
-                // not been removed yet, making the count flaky.
-                await expect(project.attributeTableActionBar(layerObj.layer).locator('.export-formats')).toHaveCount(layerObj.onPage);
-                await project.closeAttributeTable();
-            }
-
-            // reset layer export permissions
-            await adminPage.modifyRepository('testsrepository');
-            await adminPage.resetLayerExportPermission();
-
-            await adminPage.page.getByRole('button', { name: 'Save' }).click();
         })
     })
 

--- a/tests/end2end/playwright/lizmap-features-table.spec.js
+++ b/tests/end2end/playwright/lizmap-features-table.spec.js
@@ -108,16 +108,21 @@ test.describe('Display lizmap-features-table component in popup from QGIS toolti
 
         // "expression filter" attribute listening changes
         // Changing "live" the expression filter from MC to MI
+        // The previous assertion compared two unawaited `getAttribute()` promises,
+        // so it compared two Promise objects (always equal) and could never pass.
+        // The element id is set once in the constructor and does not change either:
+        // check the reload by its result, i.e. the rows now come from "MI".
         const featTable = page.locator(`lizmap-features-table`);
-        const idFeatTable = featTable.getAttribute("id");
         await featTable.evaluate(
             element => element.setAttribute('expressionfilter','quartmno = \'MI\''));
 
-        await page.waitForTimeout(200);
-
-        const newFeatTable = page.locator(`lizmap-features-table`);
-        const newIdFeatTable = newFeatTable.getAttribute("id");
-
-        await expect(idFeatTable).not.toEqual(newIdFeatTable);
+        // "MI" has 4 sub-districts, "MC" had 10
+        const reloadedItems = lizmapFeaturesTable.locator(
+            "table.lizmap-features-table-container tr.lizmap-features-table-item");
+        await expect(reloadedItems).toHaveCount(4);
+        // every remaining sub-district belongs to the "MI" district
+        await expect(reloadedItems.locator('> td:nth-child(2)')).toHaveText([
+            /^\s*MI/, /^\s*MI/, /^\s*MI/, /^\s*MI/,
+        ]);
     });
 })

--- a/tests/end2end/playwright/pages/drawpage.js
+++ b/tests/end2end/playwright/pages/drawpage.js
@@ -1,4 +1,5 @@
 // @ts-check
+import { expect } from '@playwright/test';
 import { ProjectPage } from './project';
 
 /**
@@ -87,8 +88,18 @@ export class DrawPage extends ProjectPage {
      *                      Possible values 'point', 'line', 'polygon','box','circle','freehand','text'.
      */
     async selectGeometry(type) {
-        await this.drawPanel.locator('.dropdown-toggle:nth-child(2)').click();
-        await this.drawPanel.locator(`.digitizing-${type} > svg`).click();
+        const toggle = this.drawPanel.locator('button.dropdown-toggle:nth-child(2)');
+        const geometry = this.drawPanel.locator(`.digitizing-${type} > svg`);
+        // Clicking the toggle only once is not reliable: when the draw panel has
+        // just been (re)opened the click can land while it is still being shown and
+        // the dropdown stays closed, so the geometry below never becomes visible.
+        await expect(async () => {
+            if (!await geometry.isVisible()) {
+                await toggle.click();
+            }
+            await expect(geometry).toBeVisible({ timeout: 1000 });
+        }).toPass({ timeout: 10000 });
+        await geometry.click();
     }
 
     /**

--- a/tests/end2end/playwright/popup.spec.js
+++ b/tests/end2end/playwright/popup.spec.js
@@ -4,7 +4,29 @@ import { expect as responseExpect } from './fixtures/expect-response.js'
 import { gotoMap } from './globals';
 import { ProjectPage } from "./pages/project";
 
-test.describe('Dataviz in popup @readonly', () => {
+/**
+ * Read the traces of a getPlot response.
+ *
+ * Lizmap hides the whole `div.lizdataviz` block when the plot has no data - that
+ * is what the "point without plot" case below checks. So when a plot that should
+ * have data comes back empty, the visibility assertions fail 15s later with a
+ * misleading "element is hidden", instead of pointing at the empty response.
+ * @param {import('@playwright/test').Request} getPlotRequest The getPlot request
+ * @returns {Promise<object[]>} The traces of the plot, empty when there is no data
+ */
+async function plotTraces(getPlotRequest) {
+    const response = await getPlotRequest.response();
+    const json = await response?.json();
+    return json?.data ?? [];
+}
+
+// NOTE: no "@readonly" tag here on purpose, so that these tests run in the serial
+// partition. The plot data is fetched by Lizmap through a WFS GetFeature on QGIS
+// Server, which intermittently answers short or empty responses when several
+// workers query it at the same time (the reason why the "@requests" partition also
+// runs with --workers=1, see .github/workflows/e2e_tests.yml). An empty answer
+// makes Lizmap hide the dataviz block and the test failed randomly.
+test.describe('Dataviz in popup', () => {
     test('Check lizmap feature toolbar', async ({ page }) => {
         const project = new ProjectPage(page, 'popup_bar');
         await project.open();
@@ -28,7 +50,8 @@ test.describe('Dataviz in popup @readonly', () => {
         await expect(postData).toHaveProperty('request', 'getPlot');
         await expect(postData).toHaveProperty('plot_id', 0);
         await expect(postData).toHaveProperty('exp_filter', `"fid_point" IN ('1')`);
-        await getPlotRequest.response();
+        expect(await plotTraces(getPlotRequest),
+            'the plot must have data, Lizmap hides the block otherwise').not.toHaveLength(0);
 
         // inspect feature toolbar and dataviz, expect to find only one
         await expect(project.popupContent.locator("div.lizmapPopupContent > div.lizmapPopupSingleFeature > div.lizmapPopupDiv > lizmap-feature-toolbar .feature-toolbar")).toHaveCount(1)
@@ -50,7 +73,8 @@ test.describe('Dataviz in popup @readonly', () => {
         await expect(postData).toHaveProperty('request', 'getPlot');
         await expect(postData).toHaveProperty('plot_id', 0);
         await expect(postData).toHaveProperty('exp_filter', `"fid_point" IN ('1')`);
-        await getPlotRequest.response();
+        expect(await plotTraces(getPlotRequest),
+            'the plot must have data, Lizmap hides the block otherwise').not.toHaveLength(0);
 
         // inspect feature toolbar and dataviz, expect to find only one
         await expect(project.popupContent.locator("div.lizmapPopupContent > div.lizmapPopupSingleFeature > div.lizmapPopupDiv > lizmap-feature-toolbar .feature-toolbar")).toHaveCount(1)
@@ -72,7 +96,8 @@ test.describe('Dataviz in popup @readonly', () => {
         await expect(postData).toHaveProperty('request', 'getPlot');
         await expect(postData).toHaveProperty('plot_id', 0);
         await expect(postData).toHaveProperty('exp_filter', `"fid_point" IN ('2')`);
-        await getPlotRequest.response();
+        expect(await plotTraces(getPlotRequest),
+            'the plot must have data, Lizmap hides the block otherwise').not.toHaveLength(0);
 
         // inspect feature toolbar and dataviz, expect to find only one
         await expect(project.popupContent.locator("div.lizmapPopupContent > div.lizmapPopupSingleFeature > div.lizmapPopupDiv > lizmap-feature-toolbar .feature-toolbar")).toHaveCount(1)
@@ -94,7 +119,8 @@ test.describe('Dataviz in popup @readonly', () => {
         await expect(postData).toHaveProperty('request', 'getPlot');
         await expect(postData).toHaveProperty('plot_id', 0);
         await expect(postData).toHaveProperty('exp_filter', `"fid_point" IN ('3')`);
-        await getPlotRequest.response();
+        // no plot for this feature: Lizmap hides the whole dataviz block
+        expect(await plotTraces(getPlotRequest)).toHaveLength(0);
 
         // inspect feature toolbar and dataviz, expect to find one feature toolbar and no dataviz
         await expect(project.popupContent.locator("div.lizmapPopupContent > div.lizmapPopupSingleFeature > div.lizmapPopupDiv > lizmap-feature-toolbar .feature-toolbar")).toHaveCount(1)
@@ -116,7 +142,8 @@ test.describe('Dataviz in popup @readonly', () => {
         await expect(postData).toHaveProperty('request', 'getPlot');
         await expect(postData).toHaveProperty('plot_id', 0);
         await expect(postData).toHaveProperty('exp_filter', `"fid_point" IN ('2')`);
-        await getPlotRequest.response();
+        expect(await plotTraces(getPlotRequest),
+            'the plot must have data, Lizmap hides the block otherwise').not.toHaveLength(0);
 
         // inspect feature toolbar and dataviz, expect to find only one
         await expect(project.popupContent.locator("div.lizmapPopupContent > div.lizmapPopupSingleFeature > div.lizmapPopupDiv > lizmap-feature-toolbar .feature-toolbar")).toHaveCount(1)

--- a/tests/end2end/playwright/print_in_project_projection.spec.js
+++ b/tests/end2end/playwright/print_in_project_projection.spec.js
@@ -31,6 +31,11 @@ test.describe('Print in project projection @readonly', () => {
             }
         });
 
+        // Start waiting for the download before launching the print: the browser
+        // fires it as soon as the mocked response arrives, which can happen while
+        // the parameters below are being asserted. Subscribing afterwards missed
+        // the event and the test timed out waiting for it.
+        const downloadPromise = page.waitForEvent('download');
         const getPrintPromise = project.waitForGetPrintRequest();
         await project.launchPrint();
 
@@ -55,8 +60,6 @@ test.describe('Print in project projection @readonly', () => {
         const searchParams = new URLSearchParams(getPrintRequest?.postData() ?? '');
         expect(searchParams.size).toBe(15);
 
-        // Start waiting for download before response. Note no await.
-        const downloadPromise = page.waitForEvent('download');
         responseExpect(await getPrintRequest.response()).toBePdf();
 
         // Check the suggested file name is well extracted by Lizmap from header Content-Disposition

--- a/tests/end2end/playwright/requests-api.spec.js
+++ b/tests/end2end/playwright/requests-api.spec.js
@@ -40,8 +40,19 @@ test.describe('Connected from context, as an admin',
 
             const json = await checkJson(response);
 
-            // Check number of repositories
-            expect(json).toHaveLength(5);
+            // Check the repositories of the test instance are all listed. An exact
+            // count was asserted here, which broke as soon as another repository
+            // existed: the tests below create some, and a developer instance may
+            // have its own.
+            expect(json.map(repository => repository.key)).toEqual(
+                expect.arrayContaining([
+                    'testsrepository',
+                    'private',
+                    'badrepository',
+                    'montpellier',
+                    'intranet',
+                ])
+            );
 
             // Check first repository has expected
             expect(json[0].key).toBeDefined();
@@ -55,6 +66,21 @@ test.describe('Connected via Basic auth',
     {
         tag: ['@requests', '@readonly'],
     }, () => {
+
+        // The tests below create repositories. Remove them so that running the
+        // suite twice against the same instance gives the same result: the
+        // repository list is asserted above, and a leftover repository key makes
+        // the creation requests answer 409.
+        // The directories they create (`grenoble_agglo/`, `folderNancy/`) cannot be
+        // removed through HTTP; `tests/end2end/run-all-tests.sh` takes care of them.
+        test.afterAll(async ({ browser }) => {
+            const context = await browser.newContext({ storageState: getAuthStorageStatePath('admin') });
+            const page = await context.newPage();
+            for (const repository of ['grenoble', 'nancy']) {
+                await page.goto('admin.php/admin/maps/removeSection?repository=' + repository);
+            }
+            await context.close();
+        });
 
         test('GET repositories', async ({request}) => {
             const response = await requestGETWithAdminBasicAuth(request, url + "/repositories")

--- a/tests/end2end/run-all-tests.sh
+++ b/tests/end2end/run-all-tests.sh
@@ -14,14 +14,38 @@ cd "$(dirname "$0")"
 
 PLAYWRIGHT_OPTIONS="${PLAYWRIGHT_OPTIONS:---project=chromium}"
 
+# CI runs every job on a fresh docker stack and a fresh checkout. Locally the same
+# stack is reused, so put back what the previous run changed. Set
+# LIZMAP_E2E_SKIP_RESET=1 to keep the current state of the instance instead.
+if [[ -z "${LIZMAP_E2E_SKIP_RESET}" ]]; then
+    # Reload the test dataset: the "@write" tests create, delete and update rows,
+    # and a few of the "@readonly" ones assert exact contents, so they need the
+    # dataset the fixtures describe.
+    echo "=== Reloading the test dataset (LIZMAP_E2E_SKIP_RESET=1 to skip) ==="
+    ../qgis-projects/tests/load_sql.sh > /dev/null
+
+    # `requests-api.spec.js` asks the admin API to create these directories and
+    # there is no API to delete them, so a second run would get "the directory you
+    # want to create already exists". rmdir only removes them when they are empty,
+    # which is how the tests leave them.
+    for leftover in grenoble_agglo folderNancy; do
+        rmdir "../qgis-projects/$leftover" 2>/dev/null || true
+    done
+fi
+
 echo "=== 1/4: @requests + @readonly (workers=1, avoids QGIS Server request contention) ==="
 npx playwright test --grep "(?=.*@requests)(?=.*@readonly)" $PLAYWRIGHT_OPTIONS --workers=1
 
-echo "=== 2/4: @readonly (excluding @requests), parallel-safe ==="
-npx playwright test --grep @readonly --grep-invert @requests $PLAYWRIGHT_OPTIONS
+# Same worker count as CI. With the machine default (half of the cores) the
+# concurrent load on QGIS Server and on PHP-FPM makes assertions on request
+# timings and on exact table contents fail randomly.
+echo "=== 2/4: @readonly (excluding @requests), workers=2 ==="
+npx playwright test --grep @readonly --grep-invert @requests $PLAYWRIGHT_OPTIONS --workers=2
 
+# The two serial partitions use the same config as CI: `fullyParallel: false` keeps
+# the tests of a spec file together and in order, which those specs rely on.
 echo "=== 3/4: untagged (neither @write nor @readonly), workers=1 ==="
-npx playwright test --workers 1 --grep-invert "(?=.*@write|.*@readonly)" $PLAYWRIGHT_OPTIONS
+npx playwright test --config playwright.serial.config.ts --workers 1 --grep-invert "(?=.*@write|.*@readonly)" $PLAYWRIGHT_OPTIONS
 
 echo "=== 4/4: @write (workers=1, mutates shared state) ==="
-npx playwright test --workers 1 --grep @write $PLAYWRIGHT_OPTIONS
+npx playwright test --config playwright.serial.config.ts --workers 1 --grep @write $PLAYWRIGHT_OPTIONS


### PR DESCRIPTION
Manual backport of #7062 to `release_3_9`, the automatic one failed on conflicts.

Funded by 3Liz

## Conflicts resolved

* `assets/src/modules/Permalink.js` — this branch has no short link permalink, so `_runPermalink()` / `_applyPermalink()` stay synchronous and the short link block is not part of the split.
* `tests/end2end/playwright/pages/drawpage.js` — kept the upstream `button.dropdown-toggle:nth-child(2)` selector, it matches the same `<button>` as this branch's `.dropdown-toggle:nth-child(2)`.
* `tests/end2end/playwright/export-data.spec.js` — the `@readonly` tag was already absent from the `Layer export permissions ACL` describe title here, only the `try`/`finally` restoring the export permissions is backported, and the attribute table request is still asserted as GeoJSON (`toBeGeoJson()`) as this branch does.
* `tests/end2end/playwright/requests-api.spec.js` — the expected repository list drops `mockinspection`, which this branch's test stack does not declare (3 in `tests/docker-conf/phpfpm/lizmapConfig.ini.php` + `montpellier` and `intranet` from the `lizmapdemo` module = the 5 that were asserted by count before).
* `tests/end2end/playwright/edition-form.spec.js` — **not backported**: the `Upload file renamed to field default value expression stem` test that the original commit cleans up after does not exist on this branch, so only the `attribute-table.spec.js` part of that commit is kept (its message was adapted accordingly).

Everything else applied as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
