### PR TITLE
fix(edition): read the parent feature again when creating a child feature

### DIFF
--- a/assets/src/components/FeatureToolbar.js
+++ b/assets/src/components/FeatureToolbar.js
@@ -566,9 +566,12 @@ export default class FeatureToolbar extends HTMLElement {
         const parentFeatureId = this.getAttribute('parent-feature-id');
         if (parentFeatureId && this.hasRelation){
             const parentLayerName = lizMap.getLayerConfigById(this.parentLayerId)?.[0];
+            // Force the parent feature to be fetched again (last argument): its
+            // referenced field fills the foreign key of the child feature, so it
+            // must not be served from a cache filled before the parent was edited.
             lizMap.getLayerFeature(parentLayerName, parentFeatureId, (feat) => {
                 lizMap.launchEdition(this.layerId, this.fid, { layerId: this.parentLayerId, feature: feat });
-            });
+            }, null, true);
         }else{
             lizMap.launchEdition(this.layerId, this.fid);
         }
@@ -863,7 +866,10 @@ export default class FeatureToolbar extends HTMLElement {
      */
     createChild(childItem) {
         // Get the parent feature corresponding to the popup
-        // where the create child button has been clicked
+        // where the create child button has been clicked.
+        // The last argument forces the feature to be fetched again: its referenced
+        // field fills the foreign key of the child feature, so it must not be
+        // served from a cache filled before the parent was edited.
         lizMap.getLayerFeature(this.featureType, this.fid, (parentFeature) => {
             lizMap.launchEdition(
                 // Id of the layer to edit
@@ -873,6 +879,6 @@ export default class FeatureToolbar extends HTMLElement {
                 // Parent data
                 { layerId: this.layerId, feature: parentFeature }
             );
-        });
+        }, null, true);
     }
 }

--- a/tests/end2end/playwright/form_edit_child_parent_feature_refresh.spec.js
+++ b/tests/end2end/playwright/form_edit_child_parent_feature_refresh.spec.js
@@ -1,0 +1,80 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+import { ProjectPage } from './pages/project';
+
+test.describe('Creating a child feature after the parent has been edited',
+    {
+        tag: ['@write'],
+    },
+    () => {
+        test('The foreign key uses the current value of the parent feature', async ({ page }) => {
+            const project = new ProjectPage(page, 'form_edit_related_child_data');
+            await project.open();
+
+            const districtToolbar = () => project.popupContent.locator(
+                'lizmap-feature-toolbar[value^="quartiers_"][value$=".6"]'
+            );
+            const foreignKey = project.editionForm.locator('select[name="quartmno"]');
+
+            const openDistrictPopup = async () => {
+                // map.js switches the dock to #popupcontent only when the clicked
+                // position differs from the previous identify. The same feature is
+                // clicked again here, so the popup can stay behind the edition dock
+                // and has to be brought back explicitly.
+                const getFeatureInfoPromise = project.waitForGetFeatureInfoRequest();
+                await project.clickOnMap(630, 325);
+                await (await getFeatureInfoPromise).response();
+
+                try {
+                    await expect(districtToolbar()).toBeVisible({ timeout: 2000 });
+                } catch {
+                    await page.locator('#button-popupcontent').click();
+                    await expect(districtToolbar()).toBeVisible();
+                }
+            };
+
+            const createSubdistrict = async () => {
+                const createFeaturePromise = page.waitForResponse(/lizmap\/edition\/createFeature/);
+                await districtToolbar().locator('.feature-create-child button.dropdown-toggle').click();
+                await districtToolbar().locator('.feature-create-child ul li a').click();
+                await createFeaturePromise;
+            };
+
+            const cancelForm = async () => {
+                page.once('dialog', dialog => dialog.accept());
+                await project.editingSubmit('cancel').click();
+            };
+
+            const setDistrictReference = async (value) => {
+                await districtToolbar().locator('button.feature-edit').click();
+                await expect(project.editionForm).toBeVisible();
+                await project.editingField('quartmno').fill(value);
+                await project.editingSubmitForm('close');
+            };
+
+            // Create a child feature once, so that the parent feature is put in the
+            // client side cache read by lizMap.getLayerFeature
+            await openDistrictPopup();
+            await createSubdistrict();
+            const formerValue = await foreignKey.inputValue();
+            expect(formerValue).not.toBe('');
+            await cancelForm();
+
+            // Change the referenced field of the parent feature. It is a varchar(2),
+            // and other tests filter on its values, so it is written back at the end.
+            const newValue = formerValue === 'ZZ' ? 'ZY' : 'ZZ';
+            await openDistrictPopup();
+            await setDistrictReference(newValue);
+
+            // The new child feature must be linked to the saved value, not to the one
+            // cached before the parent was edited
+            await openDistrictPopup();
+            await createSubdistrict();
+            await expect(foreignKey).toHaveValue(newValue);
+            await cancelForm();
+
+            // Write back the original data
+            await openDistrictPopup();
+            await setDistrictReference(formerValue);
+        });
+    });

--- a/tests/qgis-projects/tests/form_edit_related_child_data.qgs
+++ b/tests/qgis-projects/tests/form_edit_related_child_data.qgs
@@ -677,7 +677,7 @@ def my_form_open(dialog, layer, feature):
         <field name="libquart" editable="1"/>
         <field name="photo" editable="1"/>
         <field name="quartier" editable="0"/>
-        <field name="quartmno" editable="0"/>
+        <field name="quartmno" editable="1"/>
         <field name="url" editable="1"/>
       </editable>
       <labelOnTop>


### PR DESCRIPTION
lizMap.getLayerFeature serves features from a client side cache that the edition workflow never refreshes. A parent feature edited during the session kept its former values, so filling in its primary key and then creating a child feature right away linked the child to the previous value, usually an empty one.

Force the parent feature to be fetched again where its value fills the foreign key of a child, and drop the cached features of a layer once it has been saved, on both paths: form reopened and form closed.
