### PR TITLE
New parser for layer datasources

### DIFF
--- a/docker/update-config.php
+++ b/docker/update-config.php
@@ -66,11 +66,11 @@ function pgSqlConnect($profile)
         // we do isset instead of equality test against an empty string, to allow to specify
         // that we want to use configuration set in environment variables
         if (isset($profile['user'])) {
-            $str .= ' user=\''.$profile['user'].'\'';
+            $str .= ' user=\''.str_replace("'", "\\'", $profile['user']).'\'';
         }
 
         if (isset($profile['password'])) {
-            $str .= ' password=\''.$profile['password'].'\'';
+            $str .= ' password=\''.str_replace("'", "\\'", $profile['password']).'\'';
         }
     }
 

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -14,6 +14,7 @@
 use GuzzleHttp\Psr7\StreamWrapper as Psr7StreamWrapper;
 use Jelix\IniFile\IniModifier;
 use JsonMachine\Items as JsonMachineItems;
+use Lizmap\App\QgisConnectionStringParserException;
 use Lizmap\Project\Project;
 use Lizmap\Request\Proxy;
 use Lizmap\Request\WFSRequest;
@@ -256,12 +257,12 @@ class qgisVectorLayer extends qgisMapLayer
                 $ds[$param] = $datasourceParser->getDatasourceParameter($param);
             }
 
-        } catch (Exception $e) {
+        } catch (QgisConnectionStringParserException $e) {
             $error = 'Project '.$this->project->getKey().' layer '.$this->name.', error in datasource: '.$e->getMessage();
             jLog::log($error, 'lizmapadmin');
 
-            // As we don't have any parameters here, probably it's better to trigger an exception instead of trying
-            // to connect to a database without any connection parameters.
+            // As we don't have parsed all parameters, probably it's better to trigger an exception instead of trying
+            // to connect to a database without any or bad connection parameters.
             throw new Exception($error);
         }
 

--- a/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayer.class.php
@@ -4,7 +4,7 @@
  * Give access to qgis mapLayer configuration.
  *
  * @author    3liz
- * @copyright 2013-2023 3liz
+ * @copyright 2013-2026 3liz
  *
  * @see      http://3liz.com
  *
@@ -238,10 +238,7 @@ class qgisVectorLayer extends qgisMapLayer
             return $this->dtParams;
         }
 
-        $datasourceParser = new qgisVectorLayerDatasource(
-            $this->provider,
-            $this->datasource
-        );
+        $ds = array();
         $parameters = array(
             'dbname', 'service', 'host', 'port', 'user', 'password',
             'sslmode', 'authcfg', 'key', 'estimatedmetadata', 'selectatid',
@@ -249,8 +246,23 @@ class qgisVectorLayer extends qgisMapLayer
             'table', 'geocol', 'sql', 'schema', 'tablename',
         );
 
