### PR TITLE
[Backport release_3_9] fix(edition): save the parent foreign key of a read-only child field

### DIFF
--- a/assets/src/legacy/edition.js
+++ b/assets/src/legacy/edition.js
@@ -1668,6 +1668,25 @@ var lizEdition = function() {
 
                     }
                 } else {
+                    // Always send the foreign key value in a dedicated hidden input.
+                    // The control itself cannot be relied on: when the field is not
+                    // editable in the QGIS project, jForms renders a disabled select,
+                    // which the browser does not submit, and jForms ignores request
+                    // values of read-only controls anyway. The child feature would
+                    // then be created with an empty foreign key, without any error.
+                    if ( editionType == 'createFeature'
+                      && parentFeatProp !== null && parentFeatProp !== undefined ) {
+                        const hiddenFields = form[0].querySelector('div.jforms-hiddens');
+                        if ( hiddenFields ) {
+                            const parentFkInput = document.createElement('input');
+                            parentFkInput.type = 'hidden';
+                            parentFkInput.id = 'liz_parent_fk_hidden';
+                            parentFkInput.name = 'liz_parent_fk';
+                            parentFkInput.value = relationRefField + ':' + parentFeatProp;
+                            hiddenFields.appendChild(parentFkInput);
+                        }
+                    }
+
                     var select = form.find('select[name="'+relationRefField+'"]');
                     if( select.length == 1 ){
                         // select the option via jquery (and fire event with "change", will update depending controls)

--- a/lizmap/modules/lizmap/controllers/edition.classic.php
+++ b/lizmap/modules/lizmap/controllers/edition.classic.php
@@ -679,6 +679,82 @@ class editionCtrl extends jController
     }
 
     /**
+     * Set the foreign key value sent by the parent feature edition form.
+     *
+     * The value is given by the liz_parent_fk parameter, formatted as
+     * "<referencing field>:<value>". It cannot be read from the request by the
+     * form itself: when the field is not editable in the QGIS project, the
+     * control is read-only, the browser does not submit the disabled widget and
+     * jForms skips read-only controls in initFromRequest(). The child feature
+     * would then be created with an empty foreign key, without any error.
+     *
+     * The field name is checked against the relations of the project: only a
+     * field referencing the edited layer is accepted, so that this parameter
+     * cannot be used to set an arbitrary column.
+     *
+     * @param jFormsBase $form The edition form
+     */
+    protected function setParentForeignKey($form)
+    {
+        $parentFk = $this->param('liz_parent_fk');
+        if (!$parentFk) {
+            return;
+        }
+
+        // The value may contain the separator, the field name may not
+        $parts = explode(':', $parentFk, 2);
+        if (count($parts) != 2 || $parts[0] === '' || $parts[1] === '') {
+            return;
+        }
+        $field = $parts[0];
+        $value = $parts[1];
+
+        // The field must be the referencing field of a relation
+        // for which the edited layer is the referencing (child) layer
+        $relations = $this->project->getRelations();
+        if (!is_array($relations)) {
+            return;
+        }
+        $isReferencingField = false;
+        foreach ($relations as $referencedLayerId => $referencedRelations) {
+            if ($referencedLayerId === 'pivot' || !is_array($referencedRelations)) {
+                continue;
+            }
+            foreach ($referencedRelations as $relation) {
+                if (is_array($relation)
+                    && array_key_exists('referencingLayer', $relation)
+                    && array_key_exists('referencingField', $relation)
+                    && $relation['referencingLayer'] == $this->layerId
+                    && $relation['referencingField'] === $field) {
+                    $isReferencingField = true;
+
+                    break 2;
+                }
+            }
+        }
+
+        if (!$isReferencingField) {
+            jLog::log(
+                'The field "'.$field.'" given by liz_parent_fk is not a referencing field '.
+                'of the layer '.$this->layerId.' in project '.
+                $this->repository->getKey().'/'.$this->project->getKey(),
+                'lizmapadmin'
+            );
+
+            return;
+        }
+
+        // setData() throws an exception when the control does not exist, which
+        // happens when the field is not displayed in the form
+        $controls = $form->getControls();
+        if (!array_key_exists($field, $controls)) {
+            return;
+        }
+
+        $form->setData($field, $value);
+    }
+
+    /**
      * Save the edition form (output as html fragment).
      *
      * @urlparam string $repository Lizmap Repository
@@ -737,6 +813,12 @@ class editionCtrl extends jController
 
         // Get data from the request and set the form controls data accordingly
         $form->initFromRequest();
+
+        // Set the foreign key sent by the parent feature when creating a child
+        // feature: a read-only control gets no value from the request
+        if ($this->featureId == null) {
+            $this->setParentForeignKey($form);
+        }
 
         // Check the form data and redirect if needed
         $feature = null;

--- a/tests/end2end/playwright/form_edit_child_read_only_foreign_key.spec.js
+++ b/tests/end2end/playwright/form_edit_child_read_only_foreign_key.spec.js
@@ -1,0 +1,49 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+import { ProjectPage } from './pages/project';
+
+test.describe('Creating a child feature with a read-only foreign key',
+    {
+        tag: ['@readonly'],
+    },
+    () => {
+        test('The foreign key is carried by a dedicated hidden input', async ({ page }) => {
+            const project = new ProjectPage(page, 'form_edit_related_child_data');
+            await project.open();
+
+            // Display the popup of a district
+            const getFeatureInfoPromise = project.waitForGetFeatureInfoRequest();
+            await project.clickOnMap(630, 325);
+            await getFeatureInfoPromise;
+
+            const featureToolbar = project.popupContent.locator('lizmap-feature-toolbar[value^="quartiers_"][value$=".6"]');
+            await expect(featureToolbar).toHaveCount(1);
+
+            // Create a subdistrict, the child layer of the district
+            const createFeaturePromise = page.waitForResponse(/lizmap\/edition\/createFeature/);
+            await featureToolbar.locator('.feature-create-child button.dropdown-toggle').click();
+            await featureToolbar.locator('.feature-create-child ul li a').click();
+            await createFeaturePromise;
+
+            // The foreign key field is not editable in the QGIS project, so jForms
+            // renders a disabled select. A disabled control is not submitted by the
+            // browser, and jForms ignores request values of read-only controls, so
+            // the value cannot be carried by the control itself.
+            const foreignKey = project.editionForm.locator('select[name="quartmno"]');
+            await expect(foreignKey).toHaveCount(1);
+            await expect(foreignKey).toBeDisabled();
+
+            // It is sent in a dedicated parameter instead, as "<field>:<value>"
+            const parentForeignKey = project.editionForm.locator('input[name="liz_parent_fk"]');
+            await expect(parentForeignKey).toHaveCount(1);
+            await expect(parentForeignKey).toHaveValue(/^quartmno:.+$/);
+
+            // and it holds the value of the parent feature
+            const parentValue = (await parentForeignKey.inputValue()).split(':')[1];
+            await expect(foreignKey).toHaveValue(parentValue);
+
+            // Close the form without saving
+            page.once('dialog', dialog => dialog.accept());
+            await project.editingSubmit('cancel').click();
+        });
+    });

--- a/tests/qgis-projects/tests/form_edit_related_child_data.qgs
+++ b/tests/qgis-projects/tests/form_edit_related_child_data.qgs
@@ -1192,7 +1192,7 @@ def my_form_open(dialog, layer, feature):
         <field name="id" editable="0"/>
         <field name="libsquart" editable="1"/>
         <field name="quartiers_libquart" editable="1"/>
-        <field name="quartmno" editable="1"/>
+        <field name="quartmno" editable="0"/>
         <field name="squartmno" editable="1"/>
       </editable>
       <labelOnTop>


### PR DESCRIPTION
Backport #7097
 **Authored by:** @meyerlor