### PR TITLE
allow empty user agent for maptoken (+Refacto)

### DIFF
--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -453,12 +453,8 @@ class serviceCtrl extends jController
         // Check WFS rights
         if (isset($params['service']) && strtolower($params['service']) === 'wfs'
             && !$lproj->getAppContext()->aclCheck('lizmap.tools.layer.export', $this->repository->getKey())) {
-            $request_headers = jApp::coord()->request->headers();
             if (!isset($_SESSION['html_map_token'])
-                || $_SESSION['html_map_token'] !== md5(json_encode(array(
-                    'Host' => $request_headers['Host'],
-                    'User-Agent' => $request_headers['User-Agent'],
-                )))) {
+                || $_SESSION['html_map_token'] !== $lproj->getAppContext()->buildMapToken()) {
                 jMessage::add(jLocale::get('view~default.service.access.forbidden'), 'Forbidden');
 
                 return false;

--- a/lizmap/modules/lizmap/lib/App/AppContextInterface.php
+++ b/lizmap/modules/lizmap/lib/App/AppContextInterface.php
@@ -318,4 +318,6 @@ interface AppContextInterface
      * @param Project $project
      */
     public function getTileCaps($project);
+
+    public function buildMapToken();
 }

--- a/lizmap/modules/lizmap/lib/App/JelixContext.php
+++ b/lizmap/modules/lizmap/lib/App/JelixContext.php
@@ -410,4 +410,14 @@ class JelixContext implements AppContextInterface
 
         return $_SERVER['REMOTE_ADDR'];
     }
+
+    public function buildMapToken()
+    {
+        $request_headers = $this->getCoord()->request->headers();
+
+        return md5(json_encode(array(
+            'Host' => $request_headers['Host'],
+            'User-Agent' => $request_headers['User-Agent'] ?? '',
+        )));
+    }
 }

--- a/lizmap/modules/view/controllers/lizMap.classic.php
+++ b/lizmap/modules/view/controllers/lizMap.classic.php
@@ -636,11 +636,7 @@ class lizMapCtrl extends jController
 
         $rep->body->assign($assign);
 
-        $request_headers = jApp::coord()->request->headers();
-        $_SESSION['html_map_token'] = md5(json_encode(array(
-            'Host' => $request_headers['Host'],
-            'User-Agent' => $request_headers['User-Agent'],
-        )));
+        $_SESSION['html_map_token'] = $lproj->getAppContext()->buildMapToken();
         $referer = jApp::coord()->request->header('Referer');
         if ($referer && $lrep->checkRefererEmbededIframe($referer)) {
             $sessionsParams = &jApp::config()->sessions;

--- a/tests/units/testslib/ContextForTests.php
+++ b/tests/units/testslib/ContextForTests.php
@@ -246,4 +246,9 @@ class ContextForTests implements AppContextInterface
     {
         return LizmapTilerForTests::getTileCapabilities($project);
     }
+
+    public function buildMapToken()
+    {
+        return "TOKEN_FOR_TEST";
+    }
 }


### PR DESCRIPTION
Add `AppContextInterface` method to build map token, + check if user Agent exitsts 

Ticket : #7075

Funded by 3Liz
