### PR TITLE
Fix/popup compact table ragged rows

### DIFF
--- a/CHANGELOG-3.11.md
+++ b/CHANGELOG-3.11.md
@@ -18,4 +18,8 @@ with some extra keywords: backend, tests, test, translation, funders, important
 
 ### Changed
 
+### Fixed
+
+* Popup - Compact table of children features: build the columns from all the displayed features instead of the first one only, so features having more empty fields no longer produce rows with missing cells and a DataTables `Requested unknown parameter` warning
+
 ### Backend

--- a/CHANGELOG-3.11.md
+++ b/CHANGELOG-3.11.md
@@ -18,8 +18,4 @@ with some extra keywords: backend, tests, test, translation, funders, important
 
 ### Changed
 
-### Fixed
-
-* Popup - Compact table of children features: build the columns from all the displayed features instead of the first one only, so features having more empty fields no longer produce rows with missing cells and a DataTables `Requested unknown parameter` warning
-
 ### Backend

--- a/CHANGELOG-3.9.md
+++ b/CHANGELOG-3.9.md
@@ -8,6 +8,10 @@ with some extra keywords: backend, tests, test, translation, funders, important
 
 ## Unreleased
 
+### Fixed
+
+* Popup - Compact table of children features: build the columns from all the displayed features, so features having more empty fields no longer produce rows with missing cells and a DataTables `Requested unknown parameter` warning
+
 ## 3.9.9 - 2026-07-03
 
 ### Funders