-        foreach ($parameters as $param) {
-            $ds[$param] = $datasourceParser->getDatasourceParameter($param);
+        try {
+            $datasourceParser = new qgisVectorLayerDatasource(
+                $this->provider,
+                $this->datasource
+            );
+
+            foreach ($parameters as $param) {
+                $ds[$param] = $datasourceParser->getDatasourceParameter($param);
+            }
+
+        } catch (Exception $e) {
+            $error = 'Project '.$this->project->getKey().' layer '.$this->name.', error in datasource: '.$e->getMessage();
+            jLog::log($error, 'lizmapadmin');
+
+            // As we don't have any parameters here, probably it's better to trigger an exception instead of trying
+            // to connect to a database without any connection parameters.
+            throw new Exception($error);
         }
 
         $this->dtParams = (object) $ds;

--- a/lizmap/modules/lizmap/classes/qgisVectorLayerDatasource.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayerDatasource.class.php
@@ -4,41 +4,16 @@
  * Give access to qgis mapLayer configuration.
  *
  * @author    3liz
- * @copyright 2013-2019 3liz
+ * @copyright 2013-2026 3liz
  *
  * @see      http://3liz.com
  *
  * @license Mozilla Public License : http://www.mozilla.org/MPL/
  */
+use Lizmap\App\SqlTools;
+
 class qgisVectorLayerDatasource
 {
-    /**
-     * @var array Regexes used to get datasource parameters
-     */
-    protected $datasourceRegexes = array(
-        'dbname' => "dbname='?([^ ']+)'?(?: |$)",
-        'service' => "service='?([^ ']+)'?(?: |$)",
-        'host' => "host='?([^ ']+)'? port=",
-        'port' => 'port=([0-9]+)(?: |$)',
-        'user' => "user='?([^ ']+)'?(?: |$)",
-        'password' => array(
-            "password='((?:\\\\\\'|[^'])*)'(?: |$)",
-            'password="((?:\\\"|[^"])*)"(?: |$)',
-            "password=([^ ']+)(?: |$)",
-        ),
-        'sslmode' => "sslmode='?([^ ']+)'?(?: |$)",
-        'authcfg' => "authcfg='?([^ ']+)'?(?: |$)",
-        'key' => "key='?([^ ']+)'?(?: |$)",
-        'estimatedmetadata' => 'estimatedmetadata=([^ ]+)(?: |$)',
-        'selectatid' => 'selectatid=([^ ]+)(?: |$)',
-        'srid' => 'srid=([0-9]+)(?: |$)',
-        'type' => 'type=([a-zA-Z]+)(?: |$)',
-        'checkPrimaryKeyUnicity' => "checkPrimaryKeyUnicity='([0-1]+)'(?: |$)",
-        'table' => 'table="(.+?)"($|\s)',
-        'geocol' => '\(([^ >]+)\)',
-        'sql' => ' sql=(.*)$',
-    );
-
     protected $provider;
 
     protected $datasource;
@@ -52,125 +27,33 @@ class qgisVectorLayerDatasource
     public function __construct($provider, $datasource)
     {
         $this->provider = $provider;
-        $this->datasource = $datasource;
+        if ($this->provider == 'ogr' && preg_match('#layername=#', $datasource)) {
+            $this->datasource = $this->parseOgrConnection($datasource);
+        } else {
+            $this->datasource = SqlTools::parseQgisConnectionString($datasource);
+        }
     }
 
     public function getDatasourceParameter($param)
     {
-        if ($this->provider == 'ogr' and preg_match('#layername=#', $this->datasource)) {
-            return $this->getDatasourceParameterOgr($param);
+        if (isset($this->datasource[$param])) {
+            return $this->datasource[$param];
         }
 
-        return $this->getDatasourceParameterSql($param);
+        return '';
     }
 
-    private function getDatasourceParameterSql($param)
+    private function parseOgrConnection($datasource)
     {
-        $value = '';
-
-        // For tablename and schema, first get table
-        // and then get table name or schema
-        if ($param == 'tablename' or $param == 'schema') {
-            $table = $this->getDatasourceParameter('table');
-            if (substr($table, 0, 1) == '"') {
-                $exp = explode('.', str_replace('"', '', $table));
-                if ($param == 'tablename') {
-                    $value = $exp[1];
-                } elseif ($param == 'schema') {
-                    $value = $exp[0];
-                }
-            } else {
-                if ($param == 'tablename') {
-                    $value = $table;
-                } elseif ($param == 'schema') {
-                    $value = '';
-                }
-            }
-
-            return trim($value);
-        }
-
-        // For other parameters, use specific parameter regex
-        $regex = $this->datasourceRegexes[$param];
-
-        // Specific preg_match for the table, which can be very complex
-        $result = array();
-        $backSlashedQuoteReplacement = null;
-        if ($param == 'table') {
-            // We need to replace the \" in the datasource to avoid issues for complex sub-queries in table=()
-            $backSlashedQuoteReplacement = '@@@LIZMAP@@@';
-            preg_match(
-                '#'.$regex.'#s',
-                str_replace('\"', $backSlashedQuoteReplacement, $this->datasource),
-                $result
-            );
-        } elseif (is_array($regex)) {
-            foreach ($regex as $r) {
-                if (preg_match(
-                    '#'.$r.'#s',
-                    $this->datasource,
-                    $result
-                )) {
-                    break;
-                }
-            }
-        } else {
-            preg_match(
-                '#'.$regex.'#s',
-                $this->datasource,
-                $result
-            );
-        }
-
-        $nb_result = count($result);
-        if ((2 <= $nb_result) and ($nb_result <= 3) and strlen($result[1])) {
-            if ($param == 'table') {
-                // We replace back the backslahsed quote replacement in the value by double-quotes
-                $value = str_replace($backSlashedQuoteReplacement, '"', $result[1]);
-            } elseif ($param == 'password') {
-                $value = str_replace(array("\\'", '\"'), array("'", '"'), $result[1]);
-            } else {
-                $value = $result[1];
-            }
-
-            // Specific parsing for complex table parameter
-            if ($param == 'table') {
-                $table = $value;
-
-                // Complex sub-query
-                if (substr($table, 0, 1) == '(' and substr($table, -1) == ')') {
-                    $table .= ' fooliz';
-                }
-                // Simple "schemaname"."table_name"
-                elseif (preg_match('#"."#', $table)) {
-                    $table = '"'.$table.'"';
-                }
-                $value = $table;
-            }
-        }
-
-        return trim($value);
-    }
-
-    private function getDatasourceParameterOgr($param)
-    {
-        $split = explode('|', $this->datasource);
-        $dbname = $split[0];
-        $table = str_replace('layername=', '', $split[1]);
+        $split = explode('|', $datasource);
+        $dbname = trim($split[0]);
+        $table = trim(str_replace('layername=', '', $split[1]));
         $sql = '';
         if (count($split) == 3) {
-            $sql = str_replace('subset=', '', $split[2]);
+            $sql = trim(str_replace('subset=', '', $split[2]));
         }
 
-        // Handle schema and tablename like getDatasourceParameterSql does
-        if ($param == 'tablename') {
-            return trim($table);
-        }
-        if ($param == 'schema') {
-            return '';
-        }
-
-        $ds = array(
+        return array(
             'dbname' => $dbname,
             'service' => '',
             'host' => '',
@@ -186,10 +69,11 @@ class qgisVectorLayerDatasource
             'type' => '',
             'checkPrimaryKeyUnicity' => '',
             'table' => $table,
+            // Handle schema and tablename like getDatasourceParameterSql does
+            'tablename' => trim($table),
+            'schema' => '',
             'geocol' => 'geom',
             'sql' => $sql,
         );
-
-        return trim($ds[$param]);
     }
 }

--- a/lizmap/modules/lizmap/lib/App/QgisConnectionStringParserException.php
+++ b/lizmap/modules/lizmap/lib/App/QgisConnectionStringParserException.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Exception for the Qgis connection string parser.
+ *
+ * @author    3liz
+ * @copyright 2026 3liz
+ *
+ * @see      https://3liz.com
+ *
+ * @license Mozilla Public License : http://www.mozilla.org/MPL/
+ */
+
+namespace Lizmap\App;
+
+class QgisConnectionStringParserException extends \DomainException
+{
+    protected $validParameters = array();
+
+    public function __construct(string $message = '', int $code = 0, $validParameters = array())
+    {
+        parent::__construct($message, $code);
+        $this->validParameters = $validParameters;
+    }
+
+    /**
+     * @return array list of parameters that the parser successfully parsed before reaching the syntax error
+     */
+    public function getValidParameters(): array
+    {
+        return $this->validParameters;
+    }
+}

--- a/lizmap/modules/lizmap/lib/App/SqlTools.php
+++ b/lizmap/modules/lizmap/lib/App/SqlTools.php
@@ -15,6 +15,18 @@ namespace Lizmap\App;
 
 class SqlTools
 {
+    public const PARSER_STATE_BETWEEN_PARAMETERS = 0;
+    public const PARSER_STATE_PARAM_NAME = 1;
+    public const PARSER_STATE_PARAM_EQUAL = 2;
+    public const PARSER_STATE_IN_VALUE = 3;
+    public const PARSER_STATE_TABLE_VALUE = 4;
+    public const PARSER_STATE_TABLE_SCHEMA = 5;
+    public const PARSER_STATE_TABLE_NAME_SEPARATOR = 6;
+    public const PARSER_STATE_TABLE_NAME_DBLQUOTE = 7;
+    public const PARSER_STATE_TABLE_NAME = 8;
+    public const PARSER_STATE_TABLE_SQL = 9;
+    public const PARSER_STATE_SQL_VALUE = 10;
+
     protected static $blockSqlWords = array(
         ';',
         'select',
@@ -89,5 +101,226 @@ class SqlTools
         $filter = str_replace('geom_from_gml', 'ST_GeomFromGML', $filter);
 
         return str_replace('$geometry', '"'.$geometryColumn.'"', $filter);
+    }
+
+    /**
+     * Parse a Qgis connection string.
+     *
+     * It supports `table` and `sql` parameters, as well as geometry tags like `(geom)`.
+     *
+     * @throws \Exception
+     */
+    public static function parseQgisConnectionString(string $connection_string): array
+    {
+        $result = array();
+
+        $tokens = preg_split('/(=| +|(?<!\\\)\'|(?<!\\\)")/', $connection_string, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $state = self::PARSER_STATE_BETWEEN_PARAMETERS;
+        $currentParamName = '';
+        $currentValue = '';
+        $valueIsQuoted = '';
+        $tableSchemaName = '';
+
+        foreach ($tokens as $token) {
+            if ($token === '') {
+                continue;
+            }
+
+            switch ($state) {
+                case self::PARSER_STATE_BETWEEN_PARAMETERS:
+                    if ($token[0] == ' ') {
+                        break;
+                    }
+                    if ($token == "'" || $token == '"' || $token == '=') {
+                        throw new \Exception('syntax error, unexpected character "'.$token.'"');
+                    }
+                    if ($token[0] == '(') {
+                        $result['geocol'] = trim($token, '()');
+
+                        break;
+                    }
+
+                    $currentParamName = $token;
+                    $state = self::PARSER_STATE_PARAM_NAME;
+
+                    break;
+
+                case self::PARSER_STATE_PARAM_NAME:
+                    if ($token[0] == ' ') {
+                        break;
+                    }
+                    if ($token != '=') {
+                        throw new \Exception('syntax error, missing equal sign after parameter '.$currentParamName);
+                    }
+                    $state = self::PARSER_STATE_PARAM_EQUAL;
+
+                    break;
+
+                case self::PARSER_STATE_PARAM_EQUAL:
+                    if ($token[0] == ' ') {
+                        break;
+                    }
+                    if ($token == '=') {
+                        throw new \Exception('syntax error unexpected equal sign after parameter '.$currentParamName);
+                    }
+
+                    if ($currentParamName == 'table') {
+                        if ($token == '"') {
+                            $valueIsQuoted = $token;
+                            $currentValue = '';
+                            $state = self::PARSER_STATE_TABLE_VALUE;
+                        } else {
+                            $currentValue = $token;
+                            $state = self::PARSER_STATE_TABLE_NAME;
+                        }
+                        $tableSchemaName = '';
+
+                        break;
+                    }
+                    if ($currentParamName == 'sql') {
+                        $currentValue = $token;
+                        $state = self::PARSER_STATE_SQL_VALUE;
+
+                        break;
+                    }
+                    if ($token == "'") {
+                        $valueIsQuoted = $token;
+                    } else {
+                        $currentValue = $token;
+                    }
+                    $state = self::PARSER_STATE_IN_VALUE;
+
+                    break;
+
+                case self::PARSER_STATE_IN_VALUE:
+                    if (($valueIsQuoted && $token == $valueIsQuoted) || ($valueIsQuoted == '' && $token == ' ')) {
+
+                        if ($valueIsQuoted != '') {
+                            $currentValue = str_replace('\\'.$valueIsQuoted, $valueIsQuoted, $currentValue);
+                        }
+                        $result[$currentParamName] = $currentValue;
+                        $currentValue = '';
+                        $currentParamName = '';
+                        $state = self::PARSER_STATE_BETWEEN_PARAMETERS;
+                        $valueIsQuoted = '';
+                    } else {
+                        $currentValue .= $token;
+                    }
+
+                    break;
+
+                case self::PARSER_STATE_TABLE_VALUE:
+                    if ($token[0] == '(') {
+                        $currentValue = $token;
+                        $state = self::PARSER_STATE_TABLE_SQL;
+                    } else {
+                        $currentValue .= $token;
+                        $state = self::PARSER_STATE_TABLE_SCHEMA;
+                    }
+
+                    break;
+
+                case self::PARSER_STATE_TABLE_SCHEMA:
+                    // we take all content until the next double quote, or space if it doesn't start with double quotes
+                    if ($token == $valueIsQuoted) {
+                        $tableSchemaName = $currentValue;
+                        $currentValue = '';
+                        $state = self::PARSER_STATE_TABLE_NAME_SEPARATOR;
+                    } else {
+                        $currentValue .= $token;
+                    }
+
+                    break;
+
+                case self::PARSER_STATE_TABLE_NAME_SEPARATOR:
+                    if ($token == '.') {
+                        $state = self::PARSER_STATE_TABLE_NAME_DBLQUOTE;
+                    } elseif ($token[0] = ' ') { // no dot separator, we reach the end of the table full name
+                        $result['table'] = '"'.$tableSchemaName.'"';
+                        $result['tablename'] = $tableSchemaName;
+                        $result['schema'] = '';
+                        $state = self::PARSER_STATE_BETWEEN_PARAMETERS;
+                        $currentParamName = '';
+                        $currentValue = '';
+                    } else {
+                        throw new \Exception('table name separator is missing after '.$tableSchemaName);
+                    }
+
+                    break;
+
+                case self::PARSER_STATE_TABLE_NAME_DBLQUOTE:
+                    if ($token == '"') {
+                        $state = self::PARSER_STATE_TABLE_NAME;
+                    } else {
+                        throw new \Exception('table name is missing after the schema '.$tableSchemaName);
+                    }
+
+                    break;
+
+                case self::PARSER_STATE_TABLE_NAME:
+                    if (($valueIsQuoted && $token == '"') || ($valueIsQuoted == '' && $token[0] == ' ')) {
+                        if ($tableSchemaName) {
+                            $result['table'] = '"'.$tableSchemaName.'"."'.$currentValue.'"';
+                        } else {
+                            $result['table'] = '"'.$currentValue.'"';
+                        }
+                        $result['tablename'] = $currentValue;
+                        $result['schema'] = $tableSchemaName;
+                        $state = self::PARSER_STATE_BETWEEN_PARAMETERS;
+                        $currentParamName = '';
+                        $currentValue = '';
+                        $valueIsQuoted = '';
+                    } else {
+                        $currentValue .= $token;
+                    }
+
+                    break;
+
+                case self::PARSER_STATE_TABLE_SQL:
+                    // we take all content until the next double quote
+                    if ($valueIsQuoted && $token == $valueIsQuoted) {
+                        // fooliz is the name of the 'virtual' table
+                        $result['table'] = $result['tablename'] = trim(str_replace('\"', '"', $currentValue)).' fooliz';
+                        $result['schema'] = '';
+                        $state = self::PARSER_STATE_BETWEEN_PARAMETERS;
+                        $currentParamName = '';
+                        $currentValue = '';
+                        $valueIsQuoted = '';
+                    } else {
+                        $currentValue .= $token;
+                    }
+
+                    break;
+
+                case self::PARSER_STATE_SQL_VALUE:
+                    // we take all content until the end of string
+                    $currentValue .= $token;
+
+                    break;
+            }
+        }
+
+        if ($state == self::PARSER_STATE_SQL_VALUE) {
+            $result[$currentParamName] = trim($currentValue);
+        } elseif ($state == self::PARSER_STATE_IN_VALUE || $state == self::PARSER_STATE_TABLE_VALUE || $state == self::PARSER_STATE_TABLE_SQL) {
+            if ($valueIsQuoted) {
+                throw new \Exception('syntax error, missing ending quote for parameter='.$currentParamName);
+            }
+            $result[$currentParamName] = trim($currentValue);
+        } elseif ($state == self::PARSER_STATE_PARAM_EQUAL) {
+            $result[$currentParamName] = '';
+        } elseif ($state == self::PARSER_STATE_TABLE_NAME) {
+            if ($valueIsQuoted == '') {
+                $result['table'] = '"'.$currentValue.'"';
+                $result['tablename'] = $currentValue;
+                $result['schema'] = '';
+            } else {
+                throw new \Exception('syntax error, missing ending quote for table name');
+            }
+        } elseif ($state != self::PARSER_STATE_BETWEEN_PARAMETERS) {
+            throw new \Exception('syntax error, missing equal sign for parameter '.$currentParamName);
+        }
+
+        return $result;
     }
 }

--- a/lizmap/modules/lizmap/lib/App/SqlTools.php
+++ b/lizmap/modules/lizmap/lib/App/SqlTools.php
@@ -115,11 +115,11 @@ class SqlTools
      *
      * @return array the list of parameters
      *
-     * @throws \Exception
+     * @throws QgisConnectionStringParserException
      */
     public static function parseQgisConnectionString(string $connection_string): array
     {
-        $result = array();
+        $parameters = array();
 
         $tokens = preg_split('/(=| +|(?<!\\\)\'|(?<!\\\)")/u', $connection_string, -1, PREG_SPLIT_DELIM_CAPTURE);
         $state = self::PARSER_STATE_BETWEEN_PARAMETERS;
@@ -139,11 +139,11 @@ class SqlTools
                         break;
                     }
                     if ($token == "'" || $token == '"' || $token == '=') {
-                        throw new \Exception('syntax error, unexpected character "'.$token.'"');
+                        throw new QgisConnectionStringParserException('syntax error, unexpected character "'.$token.'"', 1, $parameters);
                     }
                     if ($token[0] == '(') {
                         // geometry column
-                        $result['geocol'] = str_replace(array('\)', '\\\\'), array(')', '\\'), trim($token, '()'));
+                        $parameters['geocol'] = str_replace(array('\)', '\\\\'), array(')', '\\'), trim($token, '()'));
 
                         break;
                     }
@@ -158,7 +158,7 @@ class SqlTools
                         break;
                     }
                     if ($token != '=') {
-                        throw new \Exception('syntax error, missing equal sign after parameter '.$currentParamName);
+                        throw new QgisConnectionStringParserException('syntax error, missing equal sign after parameter '.$currentParamName, 2, $parameters);
                     }
                     $state = self::PARSER_STATE_PARAM_EQUAL;
 
@@ -169,7 +169,7 @@ class SqlTools
                         break;
                     }
                     if ($token == '=') {
-                        throw new \Exception('syntax error unexpected equal sign after parameter '.$currentParamName);
+                        throw new QgisConnectionStringParserException('syntax error, unexpected equal sign after parameter '.$currentParamName, 3, $parameters);
                     }
 
                     if ($currentParamName == 'table') {
@@ -213,7 +213,7 @@ class SqlTools
                                 $currentValue
                             );
                         }
-                        $result[$currentParamName] = $currentValue;
+                        $parameters[$currentParamName] = $currentValue;
                         $currentValue = '';
                         $currentParamName = '';
                         $state = self::PARSER_STATE_BETWEEN_PARAMETERS;
@@ -251,14 +251,14 @@ class SqlTools
                     if ($token == '.') {
                         $state = self::PARSER_STATE_TABLE_NAME_QUOTE;
                     } elseif ($token[0] = ' ') { // no dot separator, we reach the end of the table full name
-                        $result['table'] = '"'.$tableSchemaName.'"';
-                        $result['tablename'] = $tableSchemaName;
-                        $result['schema'] = '';
+                        $parameters['table'] = '"'.$tableSchemaName.'"';
+                        $parameters['tablename'] = $tableSchemaName;
+                        $parameters['schema'] = '';
                         $state = self::PARSER_STATE_BETWEEN_PARAMETERS;
                         $currentParamName = '';
                         $currentValue = '';
                     } else {
-                        throw new \Exception('table name separator is missing after '.$tableSchemaName);
+                        throw new QgisConnectionStringParserException('syntax error, table name separator is missing after '.$tableSchemaName, 4, $parameters);
                     }
 
                     break;
@@ -268,7 +268,7 @@ class SqlTools
                         $valueIsQuoted = $token;
                         $state = self::PARSER_STATE_TABLE_NAME;
                     } else {
-                        throw new \Exception('table name is missing after the schema '.$tableSchemaName);
+                        throw new QgisConnectionStringParserException('syntax error, table name is missing after the schema '.$tableSchemaName, 5, $parameters);
                     }
 
                     break;
