### PR TITLE
fix(qgisVectorLayerDatasource) password may contain single quotes

### DIFF
--- a/lizmap/modules/lizmap/classes/qgisVectorLayerDatasource.class.php
+++ b/lizmap/modules/lizmap/classes/qgisVectorLayerDatasource.class.php
@@ -16,20 +16,24 @@ class qgisVectorLayerDatasource
      * @var array Regexes used to get datasource parameters
      */
     protected $datasourceRegexes = array(
-        'dbname' => "dbname='?([^ ']+)'? ",
-        'service' => "service='?([^ ']+)'? ",
+        'dbname' => "dbname='?([^ ']+)'?(?: |$)",
+        'service' => "service='?([^ ']+)'?(?: |$)",
         'host' => "host='?([^ ']+)'? port=",
-        'port' => 'port=([0-9]+) ',
-        'user' => "user='?([^ ']+)'? ",
-        'password' => "password='?([^ ']+)'? ",
-        'sslmode' => "sslmode='?([^ ']+)'? ",
-        'authcfg' => "authcfg='?([^ ']+)'? ",
-        'key' => "key='?([^ ']+)'? ",
-        'estimatedmetadata' => 'estimatedmetadata=([^ ]+) ',
-        'selectatid' => 'selectatid=([^ ]+) ',
-        'srid' => 'srid=([0-9]+) ',
-        'type' => 'type=([a-zA-Z]+) ',
-        'checkPrimaryKeyUnicity' => "checkPrimaryKeyUnicity='([0-1]+)' ",
+        'port' => 'port=([0-9]+)(?: |$)',
+        'user' => "user='?([^ ']+)'?(?: |$)",
+        'password' => array(
+            "password='((?:\\\\\\'|[^'])*)'(?: |$)",
+            'password="((?:\\\"|[^"])*)"(?: |$)',
+            "password=([^ ']+)(?: |$)",
+        ),
+        'sslmode' => "sslmode='?([^ ']+)'?(?: |$)",
+        'authcfg' => "authcfg='?([^ ']+)'?(?: |$)",
+        'key' => "key='?([^ ']+)'?(?: |$)",
+        'estimatedmetadata' => 'estimatedmetadata=([^ ]+)(?: |$)',
+        'selectatid' => 'selectatid=([^ ]+)(?: |$)',
+        'srid' => 'srid=([0-9]+)(?: |$)',
+        'type' => 'type=([a-zA-Z]+)(?: |$)',
+        'checkPrimaryKeyUnicity' => "checkPrimaryKeyUnicity='([0-1]+)'(?: |$)",
         'table' => 'table="(.+?)"($|\s)',
         'geocol' => '\(([^ >]+)\)',
         'sql' => ' sql=(.*)$',
@@ -100,6 +104,16 @@ class qgisVectorLayerDatasource
                 str_replace('\"', $backSlashedQuoteReplacement, $this->datasource),
                 $result
             );