--- a/lizmap/modules/lizmap/lib/Request/WMSRequest.php
+++ b/lizmap/modules/lizmap/lib/Request/WMSRequest.php
@@ -882,8 +882,12 @@ class WMSRequest extends OGCRequest
 
         // Build hidden table containing all features when there are more than one
         if (count($allFeatureAttributes) > 1) {
+            list($allFeatureColumns, $allFeatureRows) = self::buildAllFeaturesTableData(
+                array_reverse($allFeatureAttributes)
+            );
             $content[] = $this->getViewTpl('view~popup_all_features_table', $layerName, $layerId, $layerTitle, array(
-                'allFeatureAttributes' => array_reverse($allFeatureAttributes),
+                'allFeatureColumns' => $allFeatureColumns,
+                'allFeatureRows' => $allFeatureRows,
                 'remoteStorageProfile' => $remoteStorageProfile,
                 'allFeatureToolbars' => array_reverse($allFeatureToolbars),
                 'checkBoxFields' => $checkBoxFields,
@@ -891,6 +895,62 @@ class WMSRequest extends OGCRequest
         }
 
         return $content;
+    }
+
+    /**
+     * Build the columns and the rows displayed by the popup compact table.
+     *
+     * A column is kept as soon as at least one feature has a non empty value for
+     * it. Every returned row then holds one entry per kept column, an empty string
+     * when that feature has no value, so all the rows have the same number of
+     * cells. Rows with a varying number of cells break the DataTables instance
+     * built on that table.
+     *
+     * @param array $allFeatureAttributes the attributes of each feature, as given by getFeatureInfo
+     *
+     * @return array the kept column names and the rows, as array($columns, $rows)
+     */
+    protected static function buildAllFeaturesTableData($allFeatureAttributes)
+    {
+        // Keep the fields order given by QGIS Server, and the fields having data
+        $columnsOrder = array();
+        $columnsWithData = array();
+        $featuresValues = array();
+
+        foreach ($allFeatureAttributes as $featureAttributes) {
+            $values = array();
+            foreach ($featureAttributes as $attribute) {
+                $name = (string) $attribute['name'];
+                if ($name === 'geometry' || $name === 'maptip') {
+                    continue;
+                }
+                $value = (string) $attribute['value'];
+                $values[$name] = $value;
+                $columnsOrder[$name] = true;
+                if ($value !== '') {
+                    $columnsWithData[$name] = true;
+                }
+            }
+            $featuresValues[] = $values;
+        }
+
+        $columns = array();
+        foreach (array_keys($columnsOrder) as $name) {
+            if (isset($columnsWithData[$name])) {
+                $columns[] = $name;
+            }
+        }
+
+        $rows = array();
+        foreach ($featuresValues as $values) {
+            $row = array();
+            foreach ($columns as $name) {
+                $row[$name] = isset($values[$name]) ? $values[$name] : '';
+            }
+            $rows[] = $row;
+        }
+
+        return array($columns, $rows);
     }
 
     /**

--- a/lizmap/modules/view/templates/popup_all_features_table.tpl
+++ b/lizmap/modules/view/templates/popup_all_features_table.tpl
@@ -3,27 +3,20 @@
 
     <table class='table table-sm table-striped table-bordered lizmapPopupTable'>
         <thead>
-            {foreach $allFeatureAttributes as $featureAttributes}
             <tr>
                 <th></th>
-                {foreach $featureAttributes as $attribute}
-                    {if $attribute['name'] != 'geometry' && $attribute['name'] != 'maptip' && $attribute['value'] != ''}
-                        <th>{$attribute['name']}</th>
-                    {/if}
+                {foreach $allFeatureColumns as $column}
+                    <th>{$column}</th>
                 {/foreach}
             </tr>
-            {break}
-            {/foreach}
         </thead>
 
         <tbody>
-            {foreach $allFeatureAttributes as $key=>$featureAttributes}
+            {foreach $allFeatureRows as $key=>$row}
                 <tr>
                 <td>{$allFeatureToolbars[$key]}</td>
-                {foreach $featureAttributes as $attribute}
-                    {if $attribute['name'] != 'geometry' && $attribute['name'] != 'maptip' && $attribute['value'] != ''}
-                        <td>{$attribute['name']|popupcheckbox:$attribute['value'],$repository,$project,$checkBoxFields,$remoteStorageProfile}</td>
-                    {/if}
+                {foreach $row as $name=>$value}
+                    <td>{$name|popupcheckbox:$value,$repository,$project,$checkBoxFields,$remoteStorageProfile}</td>
                 {/foreach}
                 </tr>
             {/foreach}

--- a/tests/units/classes/Request/WMSRequestTest.php
+++ b/tests/units/classes/Request/WMSRequestTest.php
@@ -491,4 +491,84 @@ class WMSRequestTest extends TestCase
         $result = $wms->applyCheckBoxesToFormPopupForTests($html, $fields);
         $this->assertSame($expected, $result);
     }
+
+    public function testBuildAllFeaturesTableDataRowsAreRectangular(): void
+    {
+        // The features do not have the same empty fields: every row must still
+        // hold one cell per column, otherwise DataTables raises
+        // "Requested unknown parameter" on the popup compact table.
+        $allFeatureAttributes = self::featureAttributes(array(
+            array('idu' => '1', 'commune' => 'Weingarten', 'remark' => 'first', 'geometry' => 'POLYGON((0 0))'),
+            array('idu' => '2', 'commune' => 'Weingarten', 'remark' => '', 'geometry' => 'POLYGON((1 1))'),
+            array('idu' => '3', 'commune' => '', 'remark' => '', 'geometry' => 'POLYGON((2 2))'),
+        ));
+
+        list($columns, $rows) = WMSRequestForTests::buildAllFeaturesTableDataForTests($allFeatureAttributes);
+
+        $this->assertSame(array('idu', 'commune', 'remark'), $columns);
+        foreach ($rows as $row) {
+            $this->assertSame($columns, array_keys($row));
+        }
+        $this->assertSame(array('idu' => '1', 'commune' => 'Weingarten', 'remark' => 'first'), $rows[0]);
+        $this->assertSame(array('idu' => '2', 'commune' => 'Weingarten', 'remark' => ''), $rows[1]);
+        $this->assertSame(array('idu' => '3', 'commune' => '', 'remark' => ''), $rows[2]);
+    }
+
+    public function testBuildAllFeaturesTableDataColumnsComeFromAllFeatures(): void
+    {
+        // The columns used to be read from the first feature only, so a value
+        // only set on a following feature ended up in the wrong column.
+        $allFeatureAttributes = self::featureAttributes(array(
+            array('idu' => '1', 'remark' => ''),
+            array('idu' => '2', 'remark' => 'only here'),
+        ));
+
+        list($columns, $rows) = WMSRequestForTests::buildAllFeaturesTableDataForTests($allFeatureAttributes);
+
+        $this->assertSame(array('idu', 'remark'), $columns);
+        $this->assertSame(array('idu' => '1', 'remark' => ''), $rows[0]);
+        $this->assertSame(array('idu' => '2', 'remark' => 'only here'), $rows[1]);
+    }
+
+    public function testBuildAllFeaturesTableDataDiscardsEmptyAndInternalColumns(): void
+    {
+        // 'geometry' and 'maptip' are never displayed, and a field which is empty
+        // for every feature is still dropped.
+        $allFeatureAttributes = self::featureAttributes(array(
+            array('idu' => '1', 'unused' => '', 'geometry' => 'POLYGON((0 0))', 'maptip' => '<p>tip</p>'),
+            array('idu' => '2', 'unused' => '', 'geometry' => 'POLYGON((1 1))', 'maptip' => '<p>tip</p>'),
+        ));
+
+        list($columns, $rows) = WMSRequestForTests::buildAllFeaturesTableDataForTests($allFeatureAttributes);
+
+        $this->assertSame(array('idu'), $columns);
+        $this->assertSame(array(array('idu' => '1'), array('idu' => '2')), $rows);
+    }
+
+    /**
+     * Build the feature attribute lists the way getFeatureInfo provides them.
+     *
+     * @param array $features list of arrays of fieldName => value
+     *
+     * @return array one SimpleXMLElement attribute list per feature
+     */
+    private static function featureAttributes($features)
+    {
+        $xml = '<GetFeatureInfoResponse>';
+        foreach ($features as $index => $attributes) {
+            $xml .= '<Feature id="'.$index.'">';
+            foreach ($attributes as $name => $value) {
+                $xml .= '<Attribute name="'.$name.'" value="'.htmlspecialchars($value, ENT_QUOTES).'"/>';
+            }
+            $xml .= '</Feature>';
+        }
+        $xml .= '</GetFeatureInfoResponse>';
+
+        $allFeatureAttributes = array();
+        foreach (new SimpleXMLElement($xml) as $feature) {
+            $allFeatureAttributes[] = $feature->Attribute;
+        }
+
+        return $allFeatureAttributes;
+    }
 }

--- a/tests/units/testslib/WMSRequestForTests.php
+++ b/tests/units/testslib/WMSRequestForTests.php
@@ -38,4 +38,9 @@ class WMSRequestForTests extends WMSRequest
     {
         return self::matchCheckBoxState($value, $checkedExpected, $uncheckedExpected);
     }
+
+    public static function buildAllFeaturesTableDataForTests($allFeatureAttributes)
+    {
+        return self::buildAllFeaturesTableData($allFeatureAttributes);
+    }
 }


### PR DESCRIPTION
The compact table listing all the features of a children layer built its header from the first feature only, while each body row skipped the cells whose value was empty for that very feature. As soon as one feature had more empty fields than the first one, its row had fewer cells than the header, and the DataTables instance created on that table in map.js raised "Requested unknown  parameter 'N' for row N, column N".

Features having the same number of non empty fields, but not the same ones, were silently rendered under the wrong columns.

Compute the displayed columns from all the features, keeping a column as soon as one feature has a value for it, and give every row one cell per column so all the rows have the same length.