@@ -276,12 +276,12 @@ class SqlTools
                 case self::PARSER_STATE_TABLE_NAME:
                     if (($valueIsQuoted && $token == $valueIsQuoted) || ($valueIsQuoted == '' && $token[0] == ' ')) {
                         if ($tableSchemaName) {
-                            $result['table'] = '"'.$tableSchemaName.'"."'.$currentValue.'"';
+                            $parameters['table'] = '"'.$tableSchemaName.'"."'.$currentValue.'"';
                         } else {
-                            $result['table'] = '"'.$currentValue.'"';
+                            $parameters['table'] = '"'.$currentValue.'"';
                         }
-                        $result['tablename'] = $currentValue;
-                        $result['schema'] = $tableSchemaName;
+                        $parameters['tablename'] = $currentValue;
+                        $parameters['schema'] = $tableSchemaName;
                         $state = self::PARSER_STATE_BETWEEN_PARAMETERS;
                         $currentParamName = '';
                         $currentValue = '';
@@ -296,8 +296,8 @@ class SqlTools
                     // we take all content until the next quote
                     if ($valueIsQuoted && $token == $valueIsQuoted) {
                         // dummy_liz_alias is a SQL alias to avoid error in Postgresql. PG does not allow `FROM (subquery)` without alias.
-                        $result['table'] = $result['tablename'] = trim(str_replace('\\'.$valueIsQuoted, $valueIsQuoted, $currentValue)).' dummy_liz_alias';
-                        $result['schema'] = '';
+                        $parameters['table'] = $parameters['tablename'] = trim(str_replace('\\'.$valueIsQuoted, $valueIsQuoted, $currentValue)).' dummy_liz_alias';
+                        $parameters['schema'] = '';
                         $state = self::PARSER_STATE_BETWEEN_PARAMETERS;
                         $currentParamName = '';
                         $currentValue = '';
@@ -317,31 +317,37 @@ class SqlTools
             }
         }
 