+        } elseif (is_array($regex)) {
+            foreach ($regex as $r) {
+                if (preg_match(
+                    '#'.$r.'#s',
+                    $this->datasource,
+                    $result
+                )) {
+                    break;
+                }
+            }
         } else {
             preg_match(
                 '#'.$regex.'#s',
@@ -110,10 +124,13 @@ class qgisVectorLayerDatasource
 
         $nb_result = count($result);
         if ((2 <= $nb_result) and ($nb_result <= 3) and strlen($result[1])) {
-            // We replace back the backslahsed quote replacement in the value by double-quotes
-            $value = $result[1];
             if ($param == 'table') {
+                // We replace back the backslahsed quote replacement in the value by double-quotes
                 $value = str_replace($backSlashedQuoteReplacement, '"', $result[1]);
+            } elseif ($param == 'password') {
+                $value = str_replace(array("\\'", '\"'), array("'", '"'), $result[1]);
+            } else {
+                $value = $result[1];
             }
 
             // Specific parsing for complex table parameter

--- a/tests/units/edition/qgisVectorLayerDatasourceTest.php
+++ b/tests/units/edition/qgisVectorLayerDatasourceTest.php
@@ -63,6 +63,71 @@ class qgisVectorLayerDatasourceTest extends TestCase
         $this->assertEquals('', $element->getDatasourceParameter('sql'));
     }
 
+    public function testPostgresDatasourceWithEscapedDelimiterInPassword(): void
+    {
+        $provider = 'postgres';
+        $datasource = "dbname='test_dbname' host=test_host port=5432 user='test_user' password='test_\\'password' sslmode=prefer";
+
+        $element = new qgisVectorLayerDatasource($provider, $datasource);
+
+        $this->assertEquals('test_dbname', $element->getDatasourceParameter('dbname'));
+        $this->assertEquals('', $element->getDatasourceParameter('service'));
+        $this->assertEquals('test_host', $element->getDatasourceParameter('host'));
+        $this->assertEquals('5432', $element->getDatasourceParameter('port'));
+        $this->assertEquals('test_user', $element->getDatasourceParameter('user'));
+        $this->assertEquals('test_\'password', $element->getDatasourceParameter('password'));
+        $this->assertEquals('', $element->getDatasourceParameter('authcfg'));
+        $this->assertEquals('prefer', $element->getDatasourceParameter('sslmode'));
+        $this->assertEquals('', $element->getDatasourceParameter('key'));
+        $this->assertEquals('', $element->getDatasourceParameter('estimatedmetadata'));
+        $this->assertEquals('', $element->getDatasourceParameter('selectatid'));
+        $this->assertEquals('', $element->getDatasourceParameter('srid'));
+        $this->assertEquals('', $element->getDatasourceParameter('type'));
+        $this->assertEquals('', $element->getDatasourceParameter('checkPrimaryKeyUnicity'));
+        $this->assertEquals('', $element->getDatasourceParameter('table'));
+        $this->assertEquals('', $element->getDatasourceParameter('tablename'));
+        $this->assertEquals('', $element->getDatasourceParameter('schema'));
+        $this->assertEquals('', $element->getDatasourceParameter('geocol'));
+        $this->assertEquals('', $element->getDatasourceParameter('sql'));
+
+        $provider = 'postgres';
+        $datasource = "dbname='test_dbname' host=test_host port=5432 user='test_user' password=\"test_\\\"password\" sslmode=prefer";
+
+        $element = new qgisVectorLayerDatasource($provider, $datasource);
+
+        $this->assertEquals('test_dbname', $element->getDatasourceParameter('dbname'));
+        $this->assertEquals('test_host', $element->getDatasourceParameter('host'));
+        $this->assertEquals('5432', $element->getDatasourceParameter('port'));
+        $this->assertEquals('test_user', $element->getDatasourceParameter('user'));
+        $this->assertEquals('test_"password', $element->getDatasourceParameter('password'));
+        $this->assertEquals('prefer', $element->getDatasourceParameter('sslmode'));
+
+        $provider = 'postgres';
+        $datasource = "dbname='test_dbname' host=test_host port=5432 user='test_user' password=\"test password\" sslmode=prefer";
+
+        $element = new qgisVectorLayerDatasource($provider, $datasource);
+
+        $this->assertEquals('test_dbname', $element->getDatasourceParameter('dbname'));
+        $this->assertEquals('test_host', $element->getDatasourceParameter('host'));
+        $this->assertEquals('5432', $element->getDatasourceParameter('port'));
+        $this->assertEquals('test_user', $element->getDatasourceParameter('user'));
+        $this->assertEquals('test password', $element->getDatasourceParameter('password'));
+        $this->assertEquals('prefer', $element->getDatasourceParameter('sslmode'));
+
+        $provider = 'postgres';
+        $datasource = "dbname='test_dbname' host=test_host port=5432 user='test_user' password=test password sslmode=prefer";
+
+        $element = new qgisVectorLayerDatasource($provider, $datasource);
+
+        $this->assertEquals('test_dbname', $element->getDatasourceParameter('dbname'));
+        $this->assertEquals('test_host', $element->getDatasourceParameter('host'));
+        $this->assertEquals('5432', $element->getDatasourceParameter('port'));
+        $this->assertEquals('test_user', $element->getDatasourceParameter('user'));
+        $this->assertEquals('test', $element->getDatasourceParameter('password'));
+        $this->assertEquals('prefer', $element->getDatasourceParameter('sslmode'));
+
+    }
+
     public function testPostgresDatasourceWithoutGeometry(): void
     {
         $provider = 'postgres';


### PR DESCRIPTION
When a password contain a single quote into a connection string, it was not read correctly by the connection string parser.

Funded by 3liz
