### PR TITLE
Fix: Return error if selection token is unknown or expired

### DIFF
--- a/lizmap/modules/lizmap/controllers/service.classic.php
+++ b/lizmap/modules/lizmap/controllers/service.classic.php
@@ -297,7 +297,9 @@ class serviceCtrl extends jController
         jMessage::clearAll();
 
         foreach ($messages as $code => $msg) {
-            if ($code == 'AuthorizationRequired') {
+            if ($code == 'BadRequest') {
+                $rep->setHttpStatus(400, Proxy::getHttpStatusMsg(400));
+            } elseif ($code == 'AuthorizationRequired') {
 
                 // 401 : AuthorizationRequired
                 $rep->setHttpStatus(401, Proxy::getHttpStatusMsg(401));
@@ -525,6 +527,11 @@ class serviceCtrl extends jController
                                 $feature_ids[] = implode(',', $data_ids);
                             }
                         }
+                    } else {
+                        // Unkown or expired token
+                        jMessage::add('Unknown or expired token: '.$token, 'BadRequest');
+
+                        return false;
                     }
                 }
                 // Add SELECTION for WMS

--- a/tests/end2end/playwright/requests-wfs.spec.js
+++ b/tests/end2end/playwright/requests-wfs.spec.js
@@ -1534,6 +1534,133 @@ test.describe('WFS Requests @requests @readonly', () => {
         expect(body.features).toHaveLength(0);
     });
 
+    test('WFS GetFeature SELECTIONTOKEN', async({ request }) => {
+        // GetSelectionToken parameters
+        let params = new URLSearchParams({
+            repository: 'testsrepository',
+            project: 'selection',
+            SERVICE: 'WMS',
+            REQUEST: 'GetSelectionToken',
+            TYPENAME: 'selection_polygon',
+            IDS: '1',
+        });
+        // GetSSelectionToken request
+        let url = `/index.php/lizmap/service/?${params}`;
+        let response = await request.get(url, {});
+        // check response
+        responseExpect(response).toBeJson();
+        // get the token
+        let token = (await response.json())['token'];
+        expect(token).toBeTruthy();
+        expect(token).toHaveLength(32);
+
+        // WFS GetFeature request
+        params = new URLSearchParams({
+            repository: 'testsrepository',
+            project: 'selection',
+        });
+        url = `/index.php/lizmap/service?${params}`;
+        response = await request.post(url, {
+            form: {
+                SERVICE: 'WFS',
+                VERSION: '1.0.0',
+                REQUEST: 'GetFeature',
+                SELECTIONTOKEN: token,
+                OUTPUTFORMAT: 'GeoJSON',
+            }
+        });
+        // check response
+        responseExpect(response).toBeGeoJson();
+
+        // check body
+        let body = await response.json();
+        expect(body).toHaveProperty('type', 'FeatureCollection');
+        expect(body).toHaveProperty('features');
+        expect(body.features).toHaveLength(1);
+        let feature = body.features[0];
+        expect(feature).toHaveProperty('type', 'Feature');
+        expect(feature).toHaveProperty('id', 'selection_polygon.1');
+        expect(feature).toHaveProperty('properties');
+        expect(feature.properties).toHaveProperty('id', 1);
+
+        // GetSelectionToken parameters
+        params = new URLSearchParams({
+            repository: 'testsrepository',
+            project: 'selection',
+            SERVICE: 'WMS',
+            REQUEST: 'GetSelectionToken',
+            TYPENAME: 'selection_polygon',
+            IDS: '1,2',
+        });
+        // GetSSelectionToken request
+        url = `/index.php/lizmap/service/?${params}`;
+        response = await request.get(url, {});
+        // check response
+        responseExpect(response).toBeJson();
+        // get the token
+        token = (await response.json())['token'];
+        expect(token).toBeTruthy();
+        expect(token).toHaveLength(32);
+
+        // WFS GetFeature request
+        params = new URLSearchParams({
+            repository: 'testsrepository',
+            project: 'selection',
+        });
+        url = `/index.php/lizmap/service?${params}`;
+        response = await request.post(url, {
+            form: {
+                SERVICE: 'WFS',
+                VERSION: '1.0.0',
+                REQUEST: 'GetFeature',
+                SELECTIONTOKEN: token,
+                OUTPUTFORMAT: 'GeoJSON',
+            }
+        });
+        // check response
+        responseExpect(response).toBeGeoJson();
+
+        // check body
+        body = await response.json();
+        expect(body).toHaveProperty('type', 'FeatureCollection');
+        expect(body).toHaveProperty('features');
+        expect(body.features).toHaveLength(2);
+        feature = body.features[0];
+        expect(feature).toHaveProperty('type', 'Feature');
+        expect(feature).toHaveProperty('id', 'selection_polygon.1');
+        expect(feature).toHaveProperty('properties');
+        expect(feature.properties).toHaveProperty('id', 1);
+        feature = body.features[1];
+        expect(feature).toHaveProperty('type', 'Feature');
+        expect(feature).toHaveProperty('id', 'selection_polygon.2');
+        expect(feature).toHaveProperty('properties');
+        expect(feature.properties).toHaveProperty('id', 2);
+    });
+
+    test('WFS GetFeature SELECTIONTOKEN with bad token', async({ request }) => {
+        // WFS GetFeature request
+        let params = new URLSearchParams({
+            repository: 'testsrepository',
+            project: 'selection',
+        });
+        let url = `/index.php/lizmap/service?${params}`;
+        let response = await request.post(url, {
+            form: {
+                SERVICE: 'WFS',
+                VERSION: '1.0.0',
+                REQUEST: 'GetFeature',
+                SELECTIONTOKEN: 'token',
+                OUTPUTFORMAT: 'GeoJSON',
+            }
+        });
+        // check response
+        responseExpect(response).toBeXml(400);
+        // check body
+        let body = await response.text();
+        expect(body).toContain('ServiceException');
+        expect(body).toContain('Unknown or expired token:');
+    });
+
     test('WFS GetFeature XML', async({ request }) => {
         let params = new URLSearchParams({
             repository: 'testsrepository',


### PR DESCRIPTION
The selection token was ignored if it is unknown or expired. Now Lizmap will return an error for bar request.