+        if ($state == self::PARSER_STATE_BETWEEN_PARAMETERS) {
+            return $parameters;
+        }
+
         if ($state == self::PARSER_STATE_SQL_VALUE) {
             $currentValue = trim($currentValue);
             if ($currentValue == '""' || $currentValue == "''") {
                 $currentValue = '';
             }
-            $result[$currentParamName] = $currentValue;
+            $parameters[$currentParamName] = $currentValue;
         } elseif ($state == self::PARSER_STATE_IN_VALUE || $state == self::PARSER_STATE_TABLE_VALUE || $state == self::PARSER_STATE_TABLE_SQL) {
             if ($valueIsQuoted) {
-                throw new \Exception('syntax error, missing ending quote for parameter='.$currentParamName);
+                throw new QgisConnectionStringParserException('syntax error, missing ending quote for parameter='.$currentParamName, 6, $parameters);
             }
-            $result[$currentParamName] = trim($currentValue);
+            $parameters[$currentParamName] = trim($currentValue);
         } elseif ($state == self::PARSER_STATE_PARAM_EQUAL) {
-            $result[$currentParamName] = '';
+            $parameters[$currentParamName] = '';
         } elseif ($state == self::PARSER_STATE_TABLE_NAME) {
             if ($valueIsQuoted == '') {
-                $result['table'] = '"'.$currentValue.'"';
-                $result['tablename'] = $currentValue;
-                $result['schema'] = '';
+                $parameters['table'] = '"'.$currentValue.'"';
+                $parameters['tablename'] = $currentValue;
+                $parameters['schema'] = '';
             } else {
-                throw new \Exception('syntax error, missing ending quote for table name');
+                throw new QgisConnectionStringParserException('syntax error, missing ending quote for table name', 7, $parameters);
             }
-        } elseif ($state != self::PARSER_STATE_BETWEEN_PARAMETERS) {
-            throw new \Exception('syntax error, missing equal sign for parameter '.$currentParamName);
+        } elseif ($state == self::PARSER_STATE_TABLE_NAME_QUOTE) {
+            throw new QgisConnectionStringParserException('syntax error, table name is missing after the schema '.$tableSchemaName, 5, $parameters);
+        } else {
+            throw new QgisConnectionStringParserException('syntax error, missing equal sign for parameter '.$currentParamName, 2, $parameters);
         }
 
-        return $result;
+        return $parameters;
     }
 }

--- a/lizmap/modules/lizmap/lib/App/SqlTools.php
+++ b/lizmap/modules/lizmap/lib/App/SqlTools.php
@@ -22,7 +22,7 @@ class SqlTools
     public const PARSER_STATE_TABLE_VALUE = 4;
     public const PARSER_STATE_TABLE_SCHEMA = 5;
     public const PARSER_STATE_TABLE_NAME_SEPARATOR = 6;
-    public const PARSER_STATE_TABLE_NAME_DBLQUOTE = 7;
+    public const PARSER_STATE_TABLE_NAME_QUOTE = 7;
     public const PARSER_STATE_TABLE_NAME = 8;
     public const PARSER_STATE_TABLE_SQL = 9;
     public const PARSER_STATE_SQL_VALUE = 10;
@@ -106,7 +106,14 @@ class SqlTools
     /**
      * Parse a Qgis connection string.
      *
-     * It supports `table` and `sql` parameters, as well as geometry tags like `(geom)`.
+     * It supports `table` and `sql` parameters, as well as geometry tags like `(geom)`, in addition of
+     * other database connection parameters.
+     *
+     * It is compliant with the Qgis 4.2 parser.
+     *
+     * @see https://api.qgis.org/api/4.2/qgsdatasourceuri_8cpp_source.html
+     *
+     * @return array the list of parameters
      *
      * @throws \Exception
      */
@@ -114,7 +121,7 @@ class SqlTools
     {
         $result = array();
 
-        $tokens = preg_split('/(=| +|(?<!\\\)\'|(?<!\\\)")/', $connection_string, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $tokens = preg_split('/(=| +|(?<!\\\)\'|(?<!\\\)")/u', $connection_string, -1, PREG_SPLIT_DELIM_CAPTURE);
         $state = self::PARSER_STATE_BETWEEN_PARAMETERS;
         $currentParamName = '';
         $currentValue = '';
@@ -135,7 +142,8 @@ class SqlTools
                         throw new \Exception('syntax error, unexpected character "'.$token.'"');
                     }
                     if ($token[0] == '(') {
-                        $result['geocol'] = trim($token, '()');
+                        // geometry column
+                        $result['geocol'] = str_replace(array('\)', '\\\\'), array(')', '\\'), trim($token, '()'));
 
                         break;
                     }
@@ -165,7 +173,7 @@ class SqlTools
                     }
 
                     if ($currentParamName == 'table') {
-                        if ($token == '"') {
+                        if ($token == '"' || $token == "'") {
                             $valueIsQuoted = $token;
                             $currentValue = '';
                             $state = self::PARSER_STATE_TABLE_VALUE;
@@ -183,7 +191,7 @@ class SqlTools
 
                         break;
                     }
-                    if ($token == "'") {
+                    if ($token == "'" || $token == '"') {
                         $valueIsQuoted = $token;
                     } else {
                         $currentValue = $token;
@@ -193,10 +201,17 @@ class SqlTools
                     break;
 
                 case self::PARSER_STATE_IN_VALUE:
+                    // All characters until the delimiter are taken.
+                    // Escaped delimiters and escaped anti-slash must be unescaped.
+                    // When there are no delimiters, a space indicate the end of the value
                     if (($valueIsQuoted && $token == $valueIsQuoted) || ($valueIsQuoted == '' && $token == ' ')) {
 
                         if ($valueIsQuoted != '') {
-                            $currentValue = str_replace('\\'.$valueIsQuoted, $valueIsQuoted, $currentValue);
+                            $currentValue = str_replace(
+                                array('\\'.$valueIsQuoted, '\\\\'),
+                                array($valueIsQuoted, '\\'),
+                                $currentValue
+                            );
                         }
                         $result[$currentParamName] = $currentValue;
                         $currentValue = '';
@@ -234,7 +249,7 @@ class SqlTools
 
                 case self::PARSER_STATE_TABLE_NAME_SEPARATOR:
                     if ($token == '.') {
-                        $state = self::PARSER_STATE_TABLE_NAME_DBLQUOTE;
+                        $state = self::PARSER_STATE_TABLE_NAME_QUOTE;
                     } elseif ($token[0] = ' ') { // no dot separator, we reach the end of the table full name
                         $result['table'] = '"'.$tableSchemaName.'"';
                         $result['tablename'] = $tableSchemaName;
@@ -248,8 +263,9 @@ class SqlTools
 
                     break;
 
-                case self::PARSER_STATE_TABLE_NAME_DBLQUOTE:
-                    if ($token == '"') {
+                case self::PARSER_STATE_TABLE_NAME_QUOTE:
+                    if ($token == '"' || $token == "'") {
+                        $valueIsQuoted = $token;
                         $state = self::PARSER_STATE_TABLE_NAME;
                     } else {
                         throw new \Exception('table name is missing after the schema '.$tableSchemaName);
@@ -258,7 +274,7 @@ class SqlTools
                     break;
 
                 case self::PARSER_STATE_TABLE_NAME:
-                    if (($valueIsQuoted && $token == '"') || ($valueIsQuoted == '' && $token[0] == ' ')) {
+                    if (($valueIsQuoted && $token == $valueIsQuoted) || ($valueIsQuoted == '' && $token[0] == ' ')) {
                         if ($tableSchemaName) {
                             $result['table'] = '"'.$tableSchemaName.'"."'.$currentValue.'"';
                         } else {
@@ -277,15 +293,16 @@ class SqlTools
                     break;
 
                 case self::PARSER_STATE_TABLE_SQL:
-                    // we take all content until the next double quote
+                    // we take all content until the next quote
                     if ($valueIsQuoted && $token == $valueIsQuoted) {
-                        // fooliz is the name of the 'virtual' table
-                        $result['table'] = $result['tablename'] = trim(str_replace('\"', '"', $currentValue)).' fooliz';
+                        // dummy_liz_alias is a SQL alias to avoid error in Postgresql. PG does not allow `FROM (subquery)` without alias.
+                        $result['table'] = $result['tablename'] = trim(str_replace('\\'.$valueIsQuoted, $valueIsQuoted, $currentValue)).' dummy_liz_alias';
                         $result['schema'] = '';
                         $state = self::PARSER_STATE_BETWEEN_PARAMETERS;
                         $currentParamName = '';
                         $currentValue = '';
                         $valueIsQuoted = '';
+
                     } else {
                         $currentValue .= $token;
                     }
@@ -301,7 +318,11 @@ class SqlTools
         }
 
         if ($state == self::PARSER_STATE_SQL_VALUE) {
-            $result[$currentParamName] = trim($currentValue);
+            $currentValue = trim($currentValue);
+            if ($currentValue == '""' || $currentValue == "''") {
+                $currentValue = '';
+            }
+            $result[$currentParamName] = $currentValue;
         } elseif ($state == self::PARSER_STATE_IN_VALUE || $state == self::PARSER_STATE_TABLE_VALUE || $state == self::PARSER_STATE_TABLE_SQL) {
             if ($valueIsQuoted) {
                 throw new \Exception('syntax error, missing ending quote for parameter='.$currentParamName);

--- a/tests/units/edition/qgisVectorLayerDatasourceTest.php
+++ b/tests/units/edition/qgisVectorLayerDatasourceTest.php
@@ -115,18 +115,6 @@ class qgisVectorLayerDatasourceTest extends TestCase
         $this->assertEquals('test password', $element->getDatasourceParameter('password'));
         $this->assertEquals('prefer', $element->getDatasourceParameter('sslmode'));
 
-        $provider = 'postgres';
-        $datasource = "dbname='test_dbname' host=test_host port=5432 user='test_user' password=test password sslmode=prefer";
-
-        $element = new qgisVectorLayerDatasource($provider, $datasource);
-
-        $this->assertEquals('test_dbname', $element->getDatasourceParameter('dbname'));
-        $this->assertEquals('test_host', $element->getDatasourceParameter('host'));
-        $this->assertEquals('5432', $element->getDatasourceParameter('port'));
-        $this->assertEquals('test_user', $element->getDatasourceParameter('user'));
-        $this->assertEquals('test', $element->getDatasourceParameter('password'));
-        $this->assertEquals('prefer', $element->getDatasourceParameter('sslmode'));
-
     }
 
     public function testPostgresDatasourceWithoutGeometry(): void
@@ -636,7 +624,7 @@ WHERE fk_id_series = 2  )
     public function testBadDatasourceMissingEqual(): void
     {
         $provider = 'postgres';
-        // missing a quote for user
+        // missing value for foo
         $datasource = "dbname='test_dbname' host=127.0.0.1 port=5432 foo user='test_user' ";
         $this->expectException(QgisConnectionStringParserException::class);
         $this->expectExceptionCode(2);

--- a/tests/units/edition/qgisVectorLayerDatasourceTest.php
+++ b/tests/units/edition/qgisVectorLayerDatasourceTest.php
@@ -296,6 +296,34 @@ class qgisVectorLayerDatasourceTest extends TestCase
         $this->assertEquals("\"code_com\" = '010'", $element->getDatasourceParameter('sql'));
     }
 
+    public function testPostgresDatasourceTableWithoutSchemaWithSql(): void
+    {
+        $provider = 'postgres';
+        $datasource = "dbname='test_dbname' host=127.0.0.1 port=5432 user='test_user' password='test_password' sslmode=prefer key='id_lieux' srid=2154 type=MultiPolygon checkPrimaryKeyUnicity='1' table=\"lieux\" (geom) sql=\"code_com\" = '010'";
+
+        $element = new qgisVectorLayerDatasource($provider, $datasource);
+
+        $this->assertEquals('test_dbname', $element->getDatasourceParameter('dbname'));
+        $this->assertEquals('', $element->getDatasourceParameter('service'));
+        $this->assertEquals('127.0.0.1', $element->getDatasourceParameter('host'));
+        $this->assertEquals('5432', $element->getDatasourceParameter('port'));
+        $this->assertEquals('test_user', $element->getDatasourceParameter('user'));
+        $this->assertEquals('test_password', $element->getDatasourceParameter('password'));
+        $this->assertEquals('', $element->getDatasourceParameter('authcfg'));
+        $this->assertEquals('prefer', $element->getDatasourceParameter('sslmode'));
+        $this->assertEquals('id_lieux', $element->getDatasourceParameter('key'));
+        $this->assertEquals('', $element->getDatasourceParameter('estimatedmetadata'));
+        $this->assertEquals('', $element->getDatasourceParameter('selectatid'));
+        $this->assertEquals('2154', $element->getDatasourceParameter('srid'));
+        $this->assertEquals('MultiPolygon', $element->getDatasourceParameter('type'));
+        $this->assertEquals('1', $element->getDatasourceParameter('checkPrimaryKeyUnicity'));
+        $this->assertEquals('"lieux"', $element->getDatasourceParameter('table'));
+        $this->assertEquals('lieux', $element->getDatasourceParameter('tablename'));
+        $this->assertEquals('', $element->getDatasourceParameter('schema'));
+        $this->assertEquals('geom', $element->getDatasourceParameter('geocol'));
+        $this->assertEquals("\"code_com\" = '010'", $element->getDatasourceParameter('sql'));
+    }
+
     public function testPostgresqlDatasourceWithoutSql(): void
     {
         $provider = 'postgres';
@@ -366,6 +394,49 @@ WHERE fk_id_series = 2  )
         $this->assertEquals('geom', $element->getDatasourceParameter('geocol'));
         $sql = "\"observation_timestamp\" &lt; '2017-01-01T00:00:00' AND \"observation_timestamp\" &gt;= '2016-01-01T00:00:00'";
         $this->assertEquals($sql, $element->getDatasourceParameter('sql'));
+    }
+
+    public function testComplexQueryDatasourceWithoutGeomSql(): void
+    {
+        $provider = 'postgres';
+        $datasource = "service='test_service' key='id' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=\"((             SELECT                 o.id,&#xD;
+                 so_unique_id AS spatial_object_code,&#xD;
+				 so.geom,&#xD;
+				 ob_timestamp AS observation_timestamp
+FROM gobs.observation AS o             &#xD;
+INNER JOIN gobs.spatial_object AS so                 ON so.id = o.fk_id_spatial_object             &#xD;
+WHERE fk_id_series = 2  )
+)\"";
+
+        $element = new qgisVectorLayerDatasource($provider, $datasource);
+
+        $this->assertEquals('', $element->getDatasourceParameter('dbname'));
+        $this->assertEquals('test_service', $element->getDatasourceParameter('service'));
+        $this->assertEquals('', $element->getDatasourceParameter('host'));
+        $this->assertEquals('', $element->getDatasourceParameter('port'));
+        $this->assertEquals('', $element->getDatasourceParameter('user'));
+        $this->assertEquals('', $element->getDatasourceParameter('password'));
+        $this->assertEquals('', $element->getDatasourceParameter('sslmode'));
+        $this->assertEquals('id', $element->getDatasourceParameter('key'));
+        $this->assertEquals('true', $element->getDatasourceParameter('estimatedmetadata'));
+        $this->assertEquals('', $element->getDatasourceParameter('selectatid'));
+        $this->assertEquals('', $element->getDatasourceParameter('srid'));
+        $this->assertEquals('', $element->getDatasourceParameter('type'));
+        $this->assertEquals('1', $element->getDatasourceParameter('checkPrimaryKeyUnicity'));
+        $table = '((             SELECT                 o.id,&#xD;
+                 so_unique_id AS spatial_object_code,&#xD;
+				 so.geom,&#xD;
+				 ob_timestamp AS observation_timestamp
+FROM gobs.observation AS o             &#xD;
+INNER JOIN gobs.spatial_object AS so                 ON so.id = o.fk_id_spatial_object             &#xD;
+WHERE fk_id_series = 2  )
+) fooliz';
+
+        $this->assertEquals($table, $element->getDatasourceParameter('table'));
+        $this->assertEquals($table, $element->getDatasourceParameter('tablename'));
+        $this->assertEquals('', $element->getDatasourceParameter('schema'));
+        $this->assertEquals('', $element->getDatasourceParameter('geocol'));
+        $this->assertEquals('', $element->getDatasourceParameter('sql'));
     }
 
     public function testComplexQueryDatasourceWithEscapedDoubleQuotes(): void

--- a/tests/units/edition/qgisVectorLayerDatasourceTest.php
+++ b/tests/units/edition/qgisVectorLayerDatasourceTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Lizmap\App\QgisConnectionStringParserException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -618,5 +619,39 @@ WHERE fk_id_series = 2  )
         $this->assertEquals('', $element->getDatasourceParameter('schema'));
         $this->assertEquals('geom', $element->getDatasourceParameter('geocol'));
         $this->assertEquals('"year" > 1900', $element->getDatasourceParameter('sql'));
+    }
+
+
+    public function testBadDatasourceMissingQuote(): void
+    {
+        $provider = 'postgres';
+        // missing a quote for user
+        $datasource = "dbname='test_dbname' host=127.0.0.1 port=5432 user='test_user ";
+        $this->expectException(QgisConnectionStringParserException::class);
+        $this->expectExceptionCode(6);
+        $this->expectExceptionMessage('syntax error, missing ending quote for parameter=user');
+        $element = new qgisVectorLayerDatasource($provider, $datasource);
+    }
+
+    public function testBadDatasourceMissingEqual(): void
+    {
+        $provider = 'postgres';
+        // missing a quote for user
+        $datasource = "dbname='test_dbname' host=127.0.0.1 port=5432 foo user='test_user' ";
+        $this->expectException(QgisConnectionStringParserException::class);
+        $this->expectExceptionCode(2);
+        $this->expectExceptionMessage('syntax error, missing equal sign after parameter foo');
+        $element = new qgisVectorLayerDatasource($provider, $datasource);
+    }
+
+    public function testBadDatasourceTableMissingName(): void
+    {
+        $provider = 'postgres';
+        // missing a quote for user
+        $datasource = "dbname='test_dbname' host=127.0.0.1 port=5432 user='test_user' table=\"schem\".";
+        $this->expectException(QgisConnectionStringParserException::class);
+        $this->expectExceptionCode(5);
+        $this->expectExceptionMessage('syntax error, table name is missing after the schema schem');
+        $element = new qgisVectorLayerDatasource($provider, $datasource);
     }
 }

--- a/tests/units/edition/qgisVectorLayerDatasourceTest.php
+++ b/tests/units/edition/qgisVectorLayerDatasourceTest.php
@@ -184,10 +184,94 @@ class qgisVectorLayerDatasourceTest extends TestCase
         $this->assertEquals('', $element->getDatasourceParameter('sql'));
     }
 
+    public function testDatasourceWithEmptySql(): void
+    {
+        $provider = 'postgres';
+        $datasource = "dbname='test_dbname' service='test_service' sql=''";
+
+        $element = new qgisVectorLayerDatasource($provider, $datasource);
+
+        $this->assertEquals('test_dbname', $element->getDatasourceParameter('dbname'));
+        $this->assertEquals('test_service', $element->getDatasourceParameter('service'));
+        $this->assertEquals('', $element->getDatasourceParameter('host'));
+        $this->assertEquals('', $element->getDatasourceParameter('port'));
+        $this->assertEquals('', $element->getDatasourceParameter('user'));
+        $this->assertEquals('', $element->getDatasourceParameter('password'));
+        $this->assertEquals('', $element->getDatasourceParameter('authcfg'));
+        $this->assertEquals('', $element->getDatasourceParameter('sslmode'));
+        $this->assertEquals('', $element->getDatasourceParameter('key'));
+        $this->assertEquals('', $element->getDatasourceParameter('estimatedmetadata'));
+        $this->assertEquals('', $element->getDatasourceParameter('selectatid'));
+        $this->assertEquals('', $element->getDatasourceParameter('srid'));
+        $this->assertEquals('', $element->getDatasourceParameter('type'));
+        $this->assertEquals('', $element->getDatasourceParameter('checkPrimaryKeyUnicity'));
+        $this->assertEquals('', $element->getDatasourceParameter('table'));
+        $this->assertEquals('', $element->getDatasourceParameter('tablename'));
+        $this->assertEquals('', $element->getDatasourceParameter('schema'));
+        $this->assertEquals('', $element->getDatasourceParameter('geocol'));
+        $this->assertEquals('', $element->getDatasourceParameter('sql'));
+    }
+
+    public function testDatasourceWithEscapedAntiSlash(): void
+    {
+        $provider = 'postgres';
+        $datasource = "dbname='test_dbname' service='test_service' password='qsbc\\\\def' ";
+
+        $element = new qgisVectorLayerDatasource($provider, $datasource);
+
+        $this->assertEquals('test_dbname', $element->getDatasourceParameter('dbname'));
+        $this->assertEquals('test_service', $element->getDatasourceParameter('service'));
+        $this->assertEquals('', $element->getDatasourceParameter('host'));
+        $this->assertEquals('', $element->getDatasourceParameter('port'));
+        $this->assertEquals('', $element->getDatasourceParameter('user'));
+        $this->assertEquals('qsbc\\def', $element->getDatasourceParameter('password'));
+        $this->assertEquals('', $element->getDatasourceParameter('authcfg'));
+        $this->assertEquals('', $element->getDatasourceParameter('sslmode'));
+        $this->assertEquals('', $element->getDatasourceParameter('key'));
+        $this->assertEquals('', $element->getDatasourceParameter('estimatedmetadata'));
+        $this->assertEquals('', $element->getDatasourceParameter('selectatid'));
+        $this->assertEquals('', $element->getDatasourceParameter('srid'));
+        $this->assertEquals('', $element->getDatasourceParameter('type'));
+        $this->assertEquals('', $element->getDatasourceParameter('checkPrimaryKeyUnicity'));
+        $this->assertEquals('', $element->getDatasourceParameter('table'));
+        $this->assertEquals('', $element->getDatasourceParameter('tablename'));
+        $this->assertEquals('', $element->getDatasourceParameter('schema'));
+        $this->assertEquals('', $element->getDatasourceParameter('geocol'));
+        $this->assertEquals('', $element->getDatasourceParameter('sql'));
+    }
+
+    public function testDatasourceWithSpaceAroundEqual(): void
+    {
+        $provider = 'postgres';
+        $datasource = "dbname = 'test_dbname' service = test_service password = \"abc\"";
+
+        $element = new qgisVectorLayerDatasource($provider, $datasource);
+
+        $this->assertEquals('test_dbname', $element->getDatasourceParameter('dbname'));
+        $this->assertEquals('test_service', $element->getDatasourceParameter('service'));
+        $this->assertEquals('', $element->getDatasourceParameter('host'));
+        $this->assertEquals('', $element->getDatasourceParameter('port'));
+        $this->assertEquals('', $element->getDatasourceParameter('user'));
+        $this->assertEquals('abc', $element->getDatasourceParameter('password'));
+        $this->assertEquals('', $element->getDatasourceParameter('authcfg'));
+        $this->assertEquals('', $element->getDatasourceParameter('sslmode'));
+        $this->assertEquals('', $element->getDatasourceParameter('key'));
+        $this->assertEquals('', $element->getDatasourceParameter('estimatedmetadata'));
+        $this->assertEquals('', $element->getDatasourceParameter('selectatid'));
+        $this->assertEquals('', $element->getDatasourceParameter('srid'));
+        $this->assertEquals('', $element->getDatasourceParameter('type'));
+        $this->assertEquals('', $element->getDatasourceParameter('checkPrimaryKeyUnicity'));
+        $this->assertEquals('', $element->getDatasourceParameter('table'));
+        $this->assertEquals('', $element->getDatasourceParameter('tablename'));
+        $this->assertEquals('', $element->getDatasourceParameter('schema'));
+        $this->assertEquals('', $element->getDatasourceParameter('geocol'));
+        $this->assertEquals('', $element->getDatasourceParameter('sql'));
+    }
+
     public function testPostgresqlDatasourceWithoutGeometryWithServiceWithoutSql(): void
     {
         $provider = 'postgres';
-        $datasource = "dbname='test_dbname' service='test_service' sslmode=prefer key='id' srid=2193 checkPrimaryKeyUnicity='1' table=\"public\".\"EditTest\"";
+        $datasource = "dbname='test_dbname' service='test_service' sslmode=prefer key='id' srid=2193 checkPrimaryKeyUnicity='1' table='public'.\"EditTest\"";
 
         $element = new qgisVectorLayerDatasource($provider, $datasource);
 
@@ -215,11 +299,11 @@ class qgisVectorLayerDatasourceTest extends TestCase
     public function testPostgresqlDatasourceWithAuthcfg(): void
     {
         $provider = 'postgres';
-        $datasource = "dbname='test_dbname' host=127.0.0.1 port=5432 authcfg='lizmap-test' sslmode=prefer key='id' srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=\"test_schema\".\"test_table\" (geom) sql=";
+        $datasource = "dbname='test_😆dbname' host=127.0.0.1 port=5432 authcfg='lizmap-test' sslmode=prefer key='id' srid=4326 type=Polygon checkPrimaryKeyUnicity='1' table=\"test_schema\".\"test_table\" (geom) sql=";
 
         $element = new qgisVectorLayerDatasource($provider, $datasource);
 
-        $this->assertEquals('test_dbname', $element->getDatasourceParameter('dbname'));
+        $this->assertEquals('test_😆dbname', $element->getDatasourceParameter('dbname'));
         $this->assertEquals('', $element->getDatasourceParameter('service'));
         $this->assertEquals('127.0.0.1', $element->getDatasourceParameter('host'));
         $this->assertEquals('5432', $element->getDatasourceParameter('port'));
@@ -386,7 +470,7 @@ WHERE fk_id_series = 2  )
 FROM gobs.observation AS o             &#xD;
 INNER JOIN gobs.spatial_object AS so                 ON so.id = o.fk_id_spatial_object             &#xD;
 WHERE fk_id_series = 2  )
-) fooliz';
+) dummy_liz_alias';
 
         $this->assertEquals($table, $element->getDatasourceParameter('table'));
         $this->assertEquals($table, $element->getDatasourceParameter('tablename'));
@@ -430,7 +514,7 @@ WHERE fk_id_series = 2  )
 FROM gobs.observation AS o             &#xD;
 INNER JOIN gobs.spatial_object AS so                 ON so.id = o.fk_id_spatial_object             &#xD;
 WHERE fk_id_series = 2  )
-) fooliz';
+) dummy_liz_alias';
 
         $this->assertEquals($table, $element->getDatasourceParameter('table'));
         $this->assertEquals($table, $element->getDatasourceParameter('tablename'));
@@ -458,7 +542,7 @@ WHERE fk_id_series = 2  )
         $this->assertEquals('', $element->getDatasourceParameter('srid'));
         $this->assertEquals('', $element->getDatasourceParameter('type'));
         $this->assertEquals('1', $element->getDatasourceParameter('checkPrimaryKeyUnicity'));
-        $table = "( SELECT o.id, so_unique_id AS spatial_object_code, so.geom, to_char(ob_start_timestamp, 'YYYY') AS observation_start, to_char(ob_end_timestamp, 'YYYY') AS observation_end, ob_start_timestamp AS observation_start_timestamp, ob_end_timestamp AS observation_end_timestamp, (ob_value->>0)::integer AS \"population\" FROM gobs.observation AS o INNER JOIN gobs.spatial_object AS so ON so.id = o.fk_id_spatial_object WHERE fk_id_series = 2         ) fooliz";
+        $table = "( SELECT o.id, so_unique_id AS spatial_object_code, so.geom, to_char(ob_start_timestamp, 'YYYY') AS observation_start, to_char(ob_end_timestamp, 'YYYY') AS observation_end, ob_start_timestamp AS observation_start_timestamp, ob_end_timestamp AS observation_end_timestamp, (ob_value->>0)::integer AS \"population\" FROM gobs.observation AS o INNER JOIN gobs.spatial_object AS so ON so.id = o.fk_id_spatial_object WHERE fk_id_series = 2         ) dummy_liz_alias";
 
         $this->assertEquals($table, $element->getDatasourceParameter('table'));
         $this->assertEquals($table, $element->getDatasourceParameter('tablename'));


### PR DESCRIPTION
Fix several potential issues when the connection strings contain special characters into parameters values.

It has a better support of parameter values and quotes than a parser based on regexp. Support of escaped quote in all values etc.

It is probably faster than the previous parser, as it doesn't have to execute a regexp for each parameters.

Funded by 3liz.